### PR TITLE
Added default regex patterns for matching MIDI devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Added default regexe patterns for matching MIDI devices with alsa, jack and winmm https://github.com/GrandOrgue/grandorgue/issues/885
+- Added default regex patterns for matching MIDI devices with alsa, jack and winmm https://github.com/GrandOrgue/grandorgue/issues/885
 - Added capability of matching MIDI devices with regex expressions https://github.com/GrandOrgue/grandorgue/issues/885
 - Added a setting option whether to check for existence of active midi devices on startup https://github.com/GrandOrgue/grandorgue/issues/796
 - Added capability of switching auto enabling of new midi devices on/off https://github.com/GrandOrgue/grandorgue/issues/703

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added default regexe patterns for matching MIDI devices with alsa, jack and winmm https://github.com/GrandOrgue/grandorgue/issues/885
 - Added capability of matching MIDI devices with regex expressions https://github.com/GrandOrgue/grandorgue/issues/885
 - Added a setting option whether to check for existence of active midi devices on startup https://github.com/GrandOrgue/grandorgue/issues/796
 - Added capability of switching auto enabling of new midi devices on/off https://github.com/GrandOrgue/grandorgue/issues/703

--- a/src/grandorgue/midi/ports/GOMidiPort.h
+++ b/src/grandorgue/midi/ports/GOMidiPort.h
@@ -42,8 +42,8 @@ public:
   const wxString& GetDeviceName() const { return m_DeviceName; }
   const wxString& GetName() const { return m_FullName; }
   bool IsToUse() const;
-  const wxString GetDefaultLogicalName() const { return m_FullName; }
-  const wxString GetDefaultRegEx() const { return wxEmptyString; }
+  virtual const wxString GetDefaultLogicalName() const { return m_FullName; }
+  virtual const wxString GetDefaultRegEx() const { return wxEmptyString; }
   bool IsEqualTo(
     const wxString& portName,
     const wxString& apiName,

--- a/src/grandorgue/midi/ports/GOMidiPortFactory.cpp
+++ b/src/grandorgue/midi/ports/GOMidiPortFactory.cpp
@@ -33,32 +33,19 @@ static GOMidiPortFactory instance;
 
 GOMidiPortFactory& GOMidiPortFactory::getInstance() { return instance; }
 
-static GOMidiRtPortFactory* p_rt_factory = NULL;
-
-GOMidiRtPortFactory* get_rt()
-{
-  if (! p_rt_factory)
-    p_rt_factory = new GOMidiRtPortFactory();
-  return p_rt_factory;
-}
-
 void GOMidiPortFactory::addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports)
 {
   if (portsConfig.IsEnabled(GOMidiRtPortFactory::PORT_NAME))
-    get_rt()->addMissingInDevices(midi, portsConfig, ports);
+    GOMidiRtPortFactory::getInstance()->addMissingInDevices(midi, portsConfig, ports);
 }
 
 void GOMidiPortFactory::addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports)
 {
   if (portsConfig.IsEnabled(GOMidiRtPortFactory::PORT_NAME))
-    get_rt() -> addMissingOutDevices(midi, portsConfig, ports);
+    GOMidiRtPortFactory::getInstance()->addMissingOutDevices(midi, portsConfig, ports);
 }
 
 void GOMidiPortFactory::terminate()
 {
-  if (p_rt_factory)
-  {
-    delete p_rt_factory;
-    p_rt_factory = NULL;
-  }
+  GOMidiRtPortFactory::terminateInstance();
 }

--- a/src/grandorgue/midi/ports/GOMidiRtInPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiRtInPort.cpp
@@ -31,6 +31,20 @@ GOMidiRtInPort::~GOMidiRtInPort()
   Close(true);
 }
 
