### PR TITLE
Got rid dependency on GOOrganController from GOPipeConfig

### DIFF
--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -421,6 +421,7 @@
             <in>GOEventHandlerList.cpp</in>
             <in>GOManual.cpp</in>
             <in>GOModel.cpp</in>
+            <in>GOModificationListener.h</in>
             <in>GOPipe.cpp</in>
             <in>GORank.cpp</in>
             <in>GOReferencePipe.cpp</in>
@@ -3809,6 +3810,11 @@
             flavor2="8">
         <ccTool flags="5">
         </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOModificationListener.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
       </item>
       <item path="../../src/grandorgue/model/GOPipe.cpp"
             ex="false"
@@ -11281,6 +11287,11 @@
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOModificationListener.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
       </item>
       <item path="../../src/grandorgue/sound/GOSound.cpp"
             ex="false"

--- a/src/grandorgue/GODocument.h
+++ b/src/grandorgue/GODocument.h
@@ -35,7 +35,6 @@ private:
   GOOrganController *m_OrganController;
 
   GOMidiListener m_listener;
-  bool m_modified;
 
   void OnMidiEvent(const GOMidiEvent &event);
 
@@ -46,8 +45,7 @@ public:
   GODocument(GOResizable *pMainWindow, GOSound *sound);
   ~GODocument();
 
-  bool IsModified();
-  void Modify(bool modified);
+  bool IsModified() const;
 
   void ShowPanel(unsigned id);
   void ShowOrganDialog();

--- a/src/grandorgue/GOKeyReceiver.cpp
+++ b/src/grandorgue/GOKeyReceiver.cpp
@@ -49,5 +49,5 @@ KEY_MATCH_TYPE GOKeyReceiver::Match(unsigned key) {
 void GOKeyReceiver::Assign(const GOKeyReceiverData &data) {
   *(GOKeyReceiverData *)this = data;
   if (m_OrganController)
-    m_OrganController->Modified();
+    m_OrganController->SetOrganModified();
 }

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -34,7 +34,7 @@ void GOCombination::Copy(GOCombination *combination) {
   assert(GetTemplate() == combination->GetTemplate());
   m_State = combination->m_State;
   UpdateState();
-  m_OrganFile->Modified();
+  m_OrganFile->SetOrganModified();
 }
 
 int GOCombination::GetState(unsigned no) { return m_State[no]; }
@@ -101,7 +101,7 @@ bool GOCombination::PushLocal(GOCombination::ExtraElementsSet const *extraSet) {
         } else
           m_State[i] = 0;
       }
-      m_OrganFile->Modified();
+      m_OrganFile->SetOrganModified();
     }
     if (m_OrganFile->GetSetter()->GetSetterType() == SETTER_SCOPE) {
       for (unsigned i = 0; i < elements.size(); i++) {
@@ -115,7 +115,7 @@ bool GOCombination::PushLocal(GOCombination::ExtraElementsSet const *extraSet) {
         } else
           m_State[i] = -1;
       }
-      m_OrganFile->Modified();
+      m_OrganFile->SetOrganModified();
     }
     if (m_OrganFile->GetSetter()->GetSetterType() == SETTER_SCOPED) {
       for (unsigned i = 0; i < elements.size(); i++) {

--- a/src/grandorgue/dialogs/GOOrganDialog.cpp
+++ b/src/grandorgue/dialogs/GOOrganDialog.cpp
@@ -947,7 +947,7 @@ void GOOrganDialog::OnOK(wxCommandEvent &event) {
   }
   m_OrganController->SetIgnorePitch(m_IgnorePitch->GetValue());
   m_OrganController->SetTemperament(m_OrganController->GetTemperament());
-  m_OrganController->Modified();
+  m_OrganController->SetOrganModified();
   Destroy();
 }
 

--- a/src/grandorgue/gui/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/GOGUIPanel.cpp
@@ -851,7 +851,7 @@ void GOGUIPanel::Save(GOConfigWriter &cfg) {
     m_group, wxT("WindowHeight"), std::min(windowLimit, size.GetHeight()));
 }
 
