### PR TITLE
Fixed hang after changing the audio device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed hang after changing the audio device https://github.com/GrandOrgue/grandorgue/issues/701
 - Fixed a possible crash when playing with shared pipes https://github.com/GrandOrgue/grandorgue/issues/847
 # 3.4.2 (2021-11-14)
 - Added ASIO logo to About splash screen https://github.com/GrandOrgue/grandorgue/issues/823

--- a/src/grandorgue/sound/GOSound.h
+++ b/src/grandorgue/sound/GOSound.h
@@ -66,6 +66,8 @@ class GOSound
 	};
 
 private:
+	bool m_open;
+
 	GOMutex m_lock;
 	GOMutex m_thread_lock;
 
@@ -99,6 +101,10 @@ private:
 	void ResetMeters();
 
 	void OpenMidi();
+
+	void OpenSound();
+	void CloseSound();
+
 	void StartStreams();
 	void UpdateMeter();
 
@@ -107,9 +113,8 @@ public:
 	GOSound(GOSettings& settings);
 	~GOSound();
 
-	bool OpenSound();
-	void CloseSound();
-	bool ResetSound(bool force = false);
+	bool AssureSoundIsOpen();
+	void AssureSoundIsClosed();
 
 	wxString getLastErrorMessage() const { return m_LastErrorMessage; }
 	wxString getState();


### PR DESCRIPTION
Resolves #701

The reason of hang: getting a list of device names for `Change` opens each device.
If there was a ASIO device opened, the second open of the asio device in GetDeviceList invalidated the handle, so closing the device after exit from settings hangs.

This PR introduces a lasy closing the current device in GetDeviceList and reopening it after exit from the settings dialog.

There new public methods `GOSound::AssureSoundIsOpen()` and `GOSound::AssureSoundIsClosed` have been introduced for lazy opening and closing audio devices. The old ones: `GOSound::OpenSound`, `GOSound::CloseSound` have become private. The method ``GOSound::ResetSound`` in `GOFrame::OnAudioPanic` has been removed and the only it's call has been replaced with `GOSound::AssureSoundIsOpen()` and `GOSound::AssureSoundIsClosed`.

