### PR TITLE
Added capability of overriding wav MIDIPitchFraction with the Pipe999MIDIPitchFraction key https://github.com/GrandOrgue/grandorgue/issues/1378

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added capability of overriding wav MIDIPitchFraction with the Pipe999MIDIPitchFraction key https://github.com/GrandOrgue/grandorgue/issues/1378
 # 3.10.1 (2022-02-24)
 - Fixed crash on loading an incorrect organ
 # 3.10.0 (2022-02-17)

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -9917,7 +9917,7 @@ fraction in the sample to 0 unless Pipe999MIDIPitchFraction is also specified.
 	value. Describes the actual existing pitch fraction in cent over the
 	normal (440hz equal) tone of the midi key specified in the sample or in
 	the Pipe999MIDIKeyNumber. This setting (together with
-	Pipe999MIDIKeyNumber) is used for retuning to other temperaments.
+	Pipe999MIDIKeyNumber) is used when retuning to other temperaments.
       </para>
     </listitem>
   </varlistentry>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -9917,8 +9917,7 @@ fraction in the sample to 0 unless Pipe999MIDIPitchFraction is also specified.
 	value. Describes the actual existing pitch fraction in cent over the
 	normal (440hz equal) tone of the midi key specified in the sample or in
 	the Pipe999MIDIKeyNumber. This setting (together with
-	Pipe999MIDIKeyNumber) is used for (perhaps when is a better word than
-	for here) retuning to other temperaments.
+	Pipe999MIDIKeyNumber) is used for retuning to other temperaments.
       </para>
     </listitem>
   </varlistentry>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -9902,24 +9902,41 @@ rank size), eg. 2 2/3 =&gt; 64 / (2 2/3) = 24.
             <para>
 (integer -1 - 127, default: -1) If -1, use pitch information from the
 Pipe999 sample, else override the information in the sample with this
-MIDI note number (Pipe999PitchCorrection is used for specifying the
-fraction). Specifying the MIDI note number also reset the pitch
-fraction in the sample to 0.
-     </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>Pipe999PitchCorrection</term>
-          <listitem>
-            <para>
-	      (float -1800 - 1800, default: 0) Correction factor in cent for the
-	      pitch specified in the sample in addition to PitchCorrection of
-	      the whole organ, of the windchest and of the rank. This setting is
-	      used for retuning to other temperaments.
-     </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
+MIDI note number (Pipe999PitchFraction is used for specifying the
+fraction). Specifying the MIDI note number also resets the pitch
+fraction in the sample to 0 unless Pipe999PitchFraction is also specified.
+      </para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>Pipe999PitchFraction</term>
+    <listitem>
+      <para>
+	(float 0 - 100, default: 0) The pitch fraction in cent over the normal
+	(440hz equal) tone of the midi key specified in the sample or in the
+	Pipe999MIDIKeyNumber.This setting is
+	used for retuning to other temperaments.
+      </para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>Pipe999PitchCorrection</term>
+    <listitem>
+      <para>
+	(float -1800 - 1800, default: 0) Correction factor in cent for the
+	pitch specified in the sample in addition to PitchCorrection of
+	the whole organ, of the windchest and of the rank. This setting is
+	used for retuning to other temperaments. An upper value results the pipe
+	sounds upper, a lower value results the pipe sounds lower.
+      </para>
+      <para>
+        Specifying Pipe999PitchFraction=28 with Pipe999PitchCorrection=0 gives
+	the same effect as specifying Pipe999PitchFraction=0 with
+	Pipe999PitchCorrection=-28
+      </para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
           <term>Pipe999AcceptsRetuning</term>
           <listitem>
             <para>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -9902,14 +9902,14 @@ rank size), eg. 2 2/3 =&gt; 64 / (2 2/3) = 24.
             <para>
 (integer -1 - 127, default: -1) If -1, use pitch information from the
 Pipe999 sample, else override the information in the sample with this
-MIDI note number (Pipe999PitchFraction is used for specifying the
+MIDI note number Pipe999MIDIPitchFraction is used for specifying the
 fraction). Specifying the MIDI note number also resets the pitch
-fraction in the sample to 0 unless Pipe999PitchFraction is also specified.
+fraction in the sample to 0 unless Pipe999MIDIPitchFraction is also specified.
       </para>
     </listitem>
   </varlistentry>
   <varlistentry>
-    <term>Pipe999PitchFraction</term>
+    <term>Pipe999MIDIPitchFraction</term>
     <listitem>
       <para>
 	(float 0 - 100, default: 0) The pitch fraction in cent over the normal
@@ -9930,8 +9930,8 @@ fraction in the sample to 0 unless Pipe999PitchFraction is also specified.
 	sounds upper, a lower value results the pipe sounds lower.
       </para>
       <para>
