### PR TITLE
Fixed sending a midi event from an enclosure when it's value is not changed https://github.com/GrandOrgue/grandorgue/issues/1206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed sending a midi event from an enclosure when it's value is not changed https://github.com/GrandOrgue/grandorgue/issues/1206
 - Fixed processing enclosures with high value is less than low value https://github.com/GrandOrgue/grandorgue/issues/1266
 # 3.9.1 (2022-11-14)
 - Fixed crash on loading an organ without a pedal https://github.com/GrandOrgue/grandorgue/issues/1249

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -77,8 +77,10 @@ void GOEnclosure::Set(int n) {
     n = 0;
   if (n > 127)
     n = 127;
-  m_MIDIValue = n;
-  m_sender.SetValue(m_MIDIValue);
+  if (n != m_MIDIValue) {
+    m_MIDIValue = n;
+    m_sender.SetValue(m_MIDIValue);
+  }
   m_OrganController->UpdateVolume();
   m_OrganController->ControlChanged(this);
 }


### PR DESCRIPTION
#Resolves: #1206