### PR TITLE
Moved ReleaseTail to GOPipeConfig

### DIFF
--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -70,11 +70,15 @@ bool GODocument::LoadOrgan(
     m_sound.GetEngine().SetVolume(m_OrganController->GetVolume());
   }
 
-  const unsigned releaseTail = m_OrganController->GetReleaseTail();
+  // synchronize cfg.ReleaseTail with OrganReleaseTail.
+  unsigned cfgReleaseTail = cfg.ReleaseLength();
+  unsigned organReleaseTail = m_OrganController->GetReleaseTail();
 
-  cfg.ReleaseLength(releaseTail);
-  m_sound.GetEngine().SetReleaseLength(releaseTail);
-  m_sound.GetSettings().Flush();
+  if (organReleaseTail) // organReleaseTail has the priority
+    cfg.ReleaseLength(organReleaseTail);
+  else if (cfgReleaseTail)
+    m_OrganController->SetReleaseTail(cfgReleaseTail);
+  cfg.Flush();
 
   wxCommandEvent event(wxEVT_WINTITLE, 0);
   event.SetString(m_OrganController->GetChurchName());

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -317,7 +317,6 @@ GOFrame::GOFrame(
     wxDefaultSize,
     choices);
   m_ToolBar->AddControl(m_ReleaseLength);
