### PR TITLE
Fixed hang on Panic button after the sound had been suddenly stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
+- Fixed hang on Panic button after the sound had been suddenly stopped https://github.com/GrandOrgue/grandorgue/issues/762
+- Make the Paths settings in the Options tab expandable
 - Added build for linux appimage https://github.com/GrandOrgue/grandorgue/issues/698
 - Fixed bug preventing building with -DGO_USE_JACK=OFF
 - Moved the netbeans project files to the ide-projects/NetBeans12 subdirectory https://github.com/GrandOrgue/grandorgue/discussions/771
-- Make the Paths settings in the Options tab expandable
 # 3.3.0 (2021-10-08)
 - Added automated release tagging on GitHub https://github.com/GrandOrgue/grandorgue/issues/711
 - Added polish language support https://github.com/GrandOrgue/grandorgue/discussions/743

--- a/src/core/threading/GOCondition.cpp
+++ b/src/core/threading/GOCondition.cpp
@@ -89,7 +89,7 @@ unsigned GOCondition::DoWait(bool isWithTimeout, const char* waiterInfo, GOrgueT
     // a timeout occured
     if (isFirstTime && waiterInfo)
     {
-      wxLogWarning("GOCondition::Wait: unable to restore mutex lock for %s", wxString(waiterInfo));
+      wxLogWarning("GOCondition::Wait: unable to restore lock on the condition mutex %p:%p for %s", this, &m_Mutex, wxString(waiterInfo));
       isFirstTime = false;
     }
   } while (pThread == NULL || !pThread->ShouldStop());

--- a/src/core/threading/GOCondition.cpp
+++ b/src/core/threading/GOCondition.cpp
@@ -139,7 +139,7 @@ unsigned GOCondition::WaitOrStop(const char* waiterInfo, GOrgueThread* pThread)
     // timeout occured
     if (isFirstTime && waiterInfo)
     {
-      wxLogWarning("GOCondition::WaitOrStop: timeout while %s waited for a condition");
+      wxLogWarning("GOCondition::WaitOrStop: timeout while %s waited for condition %p", this);
       isFirstTime = false;
     }
   }

--- a/src/core/threading/GOCondition.cpp
+++ b/src/core/threading/GOCondition.cpp
@@ -7,6 +7,10 @@
 #include "threading_impl.h"
 #include "GOCondition.h"
 
