### PR TITLE
Moved build for OsX to OsX 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
             prepare: "ubuntu-18"
             build_on: linux
 
-          - run_on: macos-10.15
+          - run_on: macos-11
             for: osx
             prepare: osx
             build_on: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Moved build for OsX to OsX 11 https://github.com/GrandOrgue/grandorgue/discussions/1149
 # 3.7.0 (2022-08-11)
 - Fixed packaging for OSx https://github.com/GrandOrgue/grandorgue/issues/1135
 - Deleting an organ in the Organ tab of the Settings dialog causes also deleting it's cache and all it's presets https://github.com/GrandOrgue/grandorgue/issues/1049

--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -23,7 +23,7 @@ pushd build/osx
 rm -rf *
 export LANG=C
 
-OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
+OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15"
 GO_PRMS="-DCMAKE_BUILD_TYPE=Release $CMAKE_VERSION_PRMS"
 cmake -G "Unix Makefiles" $OS_PRMS $GO_PRMS . $SRC_DIR
 make -k $PARALLEL_PRMS VERBOSE=1 package

--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -23,7 +23,7 @@ pushd build/osx
 rm -rf *
 export LANG=C
 
-OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl"
+OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
 GO_PRMS="-DCMAKE_BUILD_TYPE=Release $CMAKE_VERSION_PRMS"
 cmake -G "Unix Makefiles" $OS_PRMS $GO_PRMS . $SRC_DIR
 make -k $PARALLEL_PRMS VERBOSE=1 package

--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 set -e
-brew install gettext jack docbook-xsl wxmac cmake pkg-config fftw wavpack imagemagick
+brew install gettext jack docbook-xsl cmake pkg-config fftw wavpack imagemagick
 brew link gettext --force
+
+# install wx for 10.15 in order to using the GrandOrgue bundle with 10.15
+# prevent upgrading wxwidgets just afrer installing
+export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+brew install -f --formula https://github.com/GrandOrgue/WxOsX/releases/download/3.2.0-1/90dab952e7e1c26dba572e1b19b7f97728cbbd4d5580a020aee0ff36eebe9138--wxwidgets--3.2.0.catalina.bottle.tar.gz
 
 # A workaround of https://gitlab.kitware.com/cmake/cmake/-/issues/23826
 for F in $(grep -l '(, weak)\?'  /usr/local/Cellar/cmake/*/share/cmake/Modules/GetPrerequisites.cmake); do


### PR DESCRIPTION
According to [this github annonce](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/) Github finishes providing a runner with OsX 10.15 at the end of august 2022.

This PR allows to continue building GrandOrgue for OsX 10.15+ (and, possible, 10.14) on a GitHub OsX 11 runner.

As discussed in #1149, I need two things
1. wxWidgets compiled for OsX 10.15. It has been saved as a release artefact in the new repository https://github.com/GrandOrgue/WxOsX.
2. Specifying the `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14` cmake parameter