### PR TITLE
Added PitchCorrection for organs and windchest. Pipe999PitchCorrection became additive to PitchCorrection of the rank, of the windchest and of the organ https://github.com/GrandOrgue/grandorgue/issues/1351

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added PitchCorrection for organs and windchest. Pipe999PitchCorrection became additive to PitchCorrection of the rank, of the windchest and of the organ https://github.com/GrandOrgue/grandorgue/issues/1351
 - Added full support of '/' as the file sepearator in ODF unless 'Check ODF for HW1-compatibility' is set https://github.com/GrandOrgue/grandorgue/issues/827
 - Added support of ODF comments from ';' at any position to the end of line https://github.com/GrandOrgue/grandorgue/issues/828
 # 3.9.5 (2022-01-23)

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -7062,6 +7062,16 @@ number of cents.
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term>PitchTuning</term>
+          <listitem>
+            <para>
+(float -1800 - 1800, default: 0) Correction factor in cent for the pitch
+of the whole organ. This setting is used for retuning to other
+temperaments.
+     </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term>TrackerDelay</term>
           <listitem>
             <para>
@@ -9630,7 +9640,7 @@ that rank.
           <listitem>
             <para>
 (float -1800 - 1800, default: 0) Correction factor in cent for the pitch
-specified in the sample. This setting is used for retuning to other
+of the rank. This setting is used for retuning to other
 temperaments.
      </para>
           </listitem>
@@ -9873,9 +9883,10 @@ fraction in the sample to 0.
           <term>Pipe999PitchCorrection</term>
           <listitem>
             <para>
-(float -1800 - 1800, default: rank pitch correction) Correction factor
-in cent for the pitch specified in the sample. This setting is used
-for retuning to other temperaments.
+	      (float -1800 - 1800, default: 0) Correction factor in cent for the
+	      pitch specified in the sample in addition to PitchCorrection of
+	      the whole organ, of the windchest and of the rank. This setting is
+	      used for retuning to other temperaments.
      </para>
           </listitem>
         </varlistentry>

