### PR TITLE
Extracted the file-finding logic from GOOrganController to the new class GOFileStore

### DIFF
--- a/src/core/archive/GOArchiveManager.h
+++ b/src/core/archive/GOArchiveManager.h
@@ -8,11 +8,10 @@
 #ifndef GOARCHIVEMANAGER_H
 #define GOARCHIVEMANAGER_H
 
+#include <wx/string.h>
+
 class GOArchive;
 class GOOrganList;
-class GOConfig;
-
-#include <wx/string.h>
 
 class GOArchiveManager {
 private:

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -97,6 +97,7 @@ gui/GOGUIRecorderPanel.cpp
 gui/GOGUISequencerPanel.cpp
 help/GOHelpController.cpp
 help/GOHelpRequestor.cpp
+loader/GOFileStore.cpp
 loader/GOLoaderFilename.cpp
 loader/GOLoadThread.cpp
 midi/ports/GOMidiInPort.cpp

--- a/src/grandorgue/GOBitmapCache.cpp
+++ b/src/grandorgue/GOBitmapCache.cpp
@@ -172,7 +172,7 @@ bool GOBitmapCache::loadFile(wxImage &img, const wxString &filename) {
 
   try {
     GOLoaderFilename name;
-    name.Assign(filename, m_OrganController);
+    name.Assign(m_OrganController->GetFileStore(), filename);
 
     std::unique_ptr<GOFile> file = name.Open();
     GOBuffer<char> data;

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -19,6 +19,7 @@
 #include "control/GOEventDistributor.h"
 #include "control/GOLabelControl.h"
 #include "gui/GOGUIMouseState.h"
+#include "loader/GOFileStore.h"
 #include "model/GOModificationListener.h"
 #include "model/GOOrganModel.h"
 #include "model/pipe-config/GOPipeConfigTreeNode.h"
@@ -65,7 +66,7 @@ private:
   wxString m_ArchiveID;
   wxString m_ArchivePath;
   wxString m_hash;
-  wxString m_path;
+  GOFileStore m_FileStore;
   wxString m_CacheFilename;
   wxString m_SettingFilename;
   wxString m_ODFHash;
@@ -99,7 +100,6 @@ private:
   ptr_vector<GOGUIPanel> m_panels;
   ptr_vector<GOGUIPanelCreator> m_panelcreators;
   ptr_vector<GOElementCreator> m_elementcreators;
-  ptr_vector<GOArchive> m_archives;
   GOStringBoolMap m_UsedSections;
 
   GOSoundEngine *m_soundengine;
@@ -136,10 +136,6 @@ private:
 
   wxString GetOrganHash();
 
-  bool LoadArchive(
-    wxString ID, wxString &name, const wxString &parentID = wxEmptyString);
-  void CloseArchives();
-
 public:
   GOOrganController(GODocument *doc, GOConfig &settings);
   ~GOOrganController();
@@ -150,6 +146,16 @@ public:
   void SetOrganModified() { SetOrganModified(true); }
   // Clears the organ modification flag
   void ResetOrganModified();
+
+  const GOFileStore &GetFileStore() const { return m_FileStore; }
+
+  /**
+   * Set organ directory without lroviding any odf. Called only from GOPerfTest
+   * @param dir the directory for loading objects from
+   */
+  void InitOrganDirectory(const wxString &dir) {
+    m_FileStore.SetDirectory(dir);
+  }
 
   wxString Load(
     GOProgressDialog *dlg,
@@ -186,9 +192,6 @@ public:
   wxString GetTemperament();
   void MarkSectionInUse(wxString name);
 
-  bool useArchives();
-  GOArchive *findArchive(const wxString &name);
-
   int GetRecorderElementID(wxString name);
   GOCombinationDefinition &GetGeneralTemplate();
   GOLabelControl *GetPitchLabel();
@@ -223,7 +226,6 @@ public:
 
   /* Filename of the organ definition used to load */
   const wxString GetODFFilename();
-  const wxString GetODFPath();
   const wxString GetOrganPathInfo();
   GOOrgan GetOrganInfo();
   const wxString GetSettingFilename();
@@ -255,9 +257,6 @@ public:
   GOMidi *GetMidi();
 
   GOGUIMouseState &GetMouseState() { return m_MouseState; }
-
-  /* For testing only */
-  void SetODFPath(wxString path);
 };
 
 #endif

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -150,7 +150,8 @@ public:
   const GOFileStore &GetFileStore() const { return m_FileStore; }
 
   /**
-   * Set organ directory without lroviding any odf. Called only from GOPerfTest
+   * Set the organ directory without providing any odf.
+   * Called only from GOPerfTest.
    * @param dir the directory for loading objects from
    */
   void InitOrganDirectory(const wxString &dir) {

--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -493,10 +493,6 @@ GOMidiReceiverBase *GOConfig::FindMidiEvent(
   return NULL;
 }
 
-const wxString GOConfig::GetResourceDirectory() {
-  return m_ResourceDir.c_str();
-}
-
 const wxString GOConfig::GetPackageDirectory() {
   return m_ResourceDir + wxFileName::GetPathSeparator() + wxT("packages");
 }

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -164,7 +164,7 @@ public:
   int GetLanguageId() const;
   void SetLanguageId(int langId);
 
-  const wxString GetResourceDirectory();
+  const wxString &GetResourceDirectory() const { return m_ResourceDir; }
   const wxString GetPackageDirectory();
 
   unsigned GetEventCount();

--- a/src/grandorgue/loader/GOFileStore.cpp
+++ b/src/grandorgue/loader/GOFileStore.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2022 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOFileStore.h"
+
+#include <wx/intl.h>
+
+#include "archive/GOArchive.h"
+#include "archive/GOArchiveFile.h"
+#include "archive/GOArchiveManager.h"
+
+#include "GOOrganList.h"
+
+void GOFileStore::SetDirectory(const wxString &directory) {
+  // we do not support if both m_directory and m_archives are filled
+  m_archives.clear();
+  m_directory = directory;
+}
+
+bool GOFileStore::LoadArchive(
+  GOOrganList &organList,
+  const wxString &cacheDir,
+  const wxString id,
+  const wxString &parentId,
+  wxString &errMsg) {
+  bool isOk = true;
+  GOArchiveManager manager(organList, cacheDir);
+  GOArchive *archive = manager.LoadArchive(id);
+
+  if (archive)
+    m_archives.push_back(archive);
+  else {
+    // get the archive name for composing an error message
+    wxString archiveName;
+    const GOArchiveFile *a = organList.GetArchiveByID(id);
+
+    if (a)
+      archiveName = a->GetName();
+    else if (parentId != wxEmptyString) {
+      a = organList.GetArchiveByID(parentId);
+      for (unsigned i = 0; i < a->GetDependencies().size(); i++)
+        if (a->GetDependencies()[i] == id)
+          archiveName = a->GetDependencyTitles()[i];
+    }
+
+    errMsg = wxString::Format(
+      _("Failed to open organ package '%s' (%s)"), archiveName, id);
+    isOk = false;
+  }
+  return isOk;
+}
+
+bool GOFileStore::LoadArchives(
+  GOOrganList &organList,
+  const wxString &cacheDir,
+  const wxString mainId,
+  wxString &errMsg) {
+  SetDirectory(wxEmptyString); // clean up all
+
+  bool isOk = LoadArchive(organList, cacheDir, mainId, wxEmptyString, errMsg);
+
+  if (isOk)
+    for (auto depId : m_archives[0]->GetDependencies()) {
+      isOk = LoadArchive(organList, cacheDir, depId, mainId, errMsg);
+      if (!isOk)
+        break;
+    }
+  return isOk;
+}
+
+GOArchive *GOFileStore::FindArchiveContaining(const wxString fileName) const {
+  GOArchive *aFound;
+
+  for (auto a : m_archives) {
+    if (a->containsFile(fileName)) {
+      aFound = a;
+      break;
+    }
+  }
+  return aFound;
+}
+
+void GOFileStore::CloseArchives() {
+  for (auto a : m_archives)
+    a->Close();
+}

--- a/src/grandorgue/loader/GOFileStore.h
+++ b/src/grandorgue/loader/GOFileStore.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2022 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOFILESTORE_H
+#define GOFILESTORE_H
+
+#include <wx/string.h>
+
+#include "ptrvector.h"
+
+class GOArchive;
+class GOOrganList;
+
+/**
+ * This class represents a container that contains other files
+ * It can be either a directory or a list of (dependent) archives
+ */
+
+class GOFileStore {
+private:
+  wxString m_directory;
+  ptr_vector<GOArchive> m_archives;
+  bool LoadArchive(
+    GOOrganList &organList,
+    const wxString &cacheDir,
+    const wxString id,
+    const wxString &parentId,
+    wxString &errMsg);
+
+public:
+  const wxString &GetDirectory() const { return m_directory; }
+  void SetDirectory(const wxString &directory);
+  bool AreArchivesUsed() const { return m_archives.size() > 0; }
+  const GOArchive *GetMainArchive() const {
+    return AreArchivesUsed() ? m_archives[0] : nullptr;
+  }
+
+  /**
+   * Load archive directories for the given archive id and all it's dependencies
+   * @param organList - a list of registered organs
+   * @param cacheDir - a directory to read/write index files
+   * @param mainId - an identifier of the main archive to load
+   * @param errMsg - an error message that is returned if the operation fails
+   * @return - true if success and false if any error occured (the error message
+   *   is returned in errMsg)
+   */
+  bool LoadArchives(
+    GOOrganList &organList,
+    const wxString &cacheDir,
+    const wxString mainId,
+    wxString &errMsg);
+
+  /**
+   * search fileName across all archives in m_archives
+   * @param fileName - a file name to search
+   * @return a pointer to an archive containing the file or nullptr if the file
+   *   does not exist in any archive
+   */
+  GOArchive *FindArchiveContaining(const wxString fileName) const;
+
+  void CloseArchives();
+};
+
+#endif /* GOFILESTORE_H */

--- a/src/grandorgue/loader/GOLoaderFilename.cpp
+++ b/src/grandorgue/loader/GOLoaderFilename.cpp
@@ -10,12 +10,13 @@
 #include <wx/filename.h>
 #include <wx/log.h>
 
-#include "GOHash.h"
-#include "GOInvalidFile.h"
-#include "GOOrganController.h"
-#include "GOStandardFile.h"
 #include "archive/GOArchive.h"
 #include "config/GOConfig.h"
+#include "loader/GOFileStore.h"
+
+#include "GOHash.h"
+#include "GOInvalidFile.h"
+#include "GOStandardFile.h"
 
 GOLoaderFilename::GOLoaderFilename()
   : m_Name(),
@@ -72,25 +73,25 @@ void GOLoaderFilename::SetPath(const wxString &base, const wxString &file) {
 }
 
 void GOLoaderFilename::Assign(
-  const wxString &name, GOOrganController *organController) {
+  const GOFileStore &fileStore, const wxString &name) {
   m_Name = name;
-  if (organController->useArchives()) {
+  if (fileStore.AreArchivesUsed()) {
     m_Path = wxEmptyString;
-    m_Archiv = organController->findArchive(name);
+    m_Archiv = fileStore.FindArchiveContaining(name);
     if (!m_Archiv) {
       wxLogError(_("File '%s' does not exists"), name.c_str());
     }
     return;
   }
-  SetPath(organController->GetODFPath(), name);
+  SetPath(fileStore.GetDirectory(), name);
 }
 
 void GOLoaderFilename::AssignResource(
-  const wxString &name, GOOrganController *organController) {
+  const wxString &resourceDirectory, const wxString &name) {
   m_Name = name;
   m_ToHashSizeTime = false;
   m_ToHashPath = false;
-  SetPath(organController->GetSettings().GetResourceDirectory(), name);
+  SetPath(resourceDirectory, name);
 }
 
 void GOLoaderFilename::AssignAbsolute(const wxString &path) {

--- a/src/grandorgue/loader/GOLoaderFilename.h
+++ b/src/grandorgue/loader/GOLoaderFilename.h
@@ -14,8 +14,8 @@
 
 class GOArchive;
 class GOFile;
+class GOFileStore;
 class GOHash;
-class GOOrganController;
 
 class GOLoaderFilename {
 private:
@@ -30,8 +30,8 @@ private:
 public:
   GOLoaderFilename();
 
-  void Assign(const wxString &name, GOOrganController *organController);
-  void AssignResource(const wxString &name, GOOrganController *organController);
+  void Assign(const GOFileStore &fileStore, const wxString &name);
+  void AssignResource(const wxString &resourceDirectory, const wxString &name);
   void AssignAbsolute(const wxString &path);
 
   const wxString &GetTitle() const;

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -62,7 +62,8 @@ void GOSoundingPipe::LoadAttack(
   GOConfigReader &cfg, wxString group, wxString prefix) {
   attack_load_info ainfo;
   ainfo.filename.Assign(
-    cfg.ReadFileName(ODFSetting, group, prefix), m_OrganController);
+    m_OrganController->GetFileStore(),
+    cfg.ReadFileName(ODFSetting, group, prefix));
   ainfo.sample_group = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("IsTremulant"), -1, 1, false, -1);
   ainfo.load_release = cfg.ReadBoolean(
@@ -143,7 +144,8 @@ void GOSoundingPipe::Init(
   m_OrganController->GetWindchest(m_SamplerGroupID - 1)->AddPipe(this);
 
   attack_load_info ainfo;
-  ainfo.filename.AssignResource(m_Filename, m_OrganController);
+  ainfo.filename.AssignResource(
+    m_OrganController->GetConfig().GetResourceDirectory(), m_Filename);
   ainfo.sample_group = -1;
   ainfo.load_release = !m_Percussive;
   ainfo.percussive = m_Percussive;
@@ -222,7 +224,8 @@ void GOSoundingPipe::Load(
     wxString p = prefix + wxString::Format(wxT("Release%03d"), i + 1);
 
     rinfo.filename.Assign(
-      cfg.ReadFileName(ODFSetting, group, p), m_OrganController);
+      m_OrganController->GetFileStore(),
+      cfg.ReadFileName(ODFSetting, group, p));
     rinfo.sample_group = cfg.ReadInteger(
       ODFSetting, group, p + wxT("IsTremulant"), -1, 1, false, -1);
     rinfo.max_playback_time = cfg.ReadInteger(

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -76,7 +76,7 @@ void GOPerfTestApp::RunTest(
                                         : GOStdPath::GetResourceDir()
         + wxFileName::GetPathSeparator() + "perftests";
 
-    organController->SetODFPath(testsDir);
+    organController->InitOrganDirectory(testsDir);
     organController->AddWindchest(new GOWindchest(organController));
     GOSoundEngine *engine = new GOSoundEngine();
     GOSoundRecorder recorder;
@@ -92,7 +92,8 @@ void GOPerfTestApp::RunTest(
         std::vector<attack_load_info> attack;
         attack_load_info ainfo;
         ainfo.filename.Assign(
-          wxString::Format(wxT("%02d.wav"), i % 3), organController);
+          organController->GetFileStore(),
+          wxString::Format(wxT("%02d.wav"), i % 3));
         ainfo.sample_group = -1;
         ainfo.load_release = true;
         ainfo.percussive = false;


### PR DESCRIPTION
Toward to simplifying GOOrganController I  extracted some code responsible for searching files and archives from the class to the new class `GOFileStore` in the `loader` subdirectory.

No GO behavior should be changed.
