### PR TITLE
Fixed crash on OSx when opening some pannels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on OSx when opening some pannels https://github.com/oleg68/GrandOrgue/issues/94
 - Updated help with changes in menus and Settings... dialog https://github.com/GrandOrgue/grandorgue/issues/17
 - The project has been moved to the new official GrandOrgue repository https://github.com/GrandOrgue/grandorgue
 # 0.3.1.2341-15.os (2021-09-04)

--- a/src/grandorgue/GOrguePanelView.cpp
+++ b/src/grandorgue/GOrguePanelView.cpp
@@ -195,10 +195,12 @@ void GOrguePanelView::OnSize(wxSizeEvent& event)
 
 		int x, xu, y, yu;
 		GetScrollPixelsPerUnit(&xu, &yu);
+		
 		GetViewStart(&x, &y);
-		if (x * xu + max.GetWidth() > event.GetSize().GetWidth())
+		
+		if (xu && x * xu + max.GetWidth() > event.GetSize().GetWidth())
 			x = (event.GetSize().GetWidth() - max.GetWidth()) / xu;
-		if (y * yu + max.GetHeight() > event.GetSize().GetHeight())
+		if (yu && y * yu + max.GetHeight() > event.GetSize().GetHeight())
 			y = (event.GetSize().GetHeight() - max.GetHeight()) / yu;
 		this->Scroll(x, y);
 


### PR DESCRIPTION
https://github.com/oleg68/GrandOrgue/issues/94

Sometimes wxWidget implementation for OSx behaviors strange: wxScrollPannel::GetScrollPixelsPerUnit returns zeros
