### PR TITLE
Midi matching Part 1

### DIFF
--- a/src/core/ptrvector.h
+++ b/src/core/ptrvector.h
@@ -10,7 +10,8 @@
 #include <vector>
 
 template<class T>
-class ptr_vector : protected std::vector<T*> {
+class ptr_vector : protected std::vector<T*>
+{
 private: 
 	/* Disable copying as it will break things */
 	ptr_vector(const ptr_vector&);
@@ -81,6 +82,12 @@ public:
 	{
 		std::vector<T*>::insert(std::vector<T*>::begin() + pos, ptr);
 	}
+
+	typename std::vector<T*>::const_iterator begin() const noexcept
+	{ return std::vector<T*>::begin(); }
+
+	typename std::vector<T*>::const_iterator end() const noexcept
+	{ return std::vector<T*>::end(); }
 };
 
 #endif

--- a/src/grandorgue/midi/GOMidi.cpp
+++ b/src/grandorgue/midi/GOMidi.cpp
@@ -6,10 +6,13 @@
 
 #include "GOMidi.h"
 
+#include "midi/GOMidiWXEvent.h"
+#include "ports/GOMidiInPort.h"
+#include "ports/GOMidiOutPort.h"
+#include "settings/GOSettings.h"
+
 #include "GOEvent.h"
 #include "GOMidiListener.h"
-#include "midi/GOMidiWXEvent.h"
-#include "settings/GOSettings.h"
 
 BEGIN_EVENT_TABLE(GOMidi, wxEvtHandler)
 	EVT_MIDI(GOMidi::OnMidiEvent)
@@ -43,30 +46,26 @@ void GOMidi::Open()
 
 	UpdateDevices(portsConfig);
 
-	for (unsigned i = 0; i < m_midi_in_devices.size(); i++)
+	for (GOMidiPort* pPort: m_midi_in_devices)
 	{
-	  GOMidiInPort* pPort = m_midi_in_devices[i];
-
 	  if (
 		  portsConfig.IsEnabled(pPort->GetPortName(), pPort->GetApiName())
 		  && m_Settings.GetMidiInState(pPort->GetName(), isToAutoAdd)
 	  )
-		  pPort->Open(m_Settings.GetMidiInDeviceChannelShift(pPort->GetName()));
+		((GOMidiInPort *) pPort)->Open(m_Settings.GetMidiInDeviceChannelShift(pPort->GetName()));
 	  else
-		  pPort->Close();
+	    pPort->Close();
 	}
 
-	for (unsigned i = 0; i < m_midi_out_devices.size(); i++)
+	for (GOMidiPort* pPort: m_midi_out_devices)
 	{
-	  GOMidiOutPort* pPort = m_midi_out_devices[i];
-
 	  if (
 		  portsConfig.IsEnabled(pPort->GetPortName(), pPort->GetApiName())
 		  && m_Settings.GetMidiOutState(pPort->GetName())
 	  )
-		  pPort->Open();
+	    pPort->Open();
 	  else
-		  pPort->Close();
+	    pPort->Close();
 	}
 }
 
@@ -96,7 +95,7 @@ void GOMidi::OnMidiEvent(wxMidiEvent& event)
 void GOMidi::Send(const GOMidiEvent& e)
 {
 	for(unsigned j = 0; j < m_midi_out_devices.size(); j++)
-		m_midi_out_devices[j]->Send(e);
+		((GOMidiOutPort*) m_midi_out_devices[j])->Send(e);
 }
 
 void GOMidi::Register(GOMidiListener* listener)

--- a/src/grandorgue/midi/GOMidi.cpp
+++ b/src/grandorgue/midi/GOMidi.cpp
@@ -46,7 +46,7 @@ void GOMidi::Open()
 
 	UpdateDevices(portsConfig);
 