+const char* const UNKNOWN_WAITER_INFO = "UnknownWaiter";
+
+#define WAITER_INFO(waiterInfo) (waiterInfo ? waiterInfo : UNKNOWN_WAITER_INFO)
+
 /**
  * Composes the result of the wait for condition.
  * @param isSignalReceived
@@ -89,7 +93,10 @@ unsigned GOCondition::DoWait(bool isWithTimeout, const char* waiterInfo, GOrgueT
     // a timeout occured
     if (isFirstTime && waiterInfo)
     {
-      wxLogWarning("GOCondition::Wait: unable to restore lock on the condition mutex %p:%p for %s", this, &m_Mutex, wxString(waiterInfo));
+      wxLogWarning(
+	"GOCondition::Wait: unable to restore lock on the condition mutex %p:%p for %s",
+	this, &m_Mutex, wxString(WAITER_INFO(waiterInfo))
+      );
       isFirstTime = false;
     }
   } while (pThread == NULL || !pThread->ShouldStop());
@@ -139,7 +146,11 @@ unsigned GOCondition::WaitOrStop(const char* waiterInfo, GOrgueThread* pThread)
     // timeout occured
     if (isFirstTime && waiterInfo)
     {
-      wxLogWarning("GOCondition::WaitOrStop: timeout while %s waited for condition %p", this);
+      wxLogWarning(
+	"GOCondition::WaitOrStop: timeout while %s waited for condition %p",
+	wxString(WAITER_INFO(waiterInfo)),
+	this
+      );
       isFirstTime = false;
     }
   }

--- a/src/core/threading/GOCondition.cpp
+++ b/src/core/threading/GOCondition.cpp
@@ -7,6 +7,13 @@
 #include "threading_impl.h"
 #include "GOCondition.h"
 
+/**
+ * Composes the result of the wait for condition.
+ * @param isSignalReceived
+ * @param isMutexLocked
+ * @return the bitwise composit result from GOCondition::SIGNAL_RECEIVED and GOCondition::MUTEX_LOCKED
+ */
+
 unsigned compose_result(bool isSignalReceived, bool isMutexLocked)
 {
   return (isSignalReceived ? GOCondition::SIGNAL_RECEIVED : 0) | (isMutexLocked ? GOCondition::MUTEX_LOCKED : 0);
@@ -78,6 +85,7 @@ unsigned GOCondition::DoWait(bool isWithTimeout, const char* waiterInfo, GOrgueT
     isMutexLocked = m_Mutex.LockOrStop(waiterInfo, pThread);
     if (isMutexLocked)
       break;
+
     // a timeout occured
     if (isFirstTime && waiterInfo)
     {

--- a/src/core/threading/GOCondition.cpp
+++ b/src/core/threading/GOCondition.cpp
@@ -4,27 +4,38 @@
 * License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 */
 
+#include "threading_impl.h"
 #include "GOCondition.h"
 
-GOCondition::GOCondition(GOMutex& mutex) :
-#ifdef WX_MUTEX
-	m_condition(mutex.m_Mutex),
-#else
-	m_Waiters(0),
-#endif
-	m_Mutex(mutex)
+unsigned compose_result(bool isSignalReceived, bool isMutexLocked)
 {
+  return (isSignalReceived ? GOCondition::SIGNAL_RECEIVED : 0) | (isMutexLocked ? GOCondition::MUTEX_LOCKED : 0);
 }
 
+
 #ifdef WX_MUTEX
+
+GOCondition::GOCondition(GOMutex& mutex) :
+	m_condition(mutex.m_Mutex)
+{
+}
 
 GOCondition::~GOCondition()
 {
 }
 
-void GOCondition::Wait()
+unsigned GOCondition::DoWait(bool isWithTimeout, const char* waiterInfo, GOrgueThread *)
 {
-	m_condition.Wait();
+  bool isSignalReceived;
+  
+  if (isWithTimeout)
+    isSignalReceived = m_condition.WaitTimeout(WAIT_TIMEOUT_MS) != wxCOND_TIMEOUT;
+  else
+  {
+    m_condition.Wait();
+    rc = true;
+  }
+  return compose_result(isSignalReceived, true);
 }
 
 void GOCondition::Signal()
@@ -39,18 +50,42 @@ void GOCondition::Broadcast()
 
 #else
 
+GOCondition::GOCondition(GOMutex& mutex) :
+	m_Waiters(0),
+	m_Mutex(mutex)
+{
+}
+
 GOCondition::~GOCondition()
 {
   while(m_Waiters > 0)
 	  Signal();
 }
 
-void GOCondition::Wait()
+unsigned GOCondition::DoWait(bool isWithTimeout, const char* waiterInfo, GOrgueThread *pThread)
 {
-	m_Waiters.fetch_add(1);
-	m_Mutex.Unlock();
-	m_Wait.Wait();
-	m_Mutex.Lock();
+  m_Waiters.fetch_add(1);
+  m_Mutex.Unlock();
+
+  bool isSignalReceived = m_Wait.Wait(isWithTimeout);
+
+  // now try to lock the mutex again
+  bool isMutexLocked = false;
+  bool isFirstTime = true;
+
+  do
+  {
+    isMutexLocked = m_Mutex.LockOrStop(waiterInfo, pThread);
+    if (isMutexLocked)
+      break;
+    // a timeout occured
+    if (isFirstTime && waiterInfo)
+    {
+      wxLogWarning("GOCondition::Wait: unable to restore mutex lock for %s", wxString(waiterInfo));
+      isFirstTime = false;
+    }
+  } while (pThread == NULL || !pThread->ShouldStop());
+  return compose_result(isSignalReceived, isMutexLocked);
 }
 
 void GOCondition::Signal()
@@ -80,3 +115,25 @@ void GOCondition::Broadcast()
 }
 
 #endif
+
+unsigned GOCondition::WaitOrStop(const char* waiterInfo, GOrgueThread* pThread)
+{
+  unsigned rc = 0;
+  bool isFirstTime = true;
+
+  while (pThread == NULL || !pThread->ShouldStop())
+  {
+    rc = DoWait(pThread != NULL, waiterInfo, pThread);
+    
+    if (rc & SIGNAL_RECEIVED)
+      break;
+    
+    // timeout occured
+    if (isFirstTime && waiterInfo)
+    {
+      wxLogWarning("GOCondition::WaitOrStop: timeout while %s waited for a condition");
+      isFirstTime = false;
+    }
+  }
+  return rc;
+}

--- a/src/core/threading/GOMutex.cpp
+++ b/src/core/threading/GOMutex.cpp
@@ -3,67 +3,77 @@
 * Copyright 2009-2021 GrandOrgue contributors (see AUTHORS)
 * License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 */
+
+#include "threading_impl.h"
 #include "GOMutex.h"
 
 #define GO_PRINTCONTENTION 0
 
-#ifdef WX_MUTEX
-
-void GOMutex::GOMutex()
+GOMutex::GOMutex():
+#ifndef WX_MUTEX
+  m_Lock(0),
+#endif
+  m_LockerInfo(NULL)
 {
-}
-
-void GOMutex::~GOMutex()
-{
-}
-
-void GOMutex::Lock()
-{
-	m_Mutex.Lock();
-}
-
-void GOMutex::Unlock()
-{
-	m_Mutex.Unlock();
-}
-
-bool GOMutex::TryLock()
-{
-	return m_Mutex.TryLock() == wxMUTEX_NO_ERROR;
-}
-
-#else
-
-GOMutex::GOMutex()
-{
-	m_Lock = 0;
 }
 
 GOMutex::~GOMutex()
 {
 }
 
-void GOMutex::Lock()
+#ifdef WX_MUTEX
+
+bool DoLock(isWithTimeout)
 {
+  bool isLocked;
+
+  if (isWithTimeout)
+    isLocked = m_Mutex.LockTimeout(WAIT_TIMEOUT_MS) != wxMUTEX_TIMEOUT;
+  else
+  {
+    m_Mutex.Lock();
+    isLocked = true;
+  }
+  return isLocked;
+}
+
+void GOMutex::DoUnlock()
+{
+	m_Mutex.Unlock();
+}
+
+bool GOMutex::DoTryLock()
+{
+	return m_Mutex.TryLock() == wxMUTEX_NO_ERROR;
+}
+
+#else
+
+bool GOMutex::DoLock(bool isWithTimeout)
+{
+  bool isLocked;
+  
   int value = m_Lock.fetch_add(1);
   
   if (!value)
   {
 	  __sync_synchronize();
-	  return;
+	  isLocked = true;
+  } else
+  {
+#if GO_PRINTCONTENTION
+    wxLogWarning(wxT("Mutex::wait %p"), this);
+    GOStackPrinter::printStack(this);
+#endif
+    isLocked = m_Wait.Wait(isWithTimeout);
+#if GO_PRINTCONTENTION
+    wxLogWarning(wxT("Mutex::end_wait %p", isLocked=%s), this, isLocked ? "true" : "false");
+#endif
   }
-#if GO_PRINTCONTENTION
-  wxLogWarning(wxT("Mutex::wait %p"), this);
-  GOStackPrinter::printStack(this);
-#endif
-
-  m_Wait.Wait();
-#if GO_PRINTCONTENTION
-  wxLogWarning(wxT("Mutex::end_wait %p"), this);
-#endif
+  return isLocked;
 }
 
-void GOMutex::Unlock()
+void GOMutex::DoUnlock()
 {
   __sync_synchronize();
   
@@ -73,7 +83,7 @@ void GOMutex::Unlock()
 	  m_Wait.Wakeup();
 }
 
-bool GOMutex::TryLock()
+bool GOMutex::DoTryLock()
 {
   int old = 0;
   
@@ -86,3 +96,45 @@ bool GOMutex::TryLock()
 }
 
 #endif
+
+bool GOMutex::LockOrStop(const char* lockerInfo, GOrgueThread *pThread)
+{
+  bool isLocked = false;
+
+  if (pThread != NULL)
+  {
+    bool isFirstTime = true;
+
+    while (! pThread->ShouldStop() && ! isLocked)
+    {
+      isLocked = DoLock(true);
+      if (! isLocked && isFirstTime)
+      {
+	const char* currentLockerInfo = m_LockerInfo;
+
+	wxLogWarning("GOMutex: timeout when locking a mutex; currentLocker=%s newLocker=%s", wxString(currentLockerInfo), wxString(lockerInfo));
+	isFirstTime = false;
+      }
+    }
+  } else
+    isLocked = DoLock(false);
+
+  if (isLocked)
+    m_LockerInfo = lockerInfo;
+  return isLocked;
+}
+
+void GOMutex::Unlock()
+{
+  m_LockerInfo = NULL;
+  DoUnlock();
+}
+
+bool GOMutex::TryLock(const char* lockerInfo)
+{
+  bool isLocked = DoTryLock();
+  
+  if (isLocked)
+    m_LockerInfo = lockerInfo;
+  return isLocked;
+}

--- a/src/core/threading/GOMutex.cpp
+++ b/src/core/threading/GOMutex.cpp
@@ -9,6 +9,10 @@
 
 #define GO_PRINTCONTENTION 0
 
+static const char* const UNKNOWN_LOCKER_INFO = "UnknownLocker";
+
+#define LOCKER_INFO(lockerInfo) (lockerInfo ? lockerInfo : UNKNOWN_LOCKER_INFO)
+
 GOMutex::GOMutex():
 #ifndef WX_MUTEX
   m_Lock(0),
@@ -112,7 +116,10 @@ bool GOMutex::LockOrStop(const char* lockerInfo, GOrgueThread *pThread)
       {
 	const char* currentLockerInfo = m_LockerInfo;
 
-	wxLogWarning("GOMutex: timeout when locking mutex %p; currentLocker=%s newLocker=%s", this, wxString(currentLockerInfo), wxString(lockerInfo));
+	wxLogWarning(
+	  "GOMutex: timeout when locking mutex %p; currentLocker=%s newLocker=%s",
+	  this, wxString(currentLockerInfo), wxString(LOCKER_INFO(lockerInfo))
+	);
 	isFirstTime = false;
       }
     }
@@ -120,7 +127,7 @@ bool GOMutex::LockOrStop(const char* lockerInfo, GOrgueThread *pThread)
     isLocked = DoLock(false);
 
   if (isLocked)
-    m_LockerInfo = lockerInfo;
+    m_LockerInfo = LOCKER_INFO(lockerInfo);
   return isLocked;
 }
 
