### PR TITLE
Moved IgnorePitch from GOOrganController to GOPipeConfig

### DIFF
--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -139,15 +139,15 @@ bool GOConfigReader::ReadBoolean(
   return ReadBoolean(type, group, key, required, false);
 }
 
-bool GOConfigReader::ReadBoolean(
+int GOConfigReader::ReadBooleanTriple(
   GOSettingType type,
-  wxString group,
-  wxString key,
-  bool required,
-  bool defaultValue) {
+  const wxString &group,
+  const wxString &key,
+  bool required) {
   wxString value;
+
   if (!Read(type, group, key, required, value))
-    return defaultValue;
+    return -1;
 
   if (value.length() > 0 && value[value.length() - 1] == ' ') {
     if (m_Strict)
@@ -159,9 +159,9 @@ bool GOConfigReader::ReadBoolean(
     value.Trim();
   }
   if (value == wxT("Y") || value == wxT("y"))
-    return true;
+    return 1;
   if (value == wxT("N") || value == wxT("n"))
-    return false;
+    return 0;
   value.MakeUpper();
   wxLogWarning(
     _("Strange boolean value for section '%s' entry '%s': %s"),
@@ -169,9 +169,9 @@ bool GOConfigReader::ReadBoolean(
     key.c_str(),
     value.c_str());
   if (value.Length() && value[0] == wxT('Y'))
-    return true;
+    return 1;
   else if (value.Length() && value[0] == wxT('N'))
-    return false;
+    return 0;
 
   wxString error;
   error.Printf(
@@ -180,6 +180,17 @@ bool GOConfigReader::ReadBoolean(
     key.c_str(),
     value.c_str());
   throw error;
+}
+
+bool GOConfigReader::ReadBoolean(
+  GOSettingType type,
+  wxString group,
+  wxString key,
+  bool required,
+  bool defaultValue) {
+  int tripleValue = ReadBooleanTriple(type, group, key, required);
+
+  return tripleValue < 0 ? defaultValue : (tripleValue);
 }
 
 GOLogicalColour GOConfigReader::ReadColor(

--- a/src/core/config/GOConfigReader.h
+++ b/src/core/config/GOConfigReader.h
@@ -36,6 +36,14 @@ private:
 public:
   GOConfigReader(GOConfigReaderDB &cfg, bool strict = true);
 
+  /**
+   * Reads a triple-value boolean (-1 - not defined, 0 - false, 1 - true)
+   */
+  int ReadBooleanTriple(
+    GOSettingType type,
+    const wxString &group,
+    const wxString &key,
+    bool required);
   bool ReadBoolean(
     GOSettingType type, wxString group, wxString key, bool required = true);
   bool ReadBoolean(

--- a/src/core/config/GOConfigWriter.cpp
+++ b/src/core/config/GOConfigWriter.cpp
@@ -50,7 +50,11 @@ void GOConfigWriter::WriteEnum(
     _("Invalid enum value for /%s/%s: %d"), group.c_str(), key.c_str(), value);
 }
 
-void GOConfigWriter::WriteBoolean(wxString group, wxString key, bool value) {
-  wxString str = value ? wxT("Y") : wxT("N");
-  WriteString(group, key, str);
+void GOConfigWriter::WriteBooleanTriple(
+  const wxString &group, const wxString &key, int value) {
+  if (value >= 0) {
+    wxString str = value ? wxT("Y") : wxT("N");
+
+    WriteString(group, key, str);
+  }
 }

--- a/src/core/config/GOConfigWriter.h
+++ b/src/core/config/GOConfigWriter.h
@@ -30,7 +30,14 @@ public:
     const struct IniFileEnumEntry *entry,
     unsigned count);
   void WriteFloat(wxString group, wxString key, float value);
-  void WriteBoolean(wxString group, wxString key, bool value);
+  /**
+   * Saves 0 as N, 1 as Y. -1 is not saved at all
+   */
+  void WriteBooleanTriple(
+    const wxString &group, const wxString &key, int value);
+  void WriteBoolean(wxString group, wxString key, bool value) {
+    WriteBooleanTriple(group, key, (int)value);
+  }
 };
 
 #endif

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -89,7 +89,6 @@ GOOrganController::GOOrganController(GODocument *doc, GOConfig &settings)
     m_MidiPlayer(NULL),
     m_MidiRecorder(NULL),
     m_volume(0),
-    m_IgnorePitch(false),
     m_b_customized(false),
     m_OrganModified(false),
     m_DivisionalsStoreIntermanualCouplers(false),
@@ -243,8 +242,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   if (m_volume > 20)
     m_volume = 0;
   m_Temperament = cfg.ReadString(CMBSetting, group, wxT("Temperament"), false);
-  m_IgnorePitch
-    = cfg.ReadBoolean(CMBSetting, group, wxT("IgnorePitch"), false, false);
   m_releaseTail = (unsigned)cfg.ReadInteger(
     CMBSetting,
     group,
@@ -731,7 +728,6 @@ bool GOOrganController::Export(const wxString &cmb) {
   cfg.WriteInteger(wxT("Organ"), wxT("Volume"), m_volume);
 
   cfg.WriteString(wxT("Organ"), wxT("Temperament"), m_Temperament);
-  cfg.WriteBoolean(wxT("Organ"), wxT("IgnorePitch"), m_IgnorePitch);
   cfg.WriteInteger(wxT("Organ"), wxT("ReleaseTail"), (int)m_releaseTail);
 
   GOEventDistributor::Save(cfg);
@@ -784,10 +780,6 @@ GODocument *GOOrganController::GetDocument() { return m_doc; }
 void GOOrganController::SetVolume(int volume) { m_volume = volume; }
 
 int GOOrganController::GetVolume() { return m_volume; }
-
-void GOOrganController::SetIgnorePitch(bool ignore) { m_IgnorePitch = ignore; }
-
-bool GOOrganController::GetIgnorePitch() { return m_IgnorePitch; }
 
 void GOOrganController::SetReleaseTail(unsigned releaseTail) {
   m_releaseTail = releaseTail;

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -77,7 +77,6 @@ private:
   GOMidiPlayer *m_MidiPlayer;
   GOMidiRecorder *m_MidiRecorder;
   int m_volume;
-  bool m_IgnorePitch;
   wxString m_Temperament;
   unsigned m_releaseTail = 0;
 
@@ -210,9 +209,6 @@ public:
 
   void SetVolume(int volume);
   int GetVolume();
-
-  void SetIgnorePitch(bool ignorepitch);
-  bool GetIgnorePitch();
 
   unsigned GetReleaseTail() const { return m_releaseTail; }
   void SetReleaseTail(unsigned releaseTail);

--- a/src/grandorgue/dialogs/GOOrganDialog.cpp
+++ b/src/grandorgue/dialogs/GOOrganDialog.cpp
@@ -343,7 +343,7 @@ GOOrganDialog::GOOrganDialog(
     0,
     wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxBOTTOM,
     5);
-  if (m_OrganController->GetIgnorePitch())
+  if (m_OrganController->GetPipeConfig().GetEffectiveIgnorePitch())
     m_IgnorePitch->SetValue(true);
 
   settingSizer->Add(box3, 0, wxEXPAND | wxALL, 4);
@@ -947,7 +947,14 @@ void GOOrganDialog::OnOK(wxCommandEvent &event) {
       _("Please apply changes first"), _("Error"), wxOK | wxICON_ERROR, this);
     return;
   }
-  m_OrganController->SetIgnorePitch(m_IgnorePitch->GetValue());
+  GOPipeConfig &rootPipeConfig(
+    m_OrganController->GetPipeConfig().GetPipeConfig());
+  bool newIgnorePitch = m_IgnorePitch->GetValue();
+
+  // for avoiding modification of rootPipeConfig when it is non necessary
+  if (newIgnorePitch != (rootPipeConfig.IsIgnorePitch() > 0))
+    m_OrganController->GetPipeConfig().GetPipeConfig().SetIgnorePitch(
+      newIgnorePitch);
   m_OrganController->SetTemperament(m_OrganController->GetTemperament());
   m_OrganController->SetOrganModified();
   Destroy();

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -490,7 +490,7 @@ void GOSoundingPipe::SetTemperament(const GOTemperament &temperament) {
     m_TemperamentOffset = 0;
   else
     m_TemperamentOffset = temperament.GetOffset(
-      m_OrganController->GetIgnorePitch(),
+      m_PipeConfigNode.GetEffectiveIgnorePitch(),
       m_MidiKeyNumber,
       m_SoundProvider.GetMidiKeyNumber(),
       m_SoundProvider.GetMidiPitchFract(),

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -31,7 +31,8 @@ GOPipeConfig::GOPipeConfig(
     m_Channels(-1),
     m_LoopLoad(-1),
     m_AttackLoad(-1),
-    m_ReleaseLoad(-1) {}
+    m_ReleaseLoad(-1),
+    m_IgnorePitch(-1) {}
 
 void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
   m_Group = group;
@@ -88,6 +89,8 @@ void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
     CMBSetting, m_Group, m_NamePrefix + wxT("AttackLoad"), -1, 1, false, -1);
   m_ReleaseLoad = cfg.ReadInteger(
     CMBSetting, m_Group, m_NamePrefix + wxT("ReleaseLoad"), -1, 1, false, -1);
+  m_IgnorePitch = cfg.ReadBooleanTriple(
+    CMBSetting, m_Group, m_NamePrefix + wxT("IgnorePitch"), false);
   m_Callback->UpdateAmplitude();
   m_Callback->UpdateTuning();
   m_Callback->UpdateAudioGroup();
@@ -152,6 +155,8 @@ void GOPipeConfig::Load(GOConfigReader &cfg, wxString group, wxString prefix) {
     CMBSetting, m_Group, m_NamePrefix + wxT("AttackLoad"), -1, 1, false, -1);
   m_ReleaseLoad = cfg.ReadInteger(
     CMBSetting, m_Group, m_NamePrefix + wxT("ReleaseLoad"), -1, 1, false, -1);
+  m_IgnorePitch = cfg.ReadBooleanTriple(
+    CMBSetting, m_Group, m_NamePrefix + wxT("IgnorePitch"), false);
   m_Callback->UpdateAmplitude();
   m_Callback->UpdateTuning();
   m_Callback->UpdateAudioGroup();
@@ -170,6 +175,8 @@ void GOPipeConfig::Save(GOConfigWriter &cfg) {
   cfg.WriteInteger(m_Group, m_NamePrefix + wxT("LoopLoad"), m_LoopLoad);
   cfg.WriteInteger(m_Group, m_NamePrefix + wxT("AttackLoad"), m_AttackLoad);
   cfg.WriteInteger(m_Group, m_NamePrefix + wxT("ReleaseLoad"), m_ReleaseLoad);
+  cfg.WriteBooleanTriple(
+    m_Group, m_NamePrefix + wxT("IgnorePitch"), m_IgnorePitch);
 }
 
 GOPipeUpdateCallback *GOPipeConfig::GetCallback() { return m_Callback; }
@@ -264,5 +271,10 @@ int GOPipeConfig::GetReleaseLoad() { return m_ReleaseLoad; }
 
 void GOPipeConfig::SetReleaseLoad(int value) {
   m_ReleaseLoad = value;
+  m_OrganModel->SetOrganModelModified();
+}
+
+void GOPipeConfig::SetIgnorePitch(int value) {
+  m_IgnorePitch = value;
   m_OrganModel->SetOrganModelModified();
 }

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -37,6 +37,7 @@ private:
   int m_LoopLoad;
   int m_AttackLoad;
   int m_ReleaseLoad;
+  int m_IgnorePitch;
 
 public:
   GOPipeConfig(GOOrganModel *organModel, GOPipeUpdateCallback *callback);
@@ -83,6 +84,9 @@ public:
 
   int GetReleaseLoad();
   void SetReleaseLoad(int value);
+
+  int IsIgnorePitch() const { return m_IgnorePitch; }
+  void SetIgnorePitch(int value);
 };
 
 #endif

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -164,6 +164,14 @@ GOSampleStatistic GOPipeConfigNode::GetStatistic() {
   return GOSampleStatistic();
 }
 
+bool GOPipeConfigNode::GetEffectiveIgnorePitch() {
+  const int thisConfigValue = m_PipeConfig.IsIgnorePitch();
+
+  return thisConfigValue != -1
+    ? (thisConfigValue)
+    : m_parent && m_parent->GetEffectiveIgnorePitch();
+}
+
 unsigned GOPipeConfigNode::GetChildCount() { return 0; }
 
 GOPipeConfigNode *GOPipeConfigNode::GetChild(unsigned index) { return NULL; }

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -58,6 +58,7 @@ public:
   unsigned GetEffectiveAttackLoad();
   unsigned GetEffectiveReleaseLoad();
   unsigned GetEffectiveChannels();
+  bool GetEffectiveIgnorePitch();
 
   virtual void AddChild(GOPipeConfigNode *node);
   virtual unsigned GetChildCount();


### PR DESCRIPTION
Toward to eliminating dependency from GOOrganModel on GOOrganController, I moved `m_IgnorePitch` from `GOOrganController` to `GOPipeConfig`. I'm planning to make this setting overridable at the winchest/rank/pipe level in the future.

I introduced the `BooleanTripple` with three values: 0 - false, 1 - true and -1 - inherit from the parent. I added new methods  for reading and writing BooleanTripple values to the config file.

NO GrandOrgue behavior should be changed.