### PR TITLE
Renamed GOOrganController::m_PipeConfig to m_RootPipeConfigNode and moved to GOOrganModel

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -149,7 +149,7 @@ void GOOrganController::OnIsModifiedChanged(bool modified) {
       m_PitchLabel.SetContent(wxString::Format(_("%f cent"), newPitch));
       m_CurrentPitch = newPitch;
     }
-    // If the organ model modified then the organ is also modified
+    // If the organ model is modified then the organ is also modified
     SetOrganModified(true);
   }
   // else nothing because the organ may be modified without the model

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -90,6 +90,7 @@ GOOrganController::GOOrganController(GODocument *doc, GOConfig &settings)
     m_MidiRecorder(NULL),
     m_volume(0),
     m_b_customized(false),
+    m_CurrentPitch(999999.0), // for enforcing updating the label first time
     m_OrganModified(false),
     m_DivisionalsStoreIntermanualCouplers(false),
     m_DivisionalsStoreIntramanualCouplers(false),
@@ -113,7 +114,6 @@ GOOrganController::GOOrganController(GODocument *doc, GOConfig &settings)
     m_SampleSetId1(0),
     m_SampleSetId2(0),
     m_bitmaps(this),
-    m_PipeConfig(NULL, this, this),
     m_config(settings),
     m_GeneralTemplate(this),
     m_PitchLabel(this),
@@ -141,8 +141,17 @@ void GOOrganController::SetOrganModified(bool modified) {
 }
 
 void GOOrganController::OnIsModifiedChanged(bool modified) {
-  if (modified) // If the organ model modified then the organ is also modified
+  if (modified) {
+    // Update the pitch label if it has been changed
+    const float newPitch = GetRootPipeConfigNode().GetPipeConfig().GetTuning();
+
+    if (newPitch != m_CurrentPitch) {
+      m_PitchLabel.SetContent(wxString::Format(_("%f cent"), newPitch));
+      m_CurrentPitch = newPitch;
+    }
+    // If the organ model modified then the organ is also modified
     SetOrganModified(true);
+  }
   // else nothing because the organ may be modified without the model
 }
 
@@ -222,7 +231,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   /* load basic organ information */
   unsigned NumberOfPanels
     = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfPanels"), 0, 100, false);
