### PR TITLE
Fixed duplicating packaged organs in the organ list https://github.com/GrandOrgue/grandorgue/issues/1367

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed duplicating packaged organs in the organ list https://github.com/GrandOrgue/grandorgue/issues/1367
 - Fixed displaying a popup window when a cache had been created with another GO version https://github.com/GrandOrgue/grandorgue/issues/1363
 - Fixed not saving midi settings of divisional buttons https://github.com/GrandOrgue/grandorgue/issues/1350
 - Added PitchCorrection for organs and windchest. Pipe999PitchCorrection became additive to PitchCorrection of the rank, of the windchest and of the organ https://github.com/GrandOrgue/grandorgue/issues/1351

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -356,7 +356,7 @@ wxString GOOrganController::Load(
     if (!m_FileStore.LoadArchives(
           m_config, m_config.OrganCachePath(), organ.GetArchiveID(), errMsg))
       return errMsg;
-
+    m_ArchivePath = organ.GetArchivePath();
     m_odf = organ.GetODFPath();
     odf_name.Assign(m_odf);
   } else {


### PR DESCRIPTION
Resolves: #1367

The reason was lack of initialising GOOrganController::m_ArchivePath, so GOOrganList::AddOrgan added the organ at the second time