### PR TITLE
Removed translation of GrandOrgue midi ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed translation of GrandOrgue midi ports https://github.com/GrandOrgue/grandorgue/issues/791
 - Switched the build for windows to use wxWidgets 3.1.5 https://github.com/GrandOrgue/grandorgue/issues/792
 - Added bundling feature of settings file and ODF with same name in same directory
 - Fixed the addition of .cmb file extension when exporting settings if necessary https://github.com/GrandOrgue/grandorgue/issues/802

--- a/src/grandorgue/GOrgueMidiInPort.cpp
+++ b/src/grandorgue/GOrgueMidiInPort.cpp
@@ -79,5 +79,5 @@ const wxString GOrgueMidiInPort::GetClientName()
 
 const wxString GOrgueMidiInPort::GetPortName()
 {
-	return _("GrandOrgue Input");
+	return wxT("GrandOrgue Input");
 }

--- a/src/grandorgue/GOrgueMidiOutPort.cpp
+++ b/src/grandorgue/GOrgueMidiOutPort.cpp
@@ -69,5 +69,5 @@ const wxString GOrgueMidiOutPort::GetClientName()
 
 const wxString GOrgueMidiOutPort::GetPortName()
 {
-	return _("GrandOrgue Output");
+	return wxT("GrandOrgue Output");
 }


### PR DESCRIPTION
Resolved: #791

Earlier the translation might cause the non-ascii characters in the midi device names