### PR TITLE
Fixed not saving midi settings of divisional buttons https://github.com/GrandOrgue/grandorgue/issues/1350

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed not saving midi settings of divisional buttons https://github.com/GrandOrgue/grandorgue/issues/1350
 - Added PitchCorrection for organs and windchest. Pipe999PitchCorrection became additive to PitchCorrection of the rank, of the windchest and of the organ https://github.com/GrandOrgue/grandorgue/issues/1351
 - Added full support of '/' as the file sepearator in ODF unless 'Check ODF for HW1-compatibility' is set https://github.com/GrandOrgue/grandorgue/issues/827
 - Added support of ODF comments from ';' at any position to the end of line https://github.com/GrandOrgue/grandorgue/issues/828

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -46,6 +46,7 @@ void GODivisionalButtonControl::LoadCombination(GOConfigReader &cfg) {
 }
 
 void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
+  GOPushbuttonControl::Save(cfg);
   m_divisional.Save(cfg);
 }
 


### PR DESCRIPTION
Resolves: #1350

This PR fixes saving midi settings for divisional buttons that was broken with #1211