### PR TITLE
Fixed segfault on exit GrandOrgue

### DIFF
--- a/src/grandorgue/GOApp.cpp
+++ b/src/grandorgue/GOApp.cpp
@@ -153,9 +153,9 @@ void GOApp::MacOpenFile(const wxString &filename) {
 int GOApp::OnRun() { return wxApp::OnRun(); }
 
 int GOApp::OnExit() {
+  wxLog::SetActiveTarget(NULL);
   delete m_soundSystem;
   delete m_config;
-  wxLog::SetActiveTarget(NULL);
   delete m_Log;
 
   int rc = wxApp::OnExit();


### PR DESCRIPTION
Sometimes GrandOrgue crashes on exit. The reason is The log window invalidation.

This change disables using the log window on destroying GO objects