### PR TITLE
Fixed switching off generals when using crescendo in not override mode https://github.com/GrandOrgue/grandorgue/issues/1299

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 3.9.3 (2022-12-09)
+- Fixed switching off generals when using crescendo in not override mode https://github.com/GrandOrgue/grandorgue/issues/1299
 - Fixed error messages of GrandOrguePerf https://github.com/GrandOrgue/grandorgue/issues/1280
 - Fixed exit from GrandOrgue with an unhandled exception occurred on loading an organ
 - Fixed displaying output volume indicators on OSx https://github.com/GrandOrgue/grandorgue/issues/1255

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -385,9 +385,10 @@ void GOGeneralCombination::Push(
   ExtraElementsSet const *extraSet, bool isFromCrescendo) {
   GOCombination::PushLocal(extraSet);
 
-  if (!isFromCrescendo || !extraSet) { // Crescendo in add mode: not to switch
-                                       // off combination
-                                       // buttons
+  if (!isFromCrescendo || !extraSet) { // Otherwise the rescendo in add mode:
+                                       // not to switch off combination buttons
+    m_OrganController->GetSetter()->ResetDisplay(); // disable buttons
+
     for (unsigned k = 0; k < m_OrganController->GetGeneralCount(); k++) {
       GOGeneralButtonControl *general = m_OrganController->GetGeneral(k);
       general->Display(&general->GetGeneral() == this);
@@ -402,8 +403,6 @@ void GOGeneralCombination::Push(
         m_OrganController->GetManual(j)->GetDivisional(k)->Display(false);
     }
   }
-
-  m_OrganController->GetSetter()->ResetDisplay();
 }
 
 void GOGeneralCombination::Save(GOConfigWriter &cfg) {


### PR DESCRIPTION
Resolves: #1299

`GOSetter::ResetDisplay()` disables all generals.

Now it is called from `GOGeneralCombination::Push()` only if it is called from another general or from a crescendo in override mode.