### PR TITLE
Renamed class GOReleaseAlignTable to GOSoundReleaseAlignTable

### DIFF
--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -464,6 +464,7 @@
             <in>GOSoundProviderSynthedTrem.cpp</in>
             <in>GOSoundProviderWave.cpp</in>
             <in>GOSoundRecorder.cpp</in>
+            <in>GOSoundReleaseAlignTable.cpp</in>
             <in>GOSoundResample.cpp</in>
             <in>GOSoundReverb.cpp</in>
             <in>GOSoundReverbEngine.cpp</in>
@@ -485,11 +486,9 @@
           <in>GODocument.cpp</in>
           <in>GODrawStop.cpp</in>
           <in>GOEvent.cpp</in>
-          <in>GOFilename.cpp</in>
           <in>GOFont.cpp</in>
           <in>GOFrame.cpp</in>
           <in>GOKeyReceiver.cpp</in>
-          <in>GOLoadThread.cpp</in>
           <in>GOLog.cpp</in>
           <in>GOLogWindow.cpp</in>
           <in>GOMainWindowData.cpp</in>
@@ -497,7 +496,6 @@
           <in>GOOrganController.cpp</in>
           <in>GOPanelView.cpp</in>
           <in>GOProperties.cpp</in>
-          <in>GOReleaseAlignTable.cpp</in>
         </df>
         <df name="images">
           <in>EnclosureA00.cpp</in>
@@ -808,10 +806,9 @@
         <element flagsID="3"
                  commonFlags="-mtune=generic -march=x86-64 -std=c++11 -fPIC"/>
         <element flagsID="4" commonFlags="-std=c++11 -O3 -ffast-math -fPIC"/>
-        <element flagsID="5" commonFlags="-std=c++11 -O3 -ffast-math -msse3"/>
-        <element flagsID="6" commonFlags="-std=c++11 -fPIC"/>
-        <element flagsID="7" commonFlags="-std=c++11 -msse3"/>
-        <element flagsID="8" commonFlags="-std=c++14"/>
+        <element flagsID="5" commonFlags="-std=c++11 -fPIC"/>
+        <element flagsID="6" commonFlags="-std=c++11 -msse3"/>
+        <element flagsID="7" commonFlags="-std=c++14"/>
       </flagsDictionary>
       <codeAssistance>
       </codeAssistance>
@@ -821,7 +818,7 @@
           <buildCommand>${MAKE} -f Makefile -j 16 -k</buildCommand>
           <cleanCommand>${MAKE} -f Makefile clean</cleanCommand>
           <executablePath>../../build/current/bin/GrandOrgue</executablePath>
-          <ccTool flags="7">
+          <ccTool flags="6">
           </ccTool>
         </makeTool>
         <preBuild>
@@ -838,7 +835,7 @@
             ex="false"
             tool="1"
             flavor2="11">
-        <ccTool flags="8">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../build/current/src/images/ASIO.cpp"
@@ -9271,33 +9268,6 @@
           </preprocessorList>
         </ccTool>
       </item>
-      <item path="../../src/grandorgue/GOFilename.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="7">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
       <item path="../../src/grandorgue/GOFont.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="0">
           <incDir>
@@ -9545,34 +9515,6 @@
             <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/GOLoadThread.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="5">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>NDEBUG</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9897,7 +9839,7 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="7">
+        <ccTool flags="6">
           <incDir>
             <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/grandorgue/resource</pElem>
