### PR TITLE
Publishing windows debug information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added publishing debug symbols on windows builds https://github.com/GrandOrgue/grandorgue/issues/853
 # 3.6.6 (2022-04-29)
 - Fixed help issues https://github.com/GrandOrgue/grandorgue/issues/1066
 - Fixed saving organ settings on closing an organ or on finishing GrandOrgue https://github.com/GrandOrgue/grandorgue/issues/1069

--- a/build-scripts/for-win64/build-on-linux.sh
+++ b/build-scripts/for-win64/build-on-linux.sh
@@ -71,5 +71,17 @@ GO_PRMS="-DGO_USE_JACK=ON $CMAKE_VERSION_PRMS"
 cmake -DINSTALL_DEPEND=ON $MINGW_PRMS $GO_WIN_PRMS $GO_PRMS . $SRC_DIR
 make $PARALLEL_PRMS VERBOSE=1 package
 
+#build debug symbols
+mkdir -p pdb
+export WINEPATH=Z:/usr/local/share/wine/msvc/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x86
+wine /usr/local/share/wine/cv2pdb/cv2pdb.exe bin/GrandOrgue.exe /tmp/GrandOrgue.exe pdb/GrandOrgue.pdb
+wine /usr/local/share/wine/cv2pdb/cv2pdb.exe bin/GrandOrguePerfTest.exe /tmp/GrandOrguePerfTest.exe pdb/GrandOrguePerfTest.pdb
+wine /usr/local/share/wine/cv2pdb/cv2pdb.exe bin/GrandOrgueTool.exe /tmp/GrandOrgueTool.exe pdb/GrandOrgueTool.pdb
+wine /usr/local/share/wine/cv2pdb/cv2pdb.exe bin/libGrandOrgueCore.dll /tmp/libGrandOrgueCore.dll pdb/libGrandOrgueCore.pdb
+
+pushd pdb
+zip ../grandorgue-debug-$1-$2.windows.x86_64.zip *
+popd
+
 popd
 

--- a/build-scripts/for-win64/build-on-linux.sh
+++ b/build-scripts/for-win64/build-on-linux.sh
@@ -65,23 +65,13 @@ GO_WIN_PRMS="-DCMAKE_SYSTEM_NAME=Windows \
   -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
   -DCMAKE_VERBOSE_MAKEFILE=ON \
   -DRTAUDIO_USE_ASIO=ON -DASIO_SDK_DIR=/usr/local/asio-sdk \
+  -DVC_PATH=/usr/local/share/wine/msvc/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x86 \
+  -DCV2PDB_EXE=/usr/local/share/wine/cv2pdb/cv2pdb.exe \
   -DIMPORT_EXECUTABLES=../build-tools/ImportExecutables.cmake"
 GO_PRMS="-DGO_USE_JACK=ON $CMAKE_VERSION_PRMS"
 
 cmake -DINSTALL_DEPEND=ON $MINGW_PRMS $GO_WIN_PRMS $GO_PRMS . $SRC_DIR
 make $PARALLEL_PRMS VERBOSE=1 package
-
-#build debug symbols
-mkdir -p pdb
-export WINEPATH=Z:/usr/local/share/wine/msvc/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x86
-wine /usr/local/share/wine/cv2pdb/cv2pdb.exe bin/GrandOrgue.exe /tmp/GrandOrgue.exe pdb/GrandOrgue.pdb
-wine /usr/local/share/wine/cv2pdb/cv2pdb.exe bin/GrandOrguePerfTest.exe /tmp/GrandOrguePerfTest.exe pdb/GrandOrguePerfTest.pdb
-wine /usr/local/share/wine/cv2pdb/cv2pdb.exe bin/GrandOrgueTool.exe /tmp/GrandOrgueTool.exe pdb/GrandOrgueTool.pdb
-wine /usr/local/share/wine/cv2pdb/cv2pdb.exe bin/libGrandOrgueCore.dll /tmp/libGrandOrgueCore.dll pdb/libGrandOrgueCore.pdb
-
-pushd pdb
-zip ../grandorgue-debug-$1-$2.windows.x86_64.zip *
-popd
 
 popd
 

--- a/build-scripts/for-win64/prepare-ubuntu-20.sh
+++ b/build-scripts/for-win64/prepare-ubuntu-20.sh
@@ -3,10 +3,15 @@
 set -e
 sudo dpkg --add-architecture i386
 sudo apt-get update
