### PR TITLE
Bugfix/help overlapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed covering the help window opened from a modal dialog under linux https://github.com/GrandOrgue/grandorgue/issues/1004
 - Fixed size of the Setting dialog if a lot of audio channels exist https://github.com/GrandOrgue/grandorgue/issues/1034
 - Fixed navigation from the Setting dialog pages to help with non-english language https://github.com/GrandOrgue/grandorgue/issues/1003
 # 3.6.2 (2022-02-09)

--- a/src/grandorgue/GOApp.cpp
+++ b/src/grandorgue/GOApp.cpp
@@ -153,9 +153,9 @@ void GOApp::MacOpenFile(const wxString &filename) {
 int GOApp::OnRun() { return wxApp::OnRun(); }
 
 int GOApp::OnExit() {
+  wxLog::SetActiveTarget(NULL);
   delete m_soundSystem;
   delete m_config;
-  wxLog::SetActiveTarget(NULL);
   delete m_Log;
 
   int rc = wxApp::OnExit();


### PR DESCRIPTION
Resolves: #1004

The root cause of the bug: dialogs are always above other kind of windows under linux: https://stackoverflow.com/questions/7545804/modeless-parentless-wxdialog-still-always-above-wxframe-window-in-z-order

For fixing it the help frame has to have the extra style wxTOPLEVEL_EX_DIALOG. The new derived class GOHelpController creates the help frame with the extra style required.

