### PR TITLE
Fixed starting 3.9.3 on Windows https://github.com/GrandOrgue/grandorgue/issues/1311

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed starting 3.9.3 on Windows https://github.com/GrandOrgue/grandorgue/issues/1311
 # 3.9.3 (2022-12-09)
 - Fixed an old version number in the gnome application metadata https://github.com/GrandOrgue/grandorgue/issues/1304
 - Fixed switching off generals when using crescendo in not override mode https://github.com/GrandOrgue/grandorgue/issues/1299

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -15,6 +15,7 @@
 #include <wx/image.h>
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
+#include <wx/platinfo.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
 #include <wx/splash.h>
@@ -389,12 +390,16 @@ bool GOFrame::AdjustVolumeControlWithSettings() {
   bool rc = false;
 
   if (count != m_VolumeGauge.size()) {
+    const wxPortId portId = wxPlatformInfo::Get().GetPortId();
+    const bool isOsX = portId == wxPORT_COCOA || portId == wxPORT_OSX;
     int volCtlId = m_VolumeControlTool->GetId();
     int volCtlPos = m_ToolBar->GetToolPos(volCtlId);
 
     // OsX doesn't relayout the toolbar correctly after changing the size of
     // a control so we need to remove it and to reinsert it later
-    m_ToolBar->RemoveTool(volCtlId);
+    // But RemoveTool hangs on windows, so we do it only on OsX
+    if (isOsX)
+      m_ToolBar->RemoveTool(volCtlId);
 
     m_VolumeGauge.clear();
     m_VolumeControl->DestroyChildren();
@@ -415,8 +420,9 @@ bool GOFrame::AdjustVolumeControlWithSettings() {
     m_VolumeControl->SetSizer(sizer);
     sizer->Fit(m_VolumeControl);
 
-    // reinsert the control and relayout the toolbar
-    m_ToolBar->InsertTool(volCtlPos, m_VolumeControlTool);
+    // reinsert the control and relayout the toolbar on OsX
+    if (isOsX)
+      m_ToolBar->InsertTool(volCtlPos, m_VolumeControlTool);
     m_ToolBar->Realize();
     rc = true;
   }


### PR DESCRIPTION
Resolves: #1311

The reason was `wxToolBar::RemoveTool` hung on windows. It was added for resolving toolbar issues on OsX (#1255).

So now `wxToolBar::RemoveTool`/`wxToolBar::InsertTool` are called only on OsX.