@@ -10027,80 +9969,6 @@
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/GOReleaseAlignTable.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
@@ -13774,74 +13642,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -13849,84 +13669,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/core/threading</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -13934,74 +13696,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/threading</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -14232,6 +13946,33 @@
             <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/sound/GOSoundReleaseAlignTable.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -14851,848 +14592,848 @@
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA00.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA01.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA02.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA03.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA04.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA05.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA06.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA07.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA08.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA09.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA10.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA11.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA12.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA13.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA14.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA15.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB00.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB01.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB02.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB03.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB04.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB05.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB06.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB07.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB08.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB09.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB10.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB11.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB12.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB13.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB14.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureB15.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC00.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC01.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC02.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC03.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC04.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC05.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC06.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC07.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC08.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC09.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC10.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC11.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC12.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC13.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC14.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureC15.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD00.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD01.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD02.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD03.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD04.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD05.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD06.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD07.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD08.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD09.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD10.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD11.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD12.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD13.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD14.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureD15.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/GOIcon.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualCBlackDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualCBlackUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualCWhiteDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualCWhiteUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualCWoodDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualCWoodUp.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualDBlackDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualDBlackUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualDWhiteDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualDWhiteUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualDWoodDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualDWoodUp.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualEBlackDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualEBlackUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualEWhiteDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualEWhiteUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualEWoodDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualEWoodUp.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualNaturalBlackDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualNaturalBlackUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualNaturalWhiteDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualNaturalWhiteUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualNaturalWoodDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualNaturalWoodUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualSharpBlackDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualSharpBlackUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualSharpWhiteDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualSharpWhiteUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualSharpWoodDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/ManualSharpWoodUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/PedalNaturalBlackDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/PedalNaturalBlackUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/PedalNaturalWoodDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/PedalNaturalWoodUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/PedalSharpBlackDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/PedalSharpBlackUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/PedalSharpWoodDown.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/PedalSharpWoodUp.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Splash.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood01.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood03.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood05.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood07.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood09.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood11.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood13.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood15.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood17.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood19.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood21.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood23.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood25.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood27.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood29.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood31.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood33.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood35.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood37.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood39.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood41.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood43.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood45.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood47.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood49.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood51.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood53.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood55.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood57.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood59.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood61.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/Wood63.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop01off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop01on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop02off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop02on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop03off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop03on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop04off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop04on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop05off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop05on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop06off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/drawstop06on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/gauge.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/help.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label01.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label02.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label03.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label04.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label05.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label06.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label07.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label08.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label09.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label10.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label11.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/label12.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/memory.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/open.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/panic.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston01off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston01on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston02off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston02on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston03off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston03on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston04off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston04on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston05off.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/piston05on.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/polyphony.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/properties.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/record.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/reload.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/reverb.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/save.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/set.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/settings.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/transpose.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/images/volume.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="5">
         </ccTool>
       </item>
       <item path="../../src/portaudio/common/pa_allocation.c"
@@ -16302,7 +16043,7 @@
             ex="false"
             tool="1"
             flavor2="11">
-        <ccTool flags="8">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <folder path="0/build">
@@ -21308,33 +21049,6 @@
           </incDir>
         </ccTool>
       </item>
-      <item path="../../src/grandorgue/GOFilename.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="5">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/contrib</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
       <item path="../../src/grandorgue/GOFont.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="0">
           <incDir>
@@ -21590,34 +21304,6 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/GOReleaseAlignTable.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="5">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/contrib</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_STD_MUTEX</Elem>
             <Elem>GO_USE_JACK</Elem>
             <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
@@ -23908,6 +23594,34 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/sound/GOSoundReleaseAlignTable.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="5">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/contrib</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_STD_MUTEX</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundResample.cpp"

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -153,6 +153,7 @@ sound/GOSoundProvider.cpp
 sound/GOSoundProviderSynthedTrem.cpp
 sound/GOSoundProviderWave.cpp
 sound/GOSoundRecorder.cpp
+sound/GOSoundReleaseAlignTable.cpp
 sound/GOSoundReverb.cpp
 sound/GOSoundReverbEngine.cpp
 sound/GOSoundReverbPartition.cpp
@@ -179,7 +180,6 @@ GOMetronome.cpp
 GOMainWindowData.cpp
 GOOrganController.cpp
 GOProperties.cpp
