### PR TITLE
Renamed audio ports: Pa to PortAudio and Rt to RtAudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Renamed audio ports: Pa to PortAudio and Rt to RtAudio https://github.com/GrandOrgue/grandorgue/issues/1216
 - Fixed size of the Organ Selection Dialog https://github.com/GrandOrgue/grandorgue/issues/1215
 - Fixed generals buttons behaviour with the crescendo in add mode https://github.com/GrandOrgue/grandorgue/issues/1209
 - Fixed an empty stop set to a general combination https://github.com/GrandOrgue/grandorgue/issues/1212

--- a/src/grandorgue/sound/ports/GOSoundPortFactory.cpp
+++ b/src/grandorgue/sound/ports/GOSoundPortFactory.cpp
@@ -47,9 +47,13 @@ GOSoundPort *GOSoundPortFactory::create(
   wxString subsysName = parser.nextComp();
   unsigned short subsysMask; // possible subsystems matching with the name
 
-  if (subsysName == GOSoundPortaudioPort::PORT_NAME)
+  if (
+    subsysName == GOSoundPortaudioPort::PORT_NAME
+    || subsysName == GOSoundPortaudioPort::PORT_NAME_OLD)
     subsysMask = SUBSYS_PA_BIT;
-  else if (subsysName == GOSoundRtPort::PORT_NAME)
+  else if (
+    subsysName == GOSoundRtPort::PORT_NAME
+    || subsysName == GOSoundRtPort::PORT_NAME_OLD)
     subsysMask = SUBSYS_RT_BIT;
   else if (subsysName == GOSoundJackPort::PORT_NAME)
     subsysMask = SUBSYS_JACK_BIT;

--- a/src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp
@@ -9,7 +9,8 @@
 
 #include <wx/intl.h>
 
-const wxString GOSoundPortaudioPort::PORT_NAME = wxT("Pa");
+const wxString GOSoundPortaudioPort::PORT_NAME = wxT("PortAudio");
+const wxString GOSoundPortaudioPort::PORT_NAME_OLD = wxT("Pa");
 
 wxString GOSoundPortaudioPort::getLastError(PaError error) {
   const char *errText = NULL;
@@ -37,11 +38,15 @@ GOSoundPortaudioPort::GOSoundPortaudioPort(GOSound *sound, wxString name)
 
 GOSoundPortaudioPort::~GOSoundPortaudioPort() { Close(); }
 
-wxString GOSoundPortaudioPort::getName(unsigned index) {
+wxString compose_device_name(const wxString &prefix, unsigned index) {
   const PaDeviceInfo *info = Pa_GetDeviceInfo(index);
   const PaHostApiInfo *api = Pa_GetHostApiInfo(info->hostApi);
   return GOSoundPortFactory::getInstance().ComposeDeviceName(
-    PORT_NAME, wxString::FromAscii(api->name), wxString(info->name));
+    prefix, wxString::FromAscii(api->name), wxString(info->name));
+}
+
+wxString GOSoundPortaudioPort::getName(unsigned index) {
+  return compose_device_name(PORT_NAME, index);
 }
 
 void GOSoundPortaudioPort::Open() {
@@ -148,7 +153,8 @@ GOSoundPort *GOSoundPortaudioPort::create(
 
       if (
         devName == name || devName + GOPortFactory::c_NameDelim == name
-        || get_oldstyle_name(i) == name)
+        || get_oldstyle_name(i) == name
+        || compose_device_name(PORT_NAME_OLD, i) == name)
         return new GOSoundPortaudioPort(sound, devName);
     }
   }

--- a/src/grandorgue/sound/ports/GOSoundPortaudioPort.h
+++ b/src/grandorgue/sound/ports/GOSoundPortaudioPort.h
@@ -29,6 +29,7 @@ private:
 
 public:
   static const wxString PORT_NAME;
+  static const wxString PORT_NAME_OLD;
 
   GOSoundPortaudioPort(GOSound *sound, wxString name);
   virtual ~GOSoundPortaudioPort();

--- a/src/grandorgue/sound/ports/GOSoundRtPort.h
+++ b/src/grandorgue/sound/ports/GOSoundRtPort.h
@@ -29,6 +29,7 @@ private:
 
 public:
   static const wxString PORT_NAME;
+  static const wxString PORT_NAME_OLD;
 
   // rtApi to be deleted in the destructor
   GOSoundRtPort(GOSound *sound, RtAudio *rtApi, wxString name);


### PR DESCRIPTION
As mentioned in #1216, the names Rt and Pa are not clear.

I renamed it to RtAudio and PortAudio. For achieving compatibility with the old settings I had to add matching with the old names too.