### PR TITLE
Fixed an empty stop set to a general combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed an empty stop set to a general combination https://github.com/GrandOrgue/grandorgue/issues/1212
 # 3.8.0 (2022-09-15)
 - Fixed setting an empty stop set to a divisional combination https://github.com/GrandOrgue/grandorgue/issues/1068
 - Added capability of switching between the Override and the Add crescendo mode https://github.com/GrandOrgue/grandorgue/issues/1170

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -382,11 +382,11 @@ void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
 }
 
 void GOGeneralCombination::Push(ExtraElementsSet const *extraSet) {
-  bool used = GOCombination::PushLocal(extraSet);
+  GOCombination::PushLocal(extraSet);
 
   for (unsigned k = 0; k < m_organfile->GetGeneralCount(); k++) {
     GOGeneralButtonControl *general = m_organfile->GetGeneral(k);
-    general->Display(&general->GetGeneral() == this && used);
+    general->Display(&general->GetGeneral() == this);
   }
 
   for (unsigned j = m_organfile->GetFirstManualIndex();


### PR DESCRIPTION
Resolves: #1212

Now general buttons are displayed as pushed even there aren't stops in the combination.