### PR TITLE
Moved several methods of loading an organ from GODocument to GOFrame::LoadOrgan

### DIFF
--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -45,11 +45,7 @@ bool GODocument::IsModified() const {
   return m_OrganController && m_OrganController->IsOrganModified();
 }
 
-bool GODocument::Load(GOProgressDialog *dlg, const GOOrgan &organ) {
-  return Import(dlg, organ, wxEmptyString);
-}
-
-bool GODocument::Import(
+bool GODocument::LoadOrgan(
   GOProgressDialog *dlg, const GOOrgan &organ, const wxString &cmb) {
   wxBusyCursor busy;
   GOConfig &cfg = m_sound.GetSettings();
@@ -140,12 +136,6 @@ void GODocument::SyncState() {
   for (unsigned i = 0; i < m_OrganController->GetPanelCount(); i++)
     m_OrganController->GetPanel(i)->SetInitialOpenWindow(false);
   GODocumentBase::SyncState();
-}
-
-bool GODocument::Revert(GOProgressDialog *dlg) {
-  if (m_OrganController)
-    m_OrganController->DeleteSettings();
-  return Load(dlg, m_OrganController->GetOrganInfo());
 }
 
 bool GODocument::Save() {

--- a/src/grandorgue/GODocument.h
+++ b/src/grandorgue/GODocument.h
@@ -58,12 +58,11 @@ public:
     GOMidiSender *division = NULL);
   void ShowMidiList();
 
-  bool Load(GOProgressDialog *dlg, const GOOrgan &organ);
   bool Save();
   bool Export(const wxString &cmb);
-  bool Import(GOProgressDialog *dlg, const GOOrgan &organ, const wxString &cmb);
+  bool LoadOrgan(
+    GOProgressDialog *dlg, const GOOrgan &organ, const wxString &cmb);
   bool ImportCombination(const wxString &cmb);
-  bool Revert(GOProgressDialog *dlg);
   bool UpdateCache(GOProgressDialog *dlg, bool compress);
 
   GOOrganController *GetOrganController() const { return m_OrganController; }

--- a/src/grandorgue/GOFrame.h
+++ b/src/grandorgue/GOFrame.h
@@ -99,8 +99,9 @@ private:
   // Returns the current open organ controller or nullptr
   GOOrganController *GetOrganController() const;
 
-  void OnMeters(wxCommandEvent &event);
+  bool LoadOrgan(const GOOrgan &organ, const wxString &cmb = wxEmptyString);
 
+  void OnMeters(wxCommandEvent &event);
   void OnLoadFile(wxCommandEvent &event);
   void OnLoad(wxCommandEvent &event);
   void OnLoadFavorite(wxCommandEvent &event);


### PR DESCRIPTION
I renamed `GODocument::Import` to `LoadOrgan` and removed it's wrappers: `GODocument::Load` and `GODocument::Revert`.

Instead I added a single method ``GOFrame::LoadOrgan`` and I moved there all extra from several places of loading an organ in GOFrame,

It is just refactoring. No GrandOrgue behavior should be changed.


