### PR TITLE
Fixed controlling stops with a touchscreen on Raspberry Pi https://github.com/GrandOrgue/grandorgue/issues/1208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed controlling stops with a touchscreen on Raspberry Pi https://github.com/GrandOrgue/grandorgue/issues/1208
 # 3.9.0 (2022-11-03)
 - Fixed playing multitrack midi files with changes of tempo https://github.com/GrandOrgue/grandorgue/discussions/1225
 - Fixed displaying audio ports on OSx https://github.com/GrandOrgue/grandorgue/issues/1216

--- a/src/grandorgue/gui/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/GOGUIPanelWidget.cpp
@@ -24,13 +24,16 @@ EVT_PAINT(GOGUIPanelWidget::OnPaint)
 EVT_COMMAND(0, wxEVT_GOCONTROL, GOGUIPanelWidget::OnGOControl)
 EVT_MOTION(GOGUIPanelWidget::OnMouseMove)
 EVT_LEFT_DOWN(GOGUIPanelWidget::OnMouseLeftDown)
-EVT_LEFT_DCLICK(GOGUIPanelWidget::OnMouseLeftDown)
+EVT_LEFT_DCLICK(GOGUIPanelWidget::OnMouseLeftDclick)
+EVT_LEFT_UP(GOGUIPanelWidget::OnMouseLeftUp)
 EVT_RIGHT_DOWN(GOGUIPanelWidget::OnMouseRightDown)
 EVT_RIGHT_DCLICK(GOGUIPanelWidget::OnMouseRightDown)
 EVT_MOUSEWHEEL(GOGUIPanelWidget::OnMouseScroll)
 EVT_KEY_DOWN(GOGUIPanelWidget::OnKeyCommand)
 EVT_KEY_UP(GOGUIPanelWidget::OnKeyUp)
 END_EVENT_TABLE()
+
+const wxPoint default_point(wxDefaultCoord, wxDefaultCoord);
 
 GOGUIPanelWidget::GOGUIPanelWidget(
   GOGUIPanel *panel, wxWindow *parent, wxWindowID id)
@@ -39,7 +42,8 @@ GOGUIPanelWidget::GOGUIPanelWidget(
     m_BGInit(false),
     m_Background(&m_BGImage),
     m_Scale(1),
-    m_FontScale(1) {
+    m_FontScale(1),
+    m_PressedPoint(default_point) {
   initFont();
   SetLabel(m_panel->GetName());
   m_ClientBitmap.Create(
@@ -147,38 +151,69 @@ bool GOGUIPanelWidget::ForwardMouseEvent(wxMouseEvent &event) {
   return true;
 }
 
+void GOGUIPanelWidget::HandleMousePress(const wxPoint &point, bool isRight) {
+  if (!isRight)
+    m_PressedPoint = point;
+  m_panel->HandleMousePress(point.x / m_Scale, point.y / m_Scale, isRight);
+}
+
+void GOGUIPanelWidget::HandleMouseRelease(bool isRight) {
+  m_panel->HandleMouseRelease(isRight);
+  if (!isRight)
+    m_PressedPoint = default_point;
+}
+
 void GOGUIPanelWidget::OnMouseMove(wxMouseEvent &event) {
   if (!event.LeftIsDown()) {
-    m_panel->HandleMouseRelease(false);
+    HandleMouseRelease(false);
     return;
   }
-
   if (ForwardMouseEvent(event))
     return;
-  m_panel->HandleMousePress(
-    event.GetX() / m_Scale, event.GetY() / m_Scale, false);
+
+  wxPoint point = event.GetPosition();
+
+  // some windows managers call several times at the same position. Skip if so
+  if (point != m_PressedPoint)
+    HandleMousePress(point, false);
   event.Skip();
 }
 
 void GOGUIPanelWidget::OnMouseLeftDown(wxMouseEvent &event) {
   Focus();
-
   if (ForwardMouseEvent(event))
     return;
 
-  m_panel->HandleMouseRelease(false);
+  wxPoint point = event.GetPosition();
 
-  m_panel->HandleMousePress(
-    event.GetX() / m_Scale, event.GetY() / m_Scale, false);
+  // some windows managers call several times at the same position. Skip if so
+  if (point != m_PressedPoint) {
+    HandleMouseRelease(false);
+    HandleMousePress(point, false);
+  }
   event.Skip();
+}
+
+void GOGUIPanelWidget::OnMouseLeftDclick(wxMouseEvent &event) {
+  if (!ForwardMouseEvent(event)) {
+    HandleMouseRelease(false);
+    HandleMousePress(event.GetPosition(), false);
+    event.Skip();
+  }
 }
 
 void GOGUIPanelWidget::OnMouseRightDown(wxMouseEvent &event) {
   Focus();
 
-  m_panel->HandleMousePress(
-    event.GetX() / m_Scale, event.GetY() / m_Scale, true);
+  HandleMousePress(event.GetPosition(), true);
   event.Skip();
+}
+
+void GOGUIPanelWidget::OnMouseLeftUp(wxMouseEvent &event) {
+  if (m_PressedPoint.IsFullySpecified() && !event.LeftIsDown()) {
+    HandleMouseRelease(false);
+    event.Skip();
+  }
 }
 
 void GOGUIPanelWidget::OnMouseScroll(wxMouseEvent &event) {

--- a/src/grandorgue/gui/GOGUIPanelWidget.h
+++ b/src/grandorgue/gui/GOGUIPanelWidget.h
@@ -27,14 +27,32 @@ private:
   double m_Scale;
   double m_FontScale;
 
+  /**
+   * A point where the mouse has been pressed. Used for deduplication
+   */
+  wxPoint m_PressedPoint;
+
   void initFont();
   void OnCreate(wxWindowCreateEvent &event);
   void OnDraw(wxDC *dc);
   void OnErase(wxEraseEvent &event);
   void OnPaint(wxPaintEvent &event);
   void OnGOControl(wxCommandEvent &event);
+
+  /**
+   * Stores m_PressedPoint and calls m_Panel->HandleMousePress with relative
+   * coords
+   */
+  void HandleMousePress(const wxPoint &point, bool isRight);
+  /**
+   * calls m_Panel->HandleMouseRelease and clears m_PressedPoint
+   */
+  void HandleMouseRelease(bool isRight);
+
   void OnMouseMove(wxMouseEvent &event);
   void OnMouseLeftDown(wxMouseEvent &event);
+  void OnMouseLeftUp(wxMouseEvent &event);
+  void OnMouseLeftDclick(wxMouseEvent &event);
   void OnMouseRightDown(wxMouseEvent &event);
   void OnMouseScroll(wxMouseEvent &event);
   bool ForwardMouseEvent(wxMouseEvent &event);


### PR DESCRIPTION
Resolves: #1208 

When a user taps a touchscreen, most window managers emulate two events:
- MouseLeftDown
- MouseMove

But the Raspbian desktop emulates three events:
- MouseMove
- MouseLeftDown
- MouseMove
It caused a stop was enabled and just was disabled

I added a deduplication code for processing mouse events. It broke processing of double clicks, so I added separate methods for MouseLeftUp and MouseLeftDblClick
