### PR TITLE
Allow to use system zita convolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for building against system-wide ZitaConvolver library
 # 3.6.4 (2022-03-18)
 - Updated the copyright headers in the source code
 - Switched ZitaConvolver to an external source https://github.com/GrandOrgue/grandorgue/issues/983

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ option(RTMIDI_USE_MM          "Enable RtMidi support for MM (Windows only)" ON)
 option(USE_INTERNAL_RTAUDIO   "Use builtin RtAudio/RtMidi sources" ON)
 option(INSTALL_DEMO           "Install demo sampleset" ON)
 option(USE_INTERNAL_PORTAUDIO "Use builtin PortAudio sources" ON)
+option(USE_INTERNAL_ZITACONVOLVER "Use builtin Zita Convolver sources" ON)
 option(GO_USE_JACK	      "Use native Jack output" ON)
 if (WIN32 OR APPLE)
    option(INSTALL_DEPEND      "Copy dependencies (wxWidgets libraries and Translations) on installation" ON)
@@ -182,6 +183,15 @@ if (USE_INTERNAL_PORTAUDIO)
   set(PORTAUDIO_LIBRARIES PortAudio)
 else()
   pkg_check_modules(PORTAUDIO REQUIRED portaudio-2.0)
+endif()
+
+# include zitaconvolver
+if (USE_INTERNAL_ZITACONVOLVER)
+  set(ZITACONVOLVER_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/submodules/ZitaConvolver/source)
+  set(ZITACONVOLVER_LIBRARIES "")
+else()
+  set(ZITACONVOLVER_INCLUDE_DIRS "")
+  set(ZITACONVOLVER_LIBRARIES zita-convolver)
 endif()
 
 # include FFTW

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -16,9 +16,10 @@ add_option(-mstackrealign)
 find_package(wxWidgets REQUIRED html net adv core base)
 include(${wxWidgets_USE_FILE})
 
-include_directories(${CMAKE_BINARY_DIR}/src/core/go_defs.h ${CMAKE_SOURCE_DIR}/submodules/ZitaConvolver/source ${CMAKE_CURRENT_SOURCE_DIR}/resource ${CMAKE_SOURCE_DIR}/src/core)
+include_directories(${CMAKE_BINARY_DIR}/src/core/go_defs.h ${CMAKE_CURRENT_SOURCE_DIR}/resource ${CMAKE_SOURCE_DIR}/src/core)
 include_directories(${RT_INCLUDE_DIRS})
 include_directories(${PORTAUDIO_INCLUDE_DIRS})
+include_directories(${ZITACONVOLVER_INCLUDE_DIRS})
 include_directories(${FFTW_INCLUDE_DIRS})
 include_directories(${wxWidgets_INCLUDE_DIRS})
 include_directories(${JACK_INCLUDE_DIRS})
@@ -30,7 +31,6 @@ config/GOMidiDeviceConfig.cpp
 config/GOMidiDeviceConfigList.cpp
 config/GOPortsConfig.cpp
 config/GOPortFactory.cpp
-${CMAKE_SOURCE_DIR}/submodules/ZitaConvolver/source/zita-convolver.cc
 dialogs/common/GODialogCloser.cpp
 dialogs/common/GODialogTab.cpp
 dialogs/common/GOTabbedDialog.cpp
@@ -175,8 +175,12 @@ GODocument.cpp
 GOPanelView.cpp
 )
 
+if (USE_INTERNAL_ZITACONVOLVER)
+  list(APPEND grandorgue_src ${CMAKE_SOURCE_DIR}/submodules/ZitaConvolver/source/zita-convolver.cc)
+endif()
+
 add_library(golib STATIC ${grandorgue_src})
-set(go_libs ${wxWidgets_LIBRARIES} ${RT_LIBRARIES} ${PORTAUDIO_LIBRARIES} ${FFTW_LIBRARIES})
+set(go_libs ${wxWidgets_LIBRARIES} ${RT_LIBRARIES} ${PORTAUDIO_LIBRARIES} ${FFTW_LIBRARIES} ${ZITACONVOLVER_LIBRARIES})
 set(go_libdir ${wxWidgets_LIBRARY_DIRS} ${RT_LIBDIR} ${PORTAUDIO_LIBDIR} ${FFTW_LIBDIR})
 target_link_libraries(golib GrandOrgueImages GrandOrgueCore ${go_libs})
 link_directories(${go_libdir})


### PR DESCRIPTION
Resolves: #1095

I am right now creating an [Arch Linux package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=grandorgue-git&id=48868a5b5853c79b9729be64fa2ebaa2c91a349e#n30) for grandorgue, but it is frowned upon compiling and bundling libraries with applications instead of dynamically linking to system shared libraries.
All other submodules already do have an `USE_INTERNAL` switch to disable the bundled library and use a system library instead, except for the zita convolver.

This patch adds a switch for zitaconvolver, so that all libraries can be linked dynamically.