-	for (GOMidiPort* pPort: m_midi_in_devices)
+	for (GOMidiPort* pPort : m_midi_in_devices)
 	{
 	  if (
 		  portsConfig.IsEnabled(pPort->GetPortName(), pPort->GetApiName())
@@ -57,7 +57,7 @@ void GOMidi::Open()
 	    pPort->Close();
 	}
 
-	for (GOMidiPort* pPort: m_midi_out_devices)
+	for (GOMidiPort* pPort : m_midi_out_devices)
 	{
 	  if (
 		  portsConfig.IsEnabled(pPort->GetPortName(), pPort->GetApiName())

--- a/src/grandorgue/midi/GOMidi.h
+++ b/src/grandorgue/midi/GOMidi.h
@@ -15,10 +15,9 @@
 #include "settings/GOPortsConfig.h"
 
 class GOMidiEvent;
-class GOMidiInPort;
+class GOMidiPort;
 class GOMidiListener;
 class GOMidiMap;
-class GOMidiOutPort;
 class GOSettings;
 class GODefinitionFile;
 class wxMidiEvent;
@@ -28,8 +27,8 @@ class GOMidi : public wxEvtHandler
 private:
 	GOSettings& m_Settings;
 
-	ptr_vector<GOMidiInPort> m_midi_in_devices;
-	ptr_vector<GOMidiOutPort> m_midi_out_devices;
+	ptr_vector<GOMidiPort> m_midi_in_devices;
+	ptr_vector<GOMidiPort> m_midi_out_devices;
 
 	int m_transpose;
 	std::vector<GOMidiListener*> m_Listeners;
@@ -47,8 +46,8 @@ public:
 	void Recv(const GOMidiEvent& e);
 	void Send(const GOMidiEvent& e);
 
-	const ptr_vector<GOMidiInPort>& GetInDevices() const { return m_midi_in_devices; }
-	const ptr_vector<GOMidiOutPort>& GetOutDevices() const { return m_midi_out_devices; }
+	const ptr_vector<GOMidiPort>& GetInDevices() const { return m_midi_in_devices; }
+	const ptr_vector<GOMidiPort>& GetOutDevices() const { return m_midi_out_devices; }
 	bool HasActiveDevice();
 	int GetTranspose();
 	void SetTranspose(int transpose);

--- a/src/grandorgue/midi/MIDIEventRecvDialog.cpp
+++ b/src/grandorgue/midi/MIDIEventRecvDialog.cpp
@@ -113,7 +113,7 @@ MIDIEventRecvDialog::MIDIEventRecvDialog (wxWindow* parent, GOMidiReceiverBase* 
 
 	m_device->Append(_("Any device"));
 
-	for (const wxString& it: m_Settings.GetMidiInDeviceList())
+	for (const wxString& it : m_Settings.GetMidiInDeviceList())
 		m_device->Append(it);
 
 	m_channel->Append(_("Any channel"));

--- a/src/grandorgue/midi/MIDIEventRecvDialog.cpp
+++ b/src/grandorgue/midi/MIDIEventRecvDialog.cpp
@@ -113,9 +113,8 @@ MIDIEventRecvDialog::MIDIEventRecvDialog (wxWindow* parent, GOMidiReceiverBase* 
 
 	m_device->Append(_("Any device"));
 
-	std::vector<wxString> device_names = m_Settings.GetMidiInDeviceList();
-	for(std::vector<wxString>::iterator it = device_names.begin(); it != device_names.end(); it++)
-		m_device->Append(*it);
+	for (const wxString& it: m_Settings.GetMidiInDeviceList())
+		m_device->Append(it);
 
 	m_channel->Append(_("Any channel"));
 	for(unsigned int i = 1 ; i <= 16; i++)

--- a/src/grandorgue/midi/MIDIEventSendDialog.cpp
+++ b/src/grandorgue/midi/MIDIEventSendDialog.cpp
@@ -96,7 +96,7 @@ MIDIEventSendDialog::MIDIEventSendDialog (wxWindow* parent, GOMidiSender* event,
 
 	m_device->Append(_("Any device"));
 
-	for (const wxString& it: m_Settings.GetMidiOutDeviceList())
+	for (const wxString& it : m_Settings.GetMidiOutDeviceList())
 		m_device->Append(it);
 
 	for(unsigned int i = 1 ; i <= 16; i++)

--- a/src/grandorgue/midi/MIDIEventSendDialog.cpp
+++ b/src/grandorgue/midi/MIDIEventSendDialog.cpp
@@ -96,9 +96,8 @@ MIDIEventSendDialog::MIDIEventSendDialog (wxWindow* parent, GOMidiSender* event,
 
 	m_device->Append(_("Any device"));
 
-	std::vector<wxString> device_names = m_Settings.GetMidiOutDeviceList();
-	for(std::vector<wxString>::iterator it = device_names.begin(); it != device_names.end(); it++)
-		m_device->Append(*it);
+	for (const wxString& it: m_Settings.GetMidiOutDeviceList())
+		m_device->Append(it);
 
 	for(unsigned int i = 1 ; i <= 16; i++)
 		m_channel->Append(wxString::Format(wxT("%d"), i));;

--- a/src/grandorgue/midi/ports/GOMidiInPort.h
+++ b/src/grandorgue/midi/ports/GOMidiInPort.h
@@ -34,8 +34,8 @@ public:
 
 	virtual ~GOMidiInPort();
 
-	virtual bool Open(int channel_shift = 0);
-	virtual void Close() = 0;
+	virtual bool Open(int channel_shift);
+	bool Open() { return Open(0); }
 };
 
 #endif

--- a/src/grandorgue/midi/ports/GOMidiOutPort.h
+++ b/src/grandorgue/midi/ports/GOMidiOutPort.h
@@ -36,7 +36,6 @@ public:
 	virtual const wxString GetMyNativePortName() const;
 
 	virtual bool Open();
-	virtual void Close() = 0;
 
 	void Send(const GOMidiEvent& e);
 };

--- a/src/grandorgue/midi/ports/GOMidiPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiPort.cpp
@@ -9,9 +9,11 @@
 #include "midi/GOMidi.h"
 #include "midi/GOMidiMap.h"
 
-const wxString GOMidiPort::GetClientName() const
+static wxString GRANDORGUE = wxT("GrandOrgue");
+
+const wxString GOMidiPort::GetClientName()
 {
-  return wxT("GrandOrgue");
+  return GRANDORGUE;
 }
 
 GOMidiPort::GOMidiPort(
@@ -29,6 +31,11 @@ GOMidiPort::GOMidiPort(
   m_FullName(fullName)
 {
   m_ID = m_midi->GetMidiMap().GetDeviceByString(GetName());
+}
+
+bool GOMidiPort::IsToUse() const
+{
+  return m_DeviceName.Find(GetClientName()) == wxNOT_FOUND;
 }
 
 bool GOMidiPort::IsEqualTo(

--- a/src/grandorgue/midi/ports/GOMidiPort.h
+++ b/src/grandorgue/midi/ports/GOMidiPort.h
@@ -24,7 +24,7 @@ protected:
 
   unsigned m_ID;
 
-  const wxString GetClientName() const;
+  static const wxString GetClientName();
   virtual const wxString GetMyNativePortName() const = 0;
 
 public:
@@ -41,6 +41,9 @@ public:
   const wxString& GetApiName() const { return m_ApiName; }
   const wxString& GetDeviceName() const { return m_DeviceName; }
   const wxString& GetName() const { return m_FullName; }
+  bool IsToUse() const;
+  const wxString GetDefaultLogicalName() const { return m_FullName; }
+  const wxString GetDefaultRegEx() const { return wxEmptyString; }
   bool IsEqualTo(
     const wxString& portName,
     const wxString& apiName,
@@ -48,6 +51,10 @@ public:
   ) const;
   unsigned GetID() const { return m_ID; }
   bool IsActive() const { return m_IsActive; }
+
+  virtual bool Open() = 0;
+  virtual void Close() = 0;
+
 };
 
 #endif /* GOMIDIPORT_H */

--- a/src/grandorgue/midi/ports/GOMidiPortFactory.cpp
+++ b/src/grandorgue/midi/ports/GOMidiPortFactory.cpp
@@ -42,13 +42,13 @@ GOMidiRtPortFactory* get_rt()
   return p_rt_factory;
 }
 
-void GOMidiPortFactory::addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiInPort>& ports)
+void GOMidiPortFactory::addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports)
 {
   if (portsConfig.IsEnabled(GOMidiRtPortFactory::PORT_NAME))
     get_rt()->addMissingInDevices(midi, portsConfig, ports);
 }
 
-void GOMidiPortFactory::addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiOutPort>& ports)
+void GOMidiPortFactory::addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports)
 {
   if (portsConfig.IsEnabled(GOMidiRtPortFactory::PORT_NAME))
     get_rt() -> addMissingOutDevices(midi, portsConfig, ports);

--- a/src/grandorgue/midi/ports/GOMidiPortFactory.h
+++ b/src/grandorgue/midi/ports/GOMidiPortFactory.h
@@ -12,8 +12,7 @@
 #include "settings/GOPortFactory.h"
 #include "settings/GOPortsConfig.h"
 
-#include "GOMidiInPort.h"
-#include "GOMidiOutPort.h"
+#include "GOMidiPort.h"
 
 class GOMidi;
 
@@ -24,8 +23,8 @@ public:
   virtual const std::vector<wxString>& GetPortApiNames(const wxString & portName) const;
 
   static GOMidiPortFactory& getInstance();
-  static void addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiInPort>& ports);
-  static void addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiOutPort>& ports);
+  static void addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports);
+  static void addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports);
   static void terminate();
 };
 

