### PR TITLE
Moved usage of GOMemoryPool from constructors to the LoadXXX methods

### DIFF
--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -798,7 +798,8 @@
         <element flagsID="4" commonFlags="-std=c++11 -O3 -ffast-math -fPIC"/>
         <element flagsID="5" commonFlags="-std=c++11 -O3 -ffast-math -msse3"/>
         <element flagsID="6" commonFlags="-std=c++11 -fPIC"/>
-        <element flagsID="7" commonFlags="-std=c++14"/>
+        <element flagsID="7" commonFlags="-std=c++11 -msse3"/>
+        <element flagsID="8" commonFlags="-std=c++14"/>
       </flagsDictionary>
       <codeAssistance>
       </codeAssistance>
@@ -813,7 +814,6 @@
               <pElem>../../build/current/src/core/go_defs.h</pElem>
             </incDir>
             <preprocessorList>
-              <Elem>NDEBUG</Elem>
               <Elem>WXUSINGDLL</Elem>
               <Elem>_FILE_OFFSET_BITS=64</Elem>
               <Elem>_REENTRANT</Elem>
@@ -835,7 +835,7 @@
             ex="false"
             tool="1"
             flavor2="11">
-        <ccTool flags="7">
+        <ccTool flags="8">
         </ccTool>
       </item>
       <item path="../../build/current/src/images/ASIO.cpp"
@@ -2524,6 +2524,9 @@
       </item>
       <item path="../../src/grandorgue/GOApp.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOAudioGauge.cpp"
@@ -2536,6 +2539,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2543,7 +2547,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOBitmap.cpp" ex="false" tool="1" flavor2="8">
@@ -2553,6 +2557,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2560,7 +2565,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOCache.cpp" ex="false" tool="1" flavor2="8">
@@ -2570,6 +2575,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2583,6 +2589,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2596,11 +2603,12 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOCoupler.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GODC.cpp" ex="false" tool="1" flavor2="8">
@@ -2610,6 +2618,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2617,21 +2626,21 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GODocument.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GODrawStop.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOEvent.cpp" ex="false" tool="1" flavor2="8">
@@ -2641,6 +2650,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2648,7 +2658,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOFont.cpp" ex="false" tool="1" flavor2="8">
@@ -2658,18 +2668,19 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOFrame.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOKeyReceiver.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOLoadThread.cpp"
@@ -2677,6 +2688,9 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOLog.cpp" ex="false" tool="1" flavor2="8">
@@ -2686,6 +2700,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2699,6 +2714,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2706,21 +2722,21 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOMetronome.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOOrganController.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOPanelView.cpp"
@@ -2733,6 +2749,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2740,34 +2757,28 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOPipeConfigNode.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOPipeConfigTreeNode.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
-          <incDir>
-            <pElem>../../build/current/src/core</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-          </preprocessorList>
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOProperties.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOReleaseAlignTable.cpp"
@@ -2780,6 +2791,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2787,56 +2799,56 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/GOSetter.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/control/GODivisionalButtonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/control/GOGeneralButtonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOCombination.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOCombinationDefinition.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GODivisionalCombination.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOGeneralCombination.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOConfig.cpp"
@@ -2878,7 +2890,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOCallbackButtonControl.cpp"
@@ -2886,6 +2898,9 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOElementCreator.cpp"
@@ -2893,27 +2908,30 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOEventDistributor.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOLabelControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPistonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPushbuttonControl.cpp"
@@ -2921,6 +2939,9 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOMidiListDialog.cpp"
@@ -2928,13 +2949,16 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOOrganDialog.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOProgressDialog.cpp"
@@ -2947,6 +2971,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2960,6 +2985,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -2973,6 +2999,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3007,6 +3034,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3020,6 +3048,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3027,7 +3056,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp"
@@ -3040,6 +3069,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3053,6 +3083,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3066,6 +3097,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3079,6 +3111,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3092,6 +3125,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3105,6 +3139,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3118,6 +3153,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3131,6 +3167,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3138,7 +3175,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPaths.cpp"
@@ -3151,6 +3188,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3164,6 +3202,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3177,6 +3216,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3190,6 +3230,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3211,7 +3252,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIButton.cpp"
@@ -3219,27 +3260,30 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUICouplerPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUICrescendoPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIDisplayMetrics.cpp"
@@ -3252,6 +3296,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3259,7 +3304,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIEnclosure.cpp"
@@ -3267,13 +3312,16 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIFloatingPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIHW1Background.cpp"
@@ -3286,6 +3334,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3299,6 +3348,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3312,6 +3362,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3319,7 +3370,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUILayoutEngine.cpp"
@@ -3332,6 +3383,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3340,6 +3392,9 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIManualBackground.cpp"
@@ -3347,27 +3402,30 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIMasterPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIMetronomePanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIPanelWidget.cpp"
@@ -3380,6 +3438,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3387,21 +3446,21 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUISequencerPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUISetterDisplayMetrics.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/help/GOHelpController.cpp"
@@ -3418,6 +3477,13 @@
         <ccTool flags="5">
         </ccTool>
       </item>