-  m_Sound.GetEngine().SetReleaseLength(m_config.ReleaseLength());
   UpdateReleaseLength();
 
   m_ToolBar->AddTool(
@@ -1193,13 +1192,12 @@ void GOFrame::OnSettingsTranspose(wxCommandEvent &event) {
 }
 
 void GOFrame::OnSettingsReleaseLength(wxCommandEvent &event) {
-  m_config.ReleaseLength(m_ReleaseLength->GetSelection() * 50);
-  m_Sound.GetEngine().SetReleaseLength(m_config.ReleaseLength());
-
+  unsigned newReleaseTail = m_ReleaseLength->GetSelection() * 50;
   GOOrganController *organController = GetOrganController();
 
+  m_config.ReleaseLength(newReleaseTail);
   if (organController)
-    organController->SetReleaseTail(m_config.ReleaseLength());
+    organController->SetReleaseTail(newReleaseTail);
 }
 
 void GOFrame::OnHelpAbout(wxCommandEvent &event) { DoSplash(false); }

--- a/src/grandorgue/GOFrame.h
+++ b/src/grandorgue/GOFrame.h
@@ -30,6 +30,7 @@
 #include "help/GOHelpRequestor.h"
 #include "midi/GOMidiCallback.h"
 #include "midi/GOMidiListener.h"
+#include "model/GOModificationListener.h"
 #include "threading/GOMutex.h"
 
 #include "GOEvent.h"
@@ -53,7 +54,8 @@ class wxToolBarToolBase;
 class GOFrame : public wxFrame,
                 private GOHelpRequestor,
                 public GOResizable,
-                protected GOMidiCallback {
+                protected GOMidiCallback,
+                private GOModificationListener {
 private:
   GOApp &m_App;
   GOMutex m_mutex;
@@ -88,7 +90,8 @@ private:
   int m_AfterSettingsEventId;
   GOOrgan *p_AfterSettingsEventOrgan;
 
-  void UpdateReleaseLength();
+  // Updates ReleseLength in the model, in the config, and in the control
+  void UpdateReleaseLength(unsigned releaseLength);
   void UpdatePanelMenu();
   void UpdateFavoritesMenu();
   void UpdateRecentMenu();
@@ -99,6 +102,10 @@ private:
 
   // Returns the current open organ controller or nullptr
   GOOrganController *GetOrganController() const;
+
+  // Processes the organ model modification event:
+  // updates some controls according the organ model changes
+  void OnIsModifiedChanged(bool modified) override;
 
   bool LoadOrgan(const GOOrgan &organ, const wxString &cmb = wxEmptyString);
 

--- a/src/grandorgue/GOFrame.h
+++ b/src/grandorgue/GOFrame.h
@@ -42,6 +42,7 @@ class GODocument;
 class GOMidiEvent;
 class GOOrgan;
 class GOOrganController;
+class GOProgressDialog;
 class GOSound;
 class wxChoice;
 class wxHtmlHelpController;

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -250,14 +250,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   if (m_volume > 20)
     m_volume = 0;
   m_Temperament = cfg.ReadString(CMBSetting, group, wxT("Temperament"), false);
-  m_releaseTail = (unsigned)cfg.ReadInteger(
-    CMBSetting,
-    group,
-    wxT("ReleaseTail"),
-    0,
-    3000,
-    false,
-    m_config.ReleaseLength());
 
   GOOrganModel::Load(cfg, this);
   wxString buffer;
@@ -749,7 +741,6 @@ bool GOOrganController::Export(const wxString &cmb) {
   cfg.WriteInteger(wxT("Organ"), wxT("Volume"), m_volume);
 
   cfg.WriteString(wxT("Organ"), wxT("Temperament"), m_Temperament);
-  cfg.WriteInteger(wxT("Organ"), wxT("ReleaseTail"), (int)m_releaseTail);
 
   GOEventDistributor::Save(cfg);
 
@@ -801,11 +792,6 @@ GODocument *GOOrganController::GetDocument() { return m_doc; }
 void GOOrganController::SetVolume(int volume) { m_volume = volume; }
 
 int GOOrganController::GetVolume() { return m_volume; }
-
-void GOOrganController::SetReleaseTail(unsigned releaseTail) {
-  m_releaseTail = releaseTail;
-  SetOrganModified();
-}
 
 bool GOOrganController::DivisionalsStoreIntermanualCouplers() {
   return m_DivisionalsStoreIntermanualCouplers;

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -76,7 +76,6 @@ private:
   GOMidiRecorder *m_MidiRecorder;
   int m_volume;
   wxString m_Temperament;
-  unsigned m_releaseTail = 0;
 
   bool m_b_customized;
   float m_CurrentPitch; // organ pitch
@@ -203,8 +202,12 @@ public:
   void SetVolume(int volume);
   int GetVolume();
 
-  unsigned GetReleaseTail() const { return m_releaseTail; }
-  void SetReleaseTail(unsigned releaseTail);
+  unsigned GetReleaseTail() {
+    return GetRootPipeConfigNode().GetEffectiveReleaseTail();
+  }
+  void SetReleaseTail(unsigned releaseTail) {
+    GetRootPipeConfigNode().GetPipeConfig().SetReleaseTail(releaseTail);
+  }
 
   GOEnclosure *GetEnclosure(const wxString &name, bool is_panel = false);
   GOLabelControl *GetLabel(const wxString &name, bool is_panel = false);

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -508,6 +508,10 @@ void GOSoundingPipe::UpdateAudioGroup() {
     m_PipeConfigNode.GetEffectiveAudioGroup());
 }
 
+void GOSoundingPipe::UpdateReleaseTail() {
+  m_SoundProvider.SetReleaseTail(m_PipeConfigNode.GetEffectiveReleaseTail());
+}
+
 void GOSoundingPipe::SetTemperament(const GOTemperament &temperament) {
   m_IsTemperamentOriginalBased = temperament.IsTemperamentOriginalBased();
   if (!m_RetunePipe)

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -68,9 +68,10 @@ private:
 
   void SetTremulant(bool on);
 
-  void UpdateAmplitude();
-  void UpdateTuning();
-  void UpdateAudioGroup();
+  void UpdateAmplitude() override;
+  void UpdateTuning() override;
+  void UpdateAudioGroup() override;
+  void UpdateReleaseTail() override;
 
   void AbortPlayback();
   void PreparePlayback();

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -32,7 +32,8 @@ GOPipeConfig::GOPipeConfig(
     m_LoopLoad(-1),
     m_AttackLoad(-1),
     m_ReleaseLoad(-1),
-    m_IgnorePitch(-1) {}
+    m_IgnorePitch(-1),
+    m_ReleaseTail(0) {}
 
 void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
   m_Group = group;
@@ -91,6 +92,9 @@ void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
     CMBSetting, m_Group, m_NamePrefix + wxT("ReleaseLoad"), -1, 1, false, -1);
   m_IgnorePitch = cfg.ReadBooleanTriple(
     CMBSetting, m_Group, m_NamePrefix + wxT("IgnorePitch"), false);
+  m_ReleaseTail = (unsigned)cfg.ReadInteger(
+    CMBSetting, group, m_NamePrefix + wxT("ReleaseTail"), 0, 3000, false, 0);
+
   m_Callback->UpdateAmplitude();
   m_Callback->UpdateTuning();
   m_Callback->UpdateAudioGroup();
@@ -157,9 +161,13 @@ void GOPipeConfig::Load(GOConfigReader &cfg, wxString group, wxString prefix) {
     CMBSetting, m_Group, m_NamePrefix + wxT("ReleaseLoad"), -1, 1, false, -1);
   m_IgnorePitch = cfg.ReadBooleanTriple(
     CMBSetting, m_Group, m_NamePrefix + wxT("IgnorePitch"), false);
+  m_ReleaseTail = (unsigned)cfg.ReadInteger(
+    CMBSetting, group, m_NamePrefix + wxT("ReleaseTail"), 0, 3000, false, 0);
+
   m_Callback->UpdateAmplitude();
   m_Callback->UpdateTuning();
   m_Callback->UpdateAudioGroup();
+  m_Callback->UpdateReleaseTail();
 }
 
 void GOPipeConfig::Save(GOConfigWriter &cfg) {
@@ -177,6 +185,8 @@ void GOPipeConfig::Save(GOConfigWriter &cfg) {
   cfg.WriteInteger(m_Group, m_NamePrefix + wxT("ReleaseLoad"), m_ReleaseLoad);
   cfg.WriteBooleanTriple(
     m_Group, m_NamePrefix + wxT("IgnorePitch"), m_IgnorePitch);
+  cfg.WriteInteger(
+    m_Group, m_NamePrefix + wxT("ReleaseTail"), (int)m_ReleaseTail);
 }
 
 GOPipeUpdateCallback *GOPipeConfig::GetCallback() { return m_Callback; }
@@ -219,8 +229,8 @@ void GOPipeConfig::SetTuning(float cent) {
   if (cent > 1800)
     cent = 1800;
   m_Tuning = cent;
-  m_OrganModel->SetOrganModelModified();
   m_Callback->UpdateTuning();
+  m_OrganModel->SetOrganModelModified();
 }
 
 unsigned GOPipeConfig::GetDelay() { return m_Delay; }
@@ -276,5 +286,11 @@ void GOPipeConfig::SetReleaseLoad(int value) {
 
 void GOPipeConfig::SetIgnorePitch(int value) {
   m_IgnorePitch = value;
+  m_OrganModel->SetOrganModelModified();
+}
+
+void GOPipeConfig::SetReleaseTail(unsigned releaseTail) {
+  m_ReleaseTail = releaseTail;
+  m_Callback->UpdateReleaseTail();
   m_OrganModel->SetOrganModelModified();
 }

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -38,6 +38,7 @@ private:
   int m_AttackLoad;
   int m_ReleaseLoad;
   int m_IgnorePitch;
+  unsigned m_ReleaseTail; // the max release length in ms
 
 public:
   GOPipeConfig(GOOrganModel *organModel, GOPipeUpdateCallback *callback);
@@ -87,6 +88,9 @@ public:
 
   int IsIgnorePitch() const { return m_IgnorePitch; }
   void SetIgnorePitch(int value);
+
+  unsigned GetReleaseTail() const { return m_ReleaseTail; }
+  void SetReleaseTail(unsigned releaseTail);
 };
 
 #endif

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -19,6 +19,7 @@ GOPipeConfigNode::GOPipeConfigNode(
   GOPipeUpdateCallback *callback,
   GOStatisticCallback *statistic)
   : m_OrganModel(organModel),
+    m_config(organModel->GetConfig()),
     m_parent(parent),
     m_PipeConfig(organModel, callback),
     m_StatisticCallback(statistic),
@@ -110,7 +111,7 @@ unsigned GOPipeConfigNode::GetEffectiveBitsPerSample() {
   if (m_parent)
     return m_parent->GetEffectiveBitsPerSample();
   else
-    return m_OrganModel->GetConfig().BitsPerSample();
+    return m_config.BitsPerSample();
 }
 
 bool GOPipeConfigNode::GetEffectiveCompress() {
@@ -119,7 +120,7 @@ bool GOPipeConfigNode::GetEffectiveCompress() {
   if (m_parent)
     return m_parent->GetEffectiveCompress();
   else
-    return m_OrganModel->GetConfig().LosslessCompression();
+    return m_config.LosslessCompression();
 }
 
 unsigned GOPipeConfigNode::GetEffectiveLoopLoad() {
@@ -128,7 +129,7 @@ unsigned GOPipeConfigNode::GetEffectiveLoopLoad() {
   if (m_parent)
     return m_parent->GetEffectiveLoopLoad();
   else
-    return m_OrganModel->GetConfig().LoopLoad();
+    return m_config.LoopLoad();
 }
 
 unsigned GOPipeConfigNode::GetEffectiveAttackLoad() {
@@ -137,7 +138,7 @@ unsigned GOPipeConfigNode::GetEffectiveAttackLoad() {
   if (m_parent)
     return m_parent->GetEffectiveAttackLoad();
   else
-    return m_OrganModel->GetConfig().AttackLoad();
+    return m_config.AttackLoad();
 }
 
 unsigned GOPipeConfigNode::GetEffectiveReleaseLoad() {
@@ -146,7 +147,7 @@ unsigned GOPipeConfigNode::GetEffectiveReleaseLoad() {
   if (m_parent)
     return m_parent->GetEffectiveReleaseLoad();
   else
-    return m_OrganModel->GetConfig().ReleaseLoad();
+    return m_config.ReleaseLoad();
 }
 
 unsigned GOPipeConfigNode::GetEffectiveChannels() {
@@ -155,7 +156,7 @@ unsigned GOPipeConfigNode::GetEffectiveChannels() {
   if (m_parent)
     return m_parent->GetEffectiveChannels();
   else
-    return m_OrganModel->GetConfig().LoadChannels();
+    return m_config.LoadChannels();
 }
 
 GOSampleStatistic GOPipeConfigNode::GetStatistic() {
@@ -164,12 +165,22 @@ GOSampleStatistic GOPipeConfigNode::GetStatistic() {
   return GOSampleStatistic();
 }
 
-bool GOPipeConfigNode::GetEffectiveIgnorePitch() {
+bool GOPipeConfigNode::GetEffectiveIgnorePitch() const {
   const int thisConfigValue = m_PipeConfig.IsIgnorePitch();
 
   return thisConfigValue != -1
     ? (thisConfigValue)
     : m_parent && m_parent->GetEffectiveIgnorePitch();
+}
+
+unsigned GOPipeConfigNode::GetEffectiveReleaseTail() const {
+  unsigned releaseTail = m_parent ? m_parent->GetEffectiveReleaseTail() : 0;
+  const unsigned thisReleaseTail = m_PipeConfig.GetReleaseTail();
+
+  // Set releaseTail as minimum between the parent release tail and this one
+  if (thisReleaseTail && (!releaseTail || thisReleaseTail < releaseTail))
+    releaseTail = thisReleaseTail;
+  return releaseTail;
 }
 
 unsigned GOPipeConfigNode::GetChildCount() { return 0; }

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -11,6 +11,7 @@
 #include "GOPipeConfig.h"
 #include "GOSaveableObject.h"
 
+class GOConfig;
 class GOOrganModel;
 class GOSampleStatistic;
 class GOStatisticCallback;
@@ -18,6 +19,7 @@ class GOStatisticCallback;
 class GOPipeConfigNode : private GOSaveableObject {
 private:
   GOOrganModel *m_OrganModel;
+  const GOConfig &m_config;
   GOPipeConfigNode *m_parent;
   GOPipeConfig m_PipeConfig;
   GOStatisticCallback *m_StatisticCallback;
@@ -58,7 +60,8 @@ public:
   unsigned GetEffectiveAttackLoad();
   unsigned GetEffectiveReleaseLoad();
   unsigned GetEffectiveChannels();
-  bool GetEffectiveIgnorePitch();
+  bool GetEffectiveIgnorePitch() const;
+  unsigned GetEffectiveReleaseTail() const;
 
   virtual void AddChild(GOPipeConfigNode *node);
   virtual unsigned GetChildCount();

--- a/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp
@@ -48,6 +48,13 @@ void GOPipeConfigTreeNode::UpdateAudioGroup() {
     m_Callback->UpdateAudioGroup();
 }
 
+void GOPipeConfigTreeNode::UpdateReleaseTail() {
+  for (auto child : m_Childs)
+    child->GetPipeConfig().GetCallback()->UpdateReleaseTail();
+  if (m_Callback)
+    m_Callback->UpdateReleaseTail();
+}
+
 GOSampleStatistic GOPipeConfigTreeNode::GetStatistic() {
   GOSampleStatistic stat = GOPipeConfigNode::GetStatistic();
   for (unsigned i = 0; i < m_Childs.size(); i++)

--- a/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.h
@@ -18,9 +18,10 @@ private:
   std::vector<GOPipeConfigNode *> m_Childs;
   GOPipeUpdateCallback *m_Callback;
 
-  void UpdateAmplitude();
-  void UpdateTuning();
-  void UpdateAudioGroup();
+  void UpdateAmplitude() override;
+  void UpdateTuning() override;
+  void UpdateAudioGroup() override;
+  void UpdateReleaseTail() override;
 
 public:
   GOPipeConfigTreeNode(

--- a/src/grandorgue/model/pipe-config/GOPipeUpdateCallback.h
+++ b/src/grandorgue/model/pipe-config/GOPipeUpdateCallback.h
@@ -15,6 +15,7 @@ public:
   virtual void UpdateAmplitude() = 0;
   virtual void UpdateTuning() = 0;
   virtual void UpdateAudioGroup() = 0;
+  virtual void UpdateReleaseTail() = 0;
 };
 
 #endif

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -29,7 +29,6 @@ GOSoundEngine::GOSoundEngine()
     m_ReleaseAlignmentEnabled(true),
     m_RandomizeSpeaking(true),
     m_Volume(-15),
-    m_ReleaseLength(0),
     m_SamplesPerBuffer(1),
     m_Gain(1),
     m_SampleRate(0),
@@ -113,10 +112,6 @@ unsigned GOSoundEngine::GetSampleRate() { return m_SampleRate; }
 void GOSoundEngine::SetHardPolyphony(unsigned polyphony) {
   m_SamplerPool.SetUsageLimit(polyphony);
   m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
-}
-
-void GOSoundEngine::SetReleaseLength(unsigned reverb) {
-  m_ReleaseLength = reverb;
 }
 
 void GOSoundEngine::SetPolyphonyLimiting(bool limiting) {
@@ -551,14 +546,17 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
           }
         }
       }
+
       unsigned cross_fade_len = this_pipe->GetReleaseCrossfadeLength();
+      const unsigned releaseLength = this_pipe->GetReleaseTail();
+
       new_sampler->fader.NewAttacking(
         gain_target, cross_fade_len, m_SampleRate);
 
-      if (m_ReleaseLength > 0) {
-        if (m_ReleaseLength < gain_decay_length || gain_decay_length == 0)
-          gain_decay_length = m_ReleaseLength;
-      }
+      if (
+        releaseLength > 0
+        && (releaseLength < gain_decay_length || gain_decay_length == 0))
+        gain_decay_length = releaseLength;
 
       if (gain_decay_length > 0)
         new_sampler->fader.StartDecay(gain_decay_length, m_SampleRate);

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -42,7 +42,6 @@ private:
   bool m_ReleaseAlignmentEnabled;
   bool m_RandomizeSpeaking;
   int m_Volume;
-  unsigned m_ReleaseLength;
   unsigned m_SamplesPerBuffer;
   float m_Gain;
   unsigned m_SampleRate;
@@ -98,7 +97,6 @@ public:
   int GetVolume() const;
   void SetScaledReleases(bool enable);
   void SetRandomizeSpeaking(bool enable);
-  void SetReleaseLength(unsigned reverb);
   const std::vector<double> &GetMeterInfo();
   void SetAudioRecorder(GOSoundRecorder *recorder, bool downmix);
 

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -29,6 +29,7 @@ GOSoundProvider::GOSoundProvider()
     m_MidiPitchFract(0),
     m_Tuning(1),
     m_SampleGroup(0),
+    m_ReleaseTail(0),
     m_Attack(),
     m_AttackInfo(),
     m_Release(),

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -38,6 +38,7 @@ protected:
   float m_Gain;
   float m_Tuning;
   bool m_SampleGroup;
+  unsigned m_ReleaseTail;
   ptr_vector<GOAudioSection> m_Attack;
   std::vector<attack_section_info> m_AttackInfo;
   ptr_vector<GOAudioSection> m_Release;
@@ -68,6 +69,8 @@ public:
 
   float GetTuning() const;
   void SetTuning(float cent);
+  unsigned GetReleaseTail() const { return m_ReleaseTail; }
+  void SetReleaseTail(unsigned releaseTail) { m_ReleaseTail = releaseTail; }
 
   unsigned GetMidiKeyNumber() const;
   float GetMidiPitchFract() const;


### PR DESCRIPTION
Toward to elimination of references from GOSoundingPipe to GOOrganController, I moved m_ReleaseTail to GOPipeConfig.

This step will allow to implement setting ReleaseLength at the Rank and the PipeLevel in the future (an alternative implementation of #774) with GUI. The model is ready after this PR, the only change will be needed is in GOSettingDialog.