@@ -135,6 +142,6 @@ bool GOMutex::TryLock(const char* lockerInfo)
   bool isLocked = DoTryLock();
   
   if (isLocked)
-    m_LockerInfo = lockerInfo;
+    m_LockerInfo = LOCKER_INFO(lockerInfo);
   return isLocked;
 }

--- a/src/core/threading/GOMutex.cpp
+++ b/src/core/threading/GOMutex.cpp
@@ -112,7 +112,7 @@ bool GOMutex::LockOrStop(const char* lockerInfo, GOrgueThread *pThread)
       {
 	const char* currentLockerInfo = m_LockerInfo;
 
-	wxLogWarning("GOMutex: timeout when locking a mutex; currentLocker=%s newLocker=%s", wxString(currentLockerInfo), wxString(lockerInfo));
+	wxLogWarning("GOMutex: timeout when locking mutex %p; currentLocker=%s newLocker=%s", this, wxString(currentLockerInfo), wxString(lockerInfo));
 	isFirstTime = false;
       }
     }

--- a/src/core/threading/GOMutex.h
+++ b/src/core/threading/GOMutex.h
@@ -14,28 +14,36 @@
 #include "GOWaitQueue.h"
 #endif
 
+#include "GOrgueThread.h"
+
 class GOMutex
 {
 private:
 #ifdef WX_MUTEX
-  friend class GOCondition;
-
   wxMutex m_Mutex;
 #else
   GOWaitQueue m_Wait;
   atomic_int m_Lock;
 #endif
+  
+  const char* volatile m_LockerInfo;
 
   GOMutex(const GOMutex&) = delete;
   const GOMutex& operator=(const GOMutex&) = delete;
+  
+  bool DoLock(bool isWithTimeout);
+  bool DoTryLock();
+  void DoUnlock();
 
 public:
   GOMutex();
   ~GOMutex();
 
-  void Lock();
+  bool LockOrStop(const char* lockerInfo = NULL, GOrgueThread *pThread = NULL);
+  void Lock(const char* lockerInfo = NULL) { LockOrStop(lockerInfo, NULL); }
   void Unlock();
-  bool TryLock();
+  bool TryLock(const char* lockerInfo = NULL);
+  const char* GetLockerInfo() const { return m_LockerInfo; }
 };
 
 #endif /* GOMUTEX_H */

