### PR TITLE
Midi matching part 3

### DIFF
--- a/src/core/ptrvector.h
+++ b/src/core/ptrvector.h
@@ -83,6 +83,13 @@ public:
 		std::vector<T*>::insert(std::vector<T*>::begin() + pos, ptr);
 	}
 
+	void erase(unsigned pos)
+	{
+		if (at(pos))
+		  delete at(pos);
+		std::vector<T*>::erase(std::vector<T*>::begin() + pos);
+	}
+
 	typename std::vector<T*>::const_iterator begin() const noexcept
 	{ return std::vector<T*>::begin(); }
 

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -147,6 +147,7 @@ GOPanelView.cpp
 settings/GOMidiDeviceConfig.cpp
 settings/GOMidiDeviceConfigList.cpp
 settings/GOPortFactory.cpp
+settings/GOSettingsMidiDeviceList.cpp
 settings/GOSettingsPorts.cpp
 settings/SettingsArchives.cpp
 settings/SettingsAudioGroup.cpp

--- a/src/grandorgue/settings/GOMidiDeviceConfig.h
+++ b/src/grandorgue/settings/GOMidiDeviceConfig.h
@@ -18,7 +18,7 @@ private:
   wxRegEx* p_CompiledRegEx = NULL;
 
 public:
-  typedef std::vector<GOMidiDeviceConfig*> List;
+  typedef std::vector<GOMidiDeviceConfig*> RefVector;
 
   wxString m_LogicalName;
   wxString m_RegEx;

--- a/src/grandorgue/settings/GOMidiDeviceConfig.h
+++ b/src/grandorgue/settings/GOMidiDeviceConfig.h
@@ -7,6 +7,8 @@
 #ifndef GOMIDIDEVICECONFIG_H
 #define GOMIDIDEVICECONFIG_H
 
+#include <vector>
+
 #include <wx/regex.h>
 #include <wx/string.h>
 
@@ -16,6 +18,8 @@ private:
   wxRegEx* p_CompiledRegEx = NULL;
 
 public:
