### PR TITLE
Making the single grandorgue linux package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Got rid of separate linux packages grandorgue-resources and grandorgue-demo https://github.com/GrandOrgue/grandorgue/issues/741
 # 3.2.0-1 (2021-09-27)
 - Renewed a default GO version during cmake build https://github.com/GrandOrgue/grandorgue/issues/14
 - Fixed initial sizing of Panel menu when organ is loaded https://github.com/GrandOrgue/grandorgue/issues/712

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ if (WIN32 OR APPLE)
 else ()
    option(INSTALL_DEPEND      "Copy dependencies (wxWidgets libraries and Translations) on installation" OFF)
 endif ()
+option(GO_SEPARATE_LINUX_PACKAGES "Generate separate linux packages for resources and demo" OFF)
 
 # only use options supported by the compiler
 include(CheckIncludeFileCXX)
@@ -286,7 +287,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CPACK_SYSTEM_NAME "linux")
   set(CPACK_GENERATOR TGZ RPM DEB)
 
-  set(CPACK_RPM_COMPONENT_INSTALL ON)
+  set(CPACK_RPM_COMPONENT_INSTALL ${GO_SEPARATE_LINUX_PACKAGES})
   set(CPACK_RPM_PACKAGE_LICENSE "GPL v2+")
   set(CPACK_RPM_PACKAGE_RELEASE "${CPACK_PACKAGE_RELEASE}")
   set(CPACK_RPM_PACKAGE_GROUP "Productivity/Multimedia/Sound/Midi")
@@ -304,13 +305,17 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CPACK_RPM_DEMO_PACKAGE_SUMMARY "${CPACK_COMPONENT_DEMO_DISPLAY_NAME}")
   set(CPACK_RPM_DEMO_PACKAGE_ARCHITECTURE noarch)
   set(CPACK_RPM_DEMO_FILE_NAME RPM-DEFAULT)
+  if(NOT GO_SEPARATE_LINUX_PACKAGES)
+    # For automatic removal of previously installed suppackages
+    set(CPACK_RPM_PACKAGE_OBSOLETES "grandorgue-resources grandorgue-demo")
+  endif()
 
   # for source rpms
   set(CPACK_RPM_BUILDREQUIRES "pkgconfig(alsa), gcc-c++, jack-audio-connection-kit-devel, cmake, wxGTK3-devel, pkgconfig(fftw3f), pkgconfig(libudev), pkgconfig(wavpack), pkgconfig(zlib), libxslt, zip, po4a")
   set(CPACK_RPM_SOURCE_PKG_BUILD_PARAMS "-DVERSION=%{version} -DBUILD_VERSION=%{release}")
 
   # for deb
-  set(CPACK_DEB_COMPONENT_INSTALL ON)
+  set(CPACK_DEB_COMPONENT_INSTALL GO_SEPARATE_LINUX_PACKAGES)
   set(CPACK_DEBIAN_UNSPECIFIED_PACKAGE_NAME "grandorgue")
   set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
   set(CPACK_DEBIAN_PACKAGE_RELEASE "${CPACK_PACKAGE_RELEASE}")
@@ -324,6 +329,10 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CPACK_DEBIAN_UNSPECIFIED_PACKAGE_RECOMMENDS "grandorgue-demo, wx3.0-i18n")
   set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON)
   set(CPACK_DEBIAN_PACKAGE_SOURCE "${CPACK_DEBIAN_UNSPECIFIED_PACKAGE_NAME}")
+  if(NOT GO_SEPARATE_LINUX_PACKAGES)
+    # For automatic removal of previously installed suppackages
+    set(CPACK_DEBIAN_PACKAGE_REPLACES "grandorgue-resources, grandorgue-demo")
+  endif()
 endif()
 
 set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CPACK_SYSTEM_NAME}.${CMAKE_SYSTEM_PROCESSOR}")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,31 +13,29 @@ These two steps will be described later in the text.
 
 ## Installation on Linux
 ### Installation on rpm-based systems (centos, fedora, redhat, oracle linux, opensuse)