+      <item path="../../src/grandorgue/loader/GOLoadThread.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="7">
+        </ccTool>
+      </item>
       <item path="../../src/grandorgue/midi/GOMidi.cpp"
             ex="false"
             tool="1"
@@ -3428,6 +3494,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3441,6 +3508,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3454,6 +3522,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3467,6 +3536,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3474,7 +3544,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiPlayerContent.cpp"
@@ -3487,6 +3557,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3494,21 +3565,21 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiRecorder.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiSender.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiInPort.cpp"
@@ -3564,14 +3635,14 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOEnclosure.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOEventHandlerList.cpp"
@@ -3579,83 +3650,86 @@
             tool="1"
             flavor2="8">
         <ccTool flags="5">
+          <preprocessorList>
+            <Elem>NDEBUG</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOManual.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOModel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOPipe.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GORank.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOReferencePipe.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOSoundingPipe.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOStop.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOSwitch.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOTremulant.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOWindchest.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSound.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundAudioSection.cpp"
@@ -3668,6 +3742,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3675,46 +3750,28 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundProvider.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
-          <incDir>
-            <pElem>../../build/current/src/core</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-          </preprocessorList>
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
-          <incDir>
-            <pElem>../../build/current/src/core</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-          </preprocessorList>
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundProviderWave.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
-          <incDir>
-            <pElem>../../build/current/src/core</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-          </preprocessorList>
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundRecorder.cpp"
@@ -3727,6 +3784,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3740,6 +3798,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3753,6 +3812,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3766,6 +3826,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3779,6 +3840,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3792,6 +3854,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3840,6 +3903,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3853,6 +3917,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3866,6 +3931,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3879,6 +3945,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3892,6 +3959,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3905,6 +3973,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3918,6 +3987,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -3925,7 +3995,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA00.cpp" ex="false" tool="1" flavor2="8">
@@ -4848,7 +4918,7 @@
         </ccTool>
       </item>
       <item path="../../src/tools/GOPerfTest.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="5">
+        <ccTool flags="7">
           <incDir>
             <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue</pElem>
@@ -4877,6 +4947,7 @@
           <preprocessorList>
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -4996,13 +5067,6 @@
         <ccTool flags="5">
         </ccTool>
       </item>
-      <item path="/home/oleg/my-projects/grandorgue/GrandOrgue/src/grandorgue/loader/GOLoadThread.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="5">
-        </ccTool>
-      </item>
       <item path="/usr/share/cmake/Modules/CMakeCCompilerABI.c"
             ex="false"
             tool="0"
@@ -5012,7 +5076,7 @@
             ex="false"
             tool="1"
             flavor2="11">
-        <ccTool flags="7">
+        <ccTool flags="8">
         </ccTool>
       </item>
       <folder path="0/build">
