### PR TITLE
Fixed playing release samples for very short notes https://github.com/GrandOrgue/grandorgue/issues/1222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed playing release samples for very short notes https://github.com/GrandOrgue/grandorgue/issues/1222
 - Fixed help: the wrong panal positioning on wayland was documented https://github.com/GrandOrgue/grandorgue/issues/1271
 - Fixed typos and spelling errors in the Help
 - Fixed continuing loading an organ after an exception in one loading thread

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -231,7 +231,6 @@ bool GOSoundEngine::ProcessSampler(
   GOSoundSampler *sampler,
   unsigned n_frames,
   float volume) {
-  const unsigned block_time = n_frames;
   float temp[n_frames * 2];
   const bool process_sampler = (sampler->time <= m_CurrentTime);
 
@@ -243,11 +242,6 @@ bool GOSoundEngine::ProcessSampler(
          sampler->drop_counter > 1))
       sampler->fader.StartDecay(
         370, m_SampleRate); /* Approx 0.37s at 44.1kHz */
-
-    if (
-      sampler->stop && sampler->stop <= m_CurrentTime
-      && sampler->stop - sampler->time <= block_time)
-      sampler->pipe = NULL;
 
     /* The decoded sampler frame will contain values containing
      * sampler->pipe_section->sample_bits worth of significant bits.


### PR DESCRIPTION
Resolves: #1222

This PR reverts [this Martin's change](https://github.com/GrandOrgue/grandorgue/commit/58c0bf31982d907829cfb7aa93d6f707a94a93ed).

I could not find any explanation, what kind of problems that change resolved. 

After this PR #1222 stopped reproducing. Today I played for two hours and could not hear any sound artifacts, mentioned by Martin in the commit message. Possible, there was another issue that has already been resolved.