### PR TITLE
Added support of ODF comments from ';' at any position to the end of line https://github.com/GrandOrgue/grandorgue/issues/828

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support of ODF comments from ';' at any position to the end of line https://github.com/GrandOrgue/grandorgue/issues/828
 # 3.9.5 (2022-01-23)
 - Fixed saving position when some panel is outside the screen area https://github.com/GrandOrgue/grandorgue/issues/1271
 - Fixed playing release samples for very short notes https://github.com/GrandOrgue/grandorgue/issues/1222

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -6260,7 +6260,8 @@ UTF-8, if it starts with an appropriate byte order marker.
       </para>
       <para>
         Comments are any text from <emphasis>;</emphasis> to the end of line.
-        Empty lines or lines containing only comments are ignored.
+        Empty lines or lines containing only comments are ignored. 
+        Thus it's not possible to include <emphasis>;</emphasis> in any string
       </para>
       <para>
 Various settings are grouped in blocks. Each block is started with a

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -6259,7 +6259,8 @@ It is a text file in ISO-8859-1 encoding. The standard extension is
 UTF-8, if it starts with an appropriate byte order marker.
       </para>
       <para>
-Comment lines are started with <emphasis>;</emphasis> in the first column. Empty lines are ignored.
+        Comments are any text from <emphasis>;</emphasis> to the end of line.
+        Empty lines or lines containing only comments are ignored.
       </para>
       <para>
 Various settings are grouped in blocks. Each block is started with a

--- a/src/core/config/GOConfigFileReader.cpp
+++ b/src/core/config/GOConfigFileReader.cpp
@@ -117,9 +117,13 @@ bool GOConfigFileReader::Read(GOOpenedFile *file) {
     wxString line = GetNextLine(input, pos);
     lineno++;
 
+    /* Skip the comment */
+    int semicolumnPos = line.find(wxT(";"), 0);
+
+    if (semicolumnPos >= 0)
+      line = line.substr(0, semicolumnPos).Trim();
+
     if (line == wxEmptyString)
-      continue;
-    if (line.Len() >= 1 && line[0] == wxT(';'))
       continue;
     if (line.Len() > 1 && line[0] == wxT('[')) {
       if (line[line.Len() - 1] != wxT(']')) {


### PR DESCRIPTION
Resolves: #828

I've checked, that hauptwerk also can open files with comments starting at not the first position, so there are no reasons why to forbid it in GrandOrgue.