+const wxString GOMidiRtInPort::GetDefaultLogicalName() const
+{
+  return GOMidiRtPortFactory::getInstance()->GetDefaultLogicalName(
+    m_api, GetDeviceName(), GetName()
+  );
+}
+
+const wxString GOMidiRtInPort::GetDefaultRegEx() const
+{
+  return GOMidiRtPortFactory::getInstance()->GetDefaultRegEx(
+    m_api, GetDeviceName(), GetName()
+  );
+}
+
 bool GOMidiRtInPort::Open(int channel_shift)
 {
   Close(false);

--- a/src/grandorgue/midi/ports/GOMidiRtInPort.h
+++ b/src/grandorgue/midi/ports/GOMidiRtInPort.h
@@ -29,6 +29,9 @@ public:
   );
   ~GOMidiRtInPort();
 
+  virtual const wxString GetDefaultLogicalName() const;
+  virtual const wxString GetDefaultRegEx() const;
+
   bool Open(int channel_shift = 0);
   void Close() { Close(true); }
 };

--- a/src/grandorgue/midi/ports/GOMidiRtOutPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiRtOutPort.cpp
@@ -31,6 +31,20 @@ GOMidiRtOutPort::~GOMidiRtOutPort()
   Close(true);
 }
 
+const wxString GOMidiRtOutPort::GetDefaultLogicalName() const
+{
+  return GOMidiRtPortFactory::getInstance()->GetDefaultLogicalName(
+    m_api, GetDeviceName(), GetName()
+  );
+}
+
+const wxString GOMidiRtOutPort::GetDefaultRegEx() const
+{
+  return GOMidiRtPortFactory::getInstance()->GetDefaultRegEx(
+    m_api, GetDeviceName(), GetName()
+  );
+}
+
 bool GOMidiRtOutPort::Open()
 {
   Close(false);

--- a/src/grandorgue/midi/ports/GOMidiRtOutPort.h
+++ b/src/grandorgue/midi/ports/GOMidiRtOutPort.h
@@ -29,6 +29,9 @@ public:
   );
   ~GOMidiRtOutPort();
 
+  virtual const wxString GetDefaultLogicalName() const;
+  virtual const wxString GetDefaultRegEx() const;
+
   bool Open();
   void Close() { Close(true); }
 };

--- a/src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp
+++ b/src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp
@@ -10,15 +10,25 @@
 #include "GOMidiPortFactory.h"
 
 #include <vector>
+
 #include <wx/intl.h>
 #include <wx/log.h>
+#include <wx/regex.h>
 
 const wxString GOMidiRtPortFactory::PORT_NAME = wxT("Rt");
 
 static std::vector<RtMidi::Api> apis;
 static bool hasApisPopulated = false;
 
-GOMidiRtPortFactory::GOMidiRtPortFactory()
+GOMidiRtPortFactory::GOMidiRtPortFactory() :
+  m_AlsaDevnamePattern ("([^:]+):([^:]+) ([0-9]+:[0-9]+)"),
+    // Client Name:Port Name ClientNum:PortNum
+  m_JackDevnamePattern (
+    "Midi-Bridge:([^:]+):\\(([a-z]+)_([0-9]+)\\) ([^:-]+)(-[0-9]+)?$"
+  ),
+    // Midi-Bridge:Client Name:(direction_num)) Port Name{-Num}
+  m_WinMmDevnamePattern ("([^:]+) ([0-9]+)$")
+    // Device Name PortNum
 {
   if (! hasApisPopulated)
   {
@@ -52,6 +62,26 @@ GOMidiRtPortFactory::~GOMidiRtPortFactory()
     }
   }
   m_RtMidiIns.clear();
+}
+
+static GOMidiRtPortFactory* instance = NULL;
+
+GOMidiRtPortFactory* GOMidiRtPortFactory::getInstance()
+{
+  if (! instance)
+    instance = new GOMidiRtPortFactory();
+  return instance;
+}
+
+void GOMidiRtPortFactory::terminateInstance()
+{
+  GOMidiRtPortFactory* oldInstance = instance;
+
+  if (oldInstance)
+  {
+    instance = NULL;
+    delete oldInstance;
+  }
 }
 
 void GOMidiRtPortFactory::addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports)