-        Specifying Pipe999PitchFraction=28 with Pipe999PitchCorrection=0 gives
-	the same effect as specifying Pipe999PitchFraction=0 with
+        Specifying Pipe999MIDIPitchFraction with Pipe999PitchCorrection=0 gives
+	the same effect as specifying Pipe999MIDIPitchFraction with
 	Pipe999PitchCorrection=-28
       </para>
     </listitem>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -9896,13 +9896,13 @@ rank size), eg. 2 2/3 =&gt; 64 / (2 2/3) = 24.
      </para>
           </listitem>
         </varlistentry>
-        <varlistentry>
-          <term>Pipe999MIDIKeyNumber</term>
-          <listitem>
-            <para>
+  <varlistentry>
+    <term>Pipe999MIDIKeyNumber</term>
+    <listitem>
+      <para>
 (integer -1 - 127, default: -1) If -1, use pitch information from the
 Pipe999 sample, else override the information in the sample with this
-MIDI note number Pipe999MIDIPitchFraction is used for specifying the
+MIDI note number (Pipe999MIDIPitchFraction is used for specifying the
 fraction). Specifying the MIDI note number also resets the pitch
 fraction in the sample to 0 unless Pipe999MIDIPitchFraction is also specified.
       </para>
@@ -9912,10 +9912,13 @@ fraction in the sample to 0 unless Pipe999MIDIPitchFraction is also specified.
     <term>Pipe999MIDIPitchFraction</term>
     <listitem>
       <para>
-	(float 0 - 100, default: 0) The pitch fraction in cent over the normal
-	(440hz equal) tone of the midi key specified in the sample or in the
-	Pipe999MIDIKeyNumber.This setting is
-	used for retuning to other temperaments.
+	(float 0 - 100, default: -1) If -1, use pitch information from the
+	Pipe999 sample, else override the information in the sample with this
+	value. Describes the actual existing pitch fraction in cent over the
+	normal (440hz equal) tone of the midi key specified in the sample or in
+	the Pipe999MIDIKeyNumber. This setting (together with
+	Pipe999MIDIKeyNumber) is used for (perhaps when is a better word than
+	for here) retuning to other temperaments.
       </para>
     </listitem>
   </varlistentry>
@@ -9925,14 +9928,9 @@ fraction in the sample to 0 unless Pipe999MIDIPitchFraction is also specified.
       <para>
 	(float -1800 - 1800, default: 0) Correction factor in cent for the
 	pitch specified in the sample in addition to PitchCorrection of
-	the whole organ, of the windchest and of the rank. This setting is
-	used for retuning to other temperaments. An upper value results the pipe
-	sounds upper, a lower value results the pipe sounds lower.
-      </para>
-      <para>
-        Specifying Pipe999MIDIPitchFraction with Pipe999PitchCorrection=0 gives
-	the same effect as specifying Pipe999MIDIPitchFraction with
-	Pipe999PitchCorrection=-28
+	the whole organ, of the windchest and of the rank. This setting is used
+	to adjust tuning while in other temperaments (than original). A positive
+	value raise the pitch, a negative value lowers the pitch.
       </para>
     </listitem>
   </varlistentry>

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -347,7 +347,12 @@ void GOSoundingPipe::Initialize() {}
 
 const wxString &GOSoundingPipe::GetLoadTitle() { return m_Filename; }
 
