### PR TITLE
Fixed generals buttons behaviour with the crescendo in add mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed generals buttons behaviour with the crescendo in add mode https://github.com/GrandOrgue/grandorgue/issues/1209
 - Fixed an empty stop set to a general combination https://github.com/GrandOrgue/grandorgue/issues/1212
 # 3.8.0 (2022-09-15)
 - Fixed setting an empty stop set to a divisional combination https://github.com/GrandOrgue/grandorgue/issues/1068

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -444,6 +444,8 @@ void GOSetter::Save(GOConfigWriter &cfg) {
 }
 
 void GOSetter::ButtonStateChanged(int id) {
+  GOCombination::ExtraElementsSet elementSet;
+
   switch (id) {
   case ID_SETTER_PREV:
     Prev();
@@ -553,7 +555,8 @@ void GOSetter::ButtonStateChanged(int id) {
   case ID_SETTER_GENERAL47:
   case ID_SETTER_GENERAL48:
   case ID_SETTER_GENERAL49:
-    m_general[id - ID_SETTER_GENERAL00 + m_bank * GENERALS]->Push();
+    m_general[id - ID_SETTER_GENERAL00 + m_bank * GENERALS]->Push(
+      GetCrescendoAddSet(elementSet));
     ResetDisplay();
     m_buttons[id]->Display(true);
     break;
@@ -718,6 +721,18 @@ void GOSetter::SetCrescendoType(unsigned no) {
     m_CrescendoOverrideMode[m_crescendobank]);
 }
 
+const GOCombination::ExtraElementsSet *GOSetter::GetCrescendoAddSet(
+  GOCombination::ExtraElementsSet &elementSet) {
+  const GOCombination::ExtraElementsSet *pResElementSet = nullptr;
+
+  if (!m_CrescendoOverrideMode[m_crescendobank]) {
+    m_crescendo[m_crescendopos + m_crescendobank * CRESCENDO_STEPS]
+      ->GetEnabledElements(elementSet);
+    pResElementSet = &elementSet;
+  }
+  return pResElementSet;
+}
+
 void GOSetter::ResetDisplay() {
   m_buttons[ID_SETTER_HOME]->Display(false);
   for (unsigned i = 0; i < 10; i++)
@@ -740,7 +755,9 @@ void GOSetter::SetPosition(int pos, bool push) {
     pos -= m_framegeneral.size();
   m_pos = pos;
   if (push) {
-    m_framegeneral[m_pos]->Push();
+    GOCombination::ExtraElementsSet elementSet;
+
+    m_framegeneral[m_pos]->Push(GetCrescendoAddSet(elementSet));
 
     m_buttons[ID_SETTER_HOME]->Display(m_pos == 0);
     for (unsigned i = 0; i < 10; i++)
@@ -781,7 +798,7 @@ void GOSetter::Crescendo(int newpos, bool force) {
       m_CrescendoExtraSets[oldIdx].clear();
     ++m_crescendopos;
     m_crescendo[newIdx]->Push(
-      crescendoAddMode ? &m_CrescendoExtraSets[oldIdx] : nullptr);
+      crescendoAddMode ? &m_CrescendoExtraSets[oldIdx] : nullptr, true);
   }
 
   while (pos < m_crescendopos) {
@@ -790,7 +807,7 @@ void GOSetter::Crescendo(int newpos, bool force) {
     const unsigned newIdx = m_crescendopos + m_crescendobank * CRESCENDO_STEPS;
 
     m_crescendo[newIdx]->Push(
-      crescendoAddMode ? &m_CrescendoExtraSets[newIdx] : nullptr);
+      crescendoAddMode ? &m_CrescendoExtraSets[newIdx] : nullptr, true);
   }
 
   wxString buffer;

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -80,6 +80,14 @@ public:
   void SetterActive(bool on);
   SetterType GetSetterType();
 
+  /*
+   * If current crescendo is in override mode then returns nullptr
+   * If current crescendo is in add mode then fills elementSet and returns a
+   * pointer to it
+   */
+  const GOCombination::ExtraElementsSet *GetCrescendoAddSet(
+    GOCombination::ExtraElementsSet &elementSet);
+
   void Next();
   void Prev();
   void Push();

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -9,6 +9,10 @@
 
 #include <wx/intl.h>
 
+#include "combinations/GOSetter.h"
+
+#include "GODefinitionFile.h"
+
 GOGeneralButtonControl::GOGeneralButtonControl(
   GOCombinationDefinition &general_template,
   GODefinitionFile *organfile,
@@ -21,7 +25,11 @@ void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
   GOPushbuttonControl::Load(cfg, group);
 }
 
-void GOGeneralButtonControl::Push() { m_general.Push(); }
+void GOGeneralButtonControl::Push() {
+  GOCombination::ExtraElementsSet elementSet;
+
+  m_general.Push(m_organfile->GetSetter()->GetCrescendoAddSet(elementSet));
+}
 
 GOGeneralCombination &GOGeneralButtonControl::GetGeneral() { return m_general; }
 

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -52,6 +52,18 @@ void GOCombination::GetExtraSetState(
   }
 }
 
+void GOCombination::GetEnabledElements(
+  GOCombination::ExtraElementsSet &enabledElements) {
+  const std::vector<GOCombinationDefinition::CombinationSlot> &elements
+    = m_Template.GetCombinationElements();
+
+  enabledElements.clear();
+  for (unsigned i = 0; i < elements.size(); i++) {
+    if (m_State[i] > 0)
+      enabledElements.insert(i);
+  }
+}
+
 void GOCombination::UpdateState() {
   const std::vector<GOCombinationDefinition::CombinationSlot> &elements
     = m_Template.GetCombinationElements();

--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -36,6 +36,8 @@ public:
   int GetState(unsigned no);
   void SetState(unsigned no, int value);
   void GetExtraSetState(ExtraElementsSet &extraSet);
+  void GetEnabledElements(GOCombination::ExtraElementsSet &enabledElements);
+
   void Copy(GOCombination *combination);
   void Clear();
   GOCombinationDefinition *GetTemplate();

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -381,20 +381,25 @@ void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
   }
 }
 
-void GOGeneralCombination::Push(ExtraElementsSet const *extraSet) {
-  GOCombination::PushLocal(extraSet);
+void GOGeneralCombination::Push(
+  ExtraElementsSet const *extraSet, bool isFromCrescendo) {
+  bool used = GOCombination::PushLocal(extraSet);
 
-  for (unsigned k = 0; k < m_organfile->GetGeneralCount(); k++) {
-    GOGeneralButtonControl *general = m_organfile->GetGeneral(k);
-    general->Display(&general->GetGeneral() == this);
-  }
+  if (!isFromCrescendo || !extraSet) { // Crescendo in add mode: not to switch
+                                       // off combination
+                                       // buttons
+    for (unsigned k = 0; k < m_organfile->GetGeneralCount(); k++) {
+      GOGeneralButtonControl *general = m_organfile->GetGeneral(k);
+      general->Display(&general->GetGeneral() == this);
+    }
 
-  for (unsigned j = m_organfile->GetFirstManualIndex();
-       j <= m_organfile->GetManualAndPedalCount();
-       j++) {
-    for (unsigned k = 0; k < m_organfile->GetManual(j)->GetDivisionalCount();
-         k++)
-      m_organfile->GetManual(j)->GetDivisional(k)->Display(false);
+    for (unsigned j = m_organfile->GetFirstManualIndex();
+         j <= m_organfile->GetManualAndPedalCount();
+         j++) {
+      for (unsigned k = 0; k < m_organfile->GetManual(j)->GetDivisionalCount();
+           k++)
+        m_organfile->GetManual(j)->GetDivisional(k)->Display(false);
+    }
   }
 
   m_organfile->GetSetter()->ResetDisplay();

--- a/src/grandorgue/combinations/model/GOGeneralCombination.h
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.h
@@ -36,8 +36,11 @@ public:
    * Activate this combination
    * If extraSet is passed then not to disable stops that are present in
    * extraSet
+   * If isFromCrescendo and extraSet is passed then does not depress other
+   * buttons
    */
-  void Push(ExtraElementsSet const *extraSet = nullptr);
+  void Push(
+    ExtraElementsSet const *extraSet = nullptr, bool isFromCrescendo = false);
 };
 
 #endif /* GOGENERALCOMBINATION_H */


### PR DESCRIPTION
Resolves: #1209

When current crescendo is operating in the Add mode

1. The current pressed general piston remains pressed when crescendo position is changed,
2. When a general piston is switched all stops added with the current crescendo position remain switched on.