### PR TITLE
Added resource directory to GOFileStore

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -79,6 +79,7 @@ GOOrganController::GOOrganController(GODocument *doc, GOConfig &settings)
     m_odf(),
     m_ArchiveID(),
     m_hash(),
+    m_FileStore(settings),
     m_CacheFilename(),
     m_SettingFilename(),
     m_ODFHash(),

--- a/src/grandorgue/loader/GOFileStore.cpp
+++ b/src/grandorgue/loader/GOFileStore.cpp
@@ -77,7 +77,7 @@ bool GOFileStore::LoadArchives(
 }
 
 GOArchive *GOFileStore::FindArchiveContaining(const wxString fileName) const {
-  GOArchive *aFound;
+  GOArchive *aFound = nullptr;
 
   for (auto a : m_archives) {
     if (a->containsFile(fileName)) {

--- a/src/grandorgue/loader/GOFileStore.cpp
+++ b/src/grandorgue/loader/GOFileStore.cpp
@@ -12,8 +12,12 @@
 #include "archive/GOArchive.h"
 #include "archive/GOArchiveFile.h"
 #include "archive/GOArchiveManager.h"
+#include "config/GOConfig.h"
 
 #include "GOOrganList.h"
+
+GOFileStore::GOFileStore(const GOConfig &config)
+  : m_ResourceDirectory(config.GetResourceDirectory()) {}
 
 void GOFileStore::SetDirectory(const wxString &directory) {
   // we do not support if both m_directory and m_archives are filled

--- a/src/grandorgue/loader/GOFileStore.h
+++ b/src/grandorgue/loader/GOFileStore.h
@@ -20,8 +20,12 @@ class GOOrganList;
  * It can be either a directory or a list of (dependent) archives
  */
 
+class GOConfig;
+
 class GOFileStore {
 private:
+  wxString m_ResourceDirectory;
+
   wxString m_directory;
   ptr_vector<GOArchive> m_archives;
   bool LoadArchive(
@@ -32,6 +36,9 @@ private:
     wxString &errMsg);
 
 public:
+  GOFileStore(const GOConfig &config);
+
+  const wxString &GetResourceDirectory() const { return m_ResourceDirectory; }
   const wxString &GetDirectory() const { return m_directory; }
   void SetDirectory(const wxString &directory);
   bool AreArchivesUsed() const { return m_archives.size() > 0; }


### PR DESCRIPTION
Because some files are loaded from ResourceDirectory instead of archives or the odf directory, I added GOFileStore::m_ResourceDirectory.
