### PR TITLE
Support of stopping the thread in GOSoundWorkItem::Run

### DIFF
--- a/src/core/GOSoundTouchWorkItem.cpp
+++ b/src/core/GOSoundTouchWorkItem.cpp
@@ -30,7 +30,7 @@ bool GOSoundTouchWorkItem::GetRepeat()
 	return false;
 }
 
-void GOSoundTouchWorkItem::Run()
+void GOSoundTouchWorkItem::Run(GOSoundThread *thread)
 {
 	GOMutexLocker locker(m_Mutex);
 	m_Pool.TouchMemory(m_Stop);

--- a/src/core/GOSoundTouchWorkItem.h
+++ b/src/core/GOSoundTouchWorkItem.h
@@ -25,7 +25,7 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run();
+	void Run(GOSoundThread *thread = nullptr);
 	void Exec();
 
 	void Clear();

--- a/src/core/GOSoundWorkItem.h
+++ b/src/core/GOSoundWorkItem.h
@@ -7,6 +7,8 @@
 #ifndef GOSOUNDWORKITEM_H
 #define GOSOUNDWORKITEM_H
 
+class GOSoundThread;
+
 class GOSoundWorkItem
 {
 public:
@@ -17,7 +19,7 @@ public:
 	virtual unsigned GetGroup() = 0;
 	virtual unsigned GetCost() = 0;
 	virtual bool GetRepeat() = 0;
-	virtual void Run() = 0;
+	virtual void Run(GOSoundThread *thread = nullptr) = 0;
 	virtual void Exec() = 0;
 
 	virtual void Clear() = 0;

--- a/src/core/threading/GOrgueThread.cpp
+++ b/src/core/threading/GOrgueThread.cpp
@@ -27,6 +27,11 @@ void GOrgueThread::Start()
 	m_Thread = std::thread(GOrgueThread::EntryPoint, this);
 }
 
+void GOrgueThread::MarkForStop()
+{
+	m_Stop = true;
+}
+
 void GOrgueThread::Wait()
 {
 	if (m_Thread.joinable())
@@ -35,7 +40,7 @@ void GOrgueThread::Wait()
 
 void GOrgueThread::Stop()
 {
-	m_Stop = true;
+	MarkForStop();
 	Wait();
 }
 

--- a/src/core/threading/GOrgueThread.h
+++ b/src/core/threading/GOrgueThread.h
@@ -25,6 +25,7 @@ public:
 	virtual ~GOrgueThread();
 
 	void Start();
+	void MarkForStop();
 	void Wait();
 	void Stop();
 	

--- a/src/grandorgue/GOSoundGroupWorkItem.cpp
+++ b/src/grandorgue/GOSoundGroupWorkItem.cpp
@@ -84,7 +84,7 @@ bool GOSoundGroupWorkItem::GetRepeat()
 	return true;
 }
 
-void GOSoundGroupWorkItem::Run()
+void GOSoundGroupWorkItem::Run(GOSoundThread *thread)
 {
 	if (m_Done == 3)
 		return;

--- a/src/grandorgue/GOSoundGroupWorkItem.h
+++ b/src/grandorgue/GOSoundGroupWorkItem.h
@@ -36,7 +36,7 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run();
+	void Run(GOSoundThread *thread = nullptr);
 	void Exec();
 	void Finish(bool stop);
 

--- a/src/grandorgue/GOSoundOutputWorkItem.cpp
+++ b/src/grandorgue/GOSoundOutputWorkItem.cpp
@@ -33,7 +33,7 @@ void GOSoundOutputWorkItem::SetOutputs(std::vector<GOSoundBufferItem*> outputs)
 	m_OutputCount = m_Outputs.size() * 2;
 }
 
-void GOSoundOutputWorkItem::Run()
+void GOSoundOutputWorkItem::Run(GOSoundThread *thread)
 {
 	if (m_Done)
 		return;

--- a/src/grandorgue/GOSoundOutputWorkItem.h
+++ b/src/grandorgue/GOSoundOutputWorkItem.h
@@ -36,7 +36,7 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run();
+	void Run(GOSoundThread *thread = nullptr);
 	void Exec();
 	void Finish(bool stop);
 

--- a/src/grandorgue/GOSoundRecorder.cpp
+++ b/src/grandorgue/GOSoundRecorder.cpp
@@ -206,7 +206,7 @@ bool GOSoundRecorder::GetRepeat()
 	return false;
 }
 
-void GOSoundRecorder::Run()
+void GOSoundRecorder::Run(GOSoundThread *thread)
 {
 	if (!m_Recording)
 		return;

--- a/src/grandorgue/GOSoundRecorder.h
+++ b/src/grandorgue/GOSoundRecorder.h
@@ -52,7 +52,7 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run();
+	void Run(GOSoundThread *thread = nullptr);
 	void Exec();
 
 	void Clear();

--- a/src/grandorgue/GOSoundReleaseWorkItem.cpp
+++ b/src/grandorgue/GOSoundReleaseWorkItem.cpp
@@ -4,6 +4,7 @@
 * License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 */
 
+
 #include "GOSoundReleaseWorkItem.h"
 
 #include "GOSoundEngine.h"
@@ -48,7 +49,7 @@ void GOSoundReleaseWorkItem::Add(GO_SAMPLER* sampler)
 	m_List.Put(sampler);
 }
 
-void GOSoundReleaseWorkItem::Run()
+void GOSoundReleaseWorkItem::Run(GOSoundThread *pThread)
 {
 	GO_SAMPLER* sampler;
 	do

--- a/src/grandorgue/GOSoundReleaseWorkItem.h
+++ b/src/grandorgue/GOSoundReleaseWorkItem.h
@@ -31,7 +31,7 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run();
+	void Run(GOSoundThread *thread = nullptr);
 	void Exec();
 
 	void Clear();

--- a/src/grandorgue/GOSoundThread.cpp
+++ b/src/grandorgue/GOSoundThread.cpp
@@ -29,7 +29,7 @@ void GOSoundThread::Entry()
 		{
 			next = m_Scheduler->GetNextGroup();
 			if (next != NULL)
-				next->Run();
+				next->Run(this);
 		}
 		while (next != NULL);
 

--- a/src/grandorgue/GOSoundThread.cpp
+++ b/src/grandorgue/GOSoundThread.cpp
@@ -14,7 +14,6 @@
 GOSoundThread::GOSoundThread(GOSoundScheduler* scheduler):
 	GOrgueThread(),
 	m_Scheduler(scheduler),
-	m_Stop(false),
 	m_Condition(m_Mutex)
 {
 	wxLogDebug(wxT("Create Thread"));
@@ -22,20 +21,26 @@ GOSoundThread::GOSoundThread(GOSoundScheduler* scheduler):
 
 void GOSoundThread::Entry()
 {
-	while(!ShouldStop() && !m_Stop)
+	while (! ShouldStop())
 	{
-		GOSoundWorkItem *next;
+		bool shouldStop = false;
+
 		do
 		{
-			next = m_Scheduler->GetNextGroup();
-			if (next != NULL)
-				next->Run(this);
+			GOSoundWorkItem *next = m_Scheduler->GetNextGroup();
+
+			if (next == NULL)
+			  break;
+			next->Run(this);
+			shouldStop = ShouldStop();
 		}
-		while (next != NULL);
+		while (! shouldStop);
+
+		if (shouldStop)
+			break;
 
 		GOMutexLocker lock(m_Mutex);
-		if (ShouldStop() || m_Stop)
-			break;
+
 		m_Condition.Wait();
 	}
 	return;
@@ -53,10 +58,7 @@ void GOSoundThread::Wakeup()
 
 void GOSoundThread::Delete()
 {
-	{
-		GOMutexLocker lock(m_Mutex);
-		m_Stop = true;
-		m_Condition.Signal();
-	}
-	Stop();
+	MarkForStop();
+	Wakeup();
+	Wait();
 }

--- a/src/grandorgue/GOSoundThread.h
+++ b/src/grandorgue/GOSoundThread.h
@@ -17,7 +17,6 @@ class GOSoundThread : public GOrgueThread
 {
 private:
 	GOSoundScheduler* m_Scheduler;
-	bool m_Stop;
 
 	GOMutex m_Mutex;
 	GOCondition m_Condition;

--- a/src/grandorgue/GOSoundThread.h
+++ b/src/grandorgue/GOSoundThread.h
@@ -13,7 +13,7 @@
 
 class GOSoundScheduler;
 
-class GOSoundThread : private GOrgueThread
+class GOSoundThread : public GOrgueThread
 {
 private:
 	GOSoundScheduler* m_Scheduler;

--- a/src/grandorgue/GOSoundTremulantWorkItem.cpp
+++ b/src/grandorgue/GOSoundTremulantWorkItem.cpp
@@ -48,7 +48,7 @@ bool GOSoundTremulantWorkItem::GetRepeat()
 	return false;
 }
 
-void GOSoundTremulantWorkItem::Run()
+void GOSoundTremulantWorkItem::Run(GOSoundThread *thread)
 {
 	if (m_Done)
 		return;

--- a/src/grandorgue/GOSoundTremulantWorkItem.h
+++ b/src/grandorgue/GOSoundTremulantWorkItem.h
@@ -29,7 +29,7 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run();
+	void Run(GOSoundThread *thread = nullptr);
 	void Exec();
 
 	void Reset();

--- a/src/grandorgue/GOSoundWindchestWorkItem.cpp
+++ b/src/grandorgue/GOSoundWindchestWorkItem.cpp
@@ -63,7 +63,7 @@ float GOSoundWindchestWorkItem::GetWindchestVolume()
 		return 1;
 }
 
-void GOSoundWindchestWorkItem::Run()
+void GOSoundWindchestWorkItem::Run(GOSoundThread *thread)
 {
 	if (m_Done)
 		return;

--- a/src/grandorgue/GOSoundWindchestWorkItem.h
+++ b/src/grandorgue/GOSoundWindchestWorkItem.h
@@ -31,7 +31,7 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run();
+	void Run(GOSoundThread *thread = nullptr);
 	void Exec();
 
 	void Clear();


### PR DESCRIPTION
This is the second part of changes caused by #762

The change is quite simple: GOSoundWorkItem::Run gets an additional parameter a GOSoundThread where the item is running now.

GOSoundThread::Entry passes the parameter to GOSoundWorkItem::Run.

It is intended GOSoundWorkItem::Run to check GOSoundThread::ShouldStop and to break its work if the thread is being stopped.

Because there are lots of derived classes from GOSoundWorkItem, their files are also changed.
None of them are using this new parameter now so the behaviour does not change yet. But I make a separate PR for it because it would difficult to review a lot of trivial changes at the same time as a change of behavior