### PR TITLE
Switched GOSOundingPipe from using GOOrganController::GetSettings to GOOrganModel::GetConfig

### DIFF
--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -585,7 +585,7 @@ void GOConfig::SetAudioGroups(const std::vector<wxString> &audio_groups) {
   m_AudioGroups = audio_groups;
 }
 
-unsigned GOConfig::GetAudioGroupId(const wxString &str) {
+unsigned GOConfig::GetAudioGroupId(const wxString &str) const {
   for (unsigned i = 0; i < m_AudioGroups.size(); i++)
     if (m_AudioGroups[i] == str)
       return i;

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -189,7 +189,7 @@ public:
 
   const std::vector<wxString> &GetAudioGroups();
   void SetAudioGroups(const std::vector<wxString> &audio_groups);
-  unsigned GetAudioGroupId(const wxString &str);
+  unsigned GetAudioGroupId(const wxString &str) const;
   int GetStrictAudioGroupId(const wxString &str);
 
   const GOPortsConfig &GetSoundPortsConfig() const {

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -346,7 +346,7 @@ void GOSoundingPipe::Initialize() {}
 const wxString &GOSoundingPipe::GetLoadTitle() { return m_Filename; }
 
 void GOSoundingPipe::Validate() {
-  if (!m_OrganController->GetSettings().ODFCheck())
+  if (!m_OrganController->GetConfig().ODFCheck())
     return;
 
   if (!m_PipeConfigNode.GetEffectiveChannels())
@@ -481,7 +481,7 @@ void GOSoundingPipe::UpdateTuning() {
 }
 
 void GOSoundingPipe::UpdateAudioGroup() {
-  m_AudioGroupID = m_OrganController->GetSettings().GetAudioGroupId(
+  m_AudioGroupID = m_OrganController->GetConfig().GetAudioGroupId(
     m_PipeConfigNode.GetEffectiveAudioGroup());
 }
 


### PR DESCRIPTION
Toward to eliminating references from GOOrganModel to GOOrganController I switched getting `GOConfig` to a `GOOrganModel` method.