### PR TITLE
Moved checking of HW1-compatibility filenames from GOLoaderFilename::Asign to the new method GOConfigReader::ReadFileName

### DIFF
--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -123,6 +123,17 @@ wxString GOConfigReader::ReadStringNotEmpty(
   return ReadStringNotEmpty(type, group, key, required, wxT(""));
 }
 
+wxString GOConfigReader::ReadFileName(
+  GOSettingType type, wxString group, wxString key, bool required) {
+  const wxString fileName = ReadStringTrim(type, group, key, required);
+
+  if (m_Strict && fileName.Find(wxT('/')) != wxNOT_FOUND) {
+    wxLogWarning(
+      _("Filename '%s' contains non-portable directory separator /"), fileName);
+  }
+  return fileName;
+}
+
 bool GOConfigReader::ReadBoolean(
   GOSettingType type, wxString group, wxString key, bool required) {
   return ReadBoolean(type, group, key, required, false);

--- a/src/core/config/GOConfigReader.h
+++ b/src/core/config/GOConfigReader.h
@@ -76,6 +76,8 @@ public:
     wxString key,
     bool required,
     wxString defaultValue);
+  wxString ReadFileName(
+    GOSettingType type, wxString group, wxString key, bool required = true);
   int ReadInteger(
     GOSettingType type,
     wxString group,

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -192,7 +192,7 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   m_RecordingDetails
     = cfg.ReadString(ODFSetting, group, wxT("RecordingDetails"), false);
   wxString info_filename
-    = cfg.ReadStringTrim(ODFSetting, group, wxT("InfoFilename"), false);
+    = cfg.ReadFileName(ODFSetting, group, wxT("InfoFilename"), false);
   wxFileName fn;
   if (info_filename.IsEmpty()) {
     /* Resolve organ file path */

--- a/src/grandorgue/loader/GOLoaderFilename.cpp
+++ b/src/grandorgue/loader/GOLoaderFilename.cpp
@@ -74,13 +74,6 @@ void GOLoaderFilename::SetPath(const wxString &base, const wxString &file) {
 void GOLoaderFilename::Assign(
   const wxString &name, GOOrganController *organController) {
   m_Name = name;
-  if (
-    organController->GetSettings().ODFCheck()
-    && name.Find(wxT('/')) != wxNOT_FOUND) {
-    wxLogWarning(
-      _("Filename '%s' contains non-portable directory separator /"),
-      name.c_str());
-  }
   if (organController->useArchives()) {
     m_Path = wxEmptyString;
     m_Archiv = organController->findArchive(name);

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -62,7 +62,7 @@ void GOSoundingPipe::LoadAttack(
   GOConfigReader &cfg, wxString group, wxString prefix) {
   attack_load_info ainfo;
   ainfo.filename.Assign(
-    cfg.ReadStringTrim(ODFSetting, group, prefix), m_OrganController);
+    cfg.ReadFileName(ODFSetting, group, prefix), m_OrganController);
   ainfo.sample_group = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("IsTremulant"), -1, 1, false, -1);
   ainfo.load_release = cfg.ReadBoolean(
@@ -222,7 +222,7 @@ void GOSoundingPipe::Load(
     wxString p = prefix + wxString::Format(wxT("Release%03d"), i + 1);
 
     rinfo.filename.Assign(
-      cfg.ReadStringTrim(ODFSetting, group, p), m_OrganController);
+      cfg.ReadFileName(ODFSetting, group, p), m_OrganController);
     rinfo.sample_group = cfg.ReadInteger(
       ODFSetting, group, p + wxT("IsTremulant"), -1, 1, false, -1);
     rinfo.max_playback_time = cfg.ReadInteger(


### PR DESCRIPTION
Toward to removing dependency on GOOrganController I removed checking filenames for containing `/` from `GOLoaderFilename::Assign`.

The checking is now when this filename is read from the ODF instead of using this filename.