### PR TITLE
Fixed incorrect error messages of GrandOrguePerf https://github.com/GrandOrgue/grandorgue/issues/1280

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed error messages of GrandOrguePerf https://github.com/GrandOrgue/grandorgue/issues/1280
 - Fixed exit from GrandOrgue with an unhandled exception occurred on loading an organ
 - Fixed displaying output volume indicators on OSx https://github.com/GrandOrgue/grandorgue/issues/1255
 - Fixed sending midi-off events from generals and another pushbuttons https://github.com/GrandOrgue/grandorgue/issues/1291

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -169,7 +169,7 @@ void GOPerfTestApp::RunTest(
 
       float playback_time
         = blocks * (double)samples_per_frame / engine->GetSampleRate();
-      wxLogError(
+      wxLogMessage(
         wxT("%u sampler, %f seconds, %u bits, %u, %s, %s, %u block: "
             "%ld ms cpu time, limit: %f"),
         pipes.size(),
@@ -197,6 +197,7 @@ void GOPerfTestApp::RunTest(
 bool GOPerfTestApp::OnInit() {
   wxLog *logger = new wxLogStream(&std::cout);
   wxLog::SetActiveTarget(logger);
+  wxLog::SetLogLevel(wxLOG_Status);
   wxImage::AddHandler(new wxJPEGHandler);
   wxImage::AddHandler(new wxGIFHandler);
   wxImage::AddHandler(new wxPNGHandler);


### PR DESCRIPTION
Resolves: #1280

1. Changed output messages from Error to Message
2. Disabled output of debug messages (ex. ``Loading file 01.wav``)