### PR TITLE
Replace using of loop_load_info with GOWaveLoop

### DIFF
--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -15309,8 +15309,6 @@
           </incDir>
         </ccTool>
       </item>
-      <item path="../../src/core/GOWaveLoop.h" ex="false" tool="3" flavor2="0">
-      </item>
       <item path="../../src/core/archive/GOArchive.cpp"
             ex="false"
             tool="1"

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -109,8 +109,9 @@ void GOSoundingPipe::LoadAttack(
   unsigned loop_cnt = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("LoopCount"), 0, 100, false, 0);
   for (unsigned j = 0; j < loop_cnt; j++) {
-    loop_load_info linfo;
-    linfo.loop_start = cfg.ReadInteger(
+    GOWaveLoop linfo;
+
+    linfo.m_StartPosition = cfg.ReadInteger(
       ODFSetting,
       group,
       prefix + wxString::Format(wxT("Loop%03dStart"), j + 1),
@@ -118,11 +119,11 @@ void GOSoundingPipe::LoadAttack(
       MAX_SAMPLE_LENGTH,
       false,
       0);
-    linfo.loop_end = cfg.ReadInteger(
+    linfo.m_EndPosition = cfg.ReadInteger(
       ODFSetting,
       group,
       prefix + wxString::Format(wxT("Loop%03dEnd"), j + 1),
-      linfo.loop_start + 1,
+      linfo.m_StartPosition + 1,
       MAX_SAMPLE_LENGTH,
       true);
     ainfo.loops.push_back(linfo);
@@ -325,8 +326,8 @@ void GOSoundingPipe::UpdateHash(GOHash &hash) {
     hash.Update(m_AttackInfo[i].attack_start);
     hash.Update(m_AttackInfo[i].release_end);
     for (unsigned j = 0; j < m_AttackInfo[i].loops.size(); j++) {
-      hash.Update(m_AttackInfo[i].loops[j].loop_start);
-      hash.Update(m_AttackInfo[i].loops[j].loop_end);
+      hash.Update(m_AttackInfo[i].loops[j].m_StartPosition);
+      hash.Update(m_AttackInfo[i].loops[j].m_EndPosition);
     }
   }
 

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -372,17 +372,10 @@ void GOSoundProviderWave::LoadFromFile(
 
   try {
     for (unsigned i = 0; i < attacks.size(); i++) {
-      std::vector<GOWaveLoop> loops;
-      for (unsigned j = 0; j < attacks[i].loops.size(); j++) {
-        GOWaveLoop loop;
-        loop.m_StartPosition = attacks[i].loops[j].loop_start;
-        loop.m_EndPosition = attacks[i].loops[j].loop_end;
-        loops.push_back(loop);
-      }
       ProcessFile(
         pool,
         attacks[i].filename,
-        loops,
+        attacks[i].loops,
         true,
         attacks[i].load_release,
         attacks[i].sample_group,

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -37,7 +37,7 @@ void GOSoundProviderWave::CreateAttack(
   const char *data,
   GOWave &wave,
   int attack_start,
-  std::vector<GOWaveLoop> loop_list,
+  const std::vector<GOWaveLoop> *pSrcLoops,
   int sample_group,
   unsigned bits_per_sample,
   unsigned channels,
@@ -47,54 +47,60 @@ void GOSoundProviderWave::CreateAttack(
   unsigned min_attack_velocity,
   unsigned loop_crossfade_length,
   unsigned max_released_time) {
+  std::vector<GOWaveLoop> waveLoops;
   std::vector<GOWaveLoop> loops;
   unsigned attack_pos = attack_start;
-  if (loop_list.size() == 0)
-    for (unsigned i = 0; i < wave.GetNbLoops(); i++)
-      loop_list.push_back(wave.GetLoop(i));
 
-  for (unsigned i = 0; i < loop_list.size(); i++) {
+  if (!pSrcLoops || pSrcLoops->size() == 0) {
+    // loops have not been provided. Read them from wave
+
+    for (unsigned i = 0; i < wave.GetNbLoops(); i++)
+      waveLoops.push_back(wave.GetLoop(i));
+    pSrcLoops = &waveLoops;
+  }
+
+  for (unsigned i = 0; i < pSrcLoops->size(); i++) {
     if (
-      loop_list[i].m_StartPosition >= wave.GetLength()
-      || loop_list[i].m_StartPosition >= loop_list[i].m_EndPosition
-      || loop_list[i].m_EndPosition >= wave.GetLength())
+      (*pSrcLoops)[i].m_StartPosition >= wave.GetLength()
+      || (*pSrcLoops)[i].m_StartPosition >= (*pSrcLoops)[i].m_EndPosition
+      || (*pSrcLoops)[i].m_EndPosition >= wave.GetLength())
       throw(wxString) _("Invalid loop definition");
     if (
       loop_crossfade_length
-      && loop_list[i].m_StartPosition + REMAINING_AFTER_CROSSFADE
+      && (*pSrcLoops)[i].m_StartPosition + REMAINING_AFTER_CROSSFADE
           + loop_crossfade_length
-        >= loop_list[i].m_EndPosition)
+        >= (*pSrcLoops)[i].m_EndPosition)
       throw(wxString) _("Loop too short for a cross fade");
   }
 
-  if ((loop_list.size() > 0) && !percussive) {
+  if ((pSrcLoops->size() > 0) && !percussive) {
     switch (loop_mode) {
     case LOOP_LOAD_ALL:
-      for (unsigned i = 0; i < loop_list.size(); i++)
-        if (attack_pos <= loop_list[i].m_StartPosition)
-          loops.push_back(loop_list[i]);
+      for (unsigned i = 0; i < pSrcLoops->size(); i++)
+        if (attack_pos <= (*pSrcLoops)[i].m_StartPosition)
+          loops.push_back((*pSrcLoops)[i]);
       break;
     case LOOP_LOAD_CONSERVATIVE: {
       unsigned cidx = 0;
-      for (unsigned i = 1; i < loop_list.size(); i++)
-        if (loop_list[i].m_EndPosition < loop_list[i].m_EndPosition)
-          if (attack_pos <= loop_list[i].m_StartPosition)
+      for (unsigned i = 1; i < pSrcLoops->size(); i++)
+        if ((*pSrcLoops)[i].m_EndPosition < (*pSrcLoops)[i].m_EndPosition)
+          if (attack_pos <= (*pSrcLoops)[i].m_StartPosition)
             cidx = i;
-      loops.push_back(loop_list[cidx]);
+      loops.push_back((*pSrcLoops)[cidx]);
     } break;
     default: {
       assert(loop_mode == LOOP_LOAD_LONGEST);
 
       unsigned lidx = 0;
-      for (unsigned int i = 1; i < loop_list.size(); i++) {
-        assert(loop_list[i].m_EndPosition > loop_list[i].m_StartPosition);
+      for (unsigned int i = 1; i < pSrcLoops->size(); i++) {
+        assert((*pSrcLoops)[i].m_EndPosition > (*pSrcLoops)[i].m_StartPosition);
         if (
-          (loop_list[i].m_EndPosition - loop_list[i].m_StartPosition)
-          > (loop_list[lidx].m_EndPosition - loop_list[lidx].m_StartPosition))
-          if (attack_pos <= loop_list[i].m_StartPosition)
+          ((*pSrcLoops)[i].m_EndPosition - (*pSrcLoops)[i].m_StartPosition)
+          > ((*pSrcLoops)[lidx].m_EndPosition - (*pSrcLoops)[lidx].m_StartPosition))
+          if (attack_pos <= (*pSrcLoops)[i].m_StartPosition)
             lidx = i;
       }
-      loops.push_back(loop_list[lidx]);
+      loops.push_back((*pSrcLoops)[lidx]);
     }
     }
     if (loops.size() == 0)
@@ -179,7 +185,7 @@ void GOSoundProviderWave::LoadPitch(const GOLoaderFilename &filename) {
 void GOSoundProviderWave::ProcessFile(
   GOMemoryPool &pool,
   const GOLoaderFilename &filename,
-  std::vector<GOWaveLoop> loops,
+  const std::vector<GOWaveLoop> *loops,
   bool is_attack,
   bool is_release,
   int sample_group,
@@ -375,7 +381,7 @@ void GOSoundProviderWave::LoadFromFile(
       ProcessFile(
         pool,
         attacks[i].filename,
-        attacks[i].loops,
+        &attacks[i].loops,
         true,
         attacks[i].load_release,
         attacks[i].sample_group,
@@ -396,11 +402,10 @@ void GOSoundProviderWave::LoadFromFile(
     }
 
     for (unsigned i = 0; i < releases.size(); i++) {
-      std::vector<GOWaveLoop> loops;
       ProcessFile(
         pool,
         releases[i].filename,
-        loops,
+        nullptr,
         false,
         true,
         releases[i].sample_group,

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -47,7 +47,7 @@ typedef struct {
   int attack_start;
   int cue_point;
   int release_end;
-    std::vector<GOWaveLoop> loops;
+  std::vector<GOWaveLoop> loops;
 } attack_load_info;
 
 typedef struct {

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -66,7 +66,7 @@ class GOSoundProviderWave : public GOSoundProvider {
     const char *data,
     GOWave &wave,
     int attack_start,
-    std::vector<GOWaveLoop> loop_list,
+    const std::vector<GOWaveLoop> *pSrcLoops,
     int sample_group,
     unsigned bits_per_sample,
     unsigned channels,
@@ -92,7 +92,7 @@ class GOSoundProviderWave : public GOSoundProvider {
   void ProcessFile(
     GOMemoryPool &pool,
     const GOLoaderFilename &filename,
-    std::vector<GOWaveLoop> loops,
+    const std::vector<GOWaveLoop> *loops,
     bool is_attack,
     bool is_release,
     int sample_group,

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -37,11 +37,6 @@ typedef enum {
 } loop_load_type;
 
 typedef struct {
-  int loop_start;
-  int loop_end;
-} loop_load_info;
-
-typedef struct {
   GOLoaderFilename filename;
   int sample_group;
   bool load_release;
@@ -52,7 +47,7 @@ typedef struct {
   int attack_start;
   int cue_point;
   int release_end;
-  std::vector<loop_load_info> loops;
+    std::vector<GOWaveLoop> loops;
 } attack_load_info;
 
 typedef struct {


### PR DESCRIPTION
I've got rid of the `loop_load_info` structure and I've replaced it with the `GOWaveLoop`. It allowed me to do some optimisation by eliminating converting vectos of `loop_load_info` to ones of `GOWaveLoop`.

No GO behavior should be changed.
