### PR TITLE
Do not try searching in an archive if an archive is not used.

### DIFF
--- a/src/grandorgue/GrandOrgueFile.cpp
+++ b/src/grandorgue/GrandOrgueFile.cpp
@@ -375,10 +375,21 @@ wxString GrandOrgueFile::Load(GOrgueProgressDialog* dlg, const GOrgueOrgan& orga
 		else
 		{
 			wxString bundledSettingsFile = m_odf.BeforeLast('.') + wxT(".cmb");
-			if (wxFileExists(bundledSettingsFile) || findArchive(m_odf)->containsFile(bundledSettingsFile))
+			if (!useArchives())
 			{
-				setting_file = bundledSettingsFile;
-				m_b_customized = true;
+				if (wxFileExists(bundledSettingsFile))
+				{
+					setting_file = bundledSettingsFile;
+					m_b_customized = true;
+				}
+			}
+			else
+			{
+				if (findArchive(m_odf)->containsFile(bundledSettingsFile))
+				{
+					setting_file = bundledSettingsFile;
+					m_b_customized = true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix crash caused by attempting to search for bundled file in a non-existing archive.