### PR TITLE
Fixed "Invalid format specifier error" when reading a setting file

### DIFF
--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -355,9 +355,9 @@ int GOConfigReader::ReadInteger(
 
   wxString error;
   error.Printf(
-    _("Out of range value at section '%s' entry '%s': %d"),
-    group.c_str(),
-    key.c_str(),
+    _("Out of range value at section '%s' entry '%s': %ld"),
+    group,
+    key,
     retval);
   throw error;
 }


### PR DESCRIPTION
`%d` format is not compatible with the `long` datatype