### PR TITLE
Renamed GO_SOUND_OUTPUT to GoSoundOutput

### DIFF
--- a/src/grandorgue/sound/GOSound.cpp
+++ b/src/grandorgue/sound/GOSound.cpp
@@ -334,7 +334,7 @@ bool GOSound::AudioCallback(unsigned dev_index, float* output_buffer, unsigned i
 		wxLogError(_("No sound output will happen. Samples per buffer has been changed by the sound driver to %d"), n_frames);
 		return 1;
 	}
-	GO_SOUND_OUTPUT* device = &m_AudioOutputs[dev_index];
+	GOSoundOutput* device = &m_AudioOutputs[dev_index];
 	GOMutexLocker locker(device->mutex);
 
 	if (device->wait && device->waiting)

--- a/src/grandorgue/sound/GOSound.h
+++ b/src/grandorgue/sound/GOSound.h
@@ -31,7 +31,7 @@ class GOSettings;
 
 class GOSound
 {
-	class GO_SOUND_OUTPUT
+	class GOSoundOutput
 	{
 	public:
 		GOSoundPort* port;
@@ -40,7 +40,7 @@ class GOSound
 		bool wait;
 		bool waiting;
 
-		GO_SOUND_OUTPUT() :
+		GOSoundOutput() :
 			condition(mutex)
 		{
 			port = 0;
@@ -48,7 +48,7 @@ class GOSound
 			waiting = false;
 		}
 
-		GO_SOUND_OUTPUT(const GO_SOUND_OUTPUT& old) :
+		GOSoundOutput(const GOSoundOutput& old) :
 			condition(mutex)
 		{
 			port = old.port;
@@ -56,7 +56,7 @@ class GOSound
 			waiting = old.waiting;
 		}
 
-		const GO_SOUND_OUTPUT& operator=(const GO_SOUND_OUTPUT& old)
+		const GOSoundOutput& operator=(const GOSoundOutput& old)
 		{
 			port = old.port;
 			wait = old.wait;
@@ -71,7 +71,7 @@ private:
 
 	bool logSoundErrors;
 
-	std::vector<GO_SOUND_OUTPUT> m_AudioOutputs;
+	std::vector<GOSoundOutput> m_AudioOutputs;
 	atomic_uint m_WaitCount;
 	atomic_uint m_CalcCount;
 


### PR DESCRIPTION
Working on #701 I noted that the class `GO_SOUND_OUTPUT` did not conform to the GO class naming conventions. This PR renames it to `GoSoundOutput`