### PR TITLE
Fixed processing of debounce time for Bx Controller events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed processing of debounce time for Bx Controller events https://github.com/GrandOrgue/grandorgue/issues/967
 - Fixed size of the Load organ dialog https://github.com/GrandOrgue/grandorgue/issues/963
 # 3.6.0 (2022-01-19)
 - Fixed crash under OSx when closing a MIDI event dialog opened from a Settings window https://github.com/GrandOrgue/grandorgue/issues/966

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -690,14 +690,14 @@ MIDI_MATCH_TYPE GOMidiReceiverBase::Match(
       && m_events[i].key == e.GetKey()) {
       if (m_events[i].low_value <= m_events[i].high_value) {
         if (e.GetValue() <= m_events[i].low_value)
-          return MIDI_MATCH_OFF;
+          return debounce(e, MIDI_MATCH_OFF, i);
         if (e.GetValue() >= m_events[i].high_value)
-          return MIDI_MATCH_ON;
+          return debounce(e, MIDI_MATCH_ON, i);
       } else {
         if (e.GetValue() >= m_events[i].low_value)
-          return MIDI_MATCH_OFF;
+          return debounce(e, MIDI_MATCH_OFF, i);
         if (e.GetValue() <= m_events[i].high_value)
-          return MIDI_MATCH_ON;
+          return debounce(e, MIDI_MATCH_ON, i);
       }
       continue;
     }
@@ -728,9 +728,9 @@ MIDI_MATCH_TYPE GOMidiReceiverBase::Match(
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED
       && m_events[i].key == e.GetKey()) {
       if (e.GetValue() == m_events[i].low_value)
-        return MIDI_MATCH_OFF;
+        return debounce(e, MIDI_MATCH_OFF, i);
       if (e.GetValue() == m_events[i].high_value)
-        return MIDI_MATCH_ON;
+        return debounce(e, MIDI_MATCH_ON, i);
       continue;
     }
     if (
@@ -760,9 +760,9 @@ MIDI_MATCH_TYPE GOMidiReceiverBase::Match(
       && m_events[i].key == e.GetKey()) {
       unsigned mask = 1 << m_events[i].low_value;
       if (e.GetValue() & mask)
-        return MIDI_MATCH_ON;
+        return debounce(e, MIDI_MATCH_ON, i);
       else
-        return MIDI_MATCH_OFF;
+        return debounce(e, MIDI_MATCH_OFF, i);
     }
 
     if (


### PR DESCRIPTION
Resolves #967

Seems Mardin did not support debounce for ``Bx Controller`` when he made 7d4de54cc57a709b7cf7135ceb9e4c1710ac9665