### PR TITLE
Fixed matching midi events with midi devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed matching midi events with midi devices https://github.com/GrandOrgue/grandorgue/issues/1000
 # 3.6.1 (2022-01-29)
 - Updating French, German, Polish, Spanish and Swedish translations of the Settings Dialog https://github.com/GrandOrgue/grandorgue/discussions/934
 - Switched to RtMidi 5.0.0

--- a/src/grandorgue/midi/GOMidi.h
+++ b/src/grandorgue/midi/GOMidi.h
@@ -25,6 +25,7 @@ class wxMidiEvent;
 class GOMidi : public wxEvtHandler {
 private:
   GOConfig &m_config;
+  GOMidiMap &m_MidiMap;
 
   ptr_vector<GOMidiPort> m_midi_in_devices;
   ptr_vector<GOMidiPort> m_midi_out_devices;
@@ -56,7 +57,7 @@ public:
   void Register(GOMidiListener *listener);
   void Unregister(GOMidiListener *listener);
 
-  GOMidiMap &GetMidiMap();
+  GOMidiMap &GetMidiMap() { return m_MidiMap; }
 
   DECLARE_EVENT_TABLE()
 };

--- a/src/grandorgue/midi/MIDIEventRecvDialog.cpp
+++ b/src/grandorgue/midi/MIDIEventRecvDialog.cpp
@@ -448,11 +448,19 @@ void MIDIEventRecvDialog::LoadEvent() {
   wxCommandEvent event;
   OnTypeChange(event);
 
+  // Select current device
   m_device->SetSelection(0);
-  for (unsigned i = 1; i < m_device->GetCount(); i++)
-    if (
-      m_MidiMap.GetDeviceLogicalNameById(e.deviceId) == m_device->GetString(i))
-      m_device->SetSelection(i);
+  if (e.deviceId > 0) {
+    const wxString &eventDeviceLogicalName
+      = m_MidiMap.GetDeviceLogicalNameById(e.deviceId);
+
+    for (unsigned i = 1; i < m_device->GetCount(); i++) {
+      const wxString &deviceLogicalName = m_device->GetString(i);
+
+      if (deviceLogicalName == eventDeviceLogicalName)
+        m_device->SetSelection(i);
+    }
+  }
 
   m_channel->SetSelection(0);
   if (e.channel == -1)

--- a/src/grandorgue/midi/ports/GOMidiInPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiInPort.cpp
@@ -46,7 +46,8 @@ void GOMidiInPort::Receive(const std::vector<unsigned char> msg) {
   m_midi->Recv(e);
 }
 
-bool GOMidiInPort::Open(int channel_shift) {
+bool GOMidiInPort::Open(unsigned id, int channel_shift) {
+  GOMidiPort::Open(id);
   m_ChannelShift = channel_shift;
   m_merger.Clear();
 

--- a/src/grandorgue/midi/ports/GOMidiInPort.h
+++ b/src/grandorgue/midi/ports/GOMidiInPort.h
@@ -31,8 +31,8 @@ public:
 
   virtual ~GOMidiInPort();
 
-  virtual bool Open(int channel_shift);
-  bool Open() { return Open(0); }
+  virtual bool Open(unsigned id, int channel_shift);
+  bool Open(unsigned id) { return Open(id, 0); }
 };
 
 #endif

--- a/src/grandorgue/midi/ports/GOMidiOutPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiOutPort.cpp
@@ -21,7 +21,8 @@ GOMidiOutPort::GOMidiOutPort(
 
 GOMidiOutPort::~GOMidiOutPort() {}
 
-bool GOMidiOutPort::Open() {
+bool GOMidiOutPort::Open(unsigned id) {
+  GOMidiPort::Open(id);
   m_merger.Clear();
   return m_IsActive;
 }

--- a/src/grandorgue/midi/ports/GOMidiOutPort.h
+++ b/src/grandorgue/midi/ports/GOMidiOutPort.h
@@ -34,7 +34,7 @@ public:
 
   virtual const wxString GetMyNativePortName() const;
 
-  virtual bool Open();
+  virtual bool Open(unsigned id);
 
   void Send(const GOMidiEvent &e);
 };

--- a/src/grandorgue/midi/ports/GOMidiPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiPort.cpp
@@ -25,9 +25,7 @@ GOMidiPort::GOMidiPort(
     m_PortName(portName),
     m_ApiName(apiName),
     m_DeviceName(deviceName),
-    m_FullName(fullName) {
-  m_ID = m_midi->GetMidiMap().GetDeviceIdByLogicalName(GetName());
-}
+    m_FullName(fullName) {}
 
 bool GOMidiPort::IsToUse() const {
   return m_DeviceName.Find(GetClientName()) == wxNOT_FOUND;
@@ -39,4 +37,9 @@ bool GOMidiPort::IsEqualTo(
   const wxString &deviceName) const {
   return m_PortName == portName && m_ApiName == apiName
     && m_DeviceName == deviceName;
+}
+
+bool GOMidiPort::Open(unsigned id) {
+  m_ID = id;
+  return true;
 }

--- a/src/grandorgue/midi/ports/GOMidiPort.h
+++ b/src/grandorgue/midi/ports/GOMidiPort.h
@@ -22,7 +22,8 @@ protected:
   wxString m_DeviceName;
   wxString m_FullName;
 
-  unsigned m_ID;
+  // only open ports have m_ID > 0
+  unsigned m_ID = 0;
 
   static const wxString GetClientName();
   virtual const wxString GetMyNativePortName() const = 0;
@@ -50,8 +51,8 @@ public:
   unsigned GetID() const { return m_ID; }
   bool IsActive() const { return m_IsActive; }
 
-  virtual bool Open() = 0;
-  virtual void Close() = 0;
+  virtual bool Open(unsigned id);
+  virtual void Close() { m_ID = 0; }
 };
 
 #endif /* GOMIDIPORT_H */

--- a/src/grandorgue/midi/ports/GOMidiRtInPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiRtInPort.cpp
@@ -38,7 +38,7 @@ const wxString GOMidiRtInPort::GetDefaultRegEx() const {
     m_api, GetDeviceName(), GetName());
 }
 
-bool GOMidiRtInPort::Open(int channel_shift) {
+bool GOMidiRtInPort::Open(unsigned id, int channel_shift) {
   Close(false);
   if (!m_port)
     try {
@@ -63,7 +63,7 @@ bool GOMidiRtInPort::Open(int channel_shift) {
     wxString error = wxString::FromAscii(e.getMessage().c_str());
     wxLogError(_("RtMidi error: %s"), error.c_str());
   }
-  return GOMidiInPort::Open(channel_shift);
+  return GOMidiInPort::Open(id, channel_shift);
 }
 
 void GOMidiRtInPort::Close(bool isToFreePort) {

--- a/src/grandorgue/midi/ports/GOMidiRtInPort.h
+++ b/src/grandorgue/midi/ports/GOMidiRtInPort.h
@@ -32,7 +32,7 @@ public:
   virtual const wxString GetDefaultLogicalName() const;
   virtual const wxString GetDefaultRegEx() const;
 
-  bool Open(int channel_shift = 0);
+  bool Open(unsigned id, int channel_shift = 0);
   void Close() { Close(true); }
 };
 

--- a/src/grandorgue/midi/ports/GOMidiRtOutPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiRtOutPort.cpp
@@ -38,7 +38,7 @@ const wxString GOMidiRtOutPort::GetDefaultRegEx() const {
     m_api, GetDeviceName(), GetName());
 }
 
-bool GOMidiRtOutPort::Open() {
+bool GOMidiRtOutPort::Open(unsigned id) {
   Close(false);
   if (!m_port)
     try {
@@ -61,7 +61,7 @@ bool GOMidiRtOutPort::Open() {
     wxString error = wxString::FromAscii(e.getMessage().c_str());
     wxLogError(_("RtMidi error: %s"), error.c_str());
   }
-  return GOMidiOutPort::Open();
+  return GOMidiOutPort::Open(id);
 }
 
 void GOMidiRtOutPort::Close(bool isToFreePort) {

--- a/src/grandorgue/midi/ports/GOMidiRtOutPort.h
+++ b/src/grandorgue/midi/ports/GOMidiRtOutPort.h
@@ -31,7 +31,7 @@ public:
   virtual const wxString GetDefaultLogicalName() const;
   virtual const wxString GetDefaultRegEx() const;
 
-  bool Open();
+  bool Open(unsigned id);
   void Close() { Close(true); }
 };
 


### PR DESCRIPTION
This PR is based on #997

Resolves: #1000 

This PR fixes the bug was introuced with midi logical names.

There is a midi map (GOConfig::m_MidiMap)  that links device ids with theirs logical names

Earlier the physical name was the only name, so GOMidiPort::GOMidiPort took the device id from it.

But now the logical name is not known at this time; it only becomes known after matching. So now the devic id is filled at the device open time.