--- a/src/core/threading/GOWaitQueue.cpp
+++ b/src/core/threading/GOWaitQueue.cpp
@@ -4,6 +4,11 @@
 * License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 */
 
+#ifdef GOWAITQUEUE_USE_STD_MUTEX
+#include <chrono>
+#endif
+
+#include "threading_impl.h"
 #include "GOWaitQueue.h"
 
 GOWaitQueue::GOWaitQueue()
@@ -20,7 +25,7 @@ GOWaitQueue::~GOWaitQueue()
 #endif
 }
 
-void GOWaitQueue::Wait()
+void GOWaitQueue::WaitInfinitelly()
 {
 #ifdef GOWAITQUEUE_USE_WX
   m_Wait.Wait();
@@ -28,6 +33,30 @@ void GOWaitQueue::Wait()
   m_Wait.lock();
 #endif
 }
+
+bool GOWaitQueue::WaitWithTimeout()
+{
+#ifdef GOWAITQUEUE_USE_WX
+  return m_Wait.WaitTimeout(WAIT_TIMEOUT_MS) != wxSEMA_TIMEOUT;
+#elif defined(GOWAITQUEUE_USE_STD_MUTEX)
+  return m_Wait.try_lock_for(timeOutMs);
+#endif
+}
+
+bool GOWaitQueue::Wait(bool isWithTimeout)
+{
+  bool rc;
+
+  if (isWithTimeout)
+    rc = WaitWithTimeout();
+  else
+  {
+    WaitInfinitelly();
+    rc = true;
+  }
+  return rc;
+}
+
 
 void GOWaitQueue::Wakeup()
 {

--- a/src/core/threading/GOWaitQueue.cpp
+++ b/src/core/threading/GOWaitQueue.cpp
@@ -25,7 +25,7 @@ GOWaitQueue::~GOWaitQueue()
 #endif
 }
 
