### PR TITLE
Fixed crash on loading an incorrect organ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on loading an incorrect organ
 # 3.10.0 (2022-02-17)
 - Added storing the GrandOrgueVersion key in the Organ Settings file https://github.com/GrandOrgue/grandorgue/issues/1375
 - Added capability of redefining ReleaseLength and IgnorePitch on each level of Organ Settings

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -545,6 +545,13 @@ void GOFrame::Init(wxString filename) {
   clean.Cleanup();
 }
 
+void GOFrame::AttachToOrganController(bool isToAttach) {
+  GOOrganController *pOrgan = GetOrganController();
+
+  if (pOrgan)
+    pOrgan->SetModificationListener(isToAttach ? this : nullptr);
+}
+
 bool GOFrame::CloseOrgan(bool isForce) {
   bool isClosed = true;
 
@@ -572,11 +579,7 @@ bool GOFrame::CloseOrgan(bool isForce) {
       GOMutexLocker m_locker(m_mutex, true);
 
       if (m_locker.IsLocked()) {
-        GOOrganController *pOrgan = m_doc->GetOrganController();
-
-        if (pOrgan)
-          pOrgan->SetModificationListener(nullptr);
-
+        AttachToOrganController(false);
         delete m_doc;
         m_doc = NULL;
         UpdatePanelMenu();
@@ -595,8 +598,9 @@ bool GOFrame::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
 
     retCode = m_doc->LoadOrgan(&dlg, organ, cmb);
     OnIsModifiedChanged(false);
+
     // for reflecting model changes
-    m_doc->GetOrganController()->SetOrganModificationListener(this);
+    AttachToOrganController(true);
   }
   return retCode;
 }

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -545,7 +545,7 @@ void GOFrame::Init(wxString filename) {
   clean.Cleanup();
 }
 
-void GOFrame::AttachToOrganController(bool isToAttach) {
+void GOFrame::AttachDetachOrganController(bool isToAttach) {
   GOOrganController *pOrgan = GetOrganController();
 
   if (pOrgan)
@@ -579,7 +579,7 @@ bool GOFrame::CloseOrgan(bool isForce) {
       GOMutexLocker m_locker(m_mutex, true);
 
       if (m_locker.IsLocked()) {
-        AttachToOrganController(false);
+        AttachDetachOrganController(false);
         delete m_doc;
         m_doc = NULL;
         UpdatePanelMenu();
@@ -600,7 +600,7 @@ bool GOFrame::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
     OnIsModifiedChanged(false);
 
     // for reflecting model changes
-    AttachToOrganController(true);
+    AttachDetachOrganController(true);
   }
   return retCode;
 }

--- a/src/grandorgue/GOFrame.h
+++ b/src/grandorgue/GOFrame.h
@@ -103,6 +103,8 @@ private:
   // Returns the current open organ controller or nullptr
   GOOrganController *GetOrganController() const;
 
+  void AttachToOrganController(bool isToAttach);
+
   // Processes the organ model modification event:
   // updates some controls according the organ model changes
   void OnIsModifiedChanged(bool modified) override;

--- a/src/grandorgue/GOFrame.h
+++ b/src/grandorgue/GOFrame.h
@@ -103,7 +103,7 @@ private:
   // Returns the current open organ controller or nullptr
   GOOrganController *GetOrganController() const;
 
-  void AttachToOrganController(bool isToAttach);
+  void AttachDetachOrganController(bool isToAttach);
 
   // Processes the organ model modification event:
   // updates some controls according the organ model changes


### PR DESCRIPTION
#1380 caused the GO crash on attempt of loaging a wrong ODF.

The reason was GOFrame::LoadOrgan called SetOrganModificationListener of unitialised organ.