-1. Download linux packages
-    1. ``grandorgue-<version>.<arch>.rpm``
-        where `<arch>` is
-        - `x86_64` for intel 64-bit OS
-        - `armhf` for arm 32-bit OS
-        - `aarch64` for arm 64-bit OS
-    2. ``grandorgue-resources-<version>.noarch.rpm``
-    3. ``grandorgue-demo-<version>.noarch.rpm``
+1. Download the linux package ``grandorgue-<version>.<arch>.rpm`` where `<arch>` is
+
+    - `x86_64` for intel 64-bit OS
+    - `armhf` for arm 32-bit OS
+    - `aarch64` for arm 64-bit OS
+
 2. Run install command as a root
     - on opensuse
 
         ```
-        zypper install <path>/grandorgue-<version>.<arch>.rpm <path>/grandorgue-resources-<version>.noarch.rpm <path>/grandorgue-demo-<version>.noarch.rpm
+        zypper install <path>/grandorgue-<version>.<arch>.rpm
         ```
 
     - on other systems
 
         ```
-        dnf install <path>/grandorgue-<version>.<arch>.rpm <path>/grandorgue-resources-<version>.noarch.rpm <path>/grandorgue-demo-<version>.noarch.rpm
+        dnf install <path>/grandorgue-<version>.<arch>.rpm
         ```
 
     - on old systems
 
         ```
-        yum install <path>/grandorgue-<version>.<arch>.rpm <path>/grandorgue-resources-<version>.noarch.rpm <path>/grandorgue-demo-<version>.noarch.rpm
+        yum install <path>/grandorgue-<version>.<arch>.rpm
         ```
 
 4. After installation, run GrandOrgue from the Aplication menu or from the overview screen.
@@ -45,14 +43,13 @@ These two steps will be described later in the text.
 
 ### Installation on debian-based systems (debian 9+, ubuntu 18+, mint, raspbian)
 
-1. Download linux packages
-    1. ``grandorgue_<version>_<arch>.deb``
-        where `<arch>` is
-        - `amd64` for intel 64-bit OS
-        - `armhf` for arm 32-bit OS
-        - `arm64` for arm 64-bit OS
-    2. ``grandorgue-resources_<version>_all.deb``
-    3. ``grandorgue-demo_<version>_all.deb``
+1. Download the linux package ``grandorgue_<version>_<arch>.deb``
+    where `<arch>` is
+
+    - `amd64` for intel 64-bit OS
+    - `armhf` for arm 32-bit OS
+    - `arm64` for arm 64-bit OS
+
 2. (Debian 9 only): install wx-gtk3
 
     ```
@@ -64,7 +61,7 @@ These two steps will be described later in the text.
 3. Install GrandOrgue with all dependencies. Execute the install command as a root:
 
     ```
-    apt-get install <path>/grandorgue_<version>_<arch>.deb <path>/grandorgue-resources_<version>_all.deb <path>/grandorgue-demo_<version>_all.deb
+    apt-get install <path>/grandorgue_<version>_<arch>.deb
     ```
 
 4. After installation, run GrandOrgue from the Aplication menu or from the overview screen.
@@ -79,15 +76,18 @@ This method requires that all dependencies have already been installed. Usually 
     - `aarch64` for arm 64-bit OS
 2. Unpack this archive to some directory
 3. Run ``bin/GrandOrgue``
+
 ## Installation on Windows 64-bit
 1. Download the file ``grandorgue-<version>.windows.x86_64.exe``
 2. Run this exe file. The installer will be launched.
 3. Follow the prompts.
 4. After installation, run GrandOrgue from the `Start` menu.
+
 ### Running Grandorgue on Windows without installation
 1. Download the file ``grandorgue-<version>.windows.x86_64.zip``
 2. Unpack it's contents to some directory.
 3. Run ``GrandOrgue.exe`` from the `bin` subdirecttory
+
 ## Installation on OSx (intel-based only)
 1. Download the file grandorgue-<version>.os.osx.x86_64.dmg
 2. Open it


### PR DESCRIPTION
Resolves: #741

It makes the grandorgue .rpm/.deb file installable with double-click
