### PR TITLE
Fixed automatic opening the Reverb settings page when there were no active midi devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
+- Fixed automatic opening the Reverb settings page when there were no active midi devices https://github.com/GrandOrgue/grandorgue/issues/1002
 - Fixed matching midi events with midi devices https://github.com/GrandOrgue/grandorgue/issues/1000
 # 3.6.1 (2022-01-29)
-- Updating French, German, Polish, Spanish and Swedish translations of the Settings Dialog https://github.com/GrandOrgue/grandorgue/discussions/934
+- Updated French, German, Polish, Spanish and Swedish translations of the Settings Dialog https://github.com/GrandOrgue/grandorgue/discussions/934
 - Switched to RtMidi 5.0.0
 - Switched to RtAudio 5.2.0
 - Fixed processing of debounce time for Bx Controller events https://github.com/GrandOrgue/grandorgue/issues/967

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -466,7 +466,7 @@ void GOFrame::Init(wxString filename) {
 
   if (soundProblems)
     settingsReasons.push_back(GOSettingsReason(
-      m_Sound.getLastErrorMessage(), GOSettingsDialog::PAGE_AUDIO_OUTPUT));
+      m_Sound.getLastErrorMessage(), GOSettingsDialog::PAGE_AUDIO));
   m_Sound.SetLogSoundErrorMessages(true);
 
   bool midiProblems

--- a/src/grandorgue/settings-gui/GOSettingsDialog.h
+++ b/src/grandorgue/settings-gui/GOSettingsDialog.h
@@ -54,15 +54,13 @@ public:
   // the order must be the same as the order of pages
   typedef enum {
     PAGE_OPTIONS = 0,
-    PAGE_DEFAULTS,
-    PAGE_AUDIO_OUTPUT,
-    PAGE_REVERB,
-    PAGE_AUDIO_GROUPS,
-    PAGE_ORGANS,
+    PAGE_PATHS,
+    PAGE_AUDIO,
     PAGE_MIDI_DEVICES,
-    PAGE_TEMPERAMENTS,
-    PAGE_INIT_MIDI_CONFIG,
-    PAGE_ORGAN_PACKAGES
+    PAGE_INITIAL_MIDI,
+    PAGE_ORGANS,
+    PAGE_REVERB,
+    PAGE_TEMPERAMENTS
   } PageSelector;
 
   GOSettingsDialog(wxWindow *parent, GOSound &sound, SettingsReasons *reasons);


### PR DESCRIPTION
Resolves: #1002

This is a temporary bugfix.

Now the tab order of the settings dialog must be in two places: in the GOSettingsDialog::PageSelector and in GOSettingsDialog::GOSettingsDialog. Making a change in one of this place without a related change in another place introduces a bug like this.

I'm going to rewrite the dialog code for #1003 that there would be only one place with the tab order.