### PR TITLE
Removed usage of GOOrganController from GOPipe

### DIFF
--- a/src/grandorgue/model/GODummyPipe.cpp
+++ b/src/grandorgue/model/GODummyPipe.cpp
@@ -8,8 +8,8 @@
 #include "GODummyPipe.h"
 
 GODummyPipe::GODummyPipe(
-  GOOrganController *organController, GORank *rank, unsigned midi_key_number)
-  : GOPipe(organController, rank, midi_key_number) {}
+  GOEventHandlerList *handlerList, GORank *rank, unsigned midi_key_number)
+  : GOPipe(handlerList, rank, midi_key_number) {}
 
 void GODummyPipe::Load(GOConfigReader &cfg, wxString group, wxString prefix) {}
 

--- a/src/grandorgue/model/GODummyPipe.h
+++ b/src/grandorgue/model/GODummyPipe.h
@@ -16,7 +16,7 @@ private:
 
 public:
   GODummyPipe(
-    GOOrganController *organController, GORank *rank, unsigned midi_key_number);
+    GOEventHandlerList *handlerList, GORank *rank, unsigned midi_key_number);
 
   void Load(GOConfigReader &cfg, wxString group, wxString prefix);
 };

--- a/src/grandorgue/model/GOPipe.cpp
+++ b/src/grandorgue/model/GOPipe.cpp
@@ -13,13 +13,12 @@
 #include "GORank.h"
 
 GOPipe::GOPipe(
-  GOOrganController *organController, GORank *rank, unsigned midi_key_number)
+  GOEventHandlerList *handlerList, GORank *rank, unsigned midi_key_number)
   : m_Velocity(0),
     m_Velocities(1),
-    m_OrganController(organController),
     m_Rank(rank),
     m_MidiKeyNumber(midi_key_number) {
-  m_OrganController->RegisterPlaybackStateHandler(this);
+  handlerList->RegisterPlaybackStateHandler(this);
 }
 
 GOPipe::~GOPipe() {}

--- a/src/grandorgue/model/GOPipe.h
+++ b/src/grandorgue/model/GOPipe.h
@@ -15,9 +15,9 @@
 #include "GOPlaybackStateHandler.h"
 
 class GOConfigReader;
+class GOEventHandlerList;
 class GORank;
 class GOTemperament;
-class GOOrganController;
 
 class GOPipe : private GOPlaybackStateHandler {
 private:
@@ -25,7 +25,6 @@ private:
   std::vector<unsigned> m_Velocities;
 
 protected:
-  GOOrganController *m_OrganController;
   GORank *m_Rank;
   unsigned m_MidiKeyNumber;
 
@@ -38,7 +37,7 @@ protected:
 
 public:
   GOPipe(
-    GOOrganController *organController, GORank *rank, unsigned midi_key_number);
+    GOEventHandlerList *handlerList, GORank *rank, unsigned midi_key_number);
   virtual ~GOPipe();
   virtual void Load(GOConfigReader &cfg, wxString group, wxString prefix) = 0;
   void Set(unsigned velocity, unsigned referenceID = 0);

--- a/src/grandorgue/model/GOReferencePipe.cpp
+++ b/src/grandorgue/model/GOReferencePipe.cpp
@@ -10,22 +10,25 @@
 #include <wx/intl.h>
 #include <wx/tokenzr.h>
 
+#include "config/GOConfigReader.h"
+
 #include "GOManual.h"
+#include "GOModel.h"
 #include "GOOrganController.h"
 #include "GORank.h"
 #include "GOStop.h"