-  m_PipeConfig.Load(cfg, group, wxEmptyString);
   m_DivisionalsStoreIntermanualCouplers = cfg.ReadBoolean(
     ODFSetting, group, wxT("DivisionalsStoreIntermanualCouplers"));
   m_DivisionalsStoreIntramanualCouplers = cfg.ReadBoolean(
@@ -315,7 +323,7 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   for (unsigned i = m_FirstManual; i < m_manuals.size(); i++)
     m_manuals[i]->GetDivisionalTemplate().InitDivisional(i);
 
-  m_PipeConfig.SetName(GetChurchName());
+  GetRootPipeConfigNode().SetName(GetChurchName());
   ReadCombinations(cfg);
 
   GOHash hash;
@@ -852,17 +860,6 @@ const wxString &GOOrganController::GetRecordingDetails() {
 }
 
 const wxString &GOOrganController::GetInfoFilename() { return m_InfoFilename; }
-
-GOPipeConfigNode &GOOrganController::GetPipeConfig() { return m_PipeConfig; }
-
-void GOOrganController::UpdateAmplitude() {}
-
-void GOOrganController::UpdateTuning() {
-  m_PitchLabel.SetContent(
-    wxString::Format(_("%f cent"), m_PipeConfig.GetPipeConfig().GetTuning()));
-}
-
-void GOOrganController::UpdateAudioGroup() {}
 
 bool GOOrganController::IsCustomized() { return m_b_customized; }
 

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -22,7 +22,6 @@
 #include "loader/GOFileStore.h"
 #include "model/GOModificationListener.h"
 #include "model/GOOrganModel.h"
-#include "model/pipe-config/GOPipeConfigTreeNode.h"
 
 #include "GOBitmapCache.h"
 #include "GOMainWindowData.h"
@@ -54,7 +53,6 @@ class GOSoundSampler;
 typedef struct _GOHashType GOHashType;
 
 class GOOrganController : public GOEventDistributor,
-                          private GOPipeUpdateCallback,
                           public GOTimer,
                           public GOOrganModel,
                           public GOModificationListener {
@@ -81,6 +79,7 @@ private:
   unsigned m_releaseTail = 0;
 
   bool m_b_customized;
+  float m_CurrentPitch; // organ pitch
   bool m_OrganModified; // always m_IsOrganModified >= IsModelModified()
   bool m_DivisionalsStoreIntermanualCouplers;
   bool m_DivisionalsStoreIntramanualCouplers;
@@ -109,7 +108,6 @@ private:
 
   GOMemoryPool m_pool;
   GOBitmapCache m_bitmaps;
-  GOPipeConfigTreeNode m_PipeConfig;
   GOConfig &m_config;
   GOCombinationDefinition m_GeneralTemplate;
   GOLabelControl m_PitchLabel;
@@ -128,10 +126,6 @@ private:
   wxString GenerateCacheFileName();
   void SetTemperament(const GOTemperament &temperament);
   void PreconfigRecorder();
-
-  void UpdateAmplitude();
-  void UpdateTuning();
-  void UpdateAudioGroup();
 
   wxString GetOrganHash();
 
@@ -187,7 +181,6 @@ public:
   GOMemoryPool &GetMemoryPool();
   GOConfig &GetSettings();
   GOBitmapCache &GetBitmapCache();
-  GOPipeConfigNode &GetPipeConfig();
   void SetTemperament(wxString name);
   wxString GetTemperament();
   void MarkSectionInUse(wxString name);

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -610,22 +610,22 @@ void GOSetter::ButtonStateChanged(int id) {
   } break;
 
   case ID_SETTER_PITCH_M1:
-    m_OrganController->GetPipeConfig().ModifyTuning(-1);
+    m_OrganController->GetRootPipeConfigNode().ModifyTuning(-1);
     break;
   case ID_SETTER_PITCH_M10:
-    m_OrganController->GetPipeConfig().ModifyTuning(-10);
+    m_OrganController->GetRootPipeConfigNode().ModifyTuning(-10);
     break;
   case ID_SETTER_PITCH_M100:
-    m_OrganController->GetPipeConfig().ModifyTuning(-100);
+    m_OrganController->GetRootPipeConfigNode().ModifyTuning(-100);
     break;
   case ID_SETTER_PITCH_P1:
-    m_OrganController->GetPipeConfig().ModifyTuning(1);
+    m_OrganController->GetRootPipeConfigNode().ModifyTuning(1);
     break;
   case ID_SETTER_PITCH_P10:
-    m_OrganController->GetPipeConfig().ModifyTuning(10);
+    m_OrganController->GetRootPipeConfigNode().ModifyTuning(10);
     break;
   case ID_SETTER_PITCH_P100:
-    m_OrganController->GetPipeConfig().ModifyTuning(100);
+    m_OrganController->GetRootPipeConfigNode().ModifyTuning(100);
     break;
   case ID_SETTER_SAVE:
     m_OrganController->Save();

--- a/src/grandorgue/dialogs/GOOrganDialog.cpp
+++ b/src/grandorgue/dialogs/GOOrganDialog.cpp
@@ -343,7 +343,7 @@ GOOrganDialog::GOOrganDialog(
     0,
     wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxBOTTOM,
     5);
-  if (m_OrganController->GetPipeConfig().GetEffectiveIgnorePitch())
+  if (m_OrganController->GetRootPipeConfigNode().GetEffectiveIgnorePitch())
     m_IgnorePitch->SetValue(true);
 
   settingSizer->Add(box3, 0, wxEXPAND | wxALL, 4);
@@ -948,12 +948,12 @@ void GOOrganDialog::OnOK(wxCommandEvent &event) {
     return;
   }
   GOPipeConfig &rootPipeConfig(
-    m_OrganController->GetPipeConfig().GetPipeConfig());
+    m_OrganController->GetRootPipeConfigNode().GetPipeConfig());
   bool newIgnorePitch = m_IgnorePitch->GetValue();
 
   // for avoiding modification of rootPipeConfig when it is non necessary
   if (newIgnorePitch != (rootPipeConfig.IsIgnorePitch() > 0))
-    m_OrganController->GetPipeConfig().GetPipeConfig().SetIgnorePitch(
+    m_OrganController->GetRootPipeConfigNode().GetPipeConfig().SetIgnorePitch(
       newIgnorePitch);
   m_OrganController->SetTemperament(m_OrganController->GetTemperament());
   m_OrganController->SetOrganModified();

--- a/src/grandorgue/dialogs/GOOrganDialog.cpp
+++ b/src/grandorgue/dialogs/GOOrganDialog.cpp
@@ -727,7 +727,7 @@ void GOOrganDialog::FillTree(wxTreeItemId parent, GOPipeConfigNode &config) {
 
 void GOOrganDialog::FillTree() {
   wxTreeItemId id_root;
-  FillTree(id_root, m_OrganController->GetPipeConfig());
+  FillTree(id_root, m_OrganController->GetRootPipeConfigNode());
 }
 
 void GOOrganDialog::OnEventApply(wxCommandEvent &e) {

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -23,6 +23,7 @@
 
 GOOrganModel::GOOrganModel(const GOConfig &config)
   : m_config(config),
+    m_RootPipeConfigNode(nullptr, this, nullptr),
     m_OrganModelModified(false),
     m_ModificationListener(nullptr),
     m_FirstManual(0),
@@ -37,6 +38,7 @@ void GOOrganModel::Load(
   unsigned NumberOfWindchestGroups
     = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfWindchestGroups"), 1, 50);
 
+  m_RootPipeConfigNode.Load(cfg, group, wxEmptyString);
   m_windchests.resize(0);
   for (unsigned i = 0; i < NumberOfWindchestGroups; i++)
     m_windchests.push_back(new GOWindchest(organController));
@@ -141,11 +143,10 @@ void GOOrganModel::Load(
 }
 
 void GOOrganModel::SetOrganModelModified(bool modified) {
-  if (modified != m_OrganModelModified) {
+  if (modified != m_OrganModelModified)
     m_OrganModelModified = modified;
-    if (m_ModificationListener)
-      m_ModificationListener->OnIsModifiedChanged(modified);
-  }
+  if (modified && m_ModificationListener)
+    m_ModificationListener->OnIsModifiedChanged(modified);
 }
 
 void GOOrganModel::UpdateTremulant(GOTremulant *tremulant) {

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -11,6 +11,7 @@
 #include "ptrvector.h"
 
 #include "GOEventHandlerList.h"
+#include "pipe-config/GOPipeConfigTreeNode.h"
 
 class GOConfig;
 class GOConfigReader;
@@ -29,6 +30,8 @@ class GOWindchest;
 class GOOrganModel : public GOEventHandlerList {
 private:
   const GOConfig &m_config;
+
+  GOPipeConfigTreeNode m_RootPipeConfigNode;
 
   bool m_OrganModelModified;
   GOModificationListener *m_ModificationListener;
@@ -54,6 +57,8 @@ public:
   ~GOOrganModel();
 
   const GOConfig &GetConfig() const { return m_config; }
+
+  GOPipeConfigNode &GetRootPipeConfigNode() { return m_RootPipeConfigNode; }
 
   bool IsOrganModelModified() const { return m_OrganModelModified; }
   void SetOrganModelModified(bool modified);

--- a/src/grandorgue/model/GOWindchest.cpp
+++ b/src/grandorgue/model/GOWindchest.cpp
@@ -24,7 +24,8 @@ GOWindchest::GOWindchest(GOOrganController *organController)
     m_tremulant(0),
     m_ranks(0),
     m_pipes(0),
-    m_PipeConfig(&organController->GetPipeConfig(), organController, NULL) {
+    m_PipeConfig(
+      &organController->GetRootPipeConfigNode(), organController, NULL) {
   m_OrganController->RegisterPlaybackStateHandler(this);
 }
 

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -185,8 +185,8 @@ const wxString &GOPipeConfig::GetAudioGroup() { return m_AudioGroup; }
 
 void GOPipeConfig::SetAudioGroup(const wxString &str) {
   m_AudioGroup = str;
-  m_OrganModel->SetOrganModelModified();
   m_Callback->UpdateAudioGroup();
+  m_OrganModel->SetOrganModelModified();
 }
 
 float GOPipeConfig::GetAmplitude() { return m_Amplitude; }
@@ -195,8 +195,8 @@ float GOPipeConfig::GetDefaultAmplitude() { return m_DefaultAmplitude; }
 
 void GOPipeConfig::SetAmplitude(float amp) {
   m_Amplitude = amp;
-  m_OrganModel->SetOrganModelModified();
   m_Callback->UpdateAmplitude();
+  m_OrganModel->SetOrganModelModified();
 }
 
 float GOPipeConfig::GetGain() { return m_Gain; }
@@ -205,8 +205,8 @@ float GOPipeConfig::GetDefaultGain() { return m_DefaultGain; }
 
 void GOPipeConfig::SetGain(float gain) {
   m_Gain = gain;
-  m_OrganModel->SetOrganModelModified();
   m_Callback->UpdateAmplitude();
+  m_OrganModel->SetOrganModelModified();
 }
 
 float GOPipeConfig::GetTuning() { return m_Tuning; }


### PR DESCRIPTION
Toward to elimination dependencies on GOOrganContoller I renamed and moved GOOrganController::m_PipeConfig to GOOrganModel::GOOrganModel.

So all GOPipeConfig instances are present in the model and noone is in the controller.
