### PR TITLE
Fixed crashing on exit in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crashing on exit in some cases
 # 3.9.2 (2022-11-29)
 - Fixed sending incorrect midi values from an enclosure https://github.com/GrandOrgue/grandorgue/issues/1267
 - Fixed not sending midi events from pushbuttons, including GC https://github.com/GrandOrgue/grandorgue/issues/1220

--- a/src/grandorgue/GOApp.cpp
+++ b/src/grandorgue/GOApp.cpp
@@ -155,12 +155,6 @@ int GOApp::OnRun() { return wxApp::OnRun(); }
 int GOApp::OnExit() {
   wxLog::SetActiveTarget(NULL);
 
-  wxApp::CleanUp(); // delete all GUI elements in order not to use m_soundSystem
-
-  delete m_soundSystem;
-  delete m_config;
-  delete m_Log;
-
   int rc = wxApp::OnExit();
 
   if (m_Restart) {
@@ -169,6 +163,26 @@ int GOApp::OnExit() {
     wxExecute(cmdargs);
   }
   return rc;
+}
+
+void GOApp::CleanUp() {
+  // Ensure that GOFrame and other objects are destroyed before deleting
+  wxApp::CleanUp();
+
+  // CleanUp() may be called even if OnInit() has not succeed, so we need to
+  // check
+  if (m_soundSystem) {
+    delete m_soundSystem;
+    m_soundSystem = nullptr;
+  }
+  if (m_config) {
+    delete m_config;
+    m_config = nullptr;
+  }
+  if (m_Log) {
+    delete m_Log;
+    m_Log = nullptr;
+  }
 }
 
 void GOApp::SetRestart() { m_Restart = true; }

--- a/src/grandorgue/GOApp.cpp
+++ b/src/grandorgue/GOApp.cpp
@@ -154,6 +154,9 @@ int GOApp::OnRun() { return wxApp::OnRun(); }
 
 int GOApp::OnExit() {
   wxLog::SetActiveTarget(NULL);
+
+  wxApp::CleanUp(); // delete all GUI elements in order not to use m_soundSystem
+
   delete m_soundSystem;
   delete m_config;
   delete m_Log;

--- a/src/grandorgue/GOApp.h
+++ b/src/grandorgue/GOApp.h
@@ -35,11 +35,12 @@ private:
   bool m_Restart;
 
   virtual void MacOpenFile(const wxString &fileName);
+  void OnInitCmdLine(wxCmdLineParser &parser);
+  bool OnCmdLineParsed(wxCmdLineParser &parser);
   bool OnInit();
   int OnRun();
   int OnExit();
-  void OnInitCmdLine(wxCmdLineParser &parser);
-  bool OnCmdLineParsed(wxCmdLineParser &parser);
+  virtual void CleanUp() override;
 
 protected:
   GOFrame *m_Frame;


### PR DESCRIPTION
In some situations, for example, if an unhandled exception occured (#1249), GrandOrgue exits and the exit causes a segfault.

The reason is `GOApp::OnExit` is called from wx when some windows, included `GOFrame` have not yet destroyed and continue to use objects `GOSound` and `GOConfig` that are deleted.

This PR forces destroying all windows before deleting the `GOSound` and `GOConfig`.