--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -113,12 +113,12 @@ void GOMetronome::Load(GOConfigReader &cfg) {
 
   GOSoundingPipe *pipe;
   pipe = new GOSoundingPipe(
-    m_OrganController, m_rank, true, samplegroup, 36, 8, 0, 100, 100, false);
+    m_OrganController, m_rank, true, samplegroup, 36, 8, 100, 100, false);
   m_rank->AddPipe(pipe);
   pipe->Init(
     cfg, wxT("MetronomSounds"), wxT("A"), wxT("sounds\\metronome\\beat.wv"));
   pipe = new GOSoundingPipe(
-    m_OrganController, m_rank, true, samplegroup, 37, 8, 0, 100, 100, false);
+    m_OrganController, m_rank, true, samplegroup, 37, 8, 100, 100, false);
   m_rank->AddPipe(pipe);
   pipe->Init(
     cfg,

--- a/src/grandorgue/model/GORank.cpp
+++ b/src/grandorgue/model/GORank.cpp
@@ -29,7 +29,6 @@ GORank::GORank(GOOrganController *organController)
     m_Percussive(false),
     m_WindchestGroup(0),
     m_HarmonicNumber(8),
-    m_PitchCorrection(0),
     m_MinVolume(100),
     m_MaxVolume(100),
     m_RetuneRank(true),
@@ -64,7 +63,6 @@ void GORank::Init(
   m_WindchestGroup = windchest_nr;
   m_Percussive = false;
   m_HarmonicNumber = 8;
-  m_PitchCorrection = 0;
   m_MinVolume = 100;
   m_MaxVolume = 100;
   m_RetuneRank = false;
@@ -108,8 +106,6 @@ void GORank::Load(
   m_Percussive = cfg.ReadBoolean(ODFSetting, group, wxT("Percussive"));
   m_HarmonicNumber = cfg.ReadInteger(
     ODFSetting, group, wxT("HarmonicNumber"), 1, 1024, false, 8);
-  m_PitchCorrection = cfg.ReadFloat(
-    ODFSetting, group, wxT("PitchCorrection"), -1800, 1800, false, 0);
   m_MinVolume = cfg.ReadFloat(
     ODFSetting, group, wxT("MinVelocityVolume"), 0, 1000, false, 100);
   m_MaxVolume = cfg.ReadFloat(
@@ -141,7 +137,6 @@ void GORank::Load(
         m_WindchestGroup,
         m_FirstMidiNoteNumber + i,
         m_HarmonicNumber,
-        m_PitchCorrection,
         m_MinVolume,
         m_MaxVolume,
         m_RetuneRank));

--- a/src/grandorgue/model/GORank.h
+++ b/src/grandorgue/model/GORank.h
@@ -36,7 +36,6 @@ private:
   bool m_Percussive;
   unsigned m_WindchestGroup;
   unsigned m_HarmonicNumber;
-  float m_PitchCorrection;
   float m_MinVolume;
   float m_MaxVolume;
   bool m_RetuneRank;

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -30,7 +30,6 @@ GOSoundingPipe::GOSoundingPipe(
   int sampler_group_id,
   unsigned midi_key_number,
   unsigned harmonic_number,
-  float pitch_correction,
   float min_volume,
   float max_volume,
   bool retune)
@@ -50,7 +49,6 @@ GOSoundingPipe::GOSoundingPipe(
     m_HarmonicNumber(harmonic_number),
     m_LoopCrossfadeLength(0),
     m_ReleaseCrossfadeLength(0),
-    m_PitchCorrection(pitch_correction),
     m_MinVolume(min_volume),
     m_MaxVolume(max_volume),
     m_SampleMidiKeyNumber(-1),
@@ -174,14 +172,6 @@ void GOSoundingPipe::Load(
     1024,
     false,
     m_HarmonicNumber);
-  m_PitchCorrection = cfg.ReadFloat(
-    ODFSetting,
-    group,
-    prefix + wxT("PitchCorrection"),
-    -1800,
-    1800,
-    false,
-    m_PitchCorrection);
   m_SamplerGroupID = cfg.ReadInteger(
     ODFSetting,
     group,
@@ -398,7 +388,8 @@ void GOSoundingPipe::Validate() {
     offset = m_SoundProvider.GetMidiKeyNumber()
       + log(8.0 / m_HarmonicNumber) * (12.0 / log(2))
       - (m_SoundProvider.GetMidiPitchFract()
-         - m_PipeConfigNode.GetEffectivePitchTuning() + m_PitchCorrection)
+         - m_PipeConfigNode.GetEffectivePitchTuning()
+         + m_PipeConfigNode.GetEffectivePitchCorrection())
         / 100.0
       - m_MidiKeyNumber;
   if (offset < -18 || offset > 18) {
@@ -497,7 +488,8 @@ void GOSoundingPipe::UpdateTuning() {
            + log(8.0 / m_HarmonicNumber) / log(2) * 1200)
         + m_SoundProvider.GetMidiPitchFract();
     }
-    pitchAdjustment = m_PipeConfigNode.GetEffectiveTuning() + m_PitchCorrection
+    pitchAdjustment = m_PipeConfigNode.GetEffectiveTuning()
+      + m_PipeConfigNode.GetEffectivePitchCorrection()
       - m_PipeConfigNode.GetEffectivePitchTuning() - concert_pitch_correction;
   }
   m_SoundProvider.SetTuning(pitchAdjustment + m_TemperamentOffset);

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -42,7 +42,6 @@ private:
   unsigned m_HarmonicNumber;
   unsigned m_LoopCrossfadeLength;
   unsigned m_ReleaseCrossfadeLength;
-  float m_PitchCorrection;
   float m_MinVolume;
   float m_MaxVolume;
   int m_SampleMidiKeyNumber;
@@ -84,7 +83,6 @@ public:
     int sampler_group_id,
     unsigned midi_key_number,
     unsigned harmonic_number,
-    float pitch_correction,
     float min_volume,
     float max_volume,
     bool retune);

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -20,10 +20,11 @@ GOPipeConfig::GOPipeConfig(
     m_AudioGroup(),
     m_Amplitude(0),
     m_DefaultAmplitude(0),
-    m_Gain(0),
     m_DefaultGain(0),
-    m_Tuning(0),
     m_PitchTuning(0),
+    m_PitchCorrection(0),
+    m_Gain(0),
+    m_Tuning(0),
     m_Delay(0),
     m_DefaultDelay(0),
     m_BitsPerSample(-1),
@@ -67,6 +68,7 @@ void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
     1800,
     false,
     m_PitchTuning);
+  m_PitchCorrection = 0;
   m_DefaultDelay = 0;
   m_Delay = cfg.ReadInteger(
     CMBSetting, group, prefix + wxT("Delay"), 0, 10000, false, m_DefaultDelay);
@@ -127,6 +129,8 @@ void GOPipeConfig::Load(GOConfigReader &cfg, wxString group, wxString prefix) {
     m_DefaultGain);
   m_PitchTuning = cfg.ReadFloat(
     ODFSetting, group, prefix + wxT("PitchTuning"), -1800, 1800, false, 0);
+  m_PitchCorrection = cfg.ReadFloat(
+    ODFSetting, group, prefix + wxT("PitchCorrection"), -1800, 1800, false, 0);
   m_Tuning = cfg.ReadFloat(
     CMBSetting,
     group,
@@ -220,8 +224,6 @@ void GOPipeConfig::SetGain(float gain) {
 }
 
 float GOPipeConfig::GetTuning() { return m_Tuning; }
-
-float GOPipeConfig::GetPitchTuning() { return m_PitchTuning; }
 
 void GOPipeConfig::SetTuning(float cent) {
   if (cent < -1800)

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -25,9 +25,12 @@ private:
   wxString m_AudioGroup;
   float m_Amplitude;
   float m_DefaultAmplitude;
-  float m_Gain;
   float m_DefaultGain;
+  // ODF pitch tuning offset for using withot auto-tuning
   float m_PitchTuning;
+  // ODF pitch tuning offset for using with auto-tuning
+  float m_PitchCorrection;
+  float m_Gain;
   float m_Tuning;
   unsigned m_Delay;
   unsigned m_DefaultDelay;
@@ -57,8 +60,9 @@ public:
   float GetDefaultGain();
   void SetGain(float gain);
 
+  float GetPitchTuning() const { return m_PitchTuning; }
+  float GetPitchCorrection() const { return m_PitchCorrection; }
   float GetTuning();
-  float GetPitchTuning();
   void SetTuning(float cent);
 
   unsigned GetDelay();

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -93,7 +93,7 @@ float GOPipeConfigNode::GetEffectivePitchCorrection() const {
   float pitchCorrection = m_PipeConfig.GetPitchCorrection();
 
   if (m_parent)
-    pitchCorrection += m_parent->GetEffectivePitchTuning();
+    pitchCorrection += m_parent->GetEffectivePitchCorrection();
   return pitchCorrection;
 }
 

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -82,11 +82,19 @@ float GOPipeConfigNode::GetEffectiveTuning() {
     return m_PipeConfig.GetTuning();
 }
 
-float GOPipeConfigNode::GetEffectivePitchTuning() {
+float GOPipeConfigNode::GetEffectivePitchTuning() const {
   if (m_parent)
     return m_PipeConfig.GetPitchTuning() + m_parent->GetEffectivePitchTuning();
   else
     return m_PipeConfig.GetPitchTuning();
+}
+
+float GOPipeConfigNode::GetEffectivePitchCorrection() const {
+  float pitchCorrection = m_PipeConfig.GetPitchCorrection();
+
+  if (m_parent)
+    pitchCorrection += m_parent->GetEffectivePitchTuning();
+  return pitchCorrection;
 }
 
 unsigned GOPipeConfigNode::GetEffectiveDelay() {

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -49,7 +49,8 @@ public:
   float GetEffectiveAmplitude();
   float GetEffectiveGain();
   float GetEffectiveTuning();
-  float GetEffectivePitchTuning();
+  float GetEffectivePitchTuning() const;
+  float GetEffectivePitchCorrection() const;
 
   unsigned GetEffectiveDelay();
   wxString GetEffectiveAudioGroup();


### PR DESCRIPTION
I removed PitchCorrection from GORank and GOSoundingPipe to GOPipeConfig.

As a result, the `PitchCorrection` ODF key became available not only on the rank level, but also at the windchest and at the organ level.

As discussed in #1351, earlier `PitchCorrection` was just a default for `Pipe999PitchCorrection`, but now `PitchCorrection` of all levels are added to `Pipe999PitchCorrection`. It may be incompatible with some old ODFs.