-void GOGUIPanel::Modified() { m_OrganController->Modified(); }
+void GOGUIPanel::Modified() { m_OrganController->SetOrganModified(); }
 
 void GOGUIPanel::HandleKey(int key) {
   switch (key) {

--- a/src/grandorgue/midi/GOMidiReceiver.cpp
+++ b/src/grandorgue/midi/GOMidiReceiver.cpp
@@ -70,5 +70,5 @@ int GOMidiReceiver::GetTranspose() {
 void GOMidiReceiver::Assign(const GOMidiReceiverData &data) {
   GOMidiReceiverBase::Assign(data);
   if (m_OrganController)
-    m_OrganController->Modified();
+    m_OrganController->SetOrganModified();
 }

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -697,5 +697,5 @@ void GOMidiSender::SetName(const wxString &text) {
 void GOMidiSender::Assign(const GOMidiSenderData &data) {
   *(GOMidiSenderData *)this = data;
   if (m_OrganController)
-    m_OrganController->Modified();
+    m_OrganController->SetOrganModified();
 }

--- a/src/grandorgue/model/GOModel.cpp
+++ b/src/grandorgue/model/GOModel.cpp
@@ -14,6 +14,7 @@
 #include "GODivisionalCoupler.h"
 #include "GOEnclosure.h"
 #include "GOManual.h"
+#include "GOModificationListener.h"
 #include "GOOrganController.h"
 #include "GORank.h"
 #include "GOSwitch.h"
@@ -22,6 +23,8 @@
 
 GOModel::GOModel(const GOConfig &config)
   : m_config(config),
+    m_OrganModelModified(false),
+    m_ModificationListener(nullptr),
     m_FirstManual(0),
     m_ODFManualCount(0),
     m_ODFRankCount(0) {}
@@ -133,6 +136,14 @@ void GOModel::Load(GOConfigReader &cfg, GOOrganController *organController) {
     m_generals.push_back(new GOGeneralButtonControl(
       organController->GetGeneralTemplate(), organController, false));
     m_generals[i]->Load(cfg, wxString::Format(wxT("General%03d"), i + 1));
+  }
+}
+
+void GOModel::SetOrganModelModified(bool modified) {
+  if (modified != m_OrganModelModified) {
+    m_OrganModelModified = modified;
+    if (m_ModificationListener)
+      m_ModificationListener->OnIsModifiedChanged(modified);
   }
 }
 

--- a/src/grandorgue/model/GOModel.h
+++ b/src/grandorgue/model/GOModel.h
@@ -18,16 +18,20 @@ class GODivisionalCoupler;
 class GOEnclosure;
 class GOGeneralButtonControl;
 class GOManual;
+class GOModificationListener;
+class GOOrganController;
 class GOPistonControl;
 class GORank;
 class GOSwitch;
 class GOTremulant;
 class GOWindchest;
-class GOOrganController;
 
 class GOModel : public GOEventHandlerList {
 private:
   const GOConfig &m_config;
+
+  bool m_OrganModelModified;
+  GOModificationListener *m_ModificationListener;
 
 protected:
   ptr_vector<GOWindchest> m_windchests;
@@ -50,6 +54,19 @@ public:
   ~GOModel();
 
   const GOConfig &GetConfig() const { return m_config; }
+
+  bool IsOrganModelModified() const { return m_OrganModelModified; }
+  void SetOrganModelModified(bool modified);
+  void SetOrganModelModified() { SetOrganModelModified(true); }
+  void ResetOrganModelModified() { SetOrganModelModified(false); }
+
+  GOModificationListener *GetModificationListener() const {
+    return m_ModificationListener;
+  }
+
+  void SetModificationListener(GOModificationListener *listener) {
+    m_ModificationListener = listener;
+  }
 
   void UpdateTremulant(GOTremulant *tremulant);
   void UpdateVolume();

--- a/src/grandorgue/model/GOModificationListener.h
+++ b/src/grandorgue/model/GOModificationListener.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2022 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMODIFICATIONLISTENER_H
+#define GOMODIFICATIONLISTENER_H
+
+class GOModificationListener {
+public:
+  virtual void OnIsModifiedChanged(bool modified) = 0;
+};
+
+#endif /* GOMODIFICATIONLISTENER_H */

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -7,13 +7,12 @@
 
 #include "GOPipeConfig.h"
 
-#include "GOOrganController.h"
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
+#include "model/GOModel.h"
 
-GOPipeConfig::GOPipeConfig(
-  GOOrganController *organController, GOPipeUpdateCallback *callback)
-  : m_OrganFile(organController),
+GOPipeConfig::GOPipeConfig(GOModel *organModel, GOPipeUpdateCallback *callback)
+  : m_OrganModel(organModel),
     m_Callback(callback),
     m_Group(),
     m_NamePrefix(),
@@ -178,7 +177,7 @@ const wxString &GOPipeConfig::GetAudioGroup() { return m_AudioGroup; }
 
 void GOPipeConfig::SetAudioGroup(const wxString &str) {
   m_AudioGroup = str;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
   m_Callback->UpdateAudioGroup();
 }
 
@@ -188,7 +187,7 @@ float GOPipeConfig::GetDefaultAmplitude() { return m_DefaultAmplitude; }
 
 void GOPipeConfig::SetAmplitude(float amp) {
   m_Amplitude = amp;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
   m_Callback->UpdateAmplitude();
 }
 
@@ -198,7 +197,7 @@ float GOPipeConfig::GetDefaultGain() { return m_DefaultGain; }
 
 void GOPipeConfig::SetGain(float gain) {
   m_Gain = gain;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
   m_Callback->UpdateAmplitude();
 }
 
@@ -212,7 +211,7 @@ void GOPipeConfig::SetTuning(float cent) {
   if (cent > 1800)
     cent = 1800;
   m_Tuning = cent;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
   m_Callback->UpdateTuning();
 }
 
@@ -222,47 +221,47 @@ unsigned GOPipeConfig::GetDefaultDelay() { return m_DefaultDelay; }
 
 void GOPipeConfig::SetDelay(unsigned delay) {
   m_Delay = delay;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
 }
 
 int GOPipeConfig::GetBitsPerSample() { return m_BitsPerSample; }
 
 void GOPipeConfig::SetBitsPerSample(int value) {
   m_BitsPerSample = value;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
 }
 
 int GOPipeConfig::GetCompress() { return m_Compress; }
 
 void GOPipeConfig::SetCompress(int value) {
   m_Compress = value;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
 }
 
 int GOPipeConfig::GetChannels() { return m_Channels; }
 
 void GOPipeConfig::SetChannels(int value) {
   m_Channels = value;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
 }
 
 int GOPipeConfig::GetLoopLoad() { return m_LoopLoad; }
 
 void GOPipeConfig::SetLoopLoad(int value) {
   m_LoopLoad = value;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
 }
 
 int GOPipeConfig::GetAttackLoad() { return m_AttackLoad; }
 
 void GOPipeConfig::SetAttackLoad(int value) {
   m_AttackLoad = value;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
 }
 
 int GOPipeConfig::GetReleaseLoad() { return m_ReleaseLoad; }
 
 void GOPipeConfig::SetReleaseLoad(int value) {
   m_ReleaseLoad = value;
-  m_OrganFile->Modified();
+  m_OrganModel->SetOrganModelModified();
 }

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -14,11 +14,11 @@
 
 class GOConfigReader;
 class GOConfigWriter;
-class GOOrganController;
+class GOModel;
 
 class GOPipeConfig {
 private:
-  GOOrganController *m_OrganFile;
+  GOModel *m_OrganModel;
   GOPipeUpdateCallback *m_Callback;
   wxString m_Group;
   wxString m_NamePrefix;
@@ -39,8 +39,7 @@ private:
   int m_ReleaseLoad;
 
 public:
-  GOPipeConfig(
-    GOOrganController *organController, GOPipeUpdateCallback *callback);
+  GOPipeConfig(GOModel *organModel, GOPipeUpdateCallback *callback);
 
   void Init(GOConfigReader &cfg, wxString group, wxString prefix);
   void Load(GOConfigReader &cfg, wxString group, wxString prefix);

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -7,10 +7,11 @@
 
 #include "GOPipeConfigNode.h"
 
+#include "config/GOConfig.h"
+
 #include "GOOrganController.h"
 #include "GOSampleStatistic.h"
 #include "GOStatisticCallback.h"
-#include "config/GOConfig.h"
 
 GOPipeConfigNode::GOPipeConfigNode(
   GOPipeConfigNode *parent,

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -11,6 +11,7 @@
 #include "GOPipeConfig.h"
 #include "GOSaveableObject.h"
 
+class GOOrganController;
 class GOSampleStatistic;
 class GOStatisticCallback;
 


### PR DESCRIPTION
1. Earlier the organ modification flag was in GODocument. Now this flag is split between GOOrganController and GOModel
2. This change allowed to replace dependency on GOOrganController with GOModel for yet another class: GOPipeConfig