### PR TITLE
Fixed allowing to select disabled devices in the Midi Event Dialog

### DIFF
--- a/src/grandorgue/config/GOMidiDeviceConfig.cpp
+++ b/src/grandorgue/config/GOMidiDeviceConfig.cpp
@@ -10,9 +10,13 @@
 GOMidiDeviceConfig::GOMidiDeviceConfig(
   const wxString &logicalName,
   const wxString &regEx,
+  const wxString portName,
+  const wxString apiName,
   bool isEnabled,
   const wxString &physicalName)
   : m_LogicalName(logicalName),
+    m_PortName(portName),
+    m_ApiName(apiName),
     m_IsEnabled(isEnabled),
     m_PhysicalName(physicalName) {
   SetRegEx(regEx);
@@ -29,6 +33,8 @@ void GOMidiDeviceConfig::SetRegEx(const wxString &regEx) {
 
 void GOMidiDeviceConfig::Assign(const GOMidiDeviceConfig &src) {
   m_LogicalName = src.m_LogicalName;
+  m_PortName = src.m_PortName;
+  m_ApiName = src.m_ApiName;
   SetRegEx(src.m_RegEx);
   m_IsEnabled = src.m_IsEnabled;
   m_ChannelShift = src.m_ChannelShift;

--- a/src/grandorgue/config/GOMidiDeviceConfig.h
+++ b/src/grandorgue/config/GOMidiDeviceConfig.h
@@ -22,6 +22,8 @@ public:
 
   wxString m_LogicalName;
   wxString m_RegEx;
+  wxString m_PortName;
+  wxString m_ApiName;
   bool m_IsEnabled;
 
   // Midi-in only
@@ -34,6 +36,8 @@ public:
   GOMidiDeviceConfig(
     const wxString &logicalName,
     const wxString &regEx = wxEmptyString,
+    const wxString portName = wxEmptyString,
+    const wxString apiName = wxEmptyString,
     bool isEnabled = true,
     const wxString &physicalName = wxEmptyString);
 

--- a/src/grandorgue/config/GOMidiDeviceConfigList.cpp
+++ b/src/grandorgue/config/GOMidiDeviceConfigList.cpp
@@ -24,7 +24,9 @@ GOMidiDeviceConfig *GOMidiDeviceConfigList::FindByLogicalName(
 }
 
 GOMidiDeviceConfig *GOMidiDeviceConfigList::FindByPhysicalName(
-  const wxString &physicalName) const {
+  const wxString &physicalName,
+  const wxString &portName,
+  const wxString &apiName) const {
   GOMidiDeviceConfig *res = NULL;
   GOMidiDeviceConfig *candidate = NULL;
 
@@ -44,6 +46,10 @@ GOMidiDeviceConfig *GOMidiDeviceConfigList::FindByPhysicalName(
   if (!res && candidate) {
     candidate->m_PhysicalName = physicalName;
     res = candidate;
+  }
+  if (res) {
+    res->m_PortName = portName;
+    res->m_ApiName = apiName;
   }
   return res;
 }
@@ -114,6 +120,8 @@ static const wxString COUNT = wxT("Count");
 static const wxString DEVICE03D = wxT("Device%03d");
 static const wxString DEVICE03D_ENABLED = wxT("Device%03dEnabled");
 static const wxString DEVICE03D_REGEX = wxT("Device%03dRegEx");
+static const wxString DEVICE03D_PORT_NAME = wxT("Device%03dPortName");
+static const wxString DEVICE03D_API_NAME = wxT("Device%03dApiName");
 static const wxString DEVICE03D_SHIFT = wxT("Device%03dShift");
 static const wxString DEVICE03D_OUTPUT_DEVICE = wxT("Device%03dOutputDevice");
 
@@ -131,6 +139,16 @@ void GOMidiDeviceConfigList::Load(
         m_GroupName,
         wxString::Format(DEVICE03D_REGEX, i),
         false), // regEx
+      cfg.ReadString(
+        CMBSetting,
+        m_GroupName,
+        wxString::Format(DEVICE03D_PORT_NAME, i),
+        false), // portName
+      cfg.ReadString(
+        CMBSetting,
+        m_GroupName,
+        wxString::Format(DEVICE03D_API_NAME, i),
+        false), // apiName
       cfg.ReadBoolean(
         CMBSetting,
         m_GroupName,
@@ -164,6 +182,12 @@ void GOMidiDeviceConfigList::Save(GOConfigWriter &cfg, const bool isInput) {
       m_GroupName, wxString::Format(DEVICE03D, i), devConf->m_LogicalName);
     cfg.WriteString(
       m_GroupName, wxString::Format(DEVICE03D_REGEX, i), devConf->m_RegEx);
+    cfg.WriteString(
+      m_GroupName,
+      wxString::Format(DEVICE03D_PORT_NAME, i),
+      devConf->m_PortName);
+    cfg.WriteString(
+      m_GroupName, wxString::Format(DEVICE03D_API_NAME, i), devConf->m_ApiName);
     cfg.WriteBoolean(
       m_GroupName,
       wxString::Format(DEVICE03D_ENABLED, i),

--- a/src/grandorgue/config/GOMidiDeviceConfigList.h
+++ b/src/grandorgue/config/GOMidiDeviceConfigList.h
@@ -43,9 +43,13 @@ public:
   /**
    * find device config by it's physical name.
    * If found, returns the reference to it in and sets m_PhysicalNameMatchedWith
+   * and updates m_PortName and m_ApiName,
    * If not found, returns NULL
    **/
-  GOMidiDeviceConfig *FindByPhysicalName(const wxString &physicalName) const;
+  GOMidiDeviceConfig *FindByPhysicalName(
+    const wxString &physicalName,
+    const wxString &portName,
+    const wxString &apiName) const;
 
   /**
    * Remove the device from the list that has the logical name specified
@@ -85,10 +89,12 @@ public:
   GOMidiDeviceConfig *Append(
     const wxString &logicalName,
     const wxString &regEx,
+    const wxString &portName,
+    const wxString &apiName,
     bool isEnabled,
     const wxString &physicalName = wxEmptyString) {
-    return Append(
-      GOMidiDeviceConfig(logicalName, regEx, isEnabled, physicalName));
+    return Append(GOMidiDeviceConfig(
+      logicalName, regEx, portName, apiName, isEnabled, physicalName));
   }
 
   /**

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp
@@ -201,10 +201,14 @@ GOMidiEventRecvTab::GOMidiEventRecvTab(
 
   SetSizer(topSizer);
 
-  m_device->Append(_("Any device"));
+  const GOPortsConfig &portsConfig = config.GetMidiPortsConfig();
 
+  m_device->Append(_("Any device"));
   for (GOMidiDeviceConfig *pDevConf : m_MidiIn)
-    m_device->Append(pDevConf->m_LogicalName);
+    if (
+      portsConfig.IsEnabled(pDevConf->m_PortName, pDevConf->m_ApiName)
+      && pDevConf->m_IsEnabled)
+      m_device->Append(pDevConf->m_LogicalName);
 
   m_channel->Append(_("Any channel"));
   for (unsigned int i = 1; i <= 16; i++)

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
@@ -180,10 +180,14 @@ GOMidiEventSendTab::GOMidiEventSendTab(
 
   SetSizer(topSizer);
 
-  m_device->Append(_("Any device"));
+  const GOPortsConfig &portsConfig = config.GetMidiPortsConfig();
 
+  m_device->Append(_("Any device"));
   for (const GOMidiDeviceConfig *pDevConf : m_MidiOut)
-    m_device->Append(pDevConf->m_LogicalName);
+    if (
+      portsConfig.IsEnabled(pDevConf->m_PortName, pDevConf->m_ApiName)
+      && pDevConf->m_IsEnabled)
+      m_device->Append(pDevConf->m_LogicalName);
 
   for (unsigned int i = 1; i <= 16; i++)
     m_channel->Append(wxString::Format(wxT("%d"), i));

--- a/src/grandorgue/dialogs/settings/GOSettingsMidiDeviceList.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsMidiDeviceList.cpp
@@ -43,15 +43,16 @@ void GOSettingsMidiDeviceList::RefreshDevices(
   const bool isToAutoEnable,
   const GOSettingsMidiDeviceList *pOutDevList) {
   ClearDevices();
-  for (GOMidiPort *port : m_Ports)
-    if (
-      port->IsToUse()
-      && portsConfig.IsEnabled(port->GetPortName(), port->GetApiName())) {
+  for (GOMidiPort *port : m_Ports) {
+    const wxString &portName = port->GetPortName();
+    const wxString &apiName = port->GetApiName();
+
+    if (port->IsToUse() && portsConfig.IsEnabled(portName, apiName)) {
       const wxString physicalName = port->GetName();
       GOMidiDeviceConfig *const pConf
-        = m_ConfList.FindByPhysicalName(physicalName);
+        = m_ConfList.FindByPhysicalName(physicalName, portName, apiName);
       GOMidiDeviceConfig *pConfTmp
-        = m_ConfListTmp.FindByPhysicalName(physicalName);
+        = m_ConfListTmp.FindByPhysicalName(physicalName, portName, apiName);
 
       if (!pConfTmp)
         pConfTmp = pConf ? m_ConfListTmp.Append(
@@ -59,6 +60,8 @@ void GOSettingsMidiDeviceList::RefreshDevices(
                          : m_ConfListTmp.Append(
                            port->GetDefaultLogicalName(),
                            port->GetDefaultRegEx(),
+                           portName,
+                           apiName,
                            isToAutoEnable,
                            physicalName);
 
@@ -69,6 +72,7 @@ void GOSettingsMidiDeviceList::RefreshDevices(
       if (pConfTmp->m_IsEnabled)
         m_LbDevices->Check(i);
     }
+  }
 }
 
 unsigned GOSettingsMidiDeviceList::GetDeviceCount() const {
@@ -104,8 +108,10 @@ void GOSettingsMidiDeviceList::OnMatchingClick(wxCommandEvent &event) {
 void GOSettingsMidiDeviceList::Save(
   const GOSettingsMidiDeviceList *pOutDevList) {
   for (GOMidiDeviceConfig *pDevConfTmp : m_ListedConfs) {
-    GOMidiDeviceConfig *pDevConf
-      = m_ConfList.FindByPhysicalName(pDevConfTmp->m_PhysicalName);
+    GOMidiDeviceConfig *pDevConf = m_ConfList.FindByPhysicalName(
+      pDevConfTmp->m_PhysicalName,
+      pDevConfTmp->m_PortName,
+      pDevConfTmp->m_ApiName);
     const GOMidiDeviceConfigList *pOutConfList
       = pOutDevList ? &pOutDevList->m_ConfList : NULL;
 

--- a/src/grandorgue/midi/GOMidi.cpp
+++ b/src/grandorgue/midi/GOMidi.cpp
@@ -40,18 +40,20 @@ void GOMidi::Open() {
   UpdateDevices(portsConfig);
 
   for (GOMidiPort *pPort : m_midi_in_devices) {
+    const wxString &portName = pPort->GetPortName();
+    const wxString &apiName = pPort->GetApiName();
     GOMidiDeviceConfig *pDevConf = NULL;
 
-    if (
-      pPort->IsToUse()
-      && portsConfig.IsEnabled(pPort->GetPortName(), pPort->GetApiName())) {
+    if (pPort->IsToUse() && portsConfig.IsEnabled(portName, apiName)) {
       const wxString &physicalName = pPort->GetName();
 
-      pDevConf = midiIn.FindByPhysicalName(physicalName);
+      pDevConf = midiIn.FindByPhysicalName(physicalName, portName, apiName);
       if (!pDevConf && isToAutoAdd)
         pDevConf = midiIn.Append(
           pPort->GetDefaultLogicalName(),
           pPort->GetDefaultRegEx(),
+          portName,
+          apiName,
           true,
           physicalName);
     }
@@ -65,12 +67,13 @@ void GOMidi::Open() {
   }
 
   for (GOMidiPort *pPort : m_midi_out_devices) {
+    const wxString &portName = pPort->GetPortName();
+    const wxString &apiName = pPort->GetApiName();
     GOMidiDeviceConfig *devConf;
 
     if (
-      pPort->IsToUse()
-      && portsConfig.IsEnabled(pPort->GetPortName(), pPort->GetApiName())
-      && (devConf = m_config.m_MidiOut.FindByPhysicalName(pPort->GetName()))
+      pPort->IsToUse() && portsConfig.IsEnabled(portName, apiName)
+      && (devConf = m_config.m_MidiOut.FindByPhysicalName(pPort->GetName(), portName, apiName))
       && devConf->m_IsEnabled)
       pPort->Open(m_MidiMap.GetDeviceIdByLogicalName(devConf->m_LogicalName));
     else


### PR DESCRIPTION
Resolves: #1044

Now GrandOrgue includes only enabled devices into the list of available devices in the Midi Event Editor.

It required to store `PortName` and `ApiName` together with `LogicalName` in the midi device config.