-void GOWaitQueue::WaitInfinitelly()
+void GOWaitQueue::WaitInfinitely()
 {
 #ifdef GOWAITQUEUE_USE_WX
   m_Wait.Wait();
@@ -51,7 +51,7 @@ bool GOWaitQueue::Wait(bool isWithTimeout)
     rc = WaitWithTimeout();
   else
   {
-    WaitInfinitelly();
+    WaitInfinitely();
     rc = true;
   }
   return rc;

--- a/src/core/threading/GOWaitQueue.h
+++ b/src/core/threading/GOWaitQueue.h
@@ -32,7 +32,7 @@ private:
   std::timed_mutex m_Wait;
 #endif
 
-  void WaitInfinitelly();
+  void WaitInfinitely();
   bool WaitWithTimeout();
 
 public:

--- a/src/core/threading/GOWaitQueue.h
+++ b/src/core/threading/GOWaitQueue.h
@@ -9,18 +9,18 @@
 
 #if 1
 //#ifdef __WIN32__
-  #define GOWAITQUEUE_USE_WX
-  #undef GOWAITQUEUE_USE_STD_MUTEX
-
   #include <wx/thread.h>
 
+  #define GOWAITQUEUE_USE_WX
+  #undef GOWAITQUEUE_USE_STD_MUTEX
 #else
-
   #include <mutex>
 
   #undef GOWAITQUEUE_USE_WX
   #define GOWAITQUEUE_USE_STD_MUTEX
 #endif
+
+#include "GOrgueThread.h"
 
 class GOWaitQueue
 {
@@ -29,14 +29,24 @@ private:
 #ifdef GOWAITQUEUE_USE_WX
   wxSemaphore m_Wait;
 #elif defined(GOWAITQUEUE_USE_STD_MUTEX)
-  std::mutex m_Wait;
+  std::timed_mutex m_Wait;
 #endif
-  
+
+  void WaitInfinitelly();
+  bool WaitWithTimeout();
+
 public:
   GOWaitQueue();
   ~GOWaitQueue();
 
-  void Wait();
+  /**
+   * Wait until a signal is received or a timeout is occured.
+   * The timeout value is defined in threading_impl.h.
+   * @param isWithTimeout - if true then to wait with timeout. If false else to wait infinitely
+   * @return true if a signal received and false if the timeout occured
+   */
+  bool Wait(bool isWithTimeout);
+
   void Wakeup();
 };
 

--- a/src/core/threading/threading_impl.h
+++ b/src/core/threading/threading_impl.h
@@ -1,0 +1,15 @@
+/*
+* Copyright 2006 Milan Digital Audio LLC
+* Copyright 2009-2021 GrandOrgue contributors (see AUTHORS)
+* License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+*/
+
+#ifndef THREADING_IMPL_H
+#define THREADING_IMPL_H
+
+#include <wx/log.h>
+
+#define WAIT_TIMEOUT_MS 1000
+
+#endif /* COMMON_IMPL_H */
+

--- a/src/grandorgue/GOSoundBufferItem.h
+++ b/src/grandorgue/GOSoundBufferItem.h
@@ -7,6 +7,8 @@
 #ifndef GOSOUNDBUFFERITEM_H
 #define GOSOUNDBUFFERITEM_H
 
+class GOSoundThread;
+
 class GOSoundBufferItem
 {
 protected:
@@ -25,7 +27,7 @@ public:
 		delete[] m_Buffer;
 	}
 
-	virtual void Finish(bool stop) = 0;
+	virtual void Finish(bool stop, GOSoundThread *pThread = nullptr) = 0;
 
 	float* m_Buffer;
 

--- a/src/grandorgue/GOSoundGroupWorkItem.cpp
+++ b/src/grandorgue/GOSoundGroupWorkItem.cpp
@@ -84,7 +84,7 @@ bool GOSoundGroupWorkItem::GetRepeat()
 	return true;
 }
 