--- a/src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp
+++ b/src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp
@@ -54,7 +54,7 @@ GOMidiRtPortFactory::~GOMidiRtPortFactory()
   m_RtMidiIns.clear();
 }
 
-void GOMidiRtPortFactory::addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiInPort>& ports)
+void GOMidiRtPortFactory::addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports)
 {
   GOMidiPortFactory& portFactory(GOMidiPortFactory::getInstance());
 
@@ -78,7 +78,7 @@ void GOMidiRtPortFactory::addMissingInDevices(GOMidi* midi, const GOPortsConfig&
 
 	  for (unsigned k = 0; k < ports.size(); k++)
 	  {
-	    GOMidiInPort* const pOld = ports[k];
+	    GOMidiPort* const pOld = ports[k];
 
 	    if (pOld && pOld->IsEqualTo(PORT_NAME, apiName, deviceName))
 	    {
@@ -105,7 +105,7 @@ void GOMidiRtPortFactory::addMissingInDevices(GOMidi* midi, const GOPortsConfig&
     }
 }
 
-void GOMidiRtPortFactory::addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiOutPort>& ports)
+void GOMidiRtPortFactory::addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports)
 {
   GOMidiPortFactory& portFactory(GOMidiPortFactory::getInstance());
 
@@ -129,7 +129,7 @@ void GOMidiRtPortFactory::addMissingOutDevices(GOMidi* midi, const GOPortsConfig
 
 	  for (unsigned k = 0; k < ports.size(); k++)
 	  {
-	    const GOMidiOutPort* const pOld = ports[k];
+	    const GOMidiPort* const pOld = ports[k];
 
 	    if (pOld && pOld->IsEqualTo(PORT_NAME, apiName, deviceName))
 	    {

--- a/src/grandorgue/midi/ports/GOMidiRtPortFactory.h
+++ b/src/grandorgue/midi/ports/GOMidiRtPortFactory.h
@@ -3,10 +3,10 @@
 
 #include <map>
 
+#include "ptrvector.h"
 #include "settings/GOPortsConfig.h"
 
-#include "GOMidiInPort.h"
-#include "GOMidiOutPort.h"
+#include "GOMidiPort.h"
 #include "RtMidi.h"
 
 class GOMidiRtPortFactory {
@@ -20,8 +20,8 @@ public:
   GOMidiRtPortFactory();
   ~GOMidiRtPortFactory();
   
-  void addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiInPort>& ports);
-  void addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiOutPort>& ports);
+  void addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports);
+  void addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports);
 
   static wxString getApiName(RtMidi::Api api);
   static const std::vector<wxString> & getApis();

--- a/src/grandorgue/settings/SettingsMidiDevices.cpp
+++ b/src/grandorgue/settings/SettingsMidiDevices.cpp
@@ -101,14 +101,13 @@ void SettingsMidiDevices::RenewDevices(
   midi.UpdateDevices(portsConfig);
 
   // Fill m_InDevices
-  const ptr_vector<GOMidiInPort>& inPorts = midi.GetInDevices();
-
   m_InDevices->Clear();
-  for (unsigned i = 0, l = inPorts.size(); i < l; i ++)
+  for (const GOMidiPort* port: midi.GetInDevices())
   {
-    const GOMidiInPort* const port = inPorts[i];
-
-    if (portsConfig.IsEnabled(port->GetPortName(), port->GetApiName()))
+    if (
+      portsConfig.IsEnabled(port->GetPortName(), port->GetApiName())
+      && port->IsToUse()
+    )
     {
       const wxString deviceName = port->GetName();
       const int i = m_InDevices->Append(deviceName);
@@ -121,17 +120,16 @@ void SettingsMidiDevices::RenewDevices(
   }
 
   // Fill m_OutDevices and m_RecorderDevice
-  const ptr_vector<GOMidiOutPort>& outPorts = midi.GetOutDevices();
-
   m_RecorderDevice->Clear();
   m_RecorderDevice->Append(_("No device"));
   m_RecorderDevice->Select(0);
   m_OutDevices->Clear();
-  for (unsigned i = 0, l = outPorts.size(); i < l; i ++)
+  for (const GOMidiPort* port: midi.GetOutDevices())
   {
-    const GOMidiOutPort* const port = outPorts[i];
-
-    if (portsConfig.IsEnabled(port->GetPortName(), port->GetApiName()))
+    if (
+      portsConfig.IsEnabled(port->GetPortName(), port->GetApiName())
+      && port->IsToUse()
+    )
     {
       const wxString deviceName = port->GetName();
       const int iOut = m_OutDevices->Append(deviceName);

--- a/src/grandorgue/settings/SettingsMidiDevices.cpp
+++ b/src/grandorgue/settings/SettingsMidiDevices.cpp
@@ -102,7 +102,7 @@ void SettingsMidiDevices::RenewDevices(
 
   // Fill m_InDevices
   m_InDevices->Clear();
-  for (const GOMidiPort* port: midi.GetInDevices())
+  for (const GOMidiPort* port : midi.GetInDevices())
   {
     if (
       portsConfig.IsEnabled(port->GetPortName(), port->GetApiName())
@@ -124,7 +124,7 @@ void SettingsMidiDevices::RenewDevices(
   m_RecorderDevice->Append(_("No device"));
   m_RecorderDevice->Select(0);
   m_OutDevices->Clear();
-  for (const GOMidiPort* port: midi.GetOutDevices())
+  for (const GOMidiPort* port : midi.GetOutDevices())
   {
     if (
       portsConfig.IsEnabled(port->GetPortName(), port->GetApiName())


### PR DESCRIPTION
This is a first preparing PR for #885. GO behaviour should not be changed.

1. Because matching is some complex thing that must be implementing in both MidiIn and MidiOut, I made some unification: replaced the lists GOMidiInPort and GOMidiOutPort with the unified list of GOMidiPort. It allows to have a single code working with the lists. I use casting from GOPort to GOMidiInPort or GOMidiOutPort in a few places where it is necessary.
2. I added const iterators to `ptr_vector` and replaced loops on it with ``for (el: list)`` form in several places.
