### PR TITLE
Fixed playing multitrack midi files with changes of tempo https://github.com/GrandOrgue/grandorgue/discussions/1225

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed playing multitrack midi files with changes of tempo https://github.com/GrandOrgue/grandorgue/discussions/1225
 - Fixed displaying audio ports on OSx https://github.com/GrandOrgue/grandorgue/issues/1216
 - Added divisional combination banks https://github.com/GrandOrgue/grandorgue/issues/708
 - Renamed audio ports: Pa to PortAudio and Rt to RtAudio https://github.com/GrandOrgue/grandorgue/issues/1216

--- a/src/core/midi/GOMidiFileReader.h
+++ b/src/core/midi/GOMidiFileReader.h
@@ -8,7 +8,9 @@
 #ifndef GOMIDIFILEREADER_H
 #define GOMIDIFILEREADER_H
 
+#include <map>
 #include <stdint.h>
+
 #include <wx/string.h>
 
 #include "GOBuffer.h"
@@ -21,14 +23,17 @@ private:
   GOMidiMap &m_Map;
   GOBuffer<uint8_t> m_Data;
   unsigned m_Tracks;
-  float m_Speed;
+  float m_Speed; // the global speed from the file header
   unsigned m_Pos;
   unsigned m_TrackEnd;
+  bool m_IsFirstTrackComplete; // the first track has been read completely
   unsigned m_LastStatus;
-  unsigned m_CurrentSpeed;
+  float m_CurrentSpeed; // the current speed for the current track
+  float m_CurrentSpeedTo;
   float m_LastTime;
+  std::map<float, float>
+    m_TempoMap; // maps start time to the speed from the first track
   unsigned m_PPQ;
-  unsigned m_Tempo;
 
   bool StartTrack();
   unsigned DecodeTime();


### PR DESCRIPTION
As discussed at #1225 GO played midi files with tempo change incorrectly: only the first track followed the tempo markers and all other tracks were played at the last tempo.

Now all tracks use the tempo map from the first track