### PR TITLE
Added implementation of the threading primitives with standard C++11 ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added implementation of the threading primitives with standard C++11 ones https://github.com/GrandOrgue/grandorgue/issues/817
 # 3.4.1 (2021-11-02)
 - Changed log error to warning when importing combinations https://github.com/GrandOrgue/grandorgue/issues/809
 - Eased restrictions on importing .cmb settings https://github.com/GrandOrgue/grandorgue/issues/807

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 
 # setup compiler flags for debug vs release compiles
 add_option(-Wall)
+add_definitions(-DGO_STD_MUTEX)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_option(-g3)
 else()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,6 +14,7 @@ threading/GOCondition.cpp
 threading/GOMutex.cpp
 threading/GOWaitQueue.cpp
 threading/GOrgueThread.cpp
+threading/threading_impl.cpp
 GOSoundTouchWorkItem.cpp
 GOrgueArchive.cpp
 GOrgueArchiveCreator.cpp

--- a/src/core/GOrgueMemoryPool.cpp
+++ b/src/core/GOrgueMemoryPool.cpp
@@ -6,6 +6,7 @@
 
 #include "GOrgueMemoryPool.h"
 
+#include "threading/atomic.h"
 #include "threading/GOMutexLocker.h"
 #include <wx/file.h>
 #include <wx/intl.h>

--- a/src/core/threading/GOCondition.cpp
+++ b/src/core/threading/GOCondition.cpp
@@ -24,7 +24,40 @@ unsigned compose_result(bool isSignalReceived, bool isMutexLocked)
 }
 
 
-#ifdef WX_MUTEX
+#if defined GO_STD_MUTEX
+GOCondition::GOCondition(GOMutex& mutex):
+    r_mutex(mutex.GetTimedMutex())
+{
+}
+
+GOCondition::~GOCondition()
+{
+}
+
+unsigned GOCondition::DoWait(bool isWithTimeout, const char* waiterInfo, GOrgueThread *)
+{
+  bool isSignalReceived;
+  
+  if (isWithTimeout)
+    isSignalReceived = m_condition.wait_for(r_mutex, THREADING_WAIT_TIMEOUT) != std::cv_status::timeout;
+  else
+  {
+    m_condition.wait(r_mutex);
+    isSignalReceived = true;
+  }
+  return compose_result(isSignalReceived, true);
+}
+
+void GOCondition::Signal()
+{
+	m_condition.notify_one();
+}
+
+void GOCondition::Broadcast()
+{
+	m_condition.notify_all();
+}
+#elif defined WX_MUTEX
 
 GOCondition::GOCondition(GOMutex& mutex) :
 	m_condition(mutex.m_Mutex)

--- a/src/core/threading/GOCondition.h
+++ b/src/core/threading/GOCondition.h
@@ -7,7 +7,9 @@
 #ifndef GOCONDITION_H
 #define GOCONDITION_H
 
-#ifdef WX_MUTEX
+#if defined GO_STD_MUTEX
+#include <condition_variable>
+#elif defined WX_MUTEX
 #include <wx/thread.h>
 #else
 #include "atomic.h"
@@ -26,7 +28,10 @@ public:
   };
 
 private:
-#ifdef WX_MUTEX
+#if defined GO_STD_MUTEX
+  std::timed_mutex &r_mutex;
+  std::condition_variable_any m_condition;
+#elif defined WX_MUTEX
   wxCondition m_condition;
 #else
   atomic_int m_Waiters;

--- a/src/core/threading/GOMutex.cpp
+++ b/src/core/threading/GOMutex.cpp
@@ -14,7 +14,7 @@ static const char* const UNKNOWN_LOCKER_INFO = "UnknownLocker";
 #define LOCKER_INFO(lockerInfo) (lockerInfo ? lockerInfo : UNKNOWN_LOCKER_INFO)
 
 GOMutex::GOMutex():
-#ifndef WX_MUTEX
+#if ! defined GO_STD_MUTEX && ! defined WX_MUTEX
   m_Lock(0),
 #endif
   m_LockerInfo(NULL)
