### PR TITLE
Fixed build for windows on github

### DIFF
--- a/build-scripts/for-win64/prepare-ubuntu-20.sh
+++ b/build-scripts/for-win64/prepare-ubuntu-20.sh
@@ -4,10 +4,11 @@ set -e
 sudo dpkg --add-architecture i386
 sudo apt-get update
 
-# remove an odd version of ibpcre2-8-0 that prevents installing wine32
-# determine the required version of ibpcre2-8-0
+# remove an odd version of packages that prevents installing wine32
 LIBPCRE_VERSION=`apt-cache policy libpcre2-8-0:i386 | awk '/Candidate:/ { print $2; }'`
-sudo DEBIAN_FRONTEND=noninteractive apt-get --allow-downgrades -y install  libpcre2-8-0=$LIBPCRE_VERSION
+LIBDG3_VERSION=`apt-cache policy libgd3:i386 | awk '/Candidate:/ { print $2; }'`
+sudo DEBIAN_FRONTEND=noninteractive apt-get --allow-downgrades -y install \
+  libpcre2-8-0=$LIBPCRE_VERSION libgd3=$LIBDG3_VERSION
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   wget unzip cmake g++ pkg-config g++-mingw-w64-x86-64 nsis \


### PR DESCRIPTION
Fixed installed dependencies for building GrandOrgue for Windows.

This solves the problem of failed builds in the Organ Settings branch