-void GOSoundGroupWorkItem::Run(GOSoundThread *thread)
+void GOSoundGroupWorkItem::Run(GOSoundThread *pThread)
 {
 	if (m_Done == 3)
 		return;

--- a/src/grandorgue/GOSoundGroupWorkItem.h
+++ b/src/grandorgue/GOSoundGroupWorkItem.h
@@ -12,6 +12,7 @@
 #include "GOSoundWorkItem.h"
 #include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
+#include "GOSoundThread.h"
 
 class GOSoundEngine;
 

--- a/src/grandorgue/GOSoundGroupWorkItem.h
+++ b/src/grandorgue/GOSoundGroupWorkItem.h
@@ -37,9 +37,9 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run(GOSoundThread *thread = nullptr);
+	void Run(GOSoundThread *pThread = nullptr);
 	void Exec();
-	void Finish(bool stop);
+	void Finish(bool stop, GOSoundThread *pThread = nullptr);
 
 	void Reset();
 	void Clear();

--- a/src/grandorgue/GOSoundOutputWorkItem.cpp
+++ b/src/grandorgue/GOSoundOutputWorkItem.cpp
@@ -33,7 +33,7 @@ void GOSoundOutputWorkItem::SetOutputs(std::vector<GOSoundBufferItem*> outputs)
 	m_OutputCount = m_Outputs.size() * 2;
 }
 