@@ -25,9 +25,35 @@ GOMutex::~GOMutex()
 {
 }
 
-#ifdef WX_MUTEX
+#if defined GO_STD_MUTEX
 
-bool DoLock(isWithTimeout)
+bool GOMutex::DoLock(bool isWithTimeout)
+{
+  bool isLocked;
+
+  if (isWithTimeout)
+    isLocked = m_mutex.try_lock_for(THREADING_WAIT_TIMEOUT);
+  else
+  {
+    m_mutex.lock();
+    isLocked = true;
+  }
+  return isLocked;
+}
+
+void GOMutex::DoUnlock()
+{
+	m_mutex.unlock();
+}
+
+bool GOMutex::DoTryLock()
+{
+	return m_mutex.try_lock();
+}
+
+#elif defined WX_MUTEX
+
+bool DoLock(bool isWithTimeout)
 {
   bool isLocked;
 

--- a/src/core/threading/GOMutex.h
+++ b/src/core/threading/GOMutex.h
@@ -7,7 +7,9 @@
 #ifndef GOMUTEX_H
 #define GOMUTEX_H
 
-#ifdef WX_MUTEX
+#ifdef GO_STD_MUTEX
+#include <mutex>
+#elif WX_MUTEX
 #include <wx/thread.h>
 #else
 #include "atomic.h"
@@ -19,7 +21,9 @@
 class GOMutex
 {
 private:
-#ifdef WX_MUTEX
+#if defined GO_STD_MUTEX
+  std::timed_mutex m_mutex;
+#elif defined WX_MUTEX
   wxMutex m_Mutex;
 #else
   GOWaitQueue m_Wait;
@@ -38,6 +42,10 @@ private:
 public:
   GOMutex();
   ~GOMutex();
+
+#if defined GO_STD_MUTEX
+  std::timed_mutex& GetTimedMutex() { return m_mutex; };
+#endif
 
   bool LockOrStop(const char* lockerInfo = NULL, GOrgueThread *pThread = NULL);
   void Lock(const char* lockerInfo = NULL) { LockOrStop(lockerInfo, NULL); }

--- a/src/core/threading/GOWaitQueue.cpp
+++ b/src/core/threading/GOWaitQueue.cpp
@@ -4,6 +4,8 @@
 * License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 */
 
+#ifndef GO_STD_MUTEX
+
 #ifdef GOWAITQUEUE_USE_STD_MUTEX
 #include <chrono>
 #endif
@@ -66,3 +68,5 @@ void GOWaitQueue::Wakeup()
   m_Wait.unlock();
 #endif
 }
+
+#endif

--- a/src/core/threading/GOWaitQueue.h
+++ b/src/core/threading/GOWaitQueue.h
@@ -7,6 +7,8 @@
 #ifndef GOWAITQUEUE_H
 #define GOWAITQUEUE_H
 
+#ifndef GO_STD_MUTEX
+
 #if 1
 //#ifdef __WIN32__
   #include <wx/thread.h>
@@ -49,5 +51,7 @@ public:
 
   void Wakeup();
 };
+
+#endif
 
 #endif

--- a/src/core/threading/threading_impl.cpp
+++ b/src/core/threading/threading_impl.cpp
@@ -4,17 +4,10 @@
 * License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 */
 
-#ifndef THREADING_IMPL_H
-#define THREADING_IMPL_H
-
-#include <wx/log.h>
-
-#define WAIT_TIMEOUT_MS 1000
+#include "threading_impl.h"
 
 #if defined GO_STD_MUTEX
 #include <chrono>
-extern std::chrono::milliseconds const THREADING_WAIT_TIMEOUT;
+std::chrono::milliseconds const THREADING_WAIT_TIMEOUT(WAIT_TIMEOUT_MS);
 #endif
-
-#endif /* COMMON_IMPL_H */
 


### PR DESCRIPTION
Resolves #817 

The new implementation is quite simple.

I keep the capability of switching to the old implementstion by undefining GO_STD_MUTEX in cmake

Unfortunally I cann't test it with high playing and jack until the Sunday.