### PR TITLE
Fixed continuing loading an organ after an exception in one thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed continuing loading an organ after an exception in one loading thread
 - Fixed size of text fields in the Organ Settings dialog on OsX https://github.com/GrandOrgue/grandorgue/issues/1315
 - Fixed missing the object filename in an error message if some exception occured when loading this object
 # 3.9.4 (2022-12-12)

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -519,7 +519,7 @@ wxString GOOrganController::Load(
       if (cache_ok) {
         try {
           while (true) {
-            GOCacheObject *obj = objectDistributor.fetchNext();
+            GOCacheObject *obj = objectDistributor.FetchNext();
 
             if (!obj)
               break;
@@ -673,7 +673,7 @@ bool GOOrganController::UpdateCache(GOProgressDialog *dlg, bool compress) {
     cache_save_ok = false;
 
   for (unsigned i = 0; cache_save_ok; i++) {
-    GOCacheObject *obj = objectDistributor.fetchNext();
+    GOCacheObject *obj = objectDistributor.FetchNext();
 
     if (!obj)
       break;

--- a/src/grandorgue/loader/GOLoadWorker.cpp
+++ b/src/grandorgue/loader/GOLoadWorker.cpp
@@ -30,7 +30,7 @@ bool GOLoadWorker::LoadNextObject(GOCacheObject *&obj) {
 
   if (
     !m_HasBeenException && !m_pool.IsPoolFull()
-    && (obj = m_distributor.fetchNext())) {
+    && (obj = m_distributor.FetchNext())) {
     assert(m_errMsg.IsEmpty()); // otherwise m_HasBeenException
     try {
       obj->LoadData(m_FileStore, m_pool);
@@ -50,6 +50,7 @@ bool GOLoadWorker::LoadNextObject(GOCacheObject *&obj) {
       if (!m_errMsg.IsEmpty())
         m_errMsg.Printf(
           _("Unable to load %s: %s"), obj->GetLoadTitle(), m_errMsg);
+      m_distributor.Break(); // force other workers to stop as soon as possible
     }
   }
   return isLoaded;


### PR DESCRIPTION
Earlier if an exception occured in one of parallel loader thread, this thread broke immediatelly, but all other loader threads continued loading. After all threads finished loading the new exception was thrown, so the organ was not still loaded/

Now if an exception occures the thread `breaks` the object distributor so all threads are finished as soon as possible and the exception is thrown.

Also I renamed `fetchNext` to `FetchNext` according to the GO method naming convention.