+
+# remove an odd version of ibpcre2-8-0 that prevents installing wine32
+# determine the required version of ibpcre2-8-0
+LIBPCRE_VERSION=`apt-cache policy libpcre2-8-0:i386 | awk '/Candidate:/ { print $2; }'`
+sudo DEBIAN_FRONTEND=noninteractive apt-get --allow-downgrades -y install  libpcre2-8-0=$LIBPCRE_VERSION
+
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   wget unzip cmake g++ pkg-config g++-mingw-w64-x86-64 nsis \
-  docbook-xsl xsltproc gettext po4a imagemagick zip libz-mingw-w64-dev \
-  wine32 winbind
+  docbook-xsl xsltproc gettext po4a imagemagick zip libz-mingw-w64-dev wine32
 
 mkdir -p deb
 pushd deb

--- a/build-scripts/for-win64/prepare-ubuntu-20.sh
+++ b/build-scripts/for-win64/prepare-ubuntu-20.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 set -e
-sudo apt update
-sudo DEBIAN_FRONTEND=noninteractive apt install -y \
+sudo dpkg --add-architecture i386
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   wget unzip cmake g++ pkg-config g++-mingw-w64-x86-64 nsis \
-  docbook-xsl xsltproc gettext po4a imagemagick zip \
-  libz-mingw-w64-dev
+  docbook-xsl xsltproc gettext po4a imagemagick zip libz-mingw-w64-dev \
+  wine32 winbind
 
 mkdir -p deb
 pushd deb
@@ -34,4 +35,26 @@ if [ ! -d /usr/local/asio-sdk ]; then
 	rm -rf $DL_DIR
 	SDK_DIR=`ls -1d /usr/local/asiosdk* | tail -1`
 	sudo ln -sf `basename $SDK_DIR` /usr/local/asio-sdk
