### PR TITLE
Omit atime+ctime from zip files

### DIFF
--- a/cmake/BuildHelp.cmake
+++ b/cmake/BuildHelp.cmake
@@ -45,7 +45,7 @@ function(BUILD_HELPFILE xmlfile VARIANT)
     WORKING_DIRECTORY ${BUILDDIR} DEPENDS ${SRCDIR}/grandorgue.xsl ${xmlfile})
 
   ADD_CUSTOM_COMMAND(OUTPUT ${HELPDIR}/GrandOrgue${VARIANT}.htb COMMAND ${ZIP} 
-    ARGS -r --filesync ${HELPDIR}/GrandOrgue${VARIANT}.htb * WORKING_DIRECTORY ${BUILDDIR}
+    ARGS -r -X --filesync ${HELPDIR}/GrandOrgue${VARIANT}.htb * WORKING_DIRECTORY ${BUILDDIR}
     DEPENDS ${_ImgList} ${BUILDDIR}/GrandOrgue.hhp)
 
   INSTALL(FILES ${HELPDIR}/GrandOrgue${VARIANT}.htb DESTINATION ${HELPINSTDIR} COMPONENT resources)


### PR DESCRIPTION
`.htb` files do not need extended UNIX metadata such as atime and ctime so we omit them with `-X` to make the result more reproducible.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).