### PR TITLE
Fixed sound distortion while a reveberation is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed sound distortion while a reveberation is active https://github.com/GrandOrgue/grandorgue/issues/983
 - Fixed hang on reopening sound device (exit from settings, Panic) while a reveberation is active https://github.com/GrandOrgue/grandorgue/issues/983
 - Added support for building against system-wide ZitaConvolver library https://github.com/GrandOrgue/grandorgue/issues/1095
 # 3.6.4 (2022-03-18)

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -146,14 +146,16 @@ float *resample_block(
     unsigned max_i = len - position_index;
 
     for (unsigned j = 0; j < SUBFILTER_TAPS; j += 4) {
-      if (j < max_i)
-        out1 += in_set[j] * coef_set[j];
-      if (j + 1 < max_i)
-        out2 += in_set[j + 1] * coef_set[j + 1];
-      if (j + 2 < max_i)
-        out3 += in_set[j + 2] * coef_set[j + 2];
-      if (j + 3 < max_i)
-        out4 += in_set[j + 3] * coef_set[j + 3];
+      unsigned k = j;
+
+      if (k < max_i)
+        out1 += in_set[k] * coef_set[k];
+      if (++k < max_i)
+        out2 += in_set[k] * coef_set[k];
+      if (++k < max_i)
+        out3 += in_set[k] * coef_set[k];
+      if (++k < max_i)
+        out4 += in_set[k] * coef_set[k];
     }
     out[i] = out1 + out2 + out3 + out4;
   }

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -143,11 +143,17 @@ float *resample_block(
     float out4 = 0.0f;
     const float *coef_set = &coef[position_fraction << SUBFILTER_BITS];
     float *in_set = &data[position_index];
+    unsigned max_i = len - position_index;
+
     for (unsigned j = 0; j < SUBFILTER_TAPS; j += 4) {
-      out1 += in_set[j] * coef_set[j];
-      out2 += in_set[j + 1] * coef_set[j + 1];
-      out3 += in_set[j + 2] * coef_set[j + 2];
-      out4 += in_set[j + 3] * coef_set[j + 3];
+      if (j < max_i)
+        out1 += in_set[j] * coef_set[j];
+      if (j + 1 < max_i)
+        out2 += in_set[j + 1] * coef_set[j + 1];
+      if (j + 2 < max_i)
+        out3 += in_set[j + 2] * coef_set[j + 2];
+      if (j + 3 < max_i)
+        out4 += in_set[j + 3] * coef_set[j + 3];
     }
     out[i] = out1 + out2 + out3 + out4;
   }


### PR DESCRIPTION
Resolves: #983

The reason of the sound boost described in #983 is reading an uninitialised buffer when preparing data for reveberation (resample_block called from GOSoundReverb::Setup).

