### PR TITLE
Fixed ignoring error of zypper on the build for windows

### DIFF
--- a/build-scripts/for-win64/prepare-ubuntu-20.sh
+++ b/build-scripts/for-win64/prepare-ubuntu-20.sh
@@ -45,7 +45,8 @@ sudo zypper -vv --installroot /zypper install -y mingw64-libgnurx0 mingw64-libgn
 sudo zypper -vv --installroot /zypper install -y mingw64-fftw3 mingw64-fftw3-devel
 sudo zypper -vv --installroot /zypper install -y mingw64-jack mingw64-jack-devel
 sudo zypper -vv --installroot /zypper install -y mingw64-wavpack mingw64-wavpack-devel 
-sudo zypper -vv --installroot /zypper install -y mingw64-wxWidgets-3_0-lang mingw64-wxWidgets-3_0-devel || true
+sudo zypper -vv --installroot /zypper install -y mingw64-wxWidgets-3_0-lang
+sudo zypper -vv --installroot /zypper install -y mingw64-wxWidgets-3_0-devel
 
 sudo ln -s /zypper/usr/x86_64-w64-mingw32/sys-root /usr/x86_64-w64-mingw32/
 sudo mv /usr/x86_64-w64-mingw32/sys-root/mingw/lib/libmingw32.a /usr/x86_64-w64-mingw32/sys-root/mingw/lib/libmingw32.save.a


### PR DESCRIPTION
Resolves #5 

This change
1. Disabled ignoring an error
2. Splitted one zypper command to two ones for decreasing probability of errors (zypper usually fails when downloading a large amount of files)