### PR TITLE
Fixed error message of loading an object without the name of this object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Fixed size of text fields in the Organ Settings dialog on OsX https://github.com/GrandOrgue/grandorgue/issues/1315
+- Fixed missing the object filename in an error message if some exception occured when loading this object
 # 3.9.4 (2022-12-12)
 - Fixed starting 3.9.3 on Windows https://github.com/GrandOrgue/grandorgue/issues/1311
 # 3.9.3 (2022-12-09)

--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -390,6 +390,8 @@
           </df>
           <df name="loader">
             <in>GOLoadThread.cpp</in>
+            <in>GOLoadWorker.cpp</in>
+            <in>GOLoadWorker.h</in>
             <in>GOLoaderFilename.cpp</in>
           </df>
           <df name="midi">
@@ -7979,73 +7981,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="7">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9155,30 +9110,27 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="7">
           <incDir>
-            <pElem>../../src/grandorgue/dialogs</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/common/GODialogCloser.cpp"
@@ -10388,6 +10340,13 @@
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoadThread.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="7">
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/loader/GOLoadWorker.cpp"
             ex="false"
             tool="1"
             flavor2="8">
@@ -18490,6 +18449,16 @@
             <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
+      </item>
+      <item path="../../src/grandorgue/loader/GOLoadWorker.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../../src/grandorgue/loader/GOLoadWorker.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
       </item>
       <item path="../../src/grandorgue/midi/GOMidi.cpp"
             ex="false"

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -100,6 +100,7 @@ help/GOHelpRequestor.cpp
 loader/GOFileStore.cpp
 loader/GOLoaderFilename.cpp
 loader/GOLoadThread.cpp
+loader/GOLoadWorker.cpp
 midi/ports/GOMidiInPort.cpp
 midi/ports/GOMidiOutPort.cpp
 midi/ports/GOMidiPort.cpp

--- a/src/grandorgue/loader/GOLoadThread.h
+++ b/src/grandorgue/loader/GOLoadThread.h
@@ -8,23 +8,12 @@
 #ifndef GOLOADTHREAD_H
 #define GOLOADTHREAD_H
 
-#include <wx/string.h>
-
 #include "threading/GOThread.h"
 
-#include "GOCacheObjectDistributor.h"
+#include "GOLoadWorker.h"
 
-class GOFileStore;
-class GOMemoryPool;
-
-class GOLoadThread : private GOThread {
+class GOLoadThread : private GOLoadWorker, private GOThread {
 private:
-  const GOFileStore &m_FileStore;
-  GOMemoryPool &m_pool;
-  GOCacheObjectDistributor &m_distributor;
-  wxString m_Error;
-  bool m_OutOfMemory;
-
   /* the main loading loop. It takes objects from the m_CacheObjects
    * concurrently with other threads loads them
    */
@@ -34,11 +23,12 @@ public:
   GOLoadThread(
     const GOFileStore &fileStore,
     GOMemoryPool &pool,
-    GOCacheObjectDistributor &distributor);
-  ~GOLoadThread();
+    GOCacheObjectDistributor &distributor)
+    : GOLoadWorker(fileStore, pool, distributor) {}
+  ~GOLoadThread() { Stop(); }
 
-  void Run();
-  void checkResult();
+  void Run() { Start(); }
+  void CheckResult();
 };
 
 #endif

