### PR TITLE
Added capability of using filestore at GOCachedObject::LoadData

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -565,7 +565,8 @@ wxString GOOrganController::Load(
     if (!cache_ok) {
       ptr_vector<GOLoadThread> threads;
       for (unsigned i = 0; i < m_config.LoadConcurrency(); i++)
-        threads.push_back(new GOLoadThread(m_pool, objectDistributor));
+        threads.push_back(
+          new GOLoadThread(m_FileStore, m_pool, objectDistributor));
 
       for (unsigned i = 0; i < threads.size(); i++)
         threads[i]->Run();
@@ -573,7 +574,7 @@ wxString GOOrganController::Load(
       GOCacheObject *obj;
 
       while ((obj = objectDistributor.fetchNext())) {
-        obj->LoadData(m_pool);
+        obj->LoadData(m_FileStore, m_pool);
         if (!dlg->Update(objectDistributor.GetPos(), obj->GetLoadTitle())) {
           dummy.free();
           SetTemperament(m_Temperament);

--- a/src/grandorgue/loader/GOLoadThread.cpp
+++ b/src/grandorgue/loader/GOLoadThread.cpp
@@ -14,8 +14,11 @@
 #include "GOMemoryPool.h"
 
 GOLoadThread::GOLoadThread(
-  GOMemoryPool &pool, GOCacheObjectDistributor &distributor)
+  const GOFileStore &fileStore,
+  GOMemoryPool &pool,
+  GOCacheObjectDistributor &distributor)
   : GOThread(),
+    m_FileStore(fileStore),
     m_pool(pool),
     m_distributor(distributor),
     m_Error(),
@@ -42,7 +45,7 @@ void GOLoadThread::Entry() {
 
       if (!obj)
         return;
-      obj->LoadData(m_pool);
+      obj->LoadData(m_FileStore, m_pool);
     } catch (GOOutOfMemory e) {
       m_OutOfMemory = true;
       return;

--- a/src/grandorgue/loader/GOLoadThread.h
+++ b/src/grandorgue/loader/GOLoadThread.h
@@ -14,10 +14,12 @@
 
 #include "GOCacheObjectDistributor.h"
 
+class GOFileStore;
 class GOMemoryPool;
 
 class GOLoadThread : private GOThread {
 private:
+  const GOFileStore &m_FileStore;
   GOMemoryPool &m_pool;
   GOCacheObjectDistributor &m_distributor;
   wxString m_Error;
@@ -29,7 +31,10 @@ private:
   void Entry() override;
 
 public:
-  GOLoadThread(GOMemoryPool &pool, GOCacheObjectDistributor &distributor);
+  GOLoadThread(
+    const GOFileStore &fileStore,
+    GOMemoryPool &pool,
+    GOCacheObjectDistributor &distributor);
   ~GOLoadThread();
 
   void Run();

--- a/src/grandorgue/model/GOCacheObject.h
+++ b/src/grandorgue/model/GOCacheObject.h
@@ -12,6 +12,7 @@
 
 class GOCache;
 class GOCacheWriter;
+class GOFileStore;
 class GOHash;
 class GOMemoryPool;
 
@@ -20,7 +21,7 @@ public:
   virtual ~GOCacheObject() {}
 
   virtual void Initialize() = 0;
-  virtual void LoadData(GOMemoryPool &pool) = 0;
+  virtual void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) = 0;
   virtual bool LoadCache(GOMemoryPool &pool, GOCache &cache) = 0;
   virtual bool SaveCache(GOCacheWriter &cache) = 0;
   virtual void UpdateHash(GOHash &hash) = 0;

--- a/src/grandorgue/model/GOReferencePipe.h
+++ b/src/grandorgue/model/GOReferencePipe.h
@@ -21,7 +21,7 @@ private:
   wxString m_Filename;
 
   void Initialize();
-  void LoadData(GOMemoryPool &pool) override {}
+  void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) override {}
   bool LoadCache(GOMemoryPool &pool, GOCache &cache) override { return true; }
   bool SaveCache(GOCacheWriter &cache) override { return true; }
   void UpdateHash(GOHash &hash);

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -253,7 +253,8 @@ void GOSoundingPipe::Load(
     wxString::Format(_("%d: %s"), m_MidiKeyNumber, m_Filename.c_str()));
 }
 
-void GOSoundingPipe::LoadData(GOMemoryPool &pool) {
+void GOSoundingPipe::LoadData(
+  const GOFileStore &fileStore, GOMemoryPool &pool) {
   try {
     m_SoundProvider.LoadFromFile(
       pool,

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -59,7 +59,7 @@ private:
   void LoadAttack(GOConfigReader &cfg, wxString group, wxString prefix);
 
   void Initialize();
-  void LoadData(GOMemoryPool &pool) override;
+  void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) override;
   bool LoadCache(GOMemoryPool &pool, GOCache &cache) override;
   bool SaveCache(GOCacheWriter &cache);
   void UpdateHash(GOHash &hash);

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -42,7 +42,9 @@ GOTremulant::~GOTremulant() { DELETE_AND_NULL(m_TremProvider); }
 
 void GOTremulant::Initialize() {}
 
-void GOTremulant::LoadData(GOMemoryPool &pool) { InitSoundProvider(pool); }
+void GOTremulant::LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) {
+  InitSoundProvider(pool);
+}
 
 bool GOTremulant::LoadCache(GOMemoryPool &pool, GOCache &cache) {
   InitSoundProvider(pool);

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -40,7 +40,7 @@ private:
   void SetupCombinationState();
 
   void Initialize();
-  void LoadData(GOMemoryPool &pool);
+  void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool);
   bool LoadCache(GOMemoryPool &pool, GOCache &cache);
   bool SaveCache(GOCacheWriter &cache);
   void UpdateHash(GOHash &hash);


### PR DESCRIPTION
For separating GOOrganModel from GOOrganController, the files should be resolved againts directories during the (multithreaded) `Load Organ` phase insead of making the OrganModels. So I added the parameter fileStore to the `GOCachedObject::LoadData` and to all subclasses.

No GO behavior should be changed.