### PR TITLE
Fixed processing enclosures with the high midi value is less than the low midi value https://github.com/GrandOrgue/grandorgue/issues/1266

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed processing enclosures with high value is less than low value https://github.com/GrandOrgue/grandorgue/issues/1266
 # 3.9.1 (2022-11-14)
 - Fixed crash on loading an organ without a pedal https://github.com/GrandOrgue/grandorgue/issues/1249
 - Fixed SYSEX Hauptwerk max. length in MIDI event editor https://github.com/GrandOrgue/grandorgue/issues/1207

--- a/src/core/midi/GOMidiReceiverEvent.cpp
+++ b/src/core/midi/GOMidiReceiverEvent.cpp
@@ -12,7 +12,7 @@
 int GOMidiReceiverEvent::GetNormalisedValue(int srcValue) {
   int value = srcValue - low_value;
 
-  if (high_value > low_value)
+  if (high_value != low_value)
     value = round(value * (float)127 / (high_value - low_value));
   if (value < 0)
     value = 0;


### PR DESCRIPTION
#Resolves: #1266

Fixed a bug introduced with #1244: I didn't know that there are **inversed** enclusures that send small midi values when they are open and large values when theay are closed.