### PR TITLE
Added support of labels without background image by specifying DispImageNum=0 https://github.com/GrandOrgue/grandorgue/issues/1386

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support of labels without a background image by specifying DispImageNum=0 https://github.com/GrandOrgue/grandorgue/issues/1386
 - Added capability of overriding wav MIDIPitchFraction with the Pipe999MIDIPitchFraction key https://github.com/GrandOrgue/grandorgue/issues/1378
 # 3.10.1 (2022-02-24)
 - Fixed crash on loading an incorrect organ

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -8826,7 +8826,7 @@ group label font of the panel.
           <listitem>
             <para>
 	      (integer 0 - 12, default: 1) Builtin bitmap set to use. 0 means
-	      the lable does not have a background image.
+	      that the lable does not have a background image.
 	    </para>
           </listitem>
         </varlistentry>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -8825,8 +8825,9 @@ group label font of the panel.
           <term>DispImageNum</term>
           <listitem>
             <para>
-(integer 1 - 12, default: 1) Builtin bitmap set to use.
-     </para>
+	      (integer 0 - 12, default: 1) Builtin bitmap set to use. 0 means
+	      the lable does not have a background image.
+	    </para>
           </listitem>
         </varlistentry>
         <varlistentry>

--- a/src/grandorgue/gui/GOGUILabel.h
+++ b/src/grandorgue/gui/GOGUILabel.h
@@ -10,10 +10,10 @@
 
 #include <wx/colour.h>
 
-#include "GOBitmap.h"
 #include "GOFont.h"
 #include "GOGUIControl.h"
 
+class GOBitmap;
 class GOLabelControl;
 
 class GOGUILabel : public GOGUIControl {
@@ -21,7 +21,7 @@ private:
   int m_DispXpos;
   int m_DispYpos;
   GOLabelControl *m_Label;
-  GOBitmap m_Bitmap;
+  GOBitmap *m_PBackgroundBitmap; // if nullptr then the label is transparent
   unsigned m_FontSize;
   wxString m_FontName;
   GOFont m_Font;
@@ -32,8 +32,17 @@ private:
   unsigned m_TileOffsetX;
   unsigned m_TileOffsetY;
 
+  void DestroyBackgroundBitmap();
+  void InitBackgroundBitmap(
+    unsigned x,
+    unsigned y,
+    wxString imageFileName,
+    unsigned imageNum,
+    const wxString &imageMaskFileneme);
+
 public:
   GOGUILabel(GOGUIPanel *panel, GOLabelControl *label);
+  ~GOGUILabel() override { DestroyBackgroundBitmap(); }
   void Init(
     GOConfigReader &cfg,
     wxString group,


### PR DESCRIPTION
Resolves: #1386

This PR allows to create a Label object without a background image.

If the label object has `DispImageNum=0`, then GO creates a label with a transparent image. By default it's size is 80x25 and it may be overriden with `Width` and `Heigh` keys.