### PR TITLE
Extracted GO_WAVE_LOOP from GOWave to a separate file and renamed to GOWaveLoop

### DIFF
--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -8662,27 +8662,27 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="7">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/GODivisionalSetter.cpp"
@@ -15308,6 +15308,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
+      </item>
+      <item path="../../src/core/GOWaveLoop.h" ex="false" tool="3" flavor2="0">
       </item>
       <item path="../../src/core/archive/GOArchive.cpp"
             ex="false"

--- a/src/core/GOWave.cpp
+++ b/src/core/GOWave.cpp
@@ -103,9 +103,9 @@ void GOWave::LoadSamplerChunk(const uint8_t *ptr, unsigned long length) {
     = (GO_WAVESAMPLERLOOP *)(ptr + sizeof(GO_WAVESAMPLERCHUNK));
   m_Loops.clear();
   for (unsigned k = 0; k < numberOfLoops; k++) {
-    GO_WAVE_LOOP l;
-    l.start_sample = loops[k].dwStart;
-    l.end_sample = loops[k].dwEnd;
+    GOWaveLoop l;
+    l.m_StartPosition = loops[k].dwStart;
+    l.m_EndPosition = loops[k].dwEnd;
     m_Loops.push_back(l);
   }
 
@@ -236,10 +236,10 @@ void GOWave::Open(const GOBuffer<uint8_t> &content, const wxString fileName) {
     // be correct!
     for (unsigned int i = 0; i < m_Loops.size(); i++) {
       if (
-        (m_Loops[i].start_sample >= m_Loops[i].end_sample)
-        || (m_Loops[i].start_sample >= GetLength())
-        || (m_Loops[i].end_sample >= GetLength())
-        || (m_Loops[i].end_sample == 0)) {
+        (m_Loops[i].m_StartPosition >= m_Loops[i].m_EndPosition)
+        || (m_Loops[i].m_StartPosition >= GetLength())
+        || (m_Loops[i].m_EndPosition >= GetLength())
+        || (m_Loops[i].m_EndPosition == 0)) {
         wxLogError(_("Invalid loop in the file: %s\n"), fileName);
         m_Loops.erase(m_Loops.begin() + i);
       }
@@ -282,17 +282,17 @@ unsigned GOWave::GetReleaseMarkerPosition() const {
   return m_CuePoint;
 }
 
-const GO_WAVE_LOOP &GOWave::GetLongestLoop() const {
+const GOWaveLoop &GOWave::GetLongestLoop() const {
   if (m_Loops.size() < 1)
     throw(wxString) _("wave does not contain loops");
 
-  assert(m_Loops[0].end_sample > m_Loops[0].start_sample);
+  assert(m_Loops[0].m_EndPosition > m_Loops[0].m_StartPosition);
   unsigned lidx = 0;
   for (unsigned int i = 1; i < m_Loops.size(); i++) {
-    assert(m_Loops[i].end_sample > m_Loops[i].start_sample);
+    assert(m_Loops[i].m_EndPosition > m_Loops[i].m_StartPosition);
     if (
-      (m_Loops[i].end_sample - m_Loops[i].start_sample)
-      > (m_Loops[lidx].end_sample - m_Loops[lidx].start_sample))
+      (m_Loops[i].m_EndPosition - m_Loops[i].m_StartPosition)
+      > (m_Loops[lidx].m_EndPosition - m_Loops[lidx].m_StartPosition))
       lidx = i;
   }
 
@@ -459,7 +459,7 @@ void GOWave::ReadSamples(
 
 unsigned GOWave::GetNbLoops() const { return m_Loops.size(); }
 
-const GO_WAVE_LOOP &GOWave::GetLoop(unsigned idx) const {
+const GOWaveLoop &GOWave::GetLoop(unsigned idx) const {
   assert(idx < m_Loops.size());
   return m_Loops[idx];
 }
@@ -527,8 +527,8 @@ bool GOWave::Save(GOBuffer<uint8_t> &buf) {
     for (unsigned i = 0; i < m_Loops.size(); i++) {
       loop.dwIdentifier = i;
       loop.dwType = 0;
-      loop.dwStart = m_Loops[i].start_sample;
-      loop.dwEnd = m_Loops[i].end_sample;
+      loop.dwStart = m_Loops[i].m_StartPosition;
+      loop.dwEnd = m_Loops[i].m_EndPosition;
       loop.dwFraction = 0;
       loop.dwPlayCount = 0;
       loops.Append((const uint8_t *)&loop, sizeof(loop));

--- a/src/core/GOWave.h
+++ b/src/core/GOWave.h
@@ -13,13 +13,9 @@
 #include <vector>
 
 #include "GOBuffer.h"
+#include "GOWaveLoop.h"
 
 class GOFile;
-
-typedef struct GO_WAVE_LOOP {
-  unsigned start_sample;
-  unsigned end_sample;
-} GO_WAVE_LOOP;
 
 class GOWave {
 private:
@@ -32,7 +28,7 @@ private:
   float m_PitchFract;
   bool m_isPacked;
   bool m_hasRelease;
-  std::vector<GO_WAVE_LOOP> m_Loops;
+  std::vector<GOWaveLoop> m_Loops;
 
   void SetInvalid();
   void LoadFormatChunk(const uint8_t *ptr, unsigned long length);
@@ -83,8 +79,8 @@ public:
   unsigned GetReleaseMarkerPosition() const;
 
   unsigned GetNbLoops() const;
-  const GO_WAVE_LOOP &GetLoop(unsigned idx) const;
-  const GO_WAVE_LOOP &GetLongestLoop() const;
+  const GOWaveLoop &GetLoop(unsigned idx) const;
+  const GOWaveLoop &GetLongestLoop() const;
 
   /* GetLength()
    * Returns the number of blocks in the wave file (there are *channel*

--- a/src/core/GOWaveLoop.h
+++ b/src/core/GOWaveLoop.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2022 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOWAVELOOP_H
+#define GOWAVELOOP_H
+
+struct GOWaveLoop {
+  unsigned m_StartPosition;
+  unsigned m_EndPosition;
+};
+
+#endif /* GOWAVELOOP_H */

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -641,7 +641,7 @@ void GOAudioSection::Setup(
   const unsigned pcm_data_channels,
   const unsigned pcm_data_sample_rate,
   const unsigned pcm_data_nb_samples,
-  const std::vector<GO_WAVE_LOOP> *loop_points,
+  const std::vector<GOWaveLoop> *loop_points,
   bool compress,
   unsigned crossfade_length) {
   if (pcm_data_channels < 1 || pcm_data_channels > 2)
@@ -671,13 +671,13 @@ void GOAudioSection::Setup(
     for (unsigned i = 0; i < loop_points->size(); i++) {
       audio_start_data_segment start_seg;
       audio_end_data_segment end_seg;
-      const GO_WAVE_LOOP &loop = (*loop_points)[i];
+      const GOWaveLoop &loop = (*loop_points)[i];
       unsigned fade_len = crossfade_length;
-      if (loop.end_sample + 1 > min_reqd_samples)
-        min_reqd_samples = loop.end_sample + 1;
+      if (loop.m_EndPosition + 1 > min_reqd_samples)
+        min_reqd_samples = loop.m_EndPosition + 1;
 
-      start_seg.start_offset = loop.start_sample;
-      end_seg.end_offset = loop.end_sample;
+      start_seg.start_offset = loop.m_StartPosition;
+      end_seg.end_offset = loop.m_EndPosition;
       end_seg.next_start_segment_index = i + 1;
       const unsigned loop_length
         = 1 + end_seg.end_offset - start_seg.start_offset;
@@ -729,7 +729,7 @@ void GOAudioSection::Setup(
       loop_memcpy(
         ((unsigned char *)end_seg.end_data) + copy_len * m_BytesPerSample,
         ((const unsigned char *)pcm_data)
-          + loop.start_sample * m_BytesPerSample,
+          + loop.m_StartPosition * m_BytesPerSample,
         loop_length * m_BytesPerSample,
         (end_length - copy_len) * m_BytesPerSample);
       if (fade_len > 0)

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -202,7 +202,7 @@ public:
     unsigned pcm_data_channels,
     unsigned pcm_data_sample_rate,
     unsigned pcm_data_nb_samples,
-    const std::vector<GO_WAVE_LOOP> *loop_points,
+    const std::vector<GOWaveLoop> *loop_points,
     bool compress,
     unsigned crossfade_length);
 

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
@@ -77,10 +77,10 @@ void GOSoundProviderSynthedTrem::Create(
   }
 
   /* Attack sustain section */
-  GO_WAVE_LOOP trem_loop;
-  trem_loop.start_sample = attack_samples;
-  trem_loop.end_sample = (attack_samples + loop_samples) - 1;
-  std::vector<GO_WAVE_LOOP> trem_loops;
+  GOWaveLoop trem_loop;
+  trem_loop.m_StartPosition = attack_samples;
+  trem_loop.m_EndPosition = (attack_samples + loop_samples) - 1;
+  std::vector<GOWaveLoop> trem_loops;
   trem_loops.push_back(trem_loop);
   attack_section_info attack_info;
   attack_info.sample_group = -1;
@@ -93,7 +93,7 @@ void GOSoundProviderSynthedTrem::Create(
     GOWave::SF_SIGNEDSHORT_16,
     1,
     sample_freq,
-    trem_loop.end_sample,
+    trem_loop.m_EndPosition,
     &trem_loops,
     false,
     0);

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -15,9 +15,9 @@
 #include "loader/GOLoaderFilename.h"
 
 #include "GOSoundProvider.h"
+#include "GOWaveLoop.h"
 
 class GOWave;
-typedef struct GO_WAVE_LOOP GO_WAVE_LOOP;
 
 typedef enum {
   /* Only the first loop with the earliest endpoint is loaded. This will
@@ -71,7 +71,7 @@ class GOSoundProviderWave : public GOSoundProvider {
     const char *data,
     GOWave &wave,
     int attack_start,
-    std::vector<GO_WAVE_LOOP> loop_list,
+    std::vector<GOWaveLoop> loop_list,
     int sample_group,
     unsigned bits_per_sample,
     unsigned channels,
@@ -97,7 +97,7 @@ class GOSoundProviderWave : public GOSoundProvider {
   void ProcessFile(
     GOMemoryPool &pool,
     const GOLoaderFilename &filename,
-    std::vector<GO_WAVE_LOOP> loops,
+    std::vector<GOWaveLoop> loops,
     bool is_attack,
     bool is_release,
     int sample_group,


### PR DESCRIPTION
There are a lot of doubled structure definitions of the same `Loop` structre in the source code. I'm going to use the single `GOWaveLoop` structure everywhere. This is PR extracts it from the `GOWave.h` file

No GO behaviour should be changed.
