### PR TITLE
Bugfix/reverb hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-- Added support for building against system-wide ZitaConvolver library
+- Fixed hang on reopening sound device (exit from settings, Panic) while a reveberation is active https://github.com/GrandOrgue/grandorgue/issues/983
+- Added support for building against system-wide ZitaConvolver library https://github.com/GrandOrgue/grandorgue/issues/1095
 # 3.6.4 (2022-03-18)
 - Updated the copyright headers in the source code
 - Switched ZitaConvolver to an external source https://github.com/GrandOrgue/grandorgue/issues/983

--- a/build-scripts/for-win64/build-on-linux.sh
+++ b/build-scripts/for-win64/build-on-linux.sh
@@ -40,19 +40,23 @@ fi
 PKG_CONFIG_PATH=$MINGW_DIR/lib/pkgconfig; export PKG_CONFIG_PATH;
 WX_CONFIG=$MINGW_DIR/bin/wx-config; export WX_CONFIG
 
+CC_EXE=/usr/bin/x86_64-w64-mingw32-gcc-posix
+[ -f $CC_EXE ] || CC_EXE=/usr/bin/x86_64-w64-mingw32-gcc
+
 CPP_EXE=/usr/bin/x86_64-w64-mingw32-g++-posix
 [ -f $CPP_EXE ] || CPP_EXE=/usr/bin/x86_64-w64-mingw32-g++
 
-LIBRARY_PATH=$MINGW_DIR/lib
-MINGW_PRMS="-DCMAKE_C_COMPILER=/usr/bin/x86_64-w64-mingw32-gcc \
-  -DCMAKE_LIBRARY_PATH=$LIBRARY_PATH \
+LIBRARY_PATH="$MINGW_DIR/lib"
+MINGW_PRMS="-DCMAKE_C_COMPILER=$CC_EXE \
   -DCMAKE_CXX_COMPILER=$CPP_EXE \
   -DCMAKE_RC_COMPILER=/usr/bin/x86_64-w64-mingw32-windres"
 
 # additional dir for finding dlls. Only for debian-based
 CPP_DLL_DIR=$(dirname $($CPP_EXE -v 2>&1 | grep COLLECT_LTO_WRAPPER= | sed 's/COLLECT_LTO_WRAPPER=//; s:-win32/:-posix/:'))
 [[ ! -f $MINGW_DIR/bin/libstdc++-6.dll ]] && [[ -d "$CPP_DLL_DIR" ]] && MINGW_PRMS="$MINGW_PRMS -DDEPEND_ADD_DIRS=$CPP_DLL_DIR"
-  
+
+MINGW_PRMS="$MINGW_PRMS -DCMAKE_LIBRARY_PATH=$CPP_DLL_DIR;$LIBRARY_PATH"
+
 GO_WIN_PRMS="-DCMAKE_SYSTEM_NAME=Windows \
   -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
   -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \

--- a/src/grandorgue/sound/GOSoundReverb.cpp
+++ b/src/grandorgue/sound/GOSoundReverb.cpp
@@ -81,6 +81,7 @@ void GOSoundReverb::Setup(GOConfig &settings) {
       data[i] *= gain;
     if (len >= offset + settings.ReverbLen() && settings.ReverbLen())
       len = offset + settings.ReverbLen();
+    /*
     wxLogMessage(
       "GOSoundReverb::Setup before resample: offset=%u, len=%u, "
       "wav.GetSampleRate()=%u, settings.SampleRate()=%u",
@@ -88,6 +89,7 @@ void GOSoundReverb::Setup(GOConfig &settings) {
       len,
       wav.GetSampleRate(),
       settings.SampleRate());
+     */
     if (wav.GetSampleRate() != settings.SampleRate()) {
       float *new_data
         = resample_block(data, len, wav.GetSampleRate(), settings.SampleRate());
@@ -97,6 +99,7 @@ void GOSoundReverb::Setup(GOConfig &settings) {
       data = new_data;
       offset = (offset * settings.SampleRate()) / (float)wav.GetSampleRate();
     }
+    /*
     wxLogMessage(
       "GOSoundReverb::Setup after resample: offset=%u, len=%u, "
       "wav.GetSampleRate()=%u, settings.SampleRate()=%u",
@@ -104,6 +107,7 @@ void GOSoundReverb::Setup(GOConfig &settings) {
       len,
       wav.GetSampleRate(),
       settings.SampleRate());
+     */
     unsigned delay = (settings.SampleRate() * settings.ReverbDelay()) / 1000;
     for (unsigned i = 0; i < m_channels; i++) {
       float *d = data + offset;


### PR DESCRIPTION
This PR resolves one of two problems mentioned in https://github.com/GrandOrgue/grandorgue/issues/983 - the hang when `Panic` or exiting from Settings.

The reason of the hang was the same as in #702 and was fixed in #837: the standard ZitaConvolver code used posix-semaphores for synchronising threads.

These semaphores worked unstable: sometimes a thread calling `sem_wait` did not return when another thread called `sem_post`.

I changed the implementation with std::mutex and std::condition_variable and now it works stable.