-float GOSoundingPipe::GetEqualTemperamentOffset() const {
+float GOSoundingPipe::GetManualTuningPitchOffset() const {
+  return m_PipeConfigNode.GetEffectivePitchTuning()
+    + m_PipeConfigNode.GetEffectiveManualTuning();
+}
+
+float GOSoundingPipe::GetAutoTuningPitchOffset() const {
   float pitchAdjustment = 0.0;
 
   // For any other temperament than original. Calculate pitchAdjustment by
@@ -419,7 +424,7 @@ void GOSoundingPipe::Validate() {
       GetLoadTitle().c_str());
     return;
   }
-  float offset = m_RetunePipe ? GetEqualTemperamentOffset() : 0.0;
+  float offset = m_RetunePipe ? GetAutoTuningPitchOffset() : 0.0;
 
   if (offset < -1800 || offset > 1800) {
     wxLogError(
@@ -498,14 +503,9 @@ void GOSoundingPipe::UpdateAmplitude() {
 }
 
 void GOSoundingPipe::UpdateTuning() {
-  float pitchAdjustment = 0;
-
-  if (m_IsTemperamentOriginalBased) {
-    // For original temperament. Set pitchAdjustment from GetEffectiveTuning
-    pitchAdjustment = m_PipeConfigNode.GetEffectivePitchTuning()
-      + m_PipeConfigNode.GetEffectiveManualTuning();
-  } else
-    pitchAdjustment = GetEqualTemperamentOffset();
+  float pitchAdjustment = m_IsTemperamentOriginalBased
+    ? GetManualTuningPitchOffset()
+    : GetAutoTuningPitchOffset();
 
   m_SoundProvider.SetTuning(pitchAdjustment + m_TemperamentOffset);
 }

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -51,7 +51,10 @@ GOSoundingPipe::GOSoundingPipe(
     m_ReleaseCrossfadeLength(0),
     m_MinVolume(min_volume),
     m_MaxVolume(max_volume),
-    m_SampleMidiKeyNumber(-1),
+    m_OdfMidiKeyNumber(-1),
+    m_OdfMidiPitchFraction(-1.0),
+    m_SampleMidiKeyNumber(0),
+    m_SampleMidiPitchFraction(0.0),
     m_RetunePipe(retune),
     m_IsTemperamentOriginalBased(true),
     m_PipeConfigNode(
@@ -135,7 +138,8 @@ void GOSoundingPipe::Init(
   m_OrganController->RegisterCacheObject(this);
   m_Filename = filename;
   m_PipeConfigNode.Init(cfg, group, prefix);
-  m_SampleMidiKeyNumber = -1;
+  m_OdfMidiKeyNumber = -1;
+  m_OdfMidiPitchFraction = -1.0;
   m_LoopCrossfadeLength = 0;
   m_ReleaseCrossfadeLength = 0;
   UpdateAmplitude();
@@ -182,8 +186,16 @@ void GOSoundingPipe::Load(
     m_SamplerGroupID);
   m_Percussive = cfg.ReadBoolean(
     ODFSetting, group, prefix + wxT("Percussive"), false, m_Percussive);
-  m_SampleMidiKeyNumber = cfg.ReadInteger(
+  m_OdfMidiKeyNumber = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("MIDIKeyNumber"), -1, 127, false, -1);
+  m_OdfMidiPitchFraction = cfg.ReadFloat(
+    ODFSetting,
+    group,
+    prefix + wxT("MIDIPitchFraction"),
+    0,
+    100.0,
+    false,
+    -1.0);
   m_LoopCrossfadeLength = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("LoopCrossfadeLength"), 0, 120, false, 0);
   m_ReleaseCrossfadeLength = cfg.ReadInteger(
@@ -254,7 +266,6 @@ void GOSoundingPipe::LoadData(
       (loop_load_type)m_PipeConfigNode.GetEffectiveLoopLoad(),
       m_PipeConfigNode.GetEffectiveAttackLoad(),
       m_PipeConfigNode.GetEffectiveReleaseLoad(),
-      m_SampleMidiKeyNumber,
       m_LoopCrossfadeLength,
       m_ReleaseCrossfadeLength);
     Validate();
@@ -301,7 +312,7 @@ void GOSoundingPipe::UpdateHash(GOHash &hash) {
   hash.Update(m_PipeConfigNode.GetEffectiveLoopLoad());
   hash.Update(m_PipeConfigNode.GetEffectiveAttackLoad());
   hash.Update(m_PipeConfigNode.GetEffectiveReleaseLoad());
-  hash.Update(m_SampleMidiKeyNumber);
+  hash.Update(m_OdfMidiKeyNumber);
   hash.Update(m_LoopCrossfadeLength);
   hash.Update(m_ReleaseCrossfadeLength);
 
@@ -337,6 +348,17 @@ void GOSoundingPipe::Initialize() {}
 const wxString &GOSoundingPipe::GetLoadTitle() { return m_Filename; }
 
 void GOSoundingPipe::Validate() {
+  // make effective values
+  m_SampleMidiKeyNumber = m_OdfMidiKeyNumber >= 0
+    ? m_OdfMidiKeyNumber
+    : m_SoundProvider.GetMidiKeyNumber();
+  m_SampleMidiPitchFraction = m_OdfMidiPitchFraction >= 0.0
+    ? m_OdfMidiPitchFraction
+    : m_OdfMidiKeyNumber < 0
+    ? m_SoundProvider.GetMidiPitchFract()
+    : 0.0; // if MidiKeyNumber is provided in the ODF then we ignore
+           // the PitchFraction from the sample
+
   if (!m_OrganController->GetConfig().ODFCheck())
     return;
 
@@ -372,9 +394,8 @@ void GOSoundingPipe::Validate() {
   }
 
   if (
-    m_RetunePipe && m_SoundProvider.GetMidiKeyNumber() == 0
-    && m_SoundProvider.GetMidiPitchFract() == 0
-    && m_SampleMidiKeyNumber == -1) {
+    m_RetunePipe && m_SampleMidiKeyNumber <= 0
+    && m_SampleMidiPitchFraction <= 0.0) {
     wxLogWarning(
       _("rank %s pipe %s: no pitch information provided"),
       m_Rank->GetName().c_str(),
@@ -479,19 +500,15 @@ void GOSoundingPipe::UpdateTuning() {
     // converting from the original temperament to the equal one before using
     // temperament offset. Take PitchCorrection into account. Also GUI tuning
     // adjustments are added and ODF adjustments removed leaving difference.
-    double concert_pitch_correction = 0;
-
-    if (
-      !m_PipeConfigNode.GetEffectiveIgnorePitch()
-      && m_SoundProvider.GetMidiKeyNumber()) {
-      concert_pitch_correction
-        = (100.0 * m_SoundProvider.GetMidiKeyNumber() - 100.0 * m_MidiKeyNumber
-           + log(8.0 / m_HarmonicNumber) / log(2) * 1200)
-        + m_SoundProvider.GetMidiPitchFract();
+    if (!m_PipeConfigNode.GetEffectiveIgnorePitch() && m_SampleMidiKeyNumber) {
+      pitchAdjustment
+        = log(m_HarmonicNumber / 8.0) / log(2) * 1200 // harmonic correction
+        + ((int)m_MidiKeyNumber - m_SampleMidiKeyNumber)
+          * 100                      // note correction
+        - m_SampleMidiPitchFraction; // fraction correction
     }
-    pitchAdjustment = m_PipeConfigNode.GetEffectivePitchCorrection()
-      + m_PipeConfigNode.GetEffectiveAutoTuningCorection()
-      - concert_pitch_correction;
+    pitchAdjustment += m_PipeConfigNode.GetEffectivePitchCorrection()
+      + m_PipeConfigNode.GetEffectiveAutoTuningCorection(); // final correction
   }
   m_SoundProvider.SetTuning(pitchAdjustment + m_TemperamentOffset);
 }

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -44,7 +44,10 @@ private:
   unsigned m_ReleaseCrossfadeLength;
   float m_MinVolume;
   float m_MaxVolume;
+  int m_OdfMidiKeyNumber;
+  float m_OdfMidiPitchFraction;
   int m_SampleMidiKeyNumber;
+  float m_SampleMidiPitchFraction;
   bool m_RetunePipe;
   bool m_IsTemperamentOriginalBased;
   GOSoundProviderWave m_SoundProvider;

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -59,11 +59,16 @@ private:
   GOSoundProvider *GetSoundProvider();
 
   /**
+   * Calculate a pitch offset for manual tuning
+   * @return pitch offset in cents
+   */
+  float GetManualTuningPitchOffset() const;
+  /**
    * Calculates a pitch offset for retuning from the sample pitch
    * to the equal temperament
    * @return pitch offset in cents
    */
-  float GetEqualTemperamentOffset() const;
+  float GetAutoTuningPitchOffset() const;
   void Validate();
 
   void LoadAttack(GOConfigReader &cfg, wxString group, wxString prefix);

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -57,6 +57,13 @@ private:
   void SetOff();
   void Change(unsigned velocity, unsigned old_velocity);
   GOSoundProvider *GetSoundProvider();
+
+  /**
+   * Calculates a pitch offset for retuning from the sample pitch
+   * to the equal temperament
+   * @return pitch offset in cents
+   */
+  float GetEqualTemperamentOffset() const;
   void Validate();
 
   void LoadAttack(GOConfigReader &cfg, wxString group, wxString prefix);

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -289,7 +289,6 @@ void GOSoundProviderWave::LoadFromFile(
   loop_load_type loop_mode,
   unsigned attack_load,
   unsigned release_load,
-  int midi_key_number,
   unsigned loop_crossfade_length,
   unsigned release_crossfase_length) {
   ClearData();
@@ -424,10 +423,6 @@ void GOSoundProviderWave::LoadFromFile(
     }
 
     ComputeReleaseAlignmentInfo();
-    if (midi_key_number != -1) {
-      m_MidiKeyNumber = midi_key_number;
-      m_MidiPitchFract = 0;
-    }
     if (release_crossfase_length)
       m_ReleaseCrossfadeLength = release_crossfase_length;
     else

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -125,7 +125,6 @@ public:
     loop_load_type loop_mode,
     unsigned attack_load,
     unsigned release_load,
-    int midi_key_number,
     unsigned loop_crossfade_length,
     unsigned release_crossfase_length);
   void SetAmplitude(float fixed_amplitude, float gain);

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -113,7 +113,6 @@ void GOPerfTestApp::RunTest(
           LOOP_LOAD_ALL,
           1,
           1,
-          -1,
           0,
           0);
         pipes.push_back(w);


### PR DESCRIPTION
Resolves: #1378

As discussed in #1378, Pipe999PitchCorrection does not override the wav PitchFraction. This PR introduces the new ODF key Pipe999MIDIPitchFraction that is used instead of the wav PitchFraction.