### PR TITLE
Fixed restoring the size and the position of panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed restoring the size and the position of panels when they did not fit their displays https://github.com/GrandOrgue/grandorgue/issues/787
 - Removed translation of GrandOrgue midi ports https://github.com/GrandOrgue/grandorgue/issues/791
 - Switched the build for windows to use wxWidgets 3.1.5 https://github.com/GrandOrgue/grandorgue/issues/792
 - Added bundling feature of settings file and ODF with same name in same directory

--- a/src/grandorgue/GOGUIPanel.cpp
+++ b/src/grandorgue/GOGUIPanel.cpp
@@ -106,7 +106,7 @@ void GOGUIPanel::Init(GOrgueConfigReader& cfg, GOGUIDisplayMetrics* metrics, wxS
 	m_GroupName = group_name;
 	m_controls.resize(0);
 
-	ReadFromCfg(cfg, false);
+	ReadSizeInfoFromCfg(cfg, false);
 }
 
 
@@ -451,7 +451,7 @@ void GOGUIPanel::Load(GOrgueConfigReader& cfg, wxString group)
 			LoadControl(control, cfg, buffer);
 		}
 	}
-	ReadFromCfg(cfg, is_main_panel);
+	ReadSizeInfoFromCfg(cfg, is_main_panel);
 }
 
 GOGUIControl* GOGUIPanel::CreateGUIElement(GOrgueConfigReader& cfg, wxString group)
@@ -553,7 +553,7 @@ void GOGUIPanel::Draw(GOrgueDC& dc)
 		m_controls[i]->Draw(dc);
 }
 
-void GOGUIPanel::ReadFromCfg(GOrgueConfigReader& cfg, bool isOpenByDefault)
+void GOGUIPanel::ReadSizeInfoFromCfg(GOrgueConfigReader& cfg, bool isOpenByDefault)
 {
 	int x = cfg.ReadInteger(CMBSetting, m_group, wxT("WindowX"), -windowLimit, windowLimit, false, 0);
 	int y = cfg.ReadInteger(CMBSetting, m_group, wxT("WindowY"), -windowLimit, windowLimit, false, 0);

--- a/src/grandorgue/GOGUIPanel.h
+++ b/src/grandorgue/GOGUIPanel.h
@@ -30,6 +30,9 @@ class GrandOrgueFile;
 
 class GOGUIPanel : private GOrgueSaveableObject
 {
+private:
+	void ReadFromCfg(GOrgueConfigReader& cfg, bool isOpenByDefault);
+
 protected:
 	GrandOrgueFile* m_organfile;
 	GOGUIMouseStateTracker& m_MouseState;
@@ -41,7 +44,9 @@ protected:
 	GOGUIDisplayMetrics* m_metrics;
 	GOGUILayoutEngine* m_layout;
 	GOrguePanelView* m_view;
-	wxRect m_size;
+	wxRect m_rect;
+	int m_DisplayNum;
+	bool m_IsMaximized;
 	bool m_InitialOpenWindow;
 
 	void LoadControl(GOGUIControl* control, GOrgueConfigReader& cfg, wxString group);
@@ -62,6 +67,7 @@ public:
 	void SetView(GOrguePanelView* view);
 
 	GrandOrgueFile* GetOrganFile();
+	const wxString& GetGroup() { return m_group; }
 	const wxString& GetName();
 	const wxString& GetGroupName();
 	void AddEvent(GOGUIControl* control);
@@ -82,8 +88,12 @@ public:
 	unsigned GetHeight();
 	bool InitialOpenWindow();
 
-	wxRect GetWindowSize();
-	void SetWindowSize(wxRect rect);
+	wxRect GetWindowRect();
+	void SetWindowRect(wxRect rect);
+	int GetDisplayNum() const { return m_DisplayNum; }
+	void SetDisplayNum(int displayNum) { m_DisplayNum = displayNum; }
+	bool IsMaximized() const { return m_IsMaximized; }
+	void SetMaximized(bool isMaximized) { m_IsMaximized = isMaximized; }
 	void SetInitialOpenWindow(bool open);
 };
 

--- a/src/grandorgue/GOGUIPanel.h
+++ b/src/grandorgue/GOGUIPanel.h
@@ -31,7 +31,7 @@ class GrandOrgueFile;
 class GOGUIPanel : private GOrgueSaveableObject
 {
 private:
-	void ReadFromCfg(GOrgueConfigReader& cfg, bool isOpenByDefault);
+	void ReadSizeInfoFromCfg(GOrgueConfigReader& cfg, bool isOpenByDefault);
 
 protected:
 	GrandOrgueFile* m_organfile;

--- a/src/grandorgue/GOrgueDocument.cpp
+++ b/src/grandorgue/GOrgueDocument.cpp
@@ -134,7 +134,7 @@ void GOrgueDocument::ShowPanel(unsigned id)
 	if (!showWindow(GOrgueDocument::PANEL, panel))
 	{
 		registerWindow(GOrgueDocument::PANEL, panel,
-			       GOrguePanelView::createWindow(this, panel, NULL));
+			       GOrguePanelView::createWithFrame(this, panel));
 	}
 }
 

--- a/src/grandorgue/GOrguePanelView.h
+++ b/src/grandorgue/GOrguePanelView.h
@@ -9,6 +9,7 @@
 
 #include "GOrgueView.h"
 #include <wx/scrolwin.h>
+#include <wx/toplevel.h>
 
 class GOGUIControl;
 class GOGUIPanel;
@@ -19,6 +20,7 @@ class GOrguePanelView : public wxScrolledWindow, public GOrgueView
 private:
 	GOGUIPanelWidget* m_panelwidget;
 	GOGUIPanel* m_panel;
+	wxTopLevelWindow* m_TopWindow; // only if the parent is top level window, else NULL
 	wxSize m_Scroll;
 
 	void OnSize(wxSizeEvent& event);
@@ -29,7 +31,8 @@ public:
 
 	void AddEvent(GOGUIControl* control);
 
-	static GOrguePanelView* createWindow(GOrgueDocumentBase* doc, GOGUIPanel* panel, wxWindow* parent);
+	// creates a PanelView and a wxFrame filled with this PanelView
+	static GOrguePanelView* createWithFrame(GOrgueDocumentBase* doc, GOGUIPanel* panel);
 	void SyncState();
 
 	void Raise();


### PR DESCRIPTION
Resolves #787

1. Eliminated restoring the original aspect ratio. Now the saved size is used
2. Saving display numbers and maximizing flags. Using them on restore
3. Renamed Size to Rect somewhere