### PR TITLE
Fixed an old version number in the gnome application metadata https://github.com/GrandOrgue/grandorgue/issues/1304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 3.9.3 (2022-12-09)
-- Fixed an old version number in the gnome application metadata 
+- Fixed an old version number in the gnome application metadata https://github.com/GrandOrgue/grandorgue/issues/1304
 - Fixed switching off generals when using crescendo in not override mode https://github.com/GrandOrgue/grandorgue/issues/1299
 - Fixed error messages of GrandOrguePerf https://github.com/GrandOrgue/grandorgue/issues/1280
 - Fixed exit from GrandOrgue with an unhandled exception occurred on loading an organ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 3.9.3 (2022-12-09)
+- Fixed an old version number in the gnome application metadata 
 - Fixed switching off generals when using crescendo in not override mode https://github.com/GrandOrgue/grandorgue/issues/1299
 - Fixed error messages of GrandOrguePerf https://github.com/GrandOrgue/grandorgue/issues/1280
 - Fixed exit from GrandOrgue with an unhandled exception occurred on loading an organ

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -92,8 +92,9 @@ elseif(UNIX)
     MESSAGE(STATUS "Not build manpage - some programs are missing")
   endif()
 
-  install(FILES GrandOrgue.appdata.xml DESTINATION share/metainfo)
-
+  string(TIMESTAMP TODAY "%Y-%m-%d")
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/GrandOrgue.appdata.xml.in" "${CMAKE_CURRENT_BINARY_DIR}/GrandOrgue.appdata.xml/GrandOrgue.appdata.xml")
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/GrandOrgue.appdata.xml/GrandOrgue.appdata.xml" DESTINATION share/metainfo)
 endif()
 
 ADD_CUSTOM_TARGET(resources ALL DEPENDS ${DEPLIST})

--- a/resources/GrandOrgue.appdata.xml.in
+++ b/resources/GrandOrgue.appdata.xml.in
@@ -63,8 +63,7 @@
   </provides>
 
   <releases>
-    <release version="3.2.0-1" date="2021-09-27"></release>
-    <release version="0.3.1.2342-1" date="2021-09-14"></release>
+    <release version="@FULL_VERSION@" date="@TODAY@"></release>
   </releases>
 
   <content_rating type="oars-1.1" />

--- a/resources/GrandOrgue.appdata.xml.in
+++ b/resources/GrandOrgue.appdata.xml.in
@@ -42,20 +42,29 @@
 
   <screenshots>
     <screenshot type="default">
-      <image>https://sourceforge.net/p/ourorgan/screenshot/PiteaMHS_main.png</image>
+      <image>https://camo.githubusercontent.com/36bf7da02a6a8220fdc12e2c2481c00df662e67a8464902beda5184577c31604/687474703a2f2f7777772e66616d696c6a656e70616c6f2e73652f73697465732f64656661756c742f66696c65732f62696c6465722f73637265656e73686f74732f50697465614d48535f6d61696e2e706e67</image>
     </screenshot>
 
     <screenshot>
-      <image>https://sourceforge.net/p/ourorgan/screenshot/Burea_funeral_extend_main.jpg</image>
+      <image>https://camo.githubusercontent.com/f92194299b21fd9cc64d51a752751fa3defa9fe2b8a2dad6651773ac44b22c70/687474703a2f2f7777772e66616d696c6a656e70616c6f2e73652f73697465732f64656661756c742f66696c65732f62696c6465722f73637265656e73686f74732f4b616c76747261736b4368757263682e706e67</image>
     </screenshot>
 
     <screenshot>
-      <image>https://sourceforge.net/p/ourorgan/screenshot/Burea_chuch_gui.png</image>
+      <image>https://camo.githubusercontent.com/12ff05f9e419d98a7280b6b2a71e5f4318f20d7bdc1f3d3a7952f68d6bbb95ec/687474703a2f2f7777772e66616d696c6a656e70616c6f2e73652f73697465732f64656661756c742f66696c65732f62696c6465722f73637265656e73686f74732f53744361726c6f427265736369612e706e67</image>
     </screenshot>
 
     <screenshot>
-      <image>https://sourceforge.net/p/ourorgan/screenshot/Burea_church_extended.png</image>
+      <image>https://camo.githubusercontent.com/4e10d9d6d467850b692f778d0179a921ffc7fabb63b436f1fd982786d1f0256e/687474703a2f2f7777772e66616d696c6a656e70616c6f2e73652f73697465732f64656661756c742f66696c65732f62696c6465722f73637265656e73686f74732f57696c64657276616e6b2e706e67</image>
     </screenshot>
+    
+    <screenshot>
+      <image>https://camo.githubusercontent.com/6703a9e8c07fe756367ac7d89eaa161de0b408ad664b487b136f5ddf0b78d8c0/687474703a2f2f7777772e66616d696c6a656e70616c6f2e73652f73697465732f64656661756c742f66696c65732f62696c6465722f73637265656e73686f74732f42757265615f63687563685f6775692e706e67</image>
+    </screenshot>
+    
+    <screenshot>
+      <image>https://camo.githubusercontent.com/ac3bd65ee6e46da77634fcb2f9ee011cd838891634c451d056ccf88e2f1e4cf2/687474703a2f2f7777772e66616d696c6a656e70616c6f2e73652f73697465732f64656661756c742f66696c65732f62696c6465722f73637265656e73686f74732f42757265615f6368757263685f657874656e6465642e706e67</image>
+    </screenshot>
+
   </screenshots>
 
   <provides>


### PR DESCRIPTION
Resolves: #1304

1. I made the automatic substitution of `version` and `date` tags in the metadata file.
2. I changed referrences to screenshots on sourceforge with ones on github