--- a/src/grandorgue/loader/GOLoadWorker.cpp
+++ b/src/grandorgue/loader/GOLoadWorker.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2022 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOLoadWorker.h"
+
+#include <wx/intl.h>
+
+#include "model/GOCacheObject.h"
+
+#include "GOAlloc.h"
+#include "GOCacheObjectDistributor.h"
+#include "GOMemoryPool.h"
+
+GOLoadWorker::GOLoadWorker(
+  const GOFileStore &fileStore,
+  GOMemoryPool &pool,
+  GOCacheObjectDistributor &distributor)
+  : m_FileStore(fileStore),
+    m_pool(pool),
+    m_distributor(distributor),
+    m_HasBeenException(false),
+    m_OutOfMemory(false) {}
+
+bool GOLoadWorker::LoadNextObject(GOCacheObject *&obj) {
+  bool isLoaded = false;
+
+  if (
+    !m_HasBeenException && !m_pool.IsPoolFull()
+    && (obj = m_distributor.fetchNext())) {
+    assert(m_errMsg.IsEmpty()); // otherwise m_HasBeenException
+    try {
+      obj->LoadData(m_FileStore, m_pool);
+      isLoaded = true;
+    } catch (GOOutOfMemory e) {
+      m_OutOfMemory = true;
+    } catch (wxString error) {
+      m_errMsg = error;
+    } catch (const std::exception &e) {
+      m_errMsg = e.what();
+    } catch (...) { // We must not allow unhandled exceptions here
+      m_errMsg = _("Unknown exception");
+    }
+    if (!isLoaded) {
+      m_HasBeenException = true;
+      // add the object title to the error message
+      if (!m_errMsg.IsEmpty())
+        m_errMsg.Printf(
+          _("Unable to load %s: %s"), obj->GetLoadTitle(), m_errMsg);
+    }
+  }
+  return isLoaded;
+}
+
+void GOLoadWorker::AssertNoException() const {
+  if (!m_errMsg.IsEmpty()) {
+    throw m_errMsg;
+  }
+  if (m_OutOfMemory)
+    throw GOOutOfMemory();
+}

--- a/src/grandorgue/loader/GOLoadWorker.h
+++ b/src/grandorgue/loader/GOLoadWorker.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2022 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOCacheObjectDistributor.h"
+
+#include <wx/string.h>
+
+class GOFileStore;
+class GOMemoryPool;
+
+#ifndef GOLOADWORKER_H
+#define GOLOADWORKER_H
+
+/**
+ * A class for loading objects taken from GOCacheObjectDistributor
+ * Usually several instances of GOLoadWorker are loading objects from one common
+ * GOCacheObjectDistributor instance in parallel
+ */
+
+class GOLoadWorker {
+private:
+  const GOFileStore &m_FileStore;
+  GOMemoryPool &m_pool;
+  GOCacheObjectDistributor &m_distributor;
+
+  GOCacheObject *m_LastObject;
+  bool m_HasBeenException; // any exception included GOOutOfMemory
+  bool m_OutOfMemory;
+  wxString m_errMsg;
+
+public:
+  /**
+   * Constructs a GOLoadWorker object
+   * @param distributor - the instacne of GOCacheObjectDistributor to take
+   *  objects from
+   * @param fileStore - passed to GOCacheObject::LoadData
+   * @param pool - passed to GOCacheObject::LoadData
+   */
+  GOLoadWorker(
+    const GOFileStore &fileStore,
+    GOMemoryPool &pool,
+    GOCacheObjectDistributor &distributor);
+
+  /**
+   * Takes a next object from m_distributor that has not been taken by any
+   *   worker and loads it. If an exception occured then remembers it for
+   *   future calls of AssertNoException()
+   * @param obj - the object tried to be loaded
+   * @return true if the object has been loaded successfully
+   *   false if there are no more objects to load or there was an exception
+   */
+  bool LoadNextObject(GOCacheObject *&obj);
+
+  /**
+   * If there was an exception in LoadNextObject then throws wxString with the
+   *   error message or GOOutOfMemory
+   * Otherwise does nothing
+   */
+  void AssertNoException() const;
+};
+
+#endif /* GOLOADWORKER_H */

--- a/src/grandorgue/loader/GOLoadWorker.h
+++ b/src/grandorgue/loader/GOLoadWorker.h
@@ -35,7 +35,7 @@ private:
 public:
   /**
    * Constructs a GOLoadWorker object
-   * @param distributor - the instacne of GOCacheObjectDistributor to take
+   * @param distributor - the instance of GOCacheObjectDistributor to take
    *  objects from
    * @param fileStore - passed to GOCacheObject::LoadData
    * @param pool - passed to GOCacheObject::LoadData


### PR DESCRIPTION
1. In order to unify exception handling in the main thread (GOOrganController::Load) and in GOLoadThread I extracted most of the code (including the exception handler) from GOLoaderThread to the new class GOLoadWorker and nou call it from these two places.
2. I added inserting the loaded object name to the error message generated from the exception