### PR TITLE
Fixed a random crash on closing an organ

### DIFF
--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -67,6 +67,10 @@ void GOSoundEngine::Reset()
   }
 
   m_Scheduler.Clear();
+
+  // clear all buffered sound
+  for (unsigned i = 0; i < m_AudioGroups.size(); i++)
+    m_AudioGroups[i]->Clear();
   
   if (m_HasBeenSetup) 
   {
@@ -403,8 +407,13 @@ void GOSoundEngine::SetupReverb(GOSettings& settings)
 
 void GOSoundEngine::GetAudioOutput(float *output_buffer, unsigned n_frames, unsigned audio_output, bool last)
 {
+  size_t const nBytes = sizeof(float) * n_frames * m_AudioOutputs[audio_output + 1]->GetChannels();
+
+  if (m_HasBeenSetup)
+  {
 	m_AudioOutputs[audio_output + 1]->Finish(last);
-	memcpy(output_buffer, m_AudioOutputs[audio_output + 1]->m_Buffer, sizeof(float) * n_frames * m_AudioOutputs[audio_output + 1]->GetChannels());
+	memcpy(output_buffer, m_AudioOutputs[audio_output + 1]->m_Buffer, nBytes);
+  } else memset(output_buffer, 0, nBytes);
 }
 
 void GOSoundEngine::NextPeriod()

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -68,10 +68,6 @@ void GOSoundEngine::Reset()
 
   m_Scheduler.Clear();
 
-  // clear all buffered sound
-  for (unsigned i = 0; i < m_AudioGroups.size(); i++)
-    m_AudioGroups[i]->Clear();
-  
   if (m_HasBeenSetup) 
   {
 	for (unsigned i = 0; i < m_Tremulants.size(); i++)
@@ -234,6 +230,12 @@ void GOSoundEngine::StartSampler(GOSoundSampler* sampler, int sampler_group_id, 
 void GOSoundEngine::ClearSetup()
 {
 	m_HasBeenSetup = false;
+
+	// the winchests may be still used from audio callbacks.
+	// clear the pending sound before destroying the windchests
+	for (unsigned i = 0; i < m_AudioGroups.size(); i++)
+	  m_AudioGroups[i]->WaitAndClear();
+
 	m_Scheduler.Clear();
 	m_Windchests.clear();
 	m_Tremulants.clear();
@@ -413,7 +415,8 @@ void GOSoundEngine::GetAudioOutput(float *output_buffer, unsigned n_frames, unsi
   {
 	m_AudioOutputs[audio_output + 1]->Finish(last);
 	memcpy(output_buffer, m_AudioOutputs[audio_output + 1]->m_Buffer, nBytes);
-  } else memset(output_buffer, 0, nBytes);
+  } else
+	memset(output_buffer, 0, nBytes);
 }
 
 void GOSoundEngine::NextPeriod()

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -65,7 +65,7 @@ private:
 
 	struct resampler_coefs_s      m_ResamplerCoefs;
 	
-	bool			      m_HasBeenSetup;
+	volatile bool		      m_HasBeenSetup;
 
 	/* samplerGroupID:
 	   -1 .. -n Tremulants

--- a/src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.cpp
@@ -46,7 +46,9 @@ void GOSoundGroupWorkItem::ProcessList(GOSoundSamplerList& list, float* output_b
 {
 	for (GOSoundSampler* sampler = list.Get(); sampler; sampler = list.Get())
 	{
-		if (m_engine.ProcessSampler(output_buffer, sampler, m_SamplesPerBuffer, sampler->windchest->GetVolume()))
+		GOSoundWindchestWorkItem* const windchest = sampler->windchest;
+
+		if (windchest && m_engine.ProcessSampler(output_buffer, sampler, m_SamplesPerBuffer, windchest->GetVolume()))
 			Add(sampler);
 	}
 }

--- a/src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.h
+++ b/src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.h
@@ -28,8 +28,7 @@ private:
 	unsigned m_Done;
 	volatile bool m_Stop;
 
-	void ProcessList(GOSoundSamplerList& list, float* output_buffer);
-	void ProcessReleaseList(GOSoundSamplerList& list, float* output_buffer);
+	void ProcessList(GOSoundSamplerList& list, bool toDropOld, float* output_buffer);
 
 public:
 	GOSoundGroupWorkItem(GOSoundEngine& sound_engine, unsigned samples_per_buffer);
@@ -44,6 +43,7 @@ public:
 	void Reset();
 	void Clear();
 	void Add(GOSoundSampler* sampler);
+	void WaitAndClear();
 };
 
 #endif


### PR DESCRIPTION
Resolves #707

The reason of crash was using in a audio-callback called GOSoundGroupWorkItem::ProcessList a windchest item that have already been destroyed when closing an organ.

This PR:

1. Adds clearing GOSoundGroupWorkItem examples on closing the organ before destroying the windchest items that no references would remain to the windchests.
2. Adds some comments to GOSoundGroupWorkItem::Run code because it is multi-threading and too complex.
3. Replaces similar GOSoundGroupWorkItem::ProcessList and GOSoundGroupWorkItem::ProcessReleaseList with GOSoundGroupWorkItem::ProcessList with a bool parameter whether is to do some specific GOSoundGroupWorkItem::ProcessReleaseList actions.

I've tested the new version by playing organ during about one hour. No issues occured with sound. @paolo2504 has tested the original issue with loading new organs.