### PR TITLE
The new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+# 3.3.0 (2021-10-08)
 - Added automated release tagging on GitHub https://github.com/GrandOrgue/grandorgue/issues/711
 - Added polish language support https://github.com/GrandOrgue/grandorgue/discussions/743
 - Added upgrade and uninstall guide to INSTALL.md https://github.com/GrandOrgue/grandorgue/issues/720


### PR DESCRIPTION
According to #711 merging this PR will trigger issuing the new release.

Now I suggest `3.3.0` because I think both changing packaging and adding polish translation cause increasing the minor version.

@larspalo If you want another version number, please suggest a change in CHANGELOG.md
