### PR TITLE
ignore 107 retcode from zypper when installing windows dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# 0.3.1.2342 (2021-09-14)
+# 0.3.1.2342 (2021-09-15)
+- Fixed build for windows on github https://github.com/GrandOrgue/grandorgue/issues/29
 - Fixed crash on OSx when opening some pannels https://github.com/oleg68/GrandOrgue/issues/94
 - Updated help with changes in menus and Settings... dialog https://github.com/GrandOrgue/grandorgue/issues/17
 - The project has been moved to the new official GrandOrgue repository https://github.com/GrandOrgue/grandorgue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.1.2342 (2021-09-15)
+# 0.3.1.2342 (2021-09-16)
 - Fixed build for windows on github https://github.com/GrandOrgue/grandorgue/issues/29
 - Fixed crash on OSx when opening some pannels https://github.com/oleg68/GrandOrgue/issues/94
 - Updated help with changes in menus and Settings... dialog https://github.com/GrandOrgue/grandorgue/issues/17

--- a/build-scripts/for-win64/prepare-ubuntu-20.sh
+++ b/build-scripts/for-win64/prepare-ubuntu-20.sh
@@ -39,7 +39,7 @@ sudo zypper --gpg-auto-import-keys refresh
 
 sudo mkdir /zypper
 
-sudo zypper -vv --installroot /zypper install -y mingw64-filesystem 
+sudo zypper -vv --installroot /zypper install -y mingw64-filesystem || [ $? -eq 107 ] 
 sudo zypper -vv --installroot /zypper install -y mingw64-zlib1 mingw64-zlib-devel
 sudo zypper -vv --installroot /zypper install -y mingw64-libgnurx0 mingw64-libgnurx-devel 
 sudo zypper -vv --installroot /zypper install -y mingw64-fftw3 mingw64-fftw3-devel


### PR DESCRIPTION
Resolves: #29

We are installing some packages from OpenSuse repositories to ubuntu into a separate root with zyper. They are needed for dependency.

Unfortunally, zypper installs a lot of extra packages. One of them statred failing on the post-install script in a non-default system root, but all necessary packages present.

This fix is a temporary workaround: ignore 107 retcode from zypper. The final solution will be done in #28 