### PR TITLE
Restored capability of logging all file-not-existing errors while loading samples

### DIFF
--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -423,6 +423,7 @@
               <in>GOPipeConfigNode.cpp</in>
               <in>GOPipeConfigTreeNode.cpp</in>
             </df>
+            <in>GOCacheObject.cpp</in>
             <in>GODummyPipe.cpp</in>
             <in>GOEnclosure.cpp</in>
             <in>GOEventHandlerList.cpp</in>
@@ -5816,7 +5817,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -5884,7 +5884,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -5950,7 +5949,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -5996,18 +5994,67 @@
         </ccTool>
       </item>
       <item path="../../src/core/GOKeyConvert.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -6021,7 +6068,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6067,50 +6113,209 @@
         </ccTool>
       </item>
       <item path="../../src/core/GOMemoryPool.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/GOOrgan.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/contrib</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/GOOrganList.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -6137,7 +6342,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6197,7 +6401,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6258,7 +6461,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6325,7 +6527,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6392,7 +6593,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6438,18 +6638,69 @@
         </ccTool>
       </item>
       <item path="../../src/core/GOTimer.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -6474,7 +6725,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6535,7 +6785,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6596,7 +6845,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -6642,18 +6890,71 @@
         </ccTool>
       </item>
       <item path="../../src/core/GOWave.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wavpack</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -6661,12 +6962,27 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/files</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6675,12 +6991,29 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/config</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6689,12 +7022,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6703,12 +7050,27 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/contrib</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6717,12 +7079,27 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/contrib</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6731,12 +7108,29 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6745,12 +7139,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/contrib</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6761,7 +7169,6 @@
             flavor2="8">
         <ccTool flags="3">
           <incDir>
-            <pElem>../../src/core/archive</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
@@ -6780,65 +7187,33 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/config/GOConfigFileReader.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/contrib</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6849,7 +7224,6 @@
             flavor2="8">
         <ccTool flags="3">
           <incDir>
-            <pElem>../../src/core/config</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
@@ -6869,65 +7243,30 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/config/GOConfigReader.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6936,12 +7275,24 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -6952,7 +7303,6 @@
             flavor2="8">
         <ccTool flags="3">
           <incDir>
-            <pElem>../../src/core/config</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -6971,53 +7321,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/contrib/sha1.cpp" ex="false" tool="1" flavor2="8">
@@ -7028,21 +7331,41 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/core/files/GOStandardFile.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/core/files/GOStdFileName.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiEvent.cpp"
@@ -7051,7 +7374,6 @@
             flavor2="8">
         <ccTool flags="3">
           <incDir>
-            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
@@ -7069,65 +7391,21 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiEventPattern.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -7136,12 +7414,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -7149,7 +7440,6 @@
       <item path="../../src/core/midi/GOMidiMap.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="3">
           <incDir>
-            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -7166,65 +7456,30 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiReceiverBase.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -7233,12 +7488,23 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -7247,12 +7513,15 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -7263,7 +7532,6 @@
             flavor2="8">
         <ccTool flags="3">
           <incDir>
-            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -7282,53 +7550,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/settings/GOSetting.cpp"
@@ -7541,78 +7762,123 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/core/temperaments/GOTemperamentCent.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/core/temperaments/GOTemperamentList.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/core/temperaments/GOTemperamentUser.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/core/threading/GOCondition.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/core</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/core/threading/GOMutex.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/core</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/core/threading/GOThread.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
         <ccTool flags="3">
           <incDir>
             <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -7651,7 +7917,136 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/core/threading/GOMutex.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/core/threading/GOThread.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="3">
+          <incDir>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../build/current/src/core</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
             <Elem>__pic__=2</Elem>
@@ -7680,8 +8075,11 @@
           <preprocessorList>
             <Elem>GO_STD_MUTEX</Elem>
             <Elem>GO_USE_JACK</Elem>