-void GOSoundOutputWorkItem::Run(GOSoundThread *thread)
+void GOSoundOutputWorkItem::Run(GOSoundThread *pThread)
 {
 	if (m_Done)
 		return;

--- a/src/grandorgue/GOSoundOutputWorkItem.cpp
+++ b/src/grandorgue/GOSoundOutputWorkItem.cpp
@@ -85,12 +85,12 @@ void GOSoundOutputWorkItem::Exec()
 	Run();
 }
 
-void GOSoundOutputWorkItem::Finish(bool stop)
+void GOSoundOutputWorkItem::Finish(bool stop, GOSoundThread *pThread)
 {
 	if (stop)
 		m_Stop = true;
 	if (!m_Done)
-		Run();
+		Run(pThread);
 }
 
 void GOSoundOutputWorkItem::Clear()

--- a/src/grandorgue/GOSoundOutputWorkItem.h
+++ b/src/grandorgue/GOSoundOutputWorkItem.h
@@ -38,7 +38,7 @@ public:
 	bool GetRepeat();
 	void Run(GOSoundThread *thread = nullptr);
 	void Exec();
-	void Finish(bool stop);
+	void Finish(bool stop, GOSoundThread *thread = nullptr);
 
 	void Clear();
 	void Reset();

--- a/src/grandorgue/GOSoundOutputWorkItem.h
+++ b/src/grandorgue/GOSoundOutputWorkItem.h
@@ -36,9 +36,9 @@ public:
 	unsigned GetGroup();
 	unsigned GetCost();
 	bool GetRepeat();
-	void Run(GOSoundThread *thread = nullptr);
+	void Run(GOSoundThread *pThread = nullptr);
 	void Exec();
-	void Finish(bool stop, GOSoundThread *thread = nullptr);
+	void Finish(bool stop, GOSoundThread *pThread = nullptr);
 
 	void Clear();
 	void Reset();

--- a/src/grandorgue/GOSoundThread.cpp
+++ b/src/grandorgue/GOSoundThread.cpp
@@ -39,9 +39,12 @@ void GOSoundThread::Entry()
 		if (shouldStop)
 			break;
 
-		GOMutexLocker lock(m_Mutex);
+		GOMutexLocker lock(m_Mutex, false, "GOSoundThread::Entry", this);
 
-		m_Condition.Wait();
+		if (! lock.IsLocked() || ShouldStop())
+		  break;
+		if (! m_Condition.WaitOrStop("GOSoundThread::Entry"))
+		  break;
 	}
 	return;
 }


### PR DESCRIPTION
Resolves #762

1. Added new functions of threading primitives GOMutex::LockOrStop and GOCondition::WaitOrStop. They wait not infinitely, but check the current thread every second: whether it has been marked for stop (with Panic button)
2. GOSoundThread, GOSoundGroupWorkItem and GOSoundOutputWorkItem started using the new functions. It allows them to finish when `Panic` button has been pressed
3. Added writing a warning to the log window with the informations about the locker and the waiter, if the mutex cann't be obtained or the condition cann't be satisfied in one second. It will help to diagnose #702 

PS. This change has already helped me to localise #702. https://github.com/GrandOrgue/grandorgue/issues/702#issuecomment-945163575