### PR TITLE
Fixed building appimage in an ubuntu container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed building appimage in an ubuntu container
 # 3.7.1 (2022-09-02)
 - Fixed translation of temperaments' names https://github.com/GrandOrgue/grandorgue/issues/1104
 - Fixed saving ReleaseTail https://github.com/GrandOrgue/grandorgue/issues/1161

--- a/build-scripts/for-appimage-x86_64/build-on-linux.sh
+++ b/build-scripts/for-appimage-x86_64/build-on-linux.sh
@@ -29,6 +29,7 @@ make -k $PARALLEL_PRMS
 make install DESTDIR=AppDir
 
 # initialize AppDir and build AppImage
+export DEPLOY_GTK_VERSION=3 APPIMAGE_EXTRACT_AND_RUN=1
 linuxdeploy-x86_64.AppImage --appdir AppDir --plugin gtk
 appimagetool-x86_64.AppImage --no-appstream AppDir grandorgue-$1-$2.x86_64.AppImage
 

--- a/build-scripts/for-appimage-x86_64/prepare-debian-ubuntu.sh
+++ b/build-scripts/for-appimage-x86_64/prepare-debian-ubuntu.sh
@@ -4,7 +4,7 @@ set -e
 
 sudo apt update
 
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake g++ pkg-config \
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake g++ pkg-config wget \
   libfftw3-dev zlib1g-dev libasound2-dev libwavpack-dev libudev-dev \
   libwxgtk3.0-gtk3-dev docbook-xsl xsltproc gettext po4a imagemagick patchelf libgtk-3-dev librsvg2-dev
 


### PR DESCRIPTION
I started working on https://github.com/GrandOrgue/grandorgue/issues/1174 but I cann't build appimage with my environment, because the build script works only on a bare Ubuntu and I have Fedora and run Ubuntu in a podman container.

This PR fixes container-related issues.