+            <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>NDEBUG</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -7689,37 +8087,152 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="3">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOApp.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/help</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -7748,32 +8261,140 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOAudioRecorder.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -7799,56 +8420,210 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOBitmapCache.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOCache.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -7856,26 +8631,79 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -7883,50 +8711,157 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOCoupler.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -7952,32 +8887,136 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GODivisionalCoupler.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -7985,26 +9024,95 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>../../src/grandorgue/help</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8012,26 +9120,83 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8154,29 +9319,148 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOFrame.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/help</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8184,26 +9468,83 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8384,26 +9725,83 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8411,26 +9809,87 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8465,26 +9924,76 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8492,26 +10001,83 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8519,26 +10085,73 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8546,82 +10159,335 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/GOSetter.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/control/GODivisionalButtonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/control/GOGeneralButtonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOCombination.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOCombinationDefinition.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GODivisionalCombination.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOGeneralCombination.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOConfig.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOMidiDeviceConfig.cpp"
@@ -8630,7 +10496,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/config</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -8647,74 +10512,32 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOMidiDeviceConfigList.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOPortFactory.cpp"
@@ -8723,7 +10546,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/config</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -8740,48 +10562,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOPortsConfig.cpp"
@@ -8790,7 +10570,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/config</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -8807,151 +10586,306 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOButtonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOCallbackButtonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOElementCreator.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOEventDistributor.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOLabelControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPistonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPushbuttonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOMidiListDialog.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOOrganDialog.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOProgressDialog.cpp"
@@ -8985,54 +10919,60 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSplash.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/common/GODialogCloser.cpp"
@@ -9113,189 +11053,281 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventDialog.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventKeyTab.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsAudio.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsDialog.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiDeviceList.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiDevices.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiMatchDialog.cpp"
@@ -9304,7 +11336,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -9332,189 +11363,238 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsOptions.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/core/settings</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPaths.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPorts.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsReverb.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsTemperaments.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/settings</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/document-base/GODocumentBase.cpp"
@@ -9571,135 +11651,172 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIButton.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUICouplerPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUICrescendoPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIDisplayMetrics.cpp"
@@ -9708,7 +11825,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/grandorgue</pElem>
@@ -9733,108 +11849,132 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIEnclosure.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIFloatingPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIHW1Background.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIHW1DisplayMetrics.cpp"
@@ -9843,7 +11983,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -9870,324 +12009,408 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUILabel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUILayoutEngine.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIManual.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIManualBackground.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIMasterPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIMetronomePanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIPanelWidget.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIRecorderPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUISequencerPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUISetterDisplayMetrics.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/help/GOHelpController.cpp"
@@ -10245,55 +12468,153 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoadThread.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoadWorker.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoaderFilename.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/contrib</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidi.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiInputMerger.cpp"
@@ -10327,27 +12648,31 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiOutputMerger.cpp"
@@ -10381,322 +12706,1067 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiPlayerContent.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiReceiver.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiRecorder.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiSender.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiInPort.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiOutPort.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiPort.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiPortFactory.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiRtInPort.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiRtOutPort.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOCacheObject.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GODummyPipe.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOEnclosure.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOEventHandlerList.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOManual.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOOrganModel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOPipe.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GORank.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOReferencePipe.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOSoundingPipe.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/contrib</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOStop.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOSwitch.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOTremulant.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOWindchest.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/pipe-config/GOPipeConfig.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSound.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10704,26 +13774,74 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10731,26 +13849,84 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10758,26 +13934,74 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10785,26 +14009,73 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10812,26 +14083,77 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10839,26 +14161,77 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10930,26 +14303,81 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10957,80 +14385,114 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundReverbPartition.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundSamplerPool.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/new</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11040,7 +14502,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/grandorgue/config</pElem>
@@ -11068,164 +14529,325 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/ports/GOSoundPortFactory.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../submodules/RtAudio</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/jack</pElem>
             <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/ports/GOSoundRtPort.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundOutputWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundReleaseWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundScheduler.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundThread.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundTouchWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundTremulantWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundWindchestWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA00.cpp" ex="false" tool="1" flavor2="8">
@@ -12148,23 +15770,67 @@
         </ccTool>
       </item>
       <item path="../../src/tools/GOPerfTest.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/tools</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>_REENTRANT</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/tools/GOTool.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="0">
           <incDir>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/tools</pElem>
           </incDir>
         </ccTool>
@@ -12174,6 +15840,42 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_converters.c"
@@ -12181,6 +15883,42 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_cpuload.c"
@@ -12188,6 +15926,42 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_debugprint.c"
@@ -12198,6 +15972,42 @@
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_dither.c"
@@ -12205,6 +16015,42 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_front.c"
@@ -12215,6 +16061,42 @@
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_process.c"
@@ -12225,6 +16107,42 @@
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_ringbuffer.c"
@@ -12235,6 +16153,42 @@
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_stream.c"
@@ -12242,6 +16196,42 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_trace.c"
@@ -12480,25 +16470,108 @@
             <Elem>GrandOrgueCore_EXPORTS=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__WXGTK__=1</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/core/archive">
         <ccTool>
+          <incDir>
+            <pElem>../../src/core/archive</pElem>
+          </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/core/config">
         <ccTool>
