### PR TITLE
Fixed displaying audio ports on OSx https://github.com/GrandOrgue/grandorgue/issues/1216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed displaying audio ports on OSx https://github.com/GrandOrgue/grandorgue/issues/1216
 - Added divisional combination banks https://github.com/GrandOrgue/grandorgue/issues/708
 - Renamed audio ports: Pa to PortAudio and Rt to RtAudio https://github.com/GrandOrgue/grandorgue/issues/1216
 - Fixed size of the Organ Selection Dialog https://github.com/GrandOrgue/grandorgue/issues/1215

--- a/src/grandorgue/dialogs/settings/GOSettingsPorts.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsPorts.cpp
@@ -77,6 +77,7 @@ GOSettingsPorts::GOSettingsPorts(
     wxDefaultSize,
     wxTL_SINGLE | wxTL_CHECKBOX | wxTL_NO_HEADER);
   m_Ports->AppendColumn(wxEmptyString);
+  m_Ports->SetColumnWidth(0, 200);
   m_Ports->Bind(
     wxEVT_TREELIST_ITEM_CHECKED, &GOSettingsPorts::OnPortItemChecked, this);
   m_PortsSizer->Add(m_Ports, 1, wxEXPAND);


### PR DESCRIPTION
Resolves: #1216 

Automatic size calculation has never worked correctly on OSx, so I added the workaround