+  typedef std::vector<GOMidiDeviceConfig*> List;
+
   wxString m_LogicalName;
   wxString m_RegEx;
   bool m_IsEnabled;

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
@@ -57,7 +57,7 @@ GOMidiDeviceConfig* GOMidiDeviceConfigList::FindByPhysicalName(
 }
 
 void GOMidiDeviceConfigList::RemoveByLogicalNameOutOf(
-  const wxString& logicalName, const GOMidiDeviceConfig::List& protectList
+  const wxString& logicalName, const GOMidiDeviceConfig::RefVector& protectList
 )
 {
   for (int i = m_list.size() - 1; i >= 0; i --)

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
@@ -138,6 +138,9 @@ void GOMidiDeviceConfigList::Save(
     cfg.WriteString(
       m_GroupName, wxString::Format(DEVICE03D, i), devConf->m_LogicalName
     );
+    cfg.WriteString(
+      m_GroupName, wxString::Format(DEVICE03D_REGEX, i), devConf->m_RegEx
+    );
     cfg.WriteBoolean(
       m_GroupName, wxString::Format(DEVICE03D_ENABLED, i), devConf->m_IsEnabled
     );

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
@@ -56,6 +56,31 @@ GOMidiDeviceConfig* GOMidiDeviceConfigList::FindByPhysicalName(
   return res;
 }
 
+void GOMidiDeviceConfigList::RemoveByLogicalNameOutOf(
+  const wxString& logicalName, const GOMidiDeviceConfig::List& protectList
+)
+{
+  for (int i = m_list.size() - 1; i >= 0; i --)
+  {
+    GOMidiDeviceConfig* pDev = m_list[i];
+
+    if (pDev->m_LogicalName == logicalName)
+    {
+      bool isProtected = false;
+
+      if (! pDev->m_PhysicalName.IsEmpty())
+	for (GOMidiDeviceConfig* pProt : protectList)
+	  if (pProt->m_PhysicalName == pDev->m_PhysicalName)
+	  {
+	    isProtected = true;
+	    break;
+	  }
+      if (! isProtected)
+	m_list.erase(i);
+    }
+  }
+}
+
 void GOMidiDeviceConfigList::MapOutputDevice(
   const GOMidiDeviceConfig& devConfSrc, GOMidiDeviceConfig& devConfDst
 ) const

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.h
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.h
@@ -30,10 +30,10 @@ public:
 
   void Clear() { m_list.clear(); }
 
-  GOMidiDeviceConfig::List::const_iterator begin() const noexcept
+  GOMidiDeviceConfig::RefVector::const_iterator begin() const noexcept
   { return m_list.begin(); }
 
-  GOMidiDeviceConfig::List::const_iterator end() const noexcept
+  GOMidiDeviceConfig::RefVector::const_iterator end() const noexcept
   { return m_list.end(); }
 
   GOMidiDeviceConfig* FindByLogicalName(const wxString& logicalName) const;
@@ -52,7 +52,7 @@ public:
    * @param protectList - the list of physical names to keep
    */
   void RemoveByLogicalNameOutOf(
-    const wxString& logicalName, const GOMidiDeviceConfig::List& protectList
+    const wxString& logicalName, const GOMidiDeviceConfig::RefVector& protectList
   );
 
   /**

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.h
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.h
@@ -34,7 +34,7 @@ public:
   { return m_list.begin(); }
 
   std::vector<GOMidiDeviceConfig*>::const_iterator end() const noexcept
-  { return m_list.begin(); }
+  { return m_list.end(); }
 
   GOMidiDeviceConfig* FindByLogicalName(const wxString& logicalName) const;
 

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.h
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.h
@@ -46,6 +46,16 @@ public:
   GOMidiDeviceConfig* FindByPhysicalName(const wxString& physicalName) const;
 
   /**
+   * Remove the device from the list that has the logical name specified
+   * and the physicalName is not in the protectList
+   * @param logicalName - the logical device name to delete
+   * @param protectList - the list of physical names to keep
+   */
+  void RemoveByLogicalNameOutOf(
+    const wxString& logicalName, const GOMidiDeviceConfig::List& protectList
+  );
+
+  /**
    * If devConfSrc.p_OutputDevice is set than fill devConfDst.p_OutputDevice
    * with a device with the same logical name in this list
    **/

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.h
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.h
@@ -30,10 +30,10 @@ public:
 
   void Clear() { m_list.clear(); }
 
-  std::vector<GOMidiDeviceConfig*>::const_iterator begin() const noexcept
+  GOMidiDeviceConfig::List::const_iterator begin() const noexcept
   { return m_list.begin(); }
 
-  std::vector<GOMidiDeviceConfig*>::const_iterator end() const noexcept
+  GOMidiDeviceConfig::List::const_iterator end() const noexcept
   { return m_list.end(); }
 
   GOMidiDeviceConfig* FindByLogicalName(const wxString& logicalName) const;

--- a/src/grandorgue/settings/GOSettingsMidiDeviceList.cpp
+++ b/src/grandorgue/settings/GOSettingsMidiDeviceList.cpp
@@ -1,0 +1,125 @@
+/*
+* Copyright 2006 Milan Digital Audio LLC
+* Copyright 2009-2021 GrandOrgue contributors (see AUTHORS)
+* License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+*/
+
+#include "GOSettingsMidiDeviceList.h"
+
+GOSettingsMidiDeviceList::GOSettingsMidiDeviceList(
+  const ptr_vector<GOMidiPort>& ports,
+  GOMidiDeviceConfigList& configListPersist,
+  wxWindow* parent,
+  wxWindowID id
+):
+  m_parent(parent), m_Ports(ports), m_ConfList(configListPersist)
+{
+  m_LbDevices = new wxCheckListBox(
+    parent, id, wxDefaultPosition, wxSize(100, 100)
+  );
+  m_LbDevices->Bind(
+    wxEVT_CHECKLISTBOX,
+    &GOSettingsMidiDeviceList::OnChecked,
+    this
+  );
+  Init();
+}
+
+void GOSettingsMidiDeviceList::ClearDevices()
+{
+  // We cann't use lbDevices->Clear() because it disables the event handler
+  for (int i = m_LbDevices->GetCount() - 1; i >= 0; i--)
+    m_LbDevices->Delete(i);
+  m_ListedConfs.clear();
+}
+
+void GOSettingsMidiDeviceList::Init()
+{
+  ClearDevices();
+  m_ConfListTmp.Clear();
+}
+
+void GOSettingsMidiDeviceList::RefreshDevices(
+  const GOPortsConfig& portsConfig,
+  const bool isToAutoEnable,
+  const GOSettingsMidiDeviceList* pOutDevList
+)
+{
+  ClearDevices();
+  for (GOMidiPort* port : m_Ports)
+    if (
+      port->IsToUse()
+      && portsConfig.IsEnabled(port->GetPortName(), port->GetApiName())
+    )
+    {
+      const wxString physicalName = port->GetName();
+      GOMidiDeviceConfig* const pConf
+	= m_ConfList.FindByPhysicalName(physicalName);
+      GOMidiDeviceConfig* pConfTmp
+	= m_ConfListTmp.FindByPhysicalName(physicalName);
+
+      if (! pConfTmp)
+	pConfTmp = pConf
+	  ? m_ConfListTmp.Append(
+	    *pConf, pOutDevList ? &pOutDevList->m_ConfListTmp : NULL
+	  )
+	  : m_ConfListTmp.Append(
+	    port->GetDefaultLogicalName(),
+	    port->GetDefaultRegEx(),
+	    isToAutoEnable,
+	    physicalName
+	  );
+
+      m_ListedConfs.push_back(pConfTmp);
+      
+      const int i = m_LbDevices->Append(physicalName);
+
+      if (pConfTmp->m_IsEnabled)
+	m_LbDevices->Check(i);
+    }
+}
+
+unsigned GOSettingsMidiDeviceList::GetDeviceCount() const
+{
+  return m_LbDevices->GetCount();
+}
+
+GOMidiDeviceConfig&
+  GOSettingsMidiDeviceList::GetSelectedDeviceConf()
+  const
+{
+  return GetDeviceConf(m_LbDevices->GetSelection());
+}
+
+void GOSettingsMidiDeviceList::OnSelected(wxCommandEvent& event)
+{
+}
+
+void GOSettingsMidiDeviceList::OnChecked(wxCommandEvent& event)
+{
+  unsigned i = (unsigned) event.GetInt();
+
+  GetDeviceConf(i).m_IsEnabled = m_LbDevices->IsChecked(i);
+}
+
+void GOSettingsMidiDeviceList::Save(
+  const GOSettingsMidiDeviceList* pOutDevList
+)
+{
+  for (GOMidiDeviceConfig* pDevConfTmp : m_ListedConfs)
+  {
+    GOMidiDeviceConfig* pDevConf = m_ConfList.FindByPhysicalName(
+      pDevConfTmp->m_PhysicalName
+    );
+    const GOMidiDeviceConfigList* pOutConfList
+      = pOutDevList ? & pOutDevList->m_ConfList : NULL;
+
+    if (pDevConf)
+    {
+      pDevConf->Assign(*pDevConfTmp);
+      if (pOutConfList)
+	pOutConfList->MapOutputDevice(*pDevConfTmp, *pDevConf);
+    } else
+      m_ConfList.Append(*pDevConfTmp, pOutConfList);
+  }
+}

--- a/src/grandorgue/settings/GOSettingsMidiDeviceList.h
+++ b/src/grandorgue/settings/GOSettingsMidiDeviceList.h
@@ -24,7 +24,7 @@ private:
   wxWindow* m_parent;
   const ptr_vector<GOMidiPort>& m_Ports;
   GOMidiDeviceConfigList& m_ConfList;
-  GOMidiDeviceConfig::List m_ListedConfs;
+  GOMidiDeviceConfig::RefVector m_ListedConfs;
   wxCheckListBox* m_LbDevices;
   
   // temporary storage for configs when edited

--- a/src/grandorgue/settings/GOSettingsMidiDeviceList.h
+++ b/src/grandorgue/settings/GOSettingsMidiDeviceList.h
@@ -1,0 +1,66 @@
+/*
+* Copyright 2006 Milan Digital Audio LLC
+* Copyright 2009-2021 GrandOrgue contributors (see AUTHORS)
+* License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+*/
+
+#ifndef GOSETTINGSMIDIDEVICELIST_H
+#define GOSETTINGSMIDIDEVICELIST_H
+
+#include <wx/button.h>
+#include <wx/checklst.h>
+#include <wx/window.h>
+
+#include "ptrvector.h"
+
+#include "midi/ports/GOMidiPort.h"
+
+#include "GOMidiDeviceConfigList.h"
+#include "GOPortsConfig.h"
+
+class GOSettingsMidiDeviceList
+{
+private:
+  wxWindow* m_parent;
+  const ptr_vector<GOMidiPort>& m_Ports;
+  GOMidiDeviceConfigList& m_ConfList;
+  GOMidiDeviceConfig::List m_ListedConfs;
+  wxCheckListBox* m_LbDevices;
+  
+  // temporary storage for configs when edited
+  GOMidiDeviceConfigList m_ConfListTmp;
+
+  void ClearDevices();
+
+  void OnChecked(wxCommandEvent& event);
+  
+public:
+  GOSettingsMidiDeviceList(
+    const ptr_vector<GOMidiPort>& ports,
+    GOMidiDeviceConfigList& configListPersist,
+    wxWindow* parent,
+    wxWindowID id
+  );
+
+  wxCheckListBox* GetListbox() const { return m_LbDevices; }
+
+  void Init();
+
+  void RefreshDevices(
+    const GOPortsConfig& portsConfig,
+    const bool isToAutoEnable,
+    const GOSettingsMidiDeviceList* pOutDevList = NULL
+  );
+
+  unsigned GetDeviceCount() const;
+  GOMidiDeviceConfig& GetDeviceConf(unsigned i) const { return *m_ListedConfs[i]; }
+  GOMidiDeviceConfig& GetSelectedDeviceConf() const;
+
+  void OnSelected(wxCommandEvent& event);
+
+  void Save(const GOSettingsMidiDeviceList* pOutDevList = NULL);
+};
+
+
+#endif /* GOSETTINGSMIDIDEVICELIST_H */
+

--- a/src/grandorgue/settings/SettingsMidiDevices.h
+++ b/src/grandorgue/settings/SettingsMidiDevices.h
@@ -7,14 +7,12 @@
 #ifndef SETTINGSMIDIDEVICES_H
 #define SETTINGSMIDIDEVICES_H
 
-#include <vector>
-
 #include <wx/checkbox.h>
 #include <wx/panel.h>
 
-#include "GOMidiDeviceConfigList.h"
 #include "GOPortsConfig.h"
 #include "GOSettings.h"
+#include "GOSettingsMidiDeviceList.h"
 #include "GOSettingsPorts.h"
 
 class wxButton;
@@ -39,47 +37,8 @@ private:
 	GOSettings& m_Settings;
 	GOMidi& m_Midi;
 
-	class MidiDeviceListSettings
-	{
-	private:
-	  const ptr_vector<GOMidiPort>& m_Ports;
-	  GOMidiDeviceConfigList& m_ConfList;
-	  wxCheckListBox* m_LbDevices;
-
-	  // temporary storage for configs when edited
-	  GOMidiDeviceConfigList m_ConfListTmp;
-
-	  void ClearDevices();
-
-	public:
-	  MidiDeviceListSettings(
-	    const ptr_vector<GOMidiPort>& ports,
-	    GOMidiDeviceConfigList& configListPersist,
-	    wxWindow* parent,
-	    wxWindowID id
-	  );
-
-	  wxCheckListBox* GetListbox() const { return m_LbDevices; }
-
-	  void Init();
-
-	  void RefreshDevices(
-	    const GOPortsConfig& portsConfig,
-	    const bool isToAutoEnable,
-	    const MidiDeviceListSettings* pOutDevList = NULL
-	  );
-
-	  unsigned GetDeviceCount() const;
-	  GOMidiDeviceConfig& GetDeviceConf(unsigned i) const;
-	  GOMidiDeviceConfig& GetSelectedDeviceConf() const;
-
-	  void OnChecked(wxCommandEvent& event);
-
-	  void Save(const MidiDeviceListSettings* pOutDevList = NULL);
-	};
-
-	MidiDeviceListSettings m_InDevices;
-	MidiDeviceListSettings m_OutDevices;
+	GOSettingsMidiDeviceList m_InDevices;
+	GOSettingsMidiDeviceList m_OutDevices;
 
 	wxCheckBox* m_AutoAddInput;
 	wxCheckBox* m_CheckOnStartup;


### PR DESCRIPTION
This is the last preparing PR for #885

1. Fixed a bug in Midi Device list iterator (GOMidiDeviceConfigList.h)
2. Added the typedef GOMidiDeviceConfig::List (GOMidiDeviceConfig.h)
3. Fixed not saving midi device regex (GOMidiDeviceConfigList.cpp)
4. Added a capability of removing `MidiDeviceConfig` elements from MidiDeviceConfigList with duplicate logical names
5. The inner class SettingsMidiDevices::MidiDeviceListSettings converted to the sepate class GOSettingsMidiDeviceList

No new features haave been added to GO.

After merging this PR I'll submit the https://github.com/oleg68/GrandOrgue-official/tree/feature/midi-matching with added a capability of redefining midi names and regex (the work is still in progress now)