@@ -177,4 +207,79 @@ const std::vector<wxString> & GOMidiRtPortFactory::getApis()
     hasApiNamesPopulated = true;
   }
   return apiNames;
+}
+
+wxString GOMidiRtPortFactory::GetDefaultLogicalName(
+  RtMidi::Api api, const wxString& deviceName, const wxString& fullName
+)
+{
+  wxString logicalName;
+
+  switch (api)
+  {
+  case RtMidi::Api::LINUX_ALSA:
+    if (m_AlsaDevnamePattern.Matches(deviceName))
+      logicalName = m_AlsaDevnamePattern.GetMatch(deviceName, 2);
+    break;
+  case RtMidi::Api::UNIX_JACK:
+    if (m_JackDevnamePattern.Matches(deviceName))
+      logicalName = m_JackDevnamePattern.GetMatch(deviceName, 4);
+    break;
+  case RtMidi::Api::WINDOWS_MM:
+    if (m_WinMmDevnamePattern.Matches(deviceName))
+      logicalName = m_WinMmDevnamePattern.GetMatch(deviceName, 1);
+    break;
+  default:
+    break;
+  }
+  if (logicalName.IsEmpty())
+    // by default logical name equals to the full physical name
+    logicalName = fullName;
+  else // add the api name to the logical name
+    logicalName = GOMidiPortFactory::getInstance()
+	.ComposeDeviceName(PORT_NAME, getApiName(api), logicalName);
+  return logicalName;
+}
+
+wxString GOMidiRtPortFactory::GetDefaultRegEx(
+  RtMidi::Api api, const wxString& deviceName, const wxString& fullName
+)
+{
+  wxString regEx;
+
+  switch (api)
+  {
+  case RtMidi::Api::LINUX_ALSA:
+    if (m_AlsaDevnamePattern.Matches(deviceName))
+      // Client Name:Port Name
+      regEx = wxString::Format(
+	wxT("%s:%s"),
+	m_AlsaDevnamePattern.GetMatch(deviceName, 1),
+	m_AlsaDevnamePattern.GetMatch(deviceName, 2)
+      );
+    break;
+  case RtMidi::Api::UNIX_JACK:
+    if (m_JackDevnamePattern.Matches(deviceName))
+      // Midi-Bridge:Client Name:(direction_num)) Port Name
+      regEx = wxString::Format(
+	wxT("Midi-Bridge:%s:(%s_%s) %s"),
+	m_JackDevnamePattern.GetMatch(deviceName, 1),
+	m_JackDevnamePattern.GetMatch(deviceName, 2),
+	m_JackDevnamePattern.GetMatch(deviceName, 3),
+	m_JackDevnamePattern.GetMatch(deviceName, 4)
+      );
+    break;
+  case RtMidi::Api::WINDOWS_MM:
+    if (m_WinMmDevnamePattern.Matches(deviceName))
+      // Device Name
+      regEx = m_WinMmDevnamePattern.GetMatch(deviceName, 1);
+    break;
+  default:
+    break;
+  }
+  if (! regEx.IsEmpty())
+    // add the api name to the regex
+    regEx = GOMidiPortFactory::getInstance()
+	.ComposeDeviceName(PORT_NAME, getApiName(api), regEx);
+  return regEx;
 }

--- a/src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp
+++ b/src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp
@@ -279,7 +279,8 @@ wxString GOMidiRtPortFactory::GetDefaultRegEx(
   }
   if (! regEx.IsEmpty())
     // add the api name to the regex
-    regEx = GOMidiPortFactory::getInstance()
-	.ComposeDeviceName(PORT_NAME, getApiName(api), regEx);
+    regEx = GOMidiPortFactory::getInstance().ComposeDeviceName(
+      PORT_NAME, getApiName(api), regEx
+    );
   return regEx;
 }

--- a/src/grandorgue/midi/ports/GOMidiRtPortFactory.h
+++ b/src/grandorgue/midi/ports/GOMidiRtPortFactory.h
@@ -2,6 +2,7 @@
 #define GOMIDIRTPORTFACTORY_H
 
 #include <map>
