### PR TITLE
Renamed OriginalTuning to PitchTuning in fields and methods names in GOPipeConfig and GOPipeConfigNode for corresponding to thhe ODF keys PitchTuning and Pipe999PitchTuning

### DIFF
--- a/src/grandorgue/dialogs/GOOrganDialog.cpp
+++ b/src/grandorgue/dialogs/GOOrganDialog.cpp
@@ -872,7 +872,7 @@ void GOOrganDialog::ResetSelectedToDefault(bool isForChildren) {
   for (OrganTreeItemData *e : oiSet) {
     e->config->SetAmplitude(e->config->GetDefaultAmplitude());
     e->config->SetGain(e->config->GetDefaultGain());
-    e->config->SetTuning(e->config->GetDefaultTuning());
+    e->config->SetTuning(e->config->GetPitchTuning());
     e->config->SetDelay(e->config->GetDefaultDelay());
     e->config->SetAudioGroup(wxEmptyString);
     e->config->SetBitsPerSample(-1);

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -398,7 +398,7 @@ void GOSoundingPipe::Validate() {
     offset = m_SoundProvider.GetMidiKeyNumber()
       + log(8.0 / m_HarmonicNumber) * (12.0 / log(2))
       - (m_SoundProvider.GetMidiPitchFract()
-         - m_PipeConfigNode.GetDefaultTuning() + m_PitchCorrection)
+         - m_PipeConfigNode.GetEffectivePitchTuning() + m_PitchCorrection)
         / 100.0
       - m_MidiKeyNumber;
   if (offset < -18 || offset > 18) {
@@ -498,7 +498,7 @@ void GOSoundingPipe::UpdateTuning() {
         + m_SoundProvider.GetMidiPitchFract();
     }
     pitchAdjustment = m_PipeConfigNode.GetEffectiveTuning() + m_PitchCorrection
-      - m_PipeConfigNode.GetDefaultTuning() - concert_pitch_correction;
+      - m_PipeConfigNode.GetEffectivePitchTuning() - concert_pitch_correction;
   }
   m_SoundProvider.SetTuning(pitchAdjustment + m_TemperamentOffset);
 }

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -23,7 +23,7 @@ GOPipeConfig::GOPipeConfig(
     m_Gain(0),
     m_DefaultGain(0),
     m_Tuning(0),
-    m_DefaultTuning(0),
+    m_PitchTuning(0),
     m_Delay(0),
     m_DefaultDelay(0),
     m_BitsPerSample(-1),
@@ -58,7 +58,7 @@ void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
     40,
     false,
     m_DefaultGain);
-  m_DefaultTuning = 0;
+  m_PitchTuning = 0;
   m_Tuning = cfg.ReadFloat(
     CMBSetting,
     group,
@@ -66,7 +66,7 @@ void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
     -1800,
     1800,
     false,
-    m_DefaultTuning);
+    m_PitchTuning);
   m_DefaultDelay = 0;
   m_Delay = cfg.ReadInteger(
     CMBSetting, group, prefix + wxT("Delay"), 0, 10000, false, m_DefaultDelay);
@@ -125,7 +125,7 @@ void GOPipeConfig::Load(GOConfigReader &cfg, wxString group, wxString prefix) {
     40,
     false,
     m_DefaultGain);
-  m_DefaultTuning = cfg.ReadFloat(
+  m_PitchTuning = cfg.ReadFloat(
     ODFSetting, group, prefix + wxT("PitchTuning"), -1800, 1800, false, 0);
   m_Tuning = cfg.ReadFloat(
     CMBSetting,
@@ -134,7 +134,7 @@ void GOPipeConfig::Load(GOConfigReader &cfg, wxString group, wxString prefix) {
     -1800,
     1800,
     false,
-    m_DefaultTuning);
+    m_PitchTuning);
   m_DefaultDelay = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("TrackerDelay"), 0, 10000, false, 0);
   m_Delay = cfg.ReadInteger(
@@ -221,7 +221,7 @@ void GOPipeConfig::SetGain(float gain) {
 
 float GOPipeConfig::GetTuning() { return m_Tuning; }
 
-float GOPipeConfig::GetDefaultTuning() { return m_DefaultTuning; }
+float GOPipeConfig::GetPitchTuning() { return m_PitchTuning; }
 
 void GOPipeConfig::SetTuning(float cent) {
   if (cent < -1800)

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -27,8 +27,8 @@ private:
   float m_DefaultAmplitude;
   float m_Gain;
   float m_DefaultGain;
+  float m_PitchTuning;
   float m_Tuning;
-  float m_DefaultTuning;
   unsigned m_Delay;
   unsigned m_DefaultDelay;
   int m_BitsPerSample;
@@ -58,7 +58,7 @@ public:
   void SetGain(float gain);
 
   float GetTuning();
-  float GetDefaultTuning();
+  float GetPitchTuning();
   void SetTuning(float cent);
 
   unsigned GetDelay();

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -82,11 +82,11 @@ float GOPipeConfigNode::GetEffectiveTuning() {
     return m_PipeConfig.GetTuning();
 }
 
-float GOPipeConfigNode::GetDefaultTuning() {
+float GOPipeConfigNode::GetEffectivePitchTuning() {
   if (m_parent)
-    return m_PipeConfig.GetDefaultTuning() + m_parent->GetDefaultTuning();
+    return m_PipeConfig.GetPitchTuning() + m_parent->GetEffectivePitchTuning();
   else
-    return m_PipeConfig.GetDefaultTuning();
+    return m_PipeConfig.GetPitchTuning();
 }
 
 unsigned GOPipeConfigNode::GetEffectiveDelay() {

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -49,7 +49,7 @@ public:
   float GetEffectiveAmplitude();
   float GetEffectiveGain();
   float GetEffectiveTuning();
-  float GetDefaultTuning();
+  float GetEffectivePitchTuning();
 
   unsigned GetEffectiveDelay();
   wxString GetEffectiveAudioGroup();


### PR DESCRIPTION
This is the first PR on #1351 and #1333.

It is just renaming. No GO behavior should be changed.