+          <incDir>
+            <pElem>../../src/core/config</pElem>
+          </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -12509,7 +16582,6 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -12557,25 +16629,111 @@
       <folder path="0/src/core/files">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/core</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/core/midi">
         <ccTool>
+          <incDir>
+            <pElem>../../src/core/midi</pElem>
+          </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -12585,7 +16743,6 @@
             <pElem>../../src/core/settings</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -12633,84 +16790,277 @@
       <folder path="0/src/core/temperaments">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/core</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/core/threading">
-        <ccTool>
-          <preprocessorList>
-            <Elem>GrandOrgueCore_EXPORTS</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/combinations">
-        <ccTool>
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/config">
         <ccTool>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
             <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/combinations/control">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+          </incDir>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/combinations/model">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+          </incDir>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/config">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/config</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/control">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs">
+        <ccTool>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -12724,25 +17074,15 @@
       <folder path="0/src/grandorgue/dialogs/midi-event">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs/settings">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
+          </incDir>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/document-base">
@@ -12752,6 +17092,107 @@
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/gui">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/help">
@@ -12761,101 +17202,331 @@
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/loader">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/midi">
+        <ccTool>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/midi/ports">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/model">
         <ccTool>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/model/pipe-config">
+        <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+          </incDir>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/sound/ports">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/sound/scheduler">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -13047,116 +17718,9 @@
       <folder path="0/src/tools">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
+            <pElem>../../src/tools</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/submodules">
-        <cTool>
-          <incDir>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/PortAudio/src/common</pElem>
-            <pElem>../../submodules/PortAudio/src/os/unix</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H</Elem>
-            <Elem>PA_USE_ALSA</Elem>
-            <Elem>PA_USE_JACK</Elem>
-            <Elem>_REENTRANT</Elem>
-          </preprocessorList>
-        </cTool>
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-            <pElem>../../build/current/src/core</pElem>
-            <pElem>/usr/include/c++/11/bits</pElem>
-            <pElem>/usr/include/c++/11</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>_REENTRANT</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/submodules/PortAudio/src/hostapi/alsa">
-        <cTool>
-          <incDir>
-            <pElem>../../submodules/PortAudio/src/hostapi/alsa</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-          </incDir>
-        </cTool>
-      </folder>
-      <folder path="0/submodules/PortAudio/src/hostapi/jack">
-        <cTool>
-          <incDir>
-            <pElem>../../submodules/PortAudio/src/hostapi/jack</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/jack</pElem>
-          </incDir>
-        </cTool>
-      </folder>
-      <folder path="0/submodules/RtAudio">
-        <ccTool>
-          <incDir>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/jack</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/rt/rtaudio</pElem>
-          </incDir>
-        </ccTool>
-      </folder>
-      <folder path="0/submodules/RtMidi">
-        <ccTool>
-          <incDir>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/jack</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/rt/rtmidi</pElem>
-          </incDir>
-        </ccTool>
-      </folder>
-      <folder path="0/submodules/ZitaConvolver">
-        <ccTool>
-          <incDir>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
@@ -13201,6 +17765,240 @@
             <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/submodules">
+        <cTool>
+          <incDir>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/PortAudio/src/common</pElem>
+            <pElem>../../submodules/PortAudio/src/os/unix</pElem>
+            <pElem>../../build/current/src/portaudio</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
+            <Elem>PA_USE_ALSA=1</Elem>
+            <Elem>PA_USE_JACK=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+          </preprocessorList>
+        </cTool>
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../build/current/src/core</pElem>
+            <pElem>/usr/include/c++/11/bits</pElem>
+            <pElem>/usr/include/c++/11</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/submodules/PortAudio/src/hostapi">
+        <cTool>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
+        </cTool>
+      </folder>
+      <folder path="0/submodules/PortAudio/src/hostapi/alsa">
+        <cTool>
+          <incDir>
+            <pElem>../../submodules/PortAudio/src/hostapi/alsa</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+          </incDir>
+        </cTool>
+      </folder>
+      <folder path="0/submodules/PortAudio/src/hostapi/jack">
+        <cTool>
+          <incDir>
+            <pElem>../../submodules/PortAudio/src/hostapi/jack</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/jack</pElem>
+          </incDir>
+        </cTool>
+      </folder>
+      <folder path="0/submodules/PortAudio/src/os">
+        <cTool>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
+        </cTool>
+      </folder>
+      <folder path="0/submodules/RtAudio">
+        <ccTool>
+          <incDir>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/jack</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../build/current/src/rt/rtaudio</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__LINUX_ALSA__=1</Elem>
+            <Elem>__UNIX_JACK__=1</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/submodules/RtMidi">
+        <ccTool>
+          <incDir>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/jack</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../build/current/src/rt/rtmidi</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>HAVE_GET_CLIENT_INFO_CARD=1</Elem>
+            <Elem>__LINUX_ALSA__=1</Elem>
+            <Elem>__UNIX_JACK__=1</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/submodules/ZitaConvolver">
+        <ccTool>
+          <incDir>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -18902,6 +23700,11 @@
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOCacheObject.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
       </item>
       <item path="../../src/grandorgue/model/GOModificationListener.h"
             ex="false"

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -120,6 +120,7 @@ midi/GOMidiRecorder.cpp
 model/pipe-config/GOPipeConfig.cpp
 model/pipe-config/GOPipeConfigNode.cpp
 model/pipe-config/GOPipeConfigTreeNode.cpp