-GOReleaseAlignTable.cpp
 GOFrame.cpp
 GODocument.cpp
 GOPanelView.cpp

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -56,6 +56,7 @@
 #include "model/GOTremulant.h"
 #include "model/GOWindchest.h"
 #include "sound/GOSoundEngine.h"
+#include "sound/GOSoundReleaseAlignTable.h"
 #include "temperaments/GOTemperament.h"
 
 #include "GOAudioRecorder.h"
@@ -70,7 +71,6 @@
 #include "GOMetronome.h"
 #include "GOOrgan.h"
 #include "GOPath.h"
-#include "GOReleaseAlignTable.h"
 
 GOOrganController::GOOrganController(GODocument *doc, GOConfig &settings)
   : GOEventDistributor(this),
@@ -169,7 +169,7 @@ GOHashType GOOrganController::GenerateCacheHash() {
   UpdateHash(hash);
   hash.Update(sizeof(GOAudioSection));
   hash.Update(sizeof(GOSoundingPipe));
-  hash.Update(sizeof(GOReleaseAlignTable));
+  hash.Update(sizeof(GOSoundReleaseAlignTable));
   hash.Update(BLOCK_HISTORY);
   hash.Update(MAX_READAHEAD);
   hash.Update(SHORT_LOOP_LENGTH);

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -13,9 +13,9 @@
 #include "GOCache.h"
 #include "GOCacheWriter.h"
 #include "GOMemoryPool.h"
-#include "GOReleaseAlignTable.h"
 #include "GOSampleStatistic.h"
 #include "GOSoundCompress.h"
+#include "GOSoundReleaseAlignTable.h"
 #include "GOSoundResample.h"
 
 #ifndef M_PI
@@ -131,7 +131,7 @@ bool GOAudioSection::LoadCache(GOCache &cache) {
     return false;
   m_ReleaseAligner = NULL;
   if (load_align_tracker) {
-    m_ReleaseAligner = new GOReleaseAlignTable();
+    m_ReleaseAligner = new GOSoundReleaseAlignTable();
     if (!m_ReleaseAligner->Load(cache))
       return false;
   }
@@ -939,7 +939,7 @@ void GOAudioSection::SetupStreamAlignment(
     m_ReleaseStartSegment = 0;
 
   if ((max_derivative != 0) && (max_amplitude != 0)) {
-    m_ReleaseAligner = new GOReleaseAlignTable();
+    m_ReleaseAligner = new GOSoundReleaseAlignTable();
     m_ReleaseAligner->ComputeTable(
       *this,
       max_amplitude,

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -21,7 +21,7 @@ class GOAudioSection;
 class GOCache;
 class GOCacheWriter;
 class GOMemoryPool;
-class GOReleaseAlignTable;
+class GOSoundReleaseAlignTable;
 class GOSampleStatistic;
 
 struct audio_section_stream_s;
@@ -144,7 +144,7 @@ private:
   unsigned char *m_Data;
 
   /* If this is a release section, it may contain an alignment table */
-  GOReleaseAlignTable *m_ReleaseAligner;
+  GOSoundReleaseAlignTable *m_ReleaseAligner;
   unsigned m_ReleaseStartSegment;
 
   /* Number of significant bits in the decoded sample data */

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -18,9 +18,9 @@
 
 #include "GOEvent.h"
 #include "GOOrganController.h"
-#include "GOReleaseAlignTable.h"
 #include "GOSoundProvider.h"
 #include "GOSoundRecorder.h"
+#include "GOSoundReleaseAlignTable.h"
 #include "GOSoundSampler.h"
 
 GOSoundEngine::GOSoundEngine()

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -12,9 +12,9 @@
 #include "GOCache.h"
 #include "GOCacheWriter.h"
 #include "GOMemoryPool.h"
-#include "GOReleaseAlignTable.h"
 #include "GOSampleStatistic.h"
 #include "GOSoundAudioSection.h"
+#include "GOSoundReleaseAlignTable.h"
 
 #define DELETE_AND_NULL(x)                                                     \
   do {                                                                         \

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
@@ -5,7 +5,7 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOReleaseAlignTable.h"
+#include "GOSoundReleaseAlignTable.h"
 
 #include <stdlib.h>
 
@@ -19,15 +19,15 @@
 #endif
 #endif
 
-GOReleaseAlignTable::GOReleaseAlignTable() {
+GOSoundReleaseAlignTable::GOSoundReleaseAlignTable() {
   memset(m_PositionEntries, 0, sizeof(m_PositionEntries));
   m_PhaseAlignMaxAmplitude = 0;
   m_PhaseAlignMaxDerivative = 0;
 }
 
-GOReleaseAlignTable::~GOReleaseAlignTable() {}
+GOSoundReleaseAlignTable::~GOSoundReleaseAlignTable() {}
 
-bool GOReleaseAlignTable::Load(GOCache &cache) {
+bool GOSoundReleaseAlignTable::Load(GOCache &cache) {
   if (!cache.Read(&m_PhaseAlignMaxAmplitude, sizeof(m_PhaseAlignMaxAmplitude)))
     return false;
   if (!cache.Read(
@@ -38,7 +38,7 @@ bool GOReleaseAlignTable::Load(GOCache &cache) {
   return true;
 }
 
-bool GOReleaseAlignTable::Save(GOCacheWriter &cache) {
+bool GOSoundReleaseAlignTable::Save(GOCacheWriter &cache) {
   if (!cache.Write(&m_PhaseAlignMaxAmplitude, sizeof(m_PhaseAlignMaxAmplitude)))
     return false;
   if (!cache.Write(
@@ -49,7 +49,7 @@ bool GOReleaseAlignTable::Save(GOCacheWriter &cache) {
   return true;
 }
 
-void GOReleaseAlignTable::ComputeTable(
+void GOSoundReleaseAlignTable::ComputeTable(
   const GOAudioSection &release,
   int phase_align_max_amplitude,
   int phase_align_max_derivative,
@@ -172,7 +172,7 @@ void GOReleaseAlignTable::ComputeTable(
       }
 }
 
-void GOReleaseAlignTable::SetupRelease(
+void GOSoundReleaseAlignTable::SetupRelease(
   audio_section_stream &release_sampler,
   const audio_section_stream &old_sampler) const {
   int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS];

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.h
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.h
@@ -5,8 +5,8 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GORELEASEALIGNTABLE_H_
-#define GORELEASEALIGNTABLE_H_
+#ifndef GOSOUNDRELEASEALIGNTABLE_H
+#define GOSOUNDRELEASEALIGNTABLE_H
 
 class GOAudioSection;
 class GOCache;
@@ -17,15 +17,15 @@ typedef struct audio_section_stream_s audio_section_stream;
 #define PHASE_ALIGN_AMPLITUDES 32
 #define PHASE_ALIGN_MIN_FREQUENCY 20 /* Hertz */
 
-class GOReleaseAlignTable {
+class GOSoundReleaseAlignTable {
 private:
   int m_PhaseAlignMaxAmplitude;
   int m_PhaseAlignMaxDerivative;
   int m_PositionEntries[PHASE_ALIGN_DERIVATIVES][PHASE_ALIGN_AMPLITUDES];
 
 public:
-  GOReleaseAlignTable();
-  ~GOReleaseAlignTable();
+  GOSoundReleaseAlignTable();
+  ~GOSoundReleaseAlignTable();
 
   bool Load(GOCache &cache);
   bool Save(GOCacheWriter &cache);
@@ -42,4 +42,4 @@ public:
     const audio_section_stream &old_sampler) const;
 };
 
-#endif /* GORELEASEALIGNTABLE_H_ */
+#endif /* GOSOUNDRELEASEALIGNTABLE_H */


### PR DESCRIPTION
The class `GOReleaseAlignTable` belongs to the sound engine, so I renamed it and moved to the `sound` subdirectory.

It is just renaming. No GO behavior should be changed.