### PR TITLE
Fixed crash when playing with shared pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Fixed crash when playing with a shared pipe https://github.com/GrandOrgue/grandorgue/issues/847
+- Fixed a possible crash when playing with shared pipes https://github.com/GrandOrgue/grandorgue/issues/847
 # 3.4.2 (2021-11-14)
 - Added ASIO logo to About splash screen https://github.com/GrandOrgue/grandorgue/issues/823
 - Upgraded PortAudio Library to the latest stable release, v19.7.0. The upgraded library corrects PortAudio errors in GrandOrgue on macOS 11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash when playing with a shared pipe https://github.com/GrandOrgue/grandorgue/issues/847
 # 3.4.2 (2021-11-14)
 - Added ASIO logo to About splash screen https://github.com/GrandOrgue/grandorgue/issues/823
 - Upgraded PortAudio Library to the latest stable release, v19.7.0. The upgraded library corrects PortAudio errors in GrandOrgue on macOS 11.

--- a/src/grandorgue/GODefinitionFile.cpp
+++ b/src/grandorgue/GODefinitionFile.cpp
@@ -1016,10 +1016,10 @@ void GODefinitionFile::SwitchSample(const GOSoundProvider *pipe, GO_SAMPLER* han
 		m_soundengine->SwitchSample(pipe, handle);
 }
 
-void GODefinitionFile::UpdateVelocity(GO_SAMPLER* handle, unsigned velocity)
+void GODefinitionFile::UpdateVelocity(const GOSoundProvider* pipe, GO_SAMPLER* handle, unsigned velocity)
 {
 	if (m_soundengine)
-		m_soundengine->UpdateVelocity(handle, velocity);
+		m_soundengine->UpdateVelocity(pipe, handle, velocity);
 }
 
 void GODefinitionFile::SendMidiMessage(GOMidiEvent& e)

--- a/src/grandorgue/GODefinitionFile.h
+++ b/src/grandorgue/GODefinitionFile.h
@@ -206,7 +206,7 @@ public:
 	GO_SAMPLER* StartSample(const GOSoundProvider *pipe, int sampler_group_id, unsigned audio_group, unsigned velocity, unsigned delay, uint64_t last_stop);
 	uint64_t StopSample(const GOSoundProvider *pipe, GO_SAMPLER* handle);
 	void SwitchSample(const GOSoundProvider *pipe, GO_SAMPLER* handle);
-	void UpdateVelocity(GO_SAMPLER* handle, unsigned velocity);
+	void UpdateVelocity(const GOSoundProvider* pipe, GO_SAMPLER* handle, unsigned velocity);
 
 	void SendMidiMessage(GOMidiEvent& e);
 	void SendMidiRecorderMessage(GOMidiEvent& e);

--- a/src/grandorgue/GOSoundingPipe.cpp
+++ b/src/grandorgue/GOSoundingPipe.cpp
@@ -359,7 +359,7 @@ void GOSoundingPipe::Change(unsigned velocity, unsigned last_velocity)
 	else if (m_Instances && !velocity)
 		SetOff();
 	else if (m_Sampler && last_velocity != velocity)
-		m_organfile->UpdateVelocity(m_Sampler, velocity);
+		m_organfile->UpdateVelocity(GetSoundProvider(), m_Sampler, velocity);
 }
 
 void GOSoundingPipe::UpdateAmplitude()

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -657,13 +657,17 @@ void GOSoundEngine::SwitchSample(const GOSoundProvider *pipe, GO_SAMPLER* handle
 void GOSoundEngine::UpdateVelocity(const GOSoundProvider* pipe, GO_SAMPLER* handle, unsigned velocity)
 {
 	assert(handle);
-	handle->velocity = velocity;
-	if (pipe && handle->pipe == pipe)
+	assert(pipe);
+
+	if (handle->pipe == pipe)
+	{
 	  // we've just checked that handle is still playing the same pipe
 	  // may be handle was switched to another pipe between checking and SetVelocityVolume
 	  // but we don't want to lock it because this functionality is not so important
 	  // Concurrent update possible, as it just update a float
+	  handle->velocity = velocity;
 	  handle->fader.SetVelocityVolume(pipe->GetVelocityVolume(handle->velocity));
+	}
 }
 
 const std::vector<double>& GOSoundEngine::GetMeterInfo()

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -654,12 +654,16 @@ void GOSoundEngine::SwitchSample(const GOSoundProvider *pipe, GO_SAMPLER* handle
 	handle->new_attack = m_CurrentTime + handle->delay;
 }
 
-void GOSoundEngine::UpdateVelocity(GO_SAMPLER* handle, unsigned velocity)
+void GOSoundEngine::UpdateVelocity(const GOSoundProvider* pipe, GO_SAMPLER* handle, unsigned velocity)
 {
 	assert(handle);
 	handle->velocity = velocity;
-	/* Concurrent update possible, as it just update a float */
-	handle->fader.SetVelocityVolume(handle->pipe->GetVelocityVolume(handle->velocity));
+	if (pipe && handle->pipe == pipe)
+	  // we've just checked that handle is still playing the same pipe
+	  // may be handle was switched to another pipe between checking and SetVelocityVolume
+	  // but we don't want to lock it because this functionality is not so important
+	  // Concurrent update possible, as it just update a float
+	  handle->fader.SetVelocityVolume(pipe->GetVelocityVolume(handle->velocity));
 }
 
 const std::vector<double>& GOSoundEngine::GetMeterInfo()

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -106,7 +106,7 @@ public:
 	GO_SAMPLER* StartSample(const GOSoundProvider *pipe, int sampler_group_id, unsigned audio_group, unsigned velocity, unsigned delay, uint64_t last_stop);
 	uint64_t StopSample(const GOSoundProvider *pipe, GO_SAMPLER* handle);
 	void SwitchSample(const GOSoundProvider *pipe, GO_SAMPLER* handle);
-	void UpdateVelocity(GO_SAMPLER* handle, unsigned velocity);
+	void UpdateVelocity(const GOSoundProvider* pipe, GO_SAMPLER* handle, unsigned velocity);
 
 	void GetAudioOutput(float *output_buffer, unsigned n_frames, unsigned audio_output, bool last);
 	void NextPeriod();


### PR DESCRIPTION
Resolves: #847

The reason of crash was in GOSoundEngine::UpdateVelocity: handle->pipe could become NULL in a parallel thread

Also it could be switched to another pipe, so I added passing the original pipe and checking. This code is not still safe: sometimes we can update velocity of a wrong pipe.  But I think the functionality of velocity is used very seldom, so I fixed only the possibility of a crash but not the possiblity of a wrong behavior.

The same possibility of a wrong behavior exists in lots of another methods of GOSoundEngine: they all check the passed pipe and do some action but do not protect against altering the pipe between the checking and the action. Fixing this behavior would require introducing a mutex in GO_SAMPLER and locking it. If another GO_SAMPLER-concurency related bugs appears we can make a more accurate locking with a mutex.

I also noted that the class name GO_SAMPLER doesn't conform our naming convention. I will rename it in a separate PR.