### PR TITLE
Fixed saving position when some panel is outside the screen area https://github.com/GrandOrgue/grandorgue/issues/1271

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
+- Fixed saving position when some panel is outside the screen area https://github.com/GrandOrgue/grandorgue/issues/1271
 - Fixed playing release samples for very short notes https://github.com/GrandOrgue/grandorgue/issues/1222
-- Fixed help: the wrong panal positioning on wayland was documented https://github.com/GrandOrgue/grandorgue/issues/1271
+- Fixed help: the wrong panel positioning on wayland was documented https://github.com/GrandOrgue/grandorgue/issues/1271
 - Fixed typos and spelling errors in the Help
 - Fixed continuing loading an organ after an exception in one loading thread
 - Fixed size of text fields in the Organ Settings dialog on OsX https://github.com/GrandOrgue/grandorgue/issues/1315

--- a/src/grandorgue/GOPanelView.cpp
+++ b/src/grandorgue/GOPanelView.cpp
@@ -85,18 +85,22 @@ GOPanelView::GOPanelView(
   int nr = savedDisplayNum >= 0 && savedDisplayNum < (int)wxDisplay::GetCount()
     ? savedDisplayNum
     : wxDisplay::GetFromWindow(frame);
-  wxDisplay display(nr != wxNOT_FOUND ? nr : 0);
-  wxRect max = display.GetClientArea();
-  // If our current window is within this area, all is fine
-  wxRect current = frame->GetRect();
-  if (!max.Contains(current)) {
-    // Otherwise, check and correct width and height,
-    // and place the frame at the center of the Client Area of the display
-    if (current.GetWidth() > max.GetWidth())
-      current.SetWidth(max.GetWidth());
-    if (current.GetHeight() > max.GetHeight())
-      current.SetHeight(max.GetHeight());
-    frame->SetSize(current.CenterIn(max, wxBOTH));
+
+  // Check if the window is visible. If not, center it at the first display
+  if (nr == wxNOT_FOUND) {
+    wxRect max = wxDisplay((unsigned)0).GetClientArea();
+    // If our current window is within this area, all is fine
+    wxRect current = frame->GetRect();
+
+    if (!max.Contains(current)) {
+      // Otherwise, check and correct width and height,
+      // and place the frame at the center of the Client Area of the display
+      if (current.GetWidth() > max.GetWidth())
+        current.SetWidth(max.GetWidth());
+      if (current.GetHeight() > max.GetHeight())
+        current.SetHeight(max.GetHeight());
+      frame->SetSize(current.CenterIn(max, wxBOTH));
+    }
   }
   if (m_TopWindow && panel->IsMaximized())
     m_TopWindow->Maximize(true);


### PR DESCRIPTION
Resolves: #1271

This PR fixes restoring panel position if the frame was not fully inside the screen area.

It works fine on windows, but some window managers (ex. gnome-shell/mutter) return the panel inside the screen area if it is only partially visible.