@@ -5048,6 +5112,7 @@
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS=1</Elem>
+            <Elem>NDEBUG</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__WXGTK__=1</Elem>
@@ -5130,6 +5195,7 @@
           <preprocessorList>
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5151,6 +5217,7 @@
           <preprocessorList>
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5180,6 +5247,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5190,6 +5258,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5200,6 +5269,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5210,6 +5280,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5220,6 +5291,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5230,6 +5302,7 @@
           </incDir>
           <preprocessorList>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5276,6 +5349,7 @@
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS=1</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__DBL_NORM_MAX__=double(1.79769313486231570814527423731704357e+308L)</Elem>
@@ -5378,6 +5452,7 @@
             <Elem>GO_STD_MUTEX=1</Elem>
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS=1</Elem>
+            <Elem>NDEBUG</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
@@ -5442,6 +5517,7 @@
           <preprocessorList>
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -5505,6 +5581,7 @@
             <Elem>GO_STD_MUTEX</Elem>
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>NDEBUG</Elem>
           </preprocessorList>
         </ccTool>
       </folder>

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -522,7 +522,7 @@ wxString GOOrganController::Load(
 
             if (!obj)
               break;
-            if (!obj->LoadCache(reader)) {
+            if (!obj->LoadCache(m_pool, reader)) {
               cache_ok = false;
               wxLogError(
                 _("Cache load failure: Failed to read %s from cache."),
@@ -573,7 +573,7 @@ wxString GOOrganController::Load(
       GOCacheObject *obj;
 
       while ((obj = objectDistributor.fetchNext())) {
-        obj->LoadData();
+        obj->LoadData(m_pool);
         if (!dlg->Update(objectDistributor.GetPos(), obj->GetLoadTitle())) {
           dummy.free();
           SetTemperament(m_Temperament);

--- a/src/grandorgue/control/GOEventDistributor.cpp
+++ b/src/grandorgue/control/GOEventDistributor.cpp
@@ -7,9 +7,8 @@
 
 #include "GOEventDistributor.h"
 
-#include "model/GOEventHandlerList.h"
-
 #include "model/GOCacheObject.h"
+#include "model/GOEventHandlerList.h"
 
 #include "GOControlChangedHandler.h"
 #include "GOEventHandler.h"

--- a/src/grandorgue/loader/GOLoadThread.cpp
+++ b/src/grandorgue/loader/GOLoadThread.cpp
@@ -42,7 +42,7 @@ void GOLoadThread::Entry() {
 
       if (!obj)
         return;
-      obj->LoadData();
+      obj->LoadData(m_pool);
     } catch (GOOutOfMemory e) {
       m_OutOfMemory = true;
       return;

--- a/src/grandorgue/model/GOCacheObject.h
+++ b/src/grandorgue/model/GOCacheObject.h
@@ -13,14 +13,15 @@
 class GOCache;
 class GOCacheWriter;
 class GOHash;
+class GOMemoryPool;
 
 class GOCacheObject {
 public:
   virtual ~GOCacheObject() {}
 
   virtual void Initialize() = 0;
-  virtual void LoadData() = 0;
-  virtual bool LoadCache(GOCache &cache) = 0;
+  virtual void LoadData(GOMemoryPool &pool) = 0;
+  virtual bool LoadCache(GOMemoryPool &pool, GOCache &cache) = 0;
   virtual bool SaveCache(GOCacheWriter &cache) = 0;
   virtual void UpdateHash(GOHash &hash) = 0;
   virtual const wxString &GetLoadTitle() = 0;

--- a/src/grandorgue/model/GOReferencePipe.cpp
+++ b/src/grandorgue/model/GOReferencePipe.cpp
@@ -57,13 +57,7 @@ void GOReferencePipe::Initialize() {
   m_ReferenceID = m_Reference->RegisterReference(this);
 }
 
-bool GOReferencePipe::LoadCache(GOCache &cache) { return true; }
-
-bool GOReferencePipe::SaveCache(GOCacheWriter &cache) { return true; }
-
 void GOReferencePipe::UpdateHash(GOHash &hash) {}
-
-void GOReferencePipe::LoadData() {}
 
 const wxString &GOReferencePipe::GetLoadTitle() { return m_Filename; }
 

--- a/src/grandorgue/model/GOReferencePipe.h
+++ b/src/grandorgue/model/GOReferencePipe.h
@@ -21,13 +21,13 @@ private:
   wxString m_Filename;
 
   void Initialize();
-  void LoadData();
-  bool LoadCache(GOCache &cache);
-  bool SaveCache(GOCacheWriter &cache);
+  void LoadData(GOMemoryPool &pool) override {}
+  bool LoadCache(GOMemoryPool &pool, GOCache &cache) override { return true; }
+  bool SaveCache(GOCacheWriter &cache) override { return true; }
   void UpdateHash(GOHash &hash);
   const wxString &GetLoadTitle();
 
-  void Change(unsigned velocity, unsigned old_velocity);
+  void Change(unsigned velocity, unsigned old_velocity) override;
 
 public:
   GOReferencePipe(GOModel *model, GORank *rank, unsigned midi_key_number);

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -10,16 +10,18 @@
 #include <wx/intl.h>
 #include <wx/log.h>
 
+#include "config/GOConfig.h"
+#include "config/GOConfigReader.h"
+#include "temperaments/GOTemperament.h"
+
 #include "GOAlloc.h"
 #include "GOHash.h"
 #include "GOOrganController.h"
 #include "GOPath.h"
 #include "GORank.h"
 #include "GOWindchest.h"
-#include "config/GOConfig.h"
-#include "config/GOConfigReader.h"
+
 #include "go_limits.h"
-#include "temperaments/GOTemperament.h"
 
 GOSoundingPipe::GOSoundingPipe(
   GOOrganController *organController,
@@ -53,7 +55,6 @@ GOSoundingPipe::GOSoundingPipe(
     m_MaxVolume(max_volume),
     m_SampleMidiKeyNumber(-1),
     m_RetunePipe(retune),
-    m_SoundProvider(organController->GetMemoryPool()),
     m_PipeConfig(
       &rank->GetPipeConfig(), organController, this, &m_SoundProvider) {}
 
@@ -249,9 +250,10 @@ void GOSoundingPipe::Load(
     wxString::Format(_("%d: %s"), m_MidiKeyNumber, m_Filename.c_str()));
 }
 
-void GOSoundingPipe::LoadData() {
+void GOSoundingPipe::LoadData(GOMemoryPool &pool) {
   try {
     m_SoundProvider.LoadFromFile(
+      pool,
       m_AttackInfo,
       m_ReleaseInfo,
       m_PipeConfig.GetEffectiveBitsPerSample(),
@@ -280,9 +282,9 @@ void GOSoundingPipe::LoadData() {
   }
 }
 
-bool GOSoundingPipe::LoadCache(GOCache &cache) {
+bool GOSoundingPipe::LoadCache(GOMemoryPool &pool, GOCache &cache) {
   try {
-    bool result = m_SoundProvider.LoadCache(cache);
+    bool result = m_SoundProvider.LoadCache(pool, cache);
     if (result)
       Validate();
     return result;

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -15,6 +15,8 @@
 #include "GOPipeConfigNode.h"
 #include "GOPipeWindchestCallback.h"
 
+class GOMemoryPool;
+class GOOrganController;
 class GOSoundSampler;
 
 class GOSoundingPipe : public GOPipe,
@@ -57,8 +59,8 @@ private:
   void LoadAttack(GOConfigReader &cfg, wxString group, wxString prefix);
 
   void Initialize();
-  void LoadData();
-  bool LoadCache(GOCache &cache);
+  void LoadData(GOMemoryPool &pool) override;
+  bool LoadCache(GOMemoryPool &pool, GOCache &cache) override;
   bool SaveCache(GOCacheWriter &cache);
   void UpdateHash(GOHash &hash);
   const wxString &GetLoadTitle();

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -66,8 +66,7 @@ void GOTremulant::Load(
     false,
     GOSynthTrem);
   if (m_TremulantType == GOSynthTrem) {
-    m_TremProvider
-      = new GOSoundProviderSynthedTrem();
+    m_TremProvider = new GOSoundProviderSynthedTrem();
     m_Period = cfg.ReadLong(ODFSetting, group, wxT("Period"), 32, 441000);
     m_StartRate = cfg.ReadInteger(ODFSetting, group, wxT("StartRate"), 1, 100);
     m_StopRate = cfg.ReadInteger(ODFSetting, group, wxT("StopRate"), 1, 100);

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -42,10 +42,10 @@ GOTremulant::~GOTremulant() { DELETE_AND_NULL(m_TremProvider); }
 
 void GOTremulant::Initialize() {}
 
-void GOTremulant::LoadData() { InitSoundProvider(); }
+void GOTremulant::LoadData(GOMemoryPool &pool) { InitSoundProvider(pool); }
 
-bool GOTremulant::LoadCache(GOCache &cache) {
-  InitSoundProvider();
+bool GOTremulant::LoadCache(GOMemoryPool &pool, GOCache &cache) {
+  InitSoundProvider(pool);
   return true;
 }
 
@@ -67,8 +67,8 @@ void GOTremulant::Load(
     GOSynthTrem);
   if (m_TremulantType == GOSynthTrem) {
     m_TremProvider
-      = new GOSoundProviderSynthedTrem(m_OrganController->GetMemoryPool()),
-      m_Period = cfg.ReadLong(ODFSetting, group, wxT("Period"), 32, 441000);
+      = new GOSoundProviderSynthedTrem();
+    m_Period = cfg.ReadLong(ODFSetting, group, wxT("Period"), 32, 441000);
     m_StartRate = cfg.ReadInteger(ODFSetting, group, wxT("StartRate"), 1, 100);
     m_StopRate = cfg.ReadInteger(ODFSetting, group, wxT("StopRate"), 1, 100);
     m_AmpModDepth
@@ -88,10 +88,10 @@ void GOTremulant::SetupCombinationState() {
     || IsDisplayed();
 }
 
-void GOTremulant::InitSoundProvider() {
+void GOTremulant::InitSoundProvider(GOMemoryPool &pool) {
   if (m_TremulantType == GOSynthTrem) {
     ((GOSoundProviderSynthedTrem *)m_TremProvider)
-      ->Create(m_Period, m_StartRate, m_StopRate, m_AmpModDepth);
+      ->Create(pool, m_Period, m_StartRate, m_StopRate, m_AmpModDepth);
     assert(!m_TremProvider->IsOneshot());
   }
 }

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -16,8 +16,9 @@
 class GOSoundProvider;
 class GOConfigReader;
 class GOConfigWriter;
-struct IniFileEnumEntry;
+class GOMemoryPool;
 class GOSoundSampler;
+struct IniFileEnumEntry;
 
 typedef enum { GOSynthTrem, GOWavTrem } GOTremulantType;
 
@@ -34,13 +35,13 @@ private:
   uint64_t m_LastStop;
   int m_SamplerGroupID;
 
-  void InitSoundProvider();
+  void InitSoundProvider(GOMemoryPool &pool);
   void ChangeState(bool on);
   void SetupCombinationState();
 
   void Initialize();
-  void LoadData();
-  bool LoadCache(GOCache &cache);
+  void LoadData(GOMemoryPool &pool);
+  bool LoadCache(GOMemoryPool &pool, GOCache &cache);
   bool SaveCache(GOCacheWriter &cache);
   void UpdateHash(GOHash &hash);
   const wxString &GetLoadTitle();

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -24,7 +24,7 @@
     }                                                                          \
   } while (0)
 
-GOSoundProvider::GOSoundProvider(GOMemoryPool &pool)
+GOSoundProvider::GOSoundProvider()
   : m_MidiKeyNumber(0),
     m_MidiPitchFract(0),
     m_Tuning(1),
@@ -33,7 +33,6 @@ GOSoundProvider::GOSoundProvider(GOMemoryPool &pool)
     m_AttackInfo(),
     m_Release(),
     m_ReleaseInfo(),
-    m_pool(pool),
     m_VelocityVolumeBase(1),
     m_VelocityVolumeIncrement(0),
     m_ReleaseCrossfadeLength(184) {
@@ -49,7 +48,7 @@ void GOSoundProvider::ClearData() {
   m_ReleaseInfo.clear();
 }
 
-bool GOSoundProvider::LoadCache(GOCache &cache) {
+bool GOSoundProvider::LoadCache(GOMemoryPool &pool, GOCache &cache) {
   if (!cache.Read(&m_MidiKeyNumber, sizeof(m_MidiKeyNumber)))
     return false;
   if (!cache.Read(&m_MidiPitchFract, sizeof(m_MidiPitchFract)))
@@ -65,7 +64,7 @@ bool GOSoundProvider::LoadCache(GOCache &cache) {
     if (!cache.Read(&info, sizeof(info)))
       return false;
     m_AttackInfo.push_back(info);
-    m_Attack.push_back(new GOAudioSection(m_pool));
+    m_Attack.push_back(new GOAudioSection(pool));
     if (!m_Attack[i]->LoadCache(cache))
       return false;
   }
@@ -78,7 +77,7 @@ bool GOSoundProvider::LoadCache(GOCache &cache) {
     if (!cache.Read(&info, sizeof(info)))
       return false;
     m_ReleaseInfo.push_back(info);
-    m_Release.push_back(new GOAudioSection(m_pool));
+    m_Release.push_back(new GOAudioSection(pool));
     if (!m_Release[i]->LoadCache(cache))
       return false;
   }

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -42,19 +42,18 @@ protected:
   std::vector<attack_section_info> m_AttackInfo;
   ptr_vector<GOAudioSection> m_Release;
   std::vector<release_section_info> m_ReleaseInfo;
-  GOMemoryPool &m_pool;
   void ComputeReleaseAlignmentInfo();
   float m_VelocityVolumeBase;
   float m_VelocityVolumeIncrement;
   unsigned m_ReleaseCrossfadeLength;
 
 public:
-  GOSoundProvider(GOMemoryPool &pool);
+  GOSoundProvider();
   virtual ~GOSoundProvider();
 
   void ClearData();
 
-  virtual bool LoadCache(GOCache &cache);
+  virtual bool LoadCache(GOMemoryPool &pool, GOCache &cache);
   virtual bool SaveCache(GOCacheWriter &cache);
 
   void UseSampleGroup(unsigned sample_group);

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
@@ -11,9 +11,7 @@
 #include "GOMemoryPool.h"
 #include "GOSoundAudioSection.h"
 
-GOSoundProviderSynthedTrem::GOSoundProviderSynthedTrem() {
-  m_Gain = 1.0f;
-}
+GOSoundProviderSynthedTrem::GOSoundProviderSynthedTrem() { m_Gain = 1.0f; }
 
 inline short SynthTrem(double amp, double angle) {
   return (short)(amp * sin(angle));
@@ -28,7 +26,11 @@ inline short SynthTrem(double amp, double angle, double fade) {
 }
 
 void GOSoundProviderSynthedTrem::Create(
-  GOMemoryPool &pool, int period, int start_rate, int stop_rate, int amp_mod_depth) {
+  GOMemoryPool &pool,
+  int period,
+  int start_rate,
+  int stop_rate,
+  int amp_mod_depth) {
   ClearData();
 
   const double trem_freq = 1000.0 / period;

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
@@ -11,8 +11,7 @@
 #include "GOMemoryPool.h"
 #include "GOSoundAudioSection.h"
 
-GOSoundProviderSynthedTrem::GOSoundProviderSynthedTrem(GOMemoryPool &pool)
-  : GOSoundProvider(pool) {
+GOSoundProviderSynthedTrem::GOSoundProviderSynthedTrem() {
   m_Gain = 1.0f;
 }
 
@@ -29,7 +28,7 @@ inline short SynthTrem(double amp, double angle, double fade) {
 }
 
 void GOSoundProviderSynthedTrem::Create(
-  int period, int start_rate, int stop_rate, int amp_mod_depth) {
+  GOMemoryPool &pool, int period, int start_rate, int stop_rate, int amp_mod_depth) {
   ClearData();
 
   const double trem_freq = 1000.0 / period;
@@ -86,7 +85,7 @@ void GOSoundProviderSynthedTrem::Create(
   attack_info.min_attack_velocity = 0;
   attack_info.max_released_time = -1;
   m_AttackInfo.push_back(attack_info);
-  m_Attack.push_back(new GOAudioSection(m_pool));
+  m_Attack.push_back(new GOAudioSection(pool));
   m_Attack[0]->Setup(
     data.get(),
     GOWave::SF_SIGNEDSHORT_16,
@@ -102,7 +101,7 @@ void GOSoundProviderSynthedTrem::Create(
   release_info.sample_group = -1;
   release_info.max_playback_time = -1;
   m_ReleaseInfo.push_back(release_info);
-  m_Release.push_back(new GOAudioSection(m_pool));
+  m_Release.push_back(new GOAudioSection(pool));
   m_Release[0]->Setup(
     data.get() + attack_samples + loop_samples,
     GOWave::SF_SIGNEDSHORT_16,

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.h
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.h
@@ -12,9 +12,9 @@
 
 class GOSoundProviderSynthedTrem : public GOSoundProvider {
 public:
-  GOSoundProviderSynthedTrem(GOMemoryPool &pool);
+  GOSoundProviderSynthedTrem();
 
-  void Create(int period, int start_rate, int stop_rate, int amp_mod_depth);
+  void Create(GOMemoryPool &pool, int period, int start_rate, int stop_rate, int amp_mod_depth);
 };
 
 #endif /* GOSOUNDPROVIDERSYNTHEDTREM_H_ */

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.h
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.h
@@ -14,7 +14,12 @@ class GOSoundProviderSynthedTrem : public GOSoundProvider {
 public:
   GOSoundProviderSynthedTrem();
 
-  void Create(GOMemoryPool &pool, int period, int start_rate, int stop_rate, int amp_mod_depth);
+  void Create(
+    GOMemoryPool &pool,
+    int period,
+    int start_rate,
+    int stop_rate,
+    int amp_mod_depth);
 };
 
 #endif /* GOSOUNDPROVIDERSYNTHEDTREM_H_ */

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -66,6 +66,7 @@ class GOSoundProviderWave : public GOSoundProvider {
   unsigned GetBytesPerSample(unsigned bits_per_sample);
 
   void CreateAttack(
+    GOMemoryPool &pool,
     const char *data,
     GOWave &wave,
     int attack_start,
@@ -79,7 +80,9 @@ class GOSoundProviderWave : public GOSoundProvider {
     unsigned min_attack_velocity,
     unsigned loop_crossfade_length,
     unsigned max_released_time);
+  
   void CreateRelease(
+    GOMemoryPool &pool,
     const char *data,
     GOWave &wave,
     int sample_group,
@@ -89,7 +92,9 @@ class GOSoundProviderWave : public GOSoundProvider {
     unsigned bits_per_sample,
     unsigned channels,
     bool compress);
+  
   void ProcessFile(
+    GOMemoryPool &pool,
     const GOFilename &filename,
     std::vector<GO_WAVE_LOOP> loops,
     bool is_attack,
@@ -108,13 +113,13 @@ class GOSoundProviderWave : public GOSoundProvider {
     bool use_pitch,
     unsigned loop_crossfade_length,
     unsigned max_released_time);
+  
   void LoadPitch(const GOFilename &filename);
   unsigned GetFaderLength(unsigned MidiKeyNumber);
 
 public:
-  GOSoundProviderWave(GOMemoryPool &pool);
-
   void LoadFromFile(
+    GOMemoryPool &pool,
     std::vector<attack_load_info> attacks,
     std::vector<release_load_info> releases,
     unsigned bits_per_sample,

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -80,7 +80,7 @@ class GOSoundProviderWave : public GOSoundProvider {
     unsigned min_attack_velocity,
     unsigned loop_crossfade_length,
     unsigned max_released_time);
-  
+
   void CreateRelease(
     GOMemoryPool &pool,
     const char *data,
@@ -92,7 +92,7 @@ class GOSoundProviderWave : public GOSoundProvider {
     unsigned bits_per_sample,
     unsigned channels,
     bool compress);
-  
+
   void ProcessFile(
     GOMemoryPool &pool,
     const GOFilename &filename,
@@ -113,7 +113,7 @@ class GOSoundProviderWave : public GOSoundProvider {
     bool use_pitch,
     unsigned loop_crossfade_length,
     unsigned max_released_time);
-  
+
   void LoadPitch(const GOFilename &filename);
   unsigned GetFaderLength(unsigned MidiKeyNumber);
 

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -85,7 +85,7 @@ void GOPerfTestApp::RunTest(
       ptr_vector<GOSoundProvider> pipes;
       for (unsigned i = 0; i < sample_instances; i++) {
         GOSoundProviderWave *w
-          = new GOSoundProviderWave(organController->GetMemoryPool());
+          = new GOSoundProviderWave();
         w->SetAmplitude(102, 0);
         std::vector<release_load_info> release;
         std::vector<attack_load_info> attack;
@@ -103,6 +103,7 @@ void GOPerfTestApp::RunTest(
         ainfo.loops.clear();
         attack.push_back(ainfo);
         w->LoadFromFile(
+          organController->GetMemoryPool(),
           attack,
           release,
           bits_per_sample,

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -84,9 +84,10 @@ void GOPerfTestApp::RunTest(
     try {
       ptr_vector<GOSoundProvider> pipes;
       for (unsigned i = 0; i < sample_instances; i++) {
-        GOSoundProviderWave *w
-          = new GOSoundProviderWave();
+        GOSoundProviderWave *w = new GOSoundProviderWave();
+
         w->SetAmplitude(102, 0);
+
         std::vector<release_load_info> release;
         std::vector<attack_load_info> attack;
         attack_load_info ainfo;


### PR DESCRIPTION
Earlier constructors of `GOSoundProvider` and related `GOSoundingPipe` used the instance of `GOMemoryPool` in the constructoes. Because the instance is a member of `GOOrganController`, it did not allow to remove usages of `GOOrganController` from the modeling objects.

Because `GOMemoryPool` is necessary only when loading sound samples for allocating memory, I removed `GOMemoryPool` from constructors and added it to the `GOCaceObject` methods `LoadData` and `LoadCache`.