### PR TITLE
Moved usages of GOFileStore from GOLoaderFilename::Assign to GOLoaderFilename::Open

### DIFF
--- a/src/grandorgue/GOBitmapCache.cpp
+++ b/src/grandorgue/GOBitmapCache.cpp
@@ -172,9 +172,9 @@ bool GOBitmapCache::loadFile(wxImage &img, const wxString &filename) {
 
   try {
     GOLoaderFilename name;
-    name.Assign(m_OrganController->GetFileStore(), filename);
+    name.Assign(filename);
 
-    std::unique_ptr<GOFile> file = name.Open();
+    std::unique_ptr<GOFile> file = name.Open(m_OrganController->GetFileStore());
     GOBuffer<char> data;
 
     result = file->ReadContent(data);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -203,8 +203,8 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   } else {
     GOLoaderFilename fname;
 
-    fname.Assign(m_FileStore, info_filename);
-    std::unique_ptr<GOFile> file = fname.Open();
+    fname.Assign(info_filename);
+    std::unique_ptr<GOFile> file = fname.Open(m_FileStore);
     fn = info_filename;
     if (
       file->isValid()
@@ -361,7 +361,7 @@ wxString GOOrganController::Load(
       return errMsg;
 
     m_odf = organ.GetODFPath();
-    odf_name.Assign(m_FileStore, m_odf);
+    odf_name.Assign(m_odf);
   } else {
     wxString file = organ.GetODFPath();
     m_odf = GONormalizePath(file);
@@ -379,7 +379,7 @@ wxString GOOrganController::Load(
 
   GOConfigFileReader odf_ini_file;
 
-  if (!odf_ini_file.Read(odf_name.Open().get())) {
+  if (!odf_ini_file.Read(odf_name.Open(m_FileStore).get())) {
     errMsg.Printf(_("Unable to read '%s'"), odf_name.GetTitle().c_str());
     return errMsg;
   }

--- a/src/grandorgue/loader/GOLoaderFilename.cpp
+++ b/src/grandorgue/loader/GOLoaderFilename.cpp
@@ -11,91 +11,57 @@
 #include <wx/log.h>
 
 #include "archive/GOArchive.h"
-#include "config/GOConfig.h"
 #include "loader/GOFileStore.h"
 
 #include "GOHash.h"
-#include "GOInvalidFile.h"
 #include "GOStandardFile.h"
 
-GOLoaderFilename::GOLoaderFilename()
-  : m_Name(),
-    m_Path(),
-    m_Archiv(NULL),
-    m_ToHashSizeTime(true),
-    m_ToHashPath(true) {}
+void GOLoaderFilename::Assign(const RootKind rootKind, const wxString &path) {
+  wxFileName tmpPath(path);
 
-const wxString &GOLoaderFilename::GetTitle() const { return m_Name; }
+  m_RootKind = rootKind;
+  tmpPath.Normalize(wxPATH_NORM_DOTS);
+  m_path = tmpPath.GetFullPath();
+  if (m_path != tmpPath.GetLongPath())
+    wxLogWarning(
+      _("Filename '%s' not compatible with case sensitive systems"), m_path);
+}
 
 void GOLoaderFilename::Hash(GOHash &hash) const {
-  if (m_Archiv) {
-    hash.Update(m_Archiv->GetArchiveID());
-    hash.Update(m_Name);
-    return;
+  hash.Update(m_RootKind);
+  hash.Update(m_path);
+}
+
+std::unique_ptr<GOFile> GOLoaderFilename::Open(
+  const GOFileStore &fileStore) const {
+  GOFile *file;
+
+  assert(m_RootKind != ROOT_UNKNOWN);
+  if (m_RootKind == ROOT_ODF && fileStore.AreArchivesUsed()) {
+    GOArchive *const archive = fileStore.FindArchiveContaining(m_path);
+
+    if (!archive)
+      throw _("File is not found in the organ package archives");
+    file = archive->OpenFile(m_path);
+  } else {
+    wxString baseDir;
+
+    if (m_RootKind == ROOT_ODF)
+      baseDir = fileStore.GetDirectory();
+    else if (m_RootKind == ROOT_RESOURCE)
+      baseDir = fileStore.GetResourceDirectory();
+
+    wxString fullPath = m_path;
+
+    fullPath.Replace(wxT("\\"), wxString(wxFileName::GetPathSeparator()));
+    if (!baseDir.IsEmpty())
+      fullPath = baseDir + wxFileName::GetPathSeparator() + fullPath;
+
+    if (fullPath.IsEmpty())
+      throw _("File name is empty");
+    if (!wxFileExists(fullPath))
+      throw wxString::Format(_("File '%s' does not exists"), fullPath);
+    file = new GOStandardFile(fullPath, m_path);
   }
-  hash.Update(m_ToHashPath ? m_Path : m_Name);
-  wxFileName path_name(m_Path);
-  if (!m_ToHashSizeTime)
-    return;
-  uint64_t size = path_name.GetSize().GetValue();
-  uint64_t time = path_name.GetModificationTime().GetTicks();
-  hash.Update(time);
-  hash.Update(size);
-}
-
-std::unique_ptr<GOFile> GOLoaderFilename::Open() const {
-  if (m_Archiv)
-    return (std::unique_ptr<GOFile>)m_Archiv->OpenFile(m_Name);
-
-  if (m_Path != wxEmptyString && wxFileExists(m_Path))
-    return (std::unique_ptr<GOFile>)new GOStandardFile(m_Path, m_Name);
-  else
-    return (std::unique_ptr<GOFile>)new GOInvalidFile(m_Name);
-}
-
-void GOLoaderFilename::SetPath(const wxString &base, const wxString &file) {
-  wxString temp = file;
-  temp.Replace(wxT("\\"), wxString(wxFileName::GetPathSeparator()));
-  temp = base + wxFileName::GetPathSeparator() + temp;
-
-  wxFileName path_name(temp);
-  path_name.Normalize(wxPATH_NORM_DOTS);
-  if (path_name.GetLongPath() != path_name.GetFullPath()) {
-    wxLogWarning(
-      _("Filename '%s' not compatible with case sensitive systems"),
-      file.c_str());
-  }
-  if (!wxFileExists(temp)) {
-    wxLogError(_("File '%s' does not exists"), file.c_str());
-    m_ToHashSizeTime = false;
-  }
-  m_Path = temp;
-}
-
-void GOLoaderFilename::Assign(
-  const GOFileStore &fileStore, const wxString &name) {
-  m_Name = name;
-  if (fileStore.AreArchivesUsed()) {
-    m_Path = wxEmptyString;
-    m_Archiv = fileStore.FindArchiveContaining(name);
-    if (!m_Archiv) {
-      wxLogError(_("File '%s' does not exists"), name.c_str());
-    }
-    return;
-  }
-  SetPath(fileStore.GetDirectory(), name);
-}
-
-void GOLoaderFilename::AssignResource(
-  const wxString &resourceDirectory, const wxString &name) {
-  m_Name = name;
-  m_ToHashSizeTime = false;
-  m_ToHashPath = false;
-  SetPath(resourceDirectory, name);
-}
-
-void GOLoaderFilename::AssignAbsolute(const wxString &path) {
-  m_Name = path;
-  m_Path = path;
-  m_ToHashSizeTime = false;
+  return std::unique_ptr<GOFile>(file);
 }

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -61,9 +61,7 @@ GOSoundingPipe::GOSoundingPipe(
 void GOSoundingPipe::LoadAttack(
   GOConfigReader &cfg, wxString group, wxString prefix) {
   attack_load_info ainfo;
-  ainfo.filename.Assign(
-    m_OrganController->GetFileStore(),
-    cfg.ReadFileName(ODFSetting, group, prefix));
+  ainfo.filename.Assign(cfg.ReadFileName(ODFSetting, group, prefix));
   ainfo.sample_group = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("IsTremulant"), -1, 1, false, -1);
   ainfo.load_release = cfg.ReadBoolean(
@@ -145,8 +143,7 @@ void GOSoundingPipe::Init(
   m_OrganController->GetWindchest(m_SamplerGroupID - 1)->AddPipe(this);
 
   attack_load_info ainfo;
-  ainfo.filename.AssignResource(
-    m_OrganController->GetConfig().GetResourceDirectory(), m_Filename);
+  ainfo.filename.AssignResource(m_Filename);
   ainfo.sample_group = -1;
   ainfo.load_release = !m_Percussive;
   ainfo.percussive = m_Percussive;
@@ -224,9 +221,7 @@ void GOSoundingPipe::Load(
     release_load_info rinfo;
     wxString p = prefix + wxString::Format(wxT("Release%03d"), i + 1);
 
-    rinfo.filename.Assign(
-      m_OrganController->GetFileStore(),
-      cfg.ReadFileName(ODFSetting, group, p));
+    rinfo.filename.Assign(cfg.ReadFileName(ODFSetting, group, p));
     rinfo.sample_group = cfg.ReadInteger(
       ODFSetting, group, p + wxT("IsTremulant"), -1, 1, false, -1);
     rinfo.max_playback_time = cfg.ReadInteger(
@@ -258,6 +253,7 @@ void GOSoundingPipe::LoadData(
   const GOFileStore &fileStore, GOMemoryPool &pool) {
   try {
     m_SoundProvider.LoadFromFile(
+      fileStore,
       pool,
       m_AttackInfo,
       m_ReleaseInfo,

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -91,7 +91,7 @@ class GOSoundProviderWave : public GOSoundProvider {
 
   void ProcessFile(
     GOMemoryPool &pool,
-    const GOLoaderFilename &filename,
+    GOFile *file,
     const std::vector<GOWaveLoop> *loops,
     bool is_attack,
     bool is_release,
@@ -110,11 +110,12 @@ class GOSoundProviderWave : public GOSoundProvider {
     unsigned loop_crossfade_length,
     unsigned max_released_time);
 
-  void LoadPitch(const GOLoaderFilename &filename);
+  void LoadPitch(GOFile *file);
   unsigned GetFaderLength(unsigned MidiKeyNumber);
 
 public:
   void LoadFromFile(
+    const GOFileStore &fileStore,
     GOMemoryPool &pool,
     std::vector<attack_load_info> attacks,
     std::vector<release_load_info> releases,

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -91,9 +91,7 @@ void GOPerfTestApp::RunTest(
         std::vector<release_load_info> release;
         std::vector<attack_load_info> attack;
         attack_load_info ainfo;
-        ainfo.filename.Assign(
-          organController->GetFileStore(),
-          wxString::Format(wxT("%02d.wav"), i % 3));
+        ainfo.filename.Assign(wxString::Format(wxT("%02d.wav"), i % 3));
         ainfo.sample_group = -1;
         ainfo.load_release = true;
         ainfo.percussive = false;
@@ -105,6 +103,7 @@ void GOPerfTestApp::RunTest(
         ainfo.loops.clear();
         attack.push_back(ainfo);
         w->LoadFromFile(
+          organController->GetFileStore(),
           organController->GetMemoryPool(),
           attack,
           release,


### PR DESCRIPTION
Earlier GOLoaderFilename knew the full path to the file after `AssignXXX` calls.

Now it knows only the relative path until the `Open` is called.

It allows to work with GOOrganModel in memory without any other files.

`Open` actually searches the file before opening. It throws an exception if the file does not exist (the handling of that loader exceptions was improved in recent PRs).

Because the full filename, it;s size and data are unknown before `Open`, I removed them from hash calculation. It impacts the hash calculation of all organs registered, so their caches will be invalidated and recalculated with the new GrandOrgue version.
