### PR TITLE
Fixed setting up output midi events for all devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed setting up output midi events for all devices https://github.com/GrandOrgue/grandorgue/issues/1097
 # 3.6.5 (2022-04-13)
 - Fixed not saving the main window position and size in organ settings https://github.com/GrandOrgue/grandorgue/issues/1093
 - Fixed sound distortion while a reveberation is active https://github.com/GrandOrgue/grandorgue/issues/983

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
@@ -263,6 +263,7 @@ bool GOMidiEventSendTab::Validate() {
 
   StoreEvent();
 
+  /*
   for (unsigned i = 0; i < m_midi.GetEventCount(); i++) {
     const GOMidiSendEvent &e = m_midi.GetEvent(i);
 
@@ -277,6 +278,7 @@ bool GOMidiEventSendTab::Validate() {
       break;
     }
   }
+  */
   return isValid;
 }
 

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
@@ -258,32 +258,9 @@ GOMidiEventSendTab::GOMidiEventSendTab(
 
 GOMidiEventSendTab::~GOMidiEventSendTab() {}
 
-bool GOMidiEventSendTab::Validate() {
-  bool isValid = true;
-
-  StoreEvent();
-
-  /*
-  for (unsigned i = 0; i < m_midi.GetEventCount(); i++) {
-    const GOMidiSendEvent &e = m_midi.GetEvent(i);
-
-    if (e.type != MIDI_S_NONE && !e.deviceId) {
-      m_current = i;
-      LoadEvent();
-      ShowErrorMessage(
-        _("Invalid MIDI event"),
-        _("Output device is not selected.\n"
-          "Select one, set the type to None or delete this event."));
-      isValid = false;
-      break;
-    }
-  }
-  */
-  return isValid;
-}
-
 bool GOMidiEventSendTab::TransferDataFromWindow() {
-  // Assume that Validate() has been called and it returned true
+  // save the current event being edited
+  StoreEvent();
 
   // Delete empty events.
   bool empty_event;

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.h
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.h
@@ -83,7 +83,6 @@ public:
     GOConfig &config);
   ~GOMidiEventSendTab();
 
-  bool Validate() override;
   virtual bool TransferDataFromWindow() override;
 
   DECLARE_EVENT_TABLE()


### PR DESCRIPTION
Resolves: #1097

This PR partially reverts the changes of #1008 that prohibited a capability of setting midi events to `Any device` up.