+#include <wx/regex.h>
 
 #include "ptrvector.h"
 #include "settings/GOPortsConfig.h"
@@ -14,17 +15,32 @@ private:
   std::map<RtMidi::Api, RtMidiIn*> m_RtMidiIns;
   std::map<RtMidi::Api, RtMidiOut*> m_RtMidiOuts;
   
+  // patterns for parsing device names of different apis,
+  wxRegEx m_AlsaDevnamePattern;
+  wxRegEx m_JackDevnamePattern;
+  wxRegEx m_WinMmDevnamePattern;
+  
 public:
   static const wxString PORT_NAME;
 
   GOMidiRtPortFactory();
   ~GOMidiRtPortFactory();
+
+  static GOMidiRtPortFactory* getInstance();
+  static void terminateInstance();
   
   void addMissingInDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports);
   void addMissingOutDevices(GOMidi* midi, const GOPortsConfig& portsConfig, ptr_vector<GOMidiPort>& ports);
 
   static wxString getApiName(RtMidi::Api api);
   static const std::vector<wxString> & getApis();
+
+  wxString GetDefaultLogicalName(
+    RtMidi::Api api, const wxString& deviceName, const wxString& fullName
+  );
+  wxString GetDefaultRegEx(
+    RtMidi::Api api, const wxString& deviceName, const wxString& fullName
+  );
 };
 
 #endif /* GOMIDIRTPORTFACTORY_H */

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
@@ -96,12 +96,38 @@ GOMidiDeviceConfig* GOMidiDeviceConfigList::Append(
   const GOMidiDeviceConfigList* outputList
 )
 {
-  GOMidiDeviceConfig* pDevConf = new GOMidiDeviceConfig(devConf);
+  // At first, find the device with the same logical name
+  GOMidiDeviceConfig* pDevConf = FindByLogicalName(devConf.m_LogicalName);
+  bool toAdd = true;
+
+  if (pDevConf && pDevConf->m_PhysicalName.IsEmpty())
+  {
+      // the device is not matched. Replase it instead of adding a new one
+    pDevConf->Assign(devConf);
+    toAdd = false;
+  }
+  else
+  {
+    bool isDuplicate = pDevConf;
+
+    pDevConf = new GOMidiDeviceConfig(devConf);
+    if (isDuplicate)
+    // construct an unique logical name
+    {
+      unsigned n = 0;
+
+      do {
+	pDevConf->m_LogicalName
+	  = wxString::Format(wxT("%s-%u"), devConf.m_LogicalName, ++n);
+      } while (FindByLogicalName(pDevConf->m_LogicalName));
+    }
+  }
 
   if (outputList)
     // Map the output device against outputList
     outputList->MapOutputDevice(devConf, *pDevConf);
-  m_list.push_back(pDevConf);
+  if (toAdd)
+    m_list.push_back(pDevConf);
   return pDevConf;
 }
 

--- a/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
+++ b/src/grandorgue/settings/GOMidiDeviceConfigList.cpp
@@ -102,7 +102,7 @@ GOMidiDeviceConfig* GOMidiDeviceConfigList::Append(
 
   if (pDevConf && pDevConf->m_PhysicalName.IsEmpty())
   {
-      // the device is not matched. Replase it instead of adding a new one
+    // the device is not matched. Replace it instead of adding a new one
     pDevConf->Assign(devConf);
     toAdd = false;
   }


### PR DESCRIPTION
Resolves: #885

This is the last PR on midi matching.

After this PR GrandOrgue tries to make a non-volatile logical name and a regex pattern for each midi device, so no user intervention is required.

The only thing rests to fix is the old devices that GrandOrgue remembered when it matched only with the physical name. Earlier I wanted to add a button and a special dialog box that would allow to see the absent devices and to remove them. But after creating GO config from scratch it is not more an issue, so now I'm not going to create such UI.