+model/GOCacheObject.cpp
 model/GODummyPipe.cpp
 model/GOEnclosure.cpp
 model/GOEventHandlerList.cpp

--- a/src/grandorgue/control/GOEventDistributor.cpp
+++ b/src/grandorgue/control/GOEventDistributor.cpp
@@ -37,7 +37,7 @@ void GOEventDistributor::Save(GOConfigWriter &cfg) {
 
 void GOEventDistributor::ResolveReferences() {
   for (auto obj : p_model->GetCacheObjects())
-    obj->Initialize();
+    obj->InitWithoutExc();
 }
 
 void GOEventDistributor::UpdateHash(GOHash &hash) {

--- a/src/grandorgue/loader/GOLoadThread.cpp
+++ b/src/grandorgue/loader/GOLoadThread.cpp
@@ -9,9 +9,9 @@
 
 #include "model/GOCacheObject.h"
 
-void GOLoadThread::CheckResult() {
+bool GOLoadThread::CheckExceptions() {
   Wait();
-  AssertNoException();
+  return WereExceptions();
 }
 
 void GOLoadThread::Entry() {

--- a/src/grandorgue/loader/GOLoadThread.h
+++ b/src/grandorgue/loader/GOLoadThread.h
@@ -28,7 +28,12 @@ public:
   ~GOLoadThread() { Stop(); }
 
   void Run() { Start(); }
-  void CheckResult();
+
+  /**
+   * Waits for completions
+   * @return true if any exceptions occured. Otherwise - false
+   */
+  bool CheckExceptions();
 };
 
 #endif

--- a/src/grandorgue/loader/GOLoadWorker.h
+++ b/src/grandorgue/loader/GOLoadWorker.h
@@ -28,9 +28,8 @@ private:
   GOCacheObjectDistributor &m_distributor;
 
   GOCacheObject *m_LastObject;
-  bool m_HasBeenException; // any exception included GOOutOfMemory
+  bool m_WereExceptions; // any exception included GOOutOfMemory
   bool m_OutOfMemory;
-  wxString m_errMsg;
 
 public:
   /**
@@ -46,21 +45,29 @@ public:
     GOCacheObjectDistributor &distributor);
 
   /**
-   * Takes a next object from m_distributor that has not been taken by any
-   *   worker and loads it. If an exception occured then remembers it for
+   * Load the object. If an exception occured then remembers it for
+   *   future calls of AssertNoException(). Only GOOutOfMemory may be thrown,
+   *   all other exceptions are catched and remembered  for
    *   future calls of AssertNoException()
+   * @param obj - the object to loaded
+   */
+  void LoadObjectNoExc(GOCacheObject *obj);
+
+  /**
+   * Takes a next object from m_distributor that has not been taken by any
+   *   worker and loads it with LoadObjectNoExc.
    * @param obj - the object tried to be loaded
-   * @return true if the object has been loaded successfully
-   *   false if there are no more objects to load or there was an exception
+   * @return true if The loading may continue
+   *   false if there are no more objects to load or there was GOOutOfMemory
    */
   bool LoadNextObject(GOCacheObject *&obj);
 
   /**
-   * If there was an exception in LoadNextObject then throws wxString with the
-   *   error message or GOOutOfMemory
+   * If there was GOOutOfMemory then rethrows it
    * Otherwise does nothing
+   * @return whether any exceptions were occured
    */
-  void AssertNoException() const;
+  bool WereExceptions() const;
 };
 
 #endif /* GOLOADWORKER_H */

--- a/src/grandorgue/model/GOCacheObject.cpp
+++ b/src/grandorgue/model/GOCacheObject.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2022 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOCacheObject.h"
+
+#include <wx/intl.h>
+
+#include "GOAlloc.h"
+
+void GOCacheObject::InitBeforeLoad() {
+  m_IsReady = false;
+  m_LoadError.Clear();
+}
+
+bool GOCacheObject::InitWithoutExc() {
+  InitBeforeLoad();
+  try {
+    Initialize();
+    m_IsReady = true;
+  } catch (GOOutOfMemory e) {
+    throw e;
+  } catch (wxString error) {
+    m_LoadError = error;
+  } catch (const std::exception &e) {
+    m_LoadError = e.what();
+  } catch (...) { // We must not allow unhandled exceptions here
+    m_LoadError = _("Unknown exception");
+  }
+  return m_IsReady;
+}
+
+bool GOCacheObject::LoadFromFileWithoutExc(
+  const GOFileStore &fileStore, GOMemoryPool &pool) {
+  InitBeforeLoad();
+  try {
+    LoadData(fileStore, pool);
+    m_IsReady = true;
+  } catch (GOOutOfMemory e) {
+    throw e;
+  } catch (wxString error) {
+    m_LoadError = error;
+  } catch (const std::exception &e) {
+    m_LoadError = e.what();
+  } catch (...) { // We must not allow unhandled exceptions here
+    m_LoadError = _("Unknown exception");
+  }
+  return m_IsReady;
+}
+
+bool GOCacheObject::LoadFromCacheWithoutExc(
+  GOMemoryPool &pool, GOCache &cache) {
+  InitBeforeLoad();
+  try {
+    m_IsReady = LoadCache(pool, cache);
+  } catch (GOOutOfMemory e) {
+    throw e;
+  } catch (wxString error) {
+    m_LoadError = error;
+  } catch (const std::exception &e) {
+    m_LoadError = e.what();
+  } catch (...) { // We must not allow unhandled exceptions here
+    m_LoadError = _("Unknown exception");
+  }
+  return m_IsReady;
+}

--- a/src/grandorgue/model/GOCacheObject.h
+++ b/src/grandorgue/model/GOCacheObject.h
@@ -17,12 +17,47 @@ class GOHash;
 class GOMemoryPool;
 
 class GOCacheObject {
-public:
-  virtual ~GOCacheObject() {}
+private:
+  bool m_IsReady = false;
+  wxString m_LoadError;
 
+  void InitBeforeLoad();
+
+protected:
   virtual void Initialize() = 0;
   virtual void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) = 0;
   virtual bool LoadCache(GOMemoryPool &pool, GOCache &cache) = 0;
+
+public:
+  virtual ~GOCacheObject() {}
+
+  bool IsReady() const { return m_IsReady; }
+  const wxString &GetLoadError() const { return m_LoadError; }
+
+  /**
+   * Initialize the object with default values.
+   * Catches all exceptions except GOOutOfMemory.
+   * Returns whether it was initialised successfully .
+   * If no then GetLoadError returns the exception message.
+   */
+  bool InitWithoutExc();
+
+  /**
+   * Load the object from files.
+   * Catches all exceptions except GOOutOfMemory.
+   * Returns whether it was loaded successfully.
+   * If no then GetLoadError returns the exception message.
+   */
+  bool LoadFromFileWithoutExc(const GOFileStore &fileStore, GOMemoryPool &pool);
+
+  /**
+   * Load the object from the cache.
+   * Catches all exceptions except GOOutOfMemory.
+   * Returns whether it was loaded successfully.
+   * If no then GetLoadError returns the exception message.
+   */
+  bool LoadFromCacheWithoutExc(GOMemoryPool &pool, GOCache &cache);
+
   virtual bool SaveCache(GOCacheWriter &cache) = 0;
   virtual void UpdateHash(GOHash &hash) = 0;
   virtual const wxString &GetLoadTitle() = 0;

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -432,10 +432,6 @@ void GOSoundProviderWave::LoadFromFile(
       m_ReleaseCrossfadeLength = release_crossfase_length;
     else
       m_ReleaseCrossfadeLength = GetFaderLength(m_MidiKeyNumber);
-  } catch (wxString error) {
-    wxLogError(_("caught exception: %s\n"), error.c_str());
-    ClearData();
-    throw;
   } catch (...) {
     ClearData();
     throw;


### PR DESCRIPTION
Before #1319 if sveral sample files had not existed, the full list of not existed files was logged in the error message, but after this change no filename appears in the logs. It makes difficult to work with ODFs with wrong filenames (for example, https://github.com/GrandOrgue/ODFEdit/discussions/7#discussioncomment-4559870).

Now I restored logging all absent filenames as it was before.

This change does not start logging absent 'bmp' files, because they also were not logged before.
