### PR TITLE
Fixed alignment of the Reason button in the Settings dialog

### DIFF
--- a/src/grandorgue/settings-gui/GOSettingsDialog.cpp
+++ b/src/grandorgue/settings-gui/GOSettingsDialog.cpp
@@ -84,7 +84,7 @@ GOSettingsDialog::GOSettingsDialog(
       pReasonBtn->Disable();
 
     pButtonSizer->Insert(
-      3, pReasonBtn, wxSizerFlags().Border(wxLEFT | wxRIGHT, 20));
+      3, pReasonBtn, 0, wxALIGN_CENTRE_VERTICAL | wxLEFT | wxRIGHT, 10);
     GetInnerSizer()->Add(
       pButtonSizer, wxSizerFlags().Expand().Border(wxALL, 2));
     GetInnerSizer()->AddSpacer(2);


### PR DESCRIPTION
As mentioned in https://github.com/GrandOrgue/grandorgue/discussions/924#discussion-3770475 , the `Reason` button looks odd.