+fi
+
+# download VC for wine
+if [ ! -d /usr/local/share/wine/msvc ]; then
+	DL_DIR=`mktemp -d -t vc.XXX`
+	wget -O $DL_DIR/VC2019.zip https://github.com/GrandOrgue/DockerMsvcCpp/releases/download/0.1/VC2019.zip
+	sudo mkdir -p /usr/local/share/wine/msvc.tmp
+	sudo rm -rf /usr/local/share/wine/msvc.tmp/*
+	sudo unzip -d /usr/local/share/wine/msvc.tmp $DL_DIR/VC2019.zip
+	rm -rf $DL_DIR
+	sudo mv /usr/local/share/wine/msvc.tmp /usr/local/share/wine/msvc
+fi
+
+# download cv2pdb
+if [ ! -d /usr/local/share/wine/cv2pdb ]; then
+	DL_DIR=`mktemp -d -t cv2pdb.XXX`
+	wget -O $DL_DIR/cv2pdb-0.51.zip https://github.com/rainers/cv2pdb/releases/download/v0.51/cv2pdb-0.51.zip
+	sudo mkdir -p /usr/local/share/wine/cv2pdb.tmp
+	sudo rm -rf /usr/local/share/wine/cv2pdb.tmp/*
+	sudo unzip -d /usr/local/share/wine/cv2pdb.tmp $DL_DIR/cv2pdb-0.51.zip
+	rm -rf $DL_DIR
+	sudo mv /usr/local/share/wine/cv2pdb.tmp /usr/local/share/wine/cv2pdb
 fi

--- a/build-scripts/for-win64/prepare-ubuntu-20.sh
+++ b/build-scripts/for-win64/prepare-ubuntu-20.sh
@@ -11,7 +11,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get --allow-downgrades -y install  libpc
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   wget unzip cmake g++ pkg-config g++-mingw-w64-x86-64 nsis \
-  docbook-xsl xsltproc gettext po4a imagemagick zip libz-mingw-w64-dev wine32
+  docbook-xsl xsltproc gettext po4a imagemagick zip libz-mingw-w64-dev \
+  wine32 winbind
 
 mkdir -p deb
 pushd deb

--- a/cmake/BuildExecutable.cmake
+++ b/cmake/BuildExecutable.cmake
@@ -24,6 +24,21 @@ function(BUILD_EXECUTABLE TARGET)
   else()
     set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${BINDIR}")
   endif()
-
   install(TARGETS ${TARGET} RUNTIME DESTINATION "${BININSTDIR}")
+
+  if(CV2PDB_EXE)
+    add_custom_command(
+      OUTPUT "${BINDIR}/${TARGET}.pdb"
+      DEPENDS ${TARGET}
+      COMMAND
+	${CMAKE_COMMAND}
+	  -E env "WINEPATH=Z:${VC_PATH}"
+	  wine "${CV2PDB_EXE}"
+	  "$<TARGET_FILE:${TARGET}>"
+	  "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_PREFIX:${TARGET}>$<TARGET_FILE_BASE_NAME:${TARGET}>-tmp$<TARGET_FILE_SUFFIX:${TARGET}>"
+	  "${BINDIR}/${TARGET}.pdb"
+    )
+    add_custom_target(${TARGET}.pdb ALL DEPENDS "${BINDIR}/${TARGET}.pdb")
+    install(FILES "${BINDIR}/${TARGET}.pdb" DESTINATION "${BININSTDIR}")
+  endif()
 endfunction()

--- a/cmake/BuildLibrary.cmake
+++ b/cmake/BuildLibrary.cmake
@@ -31,7 +31,7 @@ function(BUILD_LIBRARY TARGET)
 
   install(
     TARGETS ${TARGET} 
-    RUNTIME DESTINATION ${LIBINSTDIR} LIBRARY DESTINATION ${LIBINSTDIR} 
+    RUNTIME DESTINATION ${LIBINSTDIR} LIBRARY DESTINATION ${LIBINSTDIR}
     NAMELINK_SKIP
     # these permissions required for building rmp on debian/ubuntu
     # otherwise Autoprov doesn't work
@@ -39,4 +39,20 @@ function(BUILD_LIBRARY TARGET)
       GROUP_EXECUTE GROUP_READ
       WORLD_EXECUTE WORLD_READ
   )
+
+  if(CV2PDB_EXE)
+    add_custom_command(
+      OUTPUT "${LIBDIR}/lib${TARGET}.pdb"
+      DEPENDS ${TARGET}
+      COMMAND
+	${CMAKE_COMMAND}
+	  -E env "WINEPATH=Z:${VC_PATH}"
+	  wine "${CV2PDB_EXE}"
+	  "$<TARGET_FILE:${TARGET}>"
+	  "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_PREFIX:${TARGET}>$<TARGET_FILE_BASE_NAME:${TARGET}>-tmp$<TARGET_FILE_SUFFIX:${TARGET}>"
+	  "${LIBDIR}/lib${TARGET}.pdb"
+    )
+    add_custom_target(lib${TARGET}.pdb ALL DEPENDS "${LIBDIR}/lib${TARGET}.pdb")
+    install(FILES "${LIBDIR}/lib${TARGET}.pdb" DESTINATION "${LIBINSTDIR}")
+  endif()
 endfunction()

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -188,10 +188,10 @@ target_link_libraries(golib GrandOrgueImages GrandOrgueCore ${go_libs})
 link_directories(${go_libdir})
 
 if (WIN32)
-   set_source_files_properties("${RESOURCEDIR}/GrandOrgue.rc" PROPERTIES GENERATED "YES")
-   add_executable(GrandOrgue WIN32 GOApp.cpp "${RESOURCEDIR}/GrandOrgue.rc")
-   add_dependencies(GrandOrgue resources) # GrandOrgue.rc and GrandOrgue.manifest & GOIcon.ico referenced from GrandOrgue.rc
-   add_linker_option(GrandOrgue large-address-aware)
+  set_source_files_properties("${RESOURCEDIR}/GrandOrgue.rc" PROPERTIES GENERATED "YES")
+  add_executable(GrandOrgue WIN32 GOApp.cpp "${RESOURCEDIR}/GrandOrgue.rc")
+  add_dependencies(GrandOrgue resources) # GrandOrgue.rc and GrandOrgue.manifest & GOIcon.ico referenced from GrandOrgue.rc
+  add_linker_option(GrandOrgue large-address-aware)
 else ()
    add_executable(GrandOrgue GOApp.cpp)
 endif ()


### PR DESCRIPTION
Resolves: #853

- For converting debug symbols to the windows debugger compatible format [cv2pdb](https://github.com/rainers/cv2pdb) is used.
- It is a win32 executable and it requires MSVC to be installed
- I use a [special build of MSVC](https://github.com/GrandOrgue/DockerMsvcCpp) based on https://github.com/madduci/docker-msvc-cpp project
- for running cv2pdb under ubuntu I have to install wine32
- unfortunally there is a dependency problem while installing wine32 on a github runner machine: there is an odd version of `libpcre2-8-0` installed here buth there is no `libpcre2-8-0:i386` installed, but it is required by wine32.. This version is absent in the standard ubuntu repositories for installing the same version of `libpcre2-8-0`. So I need to replace the installed version `libpcre2-8-0` with a standard one.
- The resulting debug symbols are packaged into `grandorgue-debug`-version.`windows.x86_64.zip`