-#include "config/GOConfigReader.h"
 
 GOReferencePipe::GOReferencePipe(
-  GOOrganController *organController, GORank *rank, unsigned midi_key_number)
-  : GOPipe(organController, rank, midi_key_number),
+  GOModel *model, GORank *rank, unsigned midi_key_number)
+  : GOPipe(model, rank, midi_key_number),
+    m_model(model),
     m_Reference(NULL),
     m_ReferenceID(0),
     m_Filename() {}
 
 void GOReferencePipe::Load(
   GOConfigReader &cfg, wxString group, wxString prefix) {
-  m_OrganController->RegisterCacheObject(this);
+  m_model->RegisterCacheObject(this);
   m_Filename = cfg.ReadStringTrim(ODFSetting, group, prefix);
   if (!m_Filename.StartsWith(wxT("REF:")))
     throw(wxString) _("ReferencePipe without Reference");
@@ -43,15 +46,14 @@ void GOReferencePipe::Initialize() {
     || !strs[2].ToULong(&pipe))
     throw(wxString) _("Invalid reference ") + m_Filename;
   if (
-    (manual < m_OrganController->GetFirstManualIndex())
-    || (manual >= m_OrganController->GetODFManualCount()) || (stop <= 0)
-    || (stop > m_OrganController->GetManual(manual)->GetStopCount()) || (pipe <= 0)
-    || (pipe > m_OrganController->GetManual(manual)->GetStop(stop - 1)->GetRank(0)->GetPipeCount()))
+    (manual < m_model->GetFirstManualIndex())
+    || (manual >= m_model->GetODFManualCount()) || (stop <= 0)
+    || (stop > m_model->GetManual(manual)->GetStopCount()) || (pipe <= 0)
+    || (pipe > m_model->GetManual(manual)->GetStop(stop - 1)->GetRank(0)->GetPipeCount()))
     throw(wxString) _("Invalid reference ") + m_Filename;
-  m_Reference = m_OrganController->GetManual(manual)
-                  ->GetStop(stop - 1)
-                  ->GetRank(0)
-                  ->GetPipe(pipe - 1);
+  m_Reference
+    = m_model->GetManual(manual)->GetStop(stop - 1)->GetRank(0)->GetPipe(
+      pipe - 1);
   m_ReferenceID = m_Reference->RegisterReference(this);
 }
 

--- a/src/grandorgue/model/GOReferencePipe.h
+++ b/src/grandorgue/model/GOReferencePipe.h
@@ -11,8 +11,11 @@
 #include "GOCacheObject.h"
 #include "GOPipe.h"
 
+class GOModel;
+
 class GOReferencePipe : public GOPipe, private GOCacheObject {
 private:
+  GOModel *m_model;
   GOPipe *m_Reference;
   unsigned m_ReferenceID;
   wxString m_Filename;
@@ -27,8 +30,7 @@ private:
   void Change(unsigned velocity, unsigned old_velocity);
 
 public:
-  GOReferencePipe(
-    GOOrganController *organController, GORank *rank, unsigned midi_key_number);
+  GOReferencePipe(GOModel *model, GORank *rank, unsigned midi_key_number);
 
   void Load(GOConfigReader &cfg, wxString group, wxString prefix);
 };

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -33,6 +33,7 @@ GOSoundingPipe::GOSoundingPipe(
   float max_volume,
   bool retune)
   : GOPipe(organController, rank, midi_key_number),
+    m_OrganController(organController),
     m_Sampler(NULL),
     m_LastStop(0),
     m_Instances(0),

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -8,11 +8,12 @@
 #ifndef GOSOUNDINGPIPE_H
 #define GOSOUNDINGPIPE_H
 
+#include "sound/GOSoundProviderWave.h"
+
 #include "GOCacheObject.h"
 #include "GOPipe.h"
 #include "GOPipeConfigNode.h"
 #include "GOPipeWindchestCallback.h"
-#include "sound/GOSoundProviderWave.h"
 
 class GOSoundSampler;
 
@@ -21,6 +22,7 @@ class GOSoundingPipe : public GOPipe,
                        private GOPipeUpdateCallback,
                        private GOPipeWindchestCallback {
 private:
+  GOOrganController *m_OrganController;
   GOSoundSampler *m_Sampler;
   uint64_t m_LastStop;
   int m_Instances;


### PR DESCRIPTION
Towards to removing referrences to GOOrganController from the model I replaces all usages in `GOPipe` and it's subclasses to `GOModel`.

`GOSoundingPipe` is still uses `GOOrganController` because removing this requires more changes. They will be done in future PRs.

NO GO behavior should be changed