### PR TITLE
Declared GODocument::ShowMIDIEventDialog in a separate class GOMidiDialogCreator

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -101,6 +101,7 @@ loader/GOFileStore.cpp
 loader/GOLoaderFilename.cpp
 loader/GOLoadThread.cpp
 loader/GOLoadWorker.cpp
+midi/dialog-creator/GOMidiDialogCreatorProxy.cpp
 midi/ports/GOMidiInPort.cpp
 midi/ports/GOMidiOutPort.cpp
 midi/ports/GOMidiPort.cpp

--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -51,7 +51,7 @@ bool GODocument::LoadOrgan(
   GOConfig &cfg = m_sound.GetSettings();
 
   CloseOrgan();
-  m_OrganController = new GOOrganController(this, cfg);
+  m_OrganController = new GOOrganController(cfg, this);
   wxString error = m_OrganController->Load(dlg, organ, cmb);
   if (!error.IsEmpty()) {
     if (error != wxT("!")) {
@@ -202,7 +202,7 @@ void GODocument::ShowMidiList() {
 
 void GODocument::ShowMIDIEventDialog(
   void *element,
-  wxString title,
+  const wxString &title,
   GOMidiReceiverBase *event,
   GOMidiSender *sender,
   GOKeyReceiver *key,

--- a/src/grandorgue/GODocument.h
+++ b/src/grandorgue/GODocument.h
@@ -13,6 +13,7 @@
 #include "document-base/GODocumentBase.h"
 #include "midi/GOMidiCallback.h"
 #include "midi/GOMidiListener.h"
+#include "midi/dialog-creator/GOMidiDialogCreator.h"
 #include "threading/GOMutex.h"
 
 class GOOrganController;
@@ -25,7 +26,9 @@ class GOProgressDialog;
 class GOResizable;
 class GOSound;
 
-class GODocument : public GODocumentBase, protected GOMidiCallback {
+class GODocument : public GODocumentBase,
+                   protected GOMidiCallback,
+                   public GOMidiDialogCreator {
 private:
   GOResizable *p_MainWindow;
   GOSound &m_sound;
@@ -45,17 +48,11 @@ public:
   GODocument(GOResizable *pMainWindow, GOSound *sound);
   ~GODocument();
 
+  GOOrganController *GetOrganController() const { return m_OrganController; }
   bool IsModified() const;
 
   void ShowPanel(unsigned id);
   void ShowOrganDialog();
-  void ShowMIDIEventDialog(
-    void *element,
-    wxString title,
-    GOMidiReceiverBase *event,
-    GOMidiSender *sender,
-    GOKeyReceiver *key,
-    GOMidiSender *division = NULL);
   void ShowMidiList();
 
   bool Save();
@@ -65,7 +62,13 @@ public:
   bool ImportCombination(const wxString &cmb);
   bool UpdateCache(GOProgressDialog *dlg, bool compress);
 
-  GOOrganController *GetOrganController() const { return m_OrganController; }
+  void ShowMIDIEventDialog(
+    void *element,
+    const wxString &title,
+    GOMidiReceiverBase *event,
+    GOMidiSender *sender,
+    GOKeyReceiver *key,
+    GOMidiSender *division = nullptr) override;
 };
 
 #endif

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -77,14 +77,15 @@
 static const wxString WX_ORGAN = wxT("Organ");
 static const wxString WX_GRANDORGUE_VERSION = wxT("GrandOrgueVersion");
 
-GOOrganController::GOOrganController(GODocument *doc, GOConfig &settings)
+GOOrganController::GOOrganController(
+  GOConfig &config, GOMidiDialogCreator *pMidiDialogCreator)
   : GOEventDistributor(this),
-    GOOrganModel(settings),
-    m_doc(doc),
+    GOOrganModel(config),
+    m_config(config),
     m_odf(),
     m_ArchiveID(),
     m_hash(),
-    m_FileStore(settings),
+    m_FileStore(config),
     m_CacheFilename(),
     m_SettingFilename(),
     m_ODFHash(),
@@ -120,11 +121,11 @@ GOOrganController::GOOrganController(GODocument *doc, GOConfig &settings)
     m_SampleSetId1(0),
     m_SampleSetId2(0),
     m_bitmaps(this),
-    m_config(settings),
     m_GeneralTemplate(this),
     m_PitchLabel(this),
     m_TemperamentLabel(this),
     m_MainWindowData(this, wxT("MainWindow")) {
+  GOOrganModel::SetMidiDialogCreator(pMidiDialogCreator);
   GOOrganModel::SetModificationListener(this);
   m_pool.SetMemoryLimit(m_config.MemoryLimit() * 1024 * 1024);
 }
@@ -137,6 +138,7 @@ GOOrganController::~GOOrganController() {
   m_tremulants.clear();
   m_ranks.clear();
   GOOrganModel::SetModificationListener(nullptr);
+  GOOrganModel::SetMidiDialogCreator(nullptr);
 }
 
 void GOOrganController::SetOrganModified(bool modified) {
@@ -788,7 +790,7 @@ GOButtonControl *GOOrganController::GetButtonControl(
   return NULL;
 }
 
-GODocument *GOOrganController::GetDocument() { return m_doc; }
+// GODocument *GOOrganController::GetDocument() { return m_doc; }
 
 void GOOrganController::SetVolume(int volume) { m_volume = volume; }
 

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -59,7 +59,7 @@ class GOOrganController : public GOEventDistributor,
   WX_DECLARE_STRING_HASH_MAP(bool, GOStringBoolMap);
 
 private:
-  GODocument *m_doc;
+  GOConfig &m_config;
   wxString m_odf;
   wxString m_ArchiveID;
   wxString m_ArchivePath;
@@ -108,7 +108,6 @@ private:
 
   GOMemoryPool m_pool;
   GOBitmapCache m_bitmaps;
-  GOConfig &m_config;
   GOCombinationDefinition m_GeneralTemplate;
   GOLabelControl m_PitchLabel;
   GOLabelControl m_TemperamentLabel;
@@ -130,7 +129,8 @@ private:
   wxString GetOrganHash();
 
 public:
-  GOOrganController(GODocument *doc, GOConfig &settings);
+  GOOrganController(
+    GOConfig &config, GOMidiDialogCreator *pMidiDialogCreator = nullptr);
   ~GOOrganController();
 
   // Returns organ modification flag
@@ -174,7 +174,7 @@ public:
   void Reset();
   void ProcessMidi(const GOMidiEvent &event);
   void AllNotesOff();
-  GODocument *GetDocument();
+  // GODocument *GetDocument();
 
   /* Access to internal ODF objects */
   GOSetter *GetSetter();

--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -187,8 +187,7 @@ void GOButtonControl::ShowConfigDialog() {
     key = NULL;
   }
 
-  m_OrganController->GetDocument()->ShowMIDIEventDialog(
-    this, title, midi, &m_sender, key);
+  m_OrganController->ShowMIDIEventDialog(this, title, midi, &m_sender, key);
 }
 
 wxString GOButtonControl::GetElementStatus() {

--- a/src/grandorgue/control/GOLabelControl.cpp
+++ b/src/grandorgue/control/GOLabelControl.cpp
@@ -73,8 +73,8 @@ void GOLabelControl::ShowConfigDialog() {
     GetMidiType().c_str(),
     GetMidiName().c_str());
 
-  m_OrganController->GetDocument()->ShowMIDIEventDialog(
-    this, title, NULL, &m_sender, NULL);
+  m_OrganController->ShowMIDIEventDialog(
+    this, title, nullptr, &m_sender, nullptr);
 }
 
 wxString GOLabelControl::GetElementStatus() { return m_Content; }

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreator.h
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreator.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDIDIALOGCREATOR_H
+#define GOMIDIDIALOGCREATOR_H
+
+class wxString;
+
+class GOMidiReceiverBase;
+class GOMidiSender;
+class GOKeyReceiver;
+
+/**
+ * An abstract class that can show a MIDIEventDialog
+ */
+class GOMidiDialogCreator {
+public:
+  virtual void ShowMIDIEventDialog(
+    void *element,
+    const wxString &title,
+    GOMidiReceiverBase *event,
+    GOMidiSender *sender,
+    GOKeyReceiver *key,
+    GOMidiSender *division = nullptr)
+    = 0;
+};
+
+#endif /* GOMIDIDIALOGCREATOR_H */

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.cpp
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOMidiDialogCreatorProxy.h"
+
+void GOMidiDialogCreatorProxy::ShowMIDIEventDialog(
+  void *element,
+  const wxString &title,
+  GOMidiReceiverBase *event,
+  GOMidiSender *sender,
+  GOKeyReceiver *key,
+  GOMidiSender *division) {
+  if (p_creator)
+    p_creator->ShowMIDIEventDialog(
+      element, title, event, sender, key, division);
+}

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.h
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDIDIALOGCREATORPROXY_H
+#define GOMIDIDIALOGCREATORPROXY_H
+
+#include "GOMidiDialogCreator.h"
+
+class GOMidiDialogCreatorProxy : public GOMidiDialogCreator {
+private:
+  GOMidiDialogCreator *p_creator = nullptr;
+
+public:
+  void SetMidiDialogCreator(GOMidiDialogCreator *pCreator) {
+    p_creator = pCreator;
+  }
+
+  void ShowMIDIEventDialog(
+    void *element,
+    const wxString &title,
+    GOMidiReceiverBase *event,
+    GOMidiSender *sender,
+    GOKeyReceiver *key,
+    GOMidiSender *division = nullptr) override;
+};
+
+#endif /* GOMIDIDIALOGCREATORPROXY_H */

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -157,7 +157,7 @@ void GOEnclosure::ShowConfigDialog() {
     GetMidiType().c_str(),
     GetMidiName().c_str());
 
-  m_OrganController->GetDocument()->ShowMIDIEventDialog(
+  m_OrganController->ShowMIDIEventDialog(
     this, title, &m_midi, &m_sender, &m_shortcut);
 }
 

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -516,7 +516,7 @@ void GOManual::ShowConfigDialog() {
     GetMidiType().c_str(),
     GetMidiName().c_str());
 
-  m_OrganController->GetDocument()->ShowMIDIEventDialog(
+  m_OrganController->ShowMIDIEventDialog(
     this, title, &m_midi, &m_sender, NULL, &m_division);
 }
 

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -10,8 +10,10 @@
 
 #include "ptrvector.h"
 
-#include "GOEventHandlerList.h"
+#include "midi/dialog-creator/GOMidiDialogCreatorProxy.h"
 #include "pipe-config/GOPipeConfigTreeNode.h"
+
+#include "GOEventHandlerList.h"
 
 class GOConfig;
 class GOConfigReader;
@@ -27,7 +29,8 @@ class GOSwitch;
 class GOTremulant;
 class GOWindchest;
 
-class GOOrganModel : public GOEventHandlerList {
+class GOOrganModel : public GOEventHandlerList,
+                     public GOMidiDialogCreatorProxy {
 private:
   const GOConfig &m_config;
 

--- a/src/grandorgue/model/GORank.cpp
+++ b/src/grandorgue/model/GORank.cpp
@@ -229,8 +229,7 @@ void GORank::ShowConfigDialog() {
     GetMidiType().c_str(),
     GetMidiName().c_str());
 
-  m_OrganController->GetDocument()->ShowMIDIEventDialog(
-    this, title, NULL, &m_sender, NULL, NULL);
+  m_OrganController->ShowMIDIEventDialog(this, title, NULL, &m_sender, NULL);
 }
 
 wxString GORank::GetElementStatus() { return _("-"); }

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -71,7 +71,7 @@ void GOPerfTestApp::RunTest(
   unsigned samples_per_frame) {
   try {
     GOConfig settings(wxT("perftest"));
-    GOOrganController *organController = new GOOrganController(NULL, settings);
+    GOOrganController *organController = new GOOrganController(settings);
     const wxString testsDir = argc >= 2 ? argv[1]
                                         : GOStdPath::GetResourceDir()
         + wxFileName::GetPathSeparator() + "perftests";


### PR DESCRIPTION
Toward to removing dependency on GOOrganController from GOOrganModel I 
1. Created a sepearate class GOMidiDialogCreator with a pure virtual method ShowMIDIEventDialog
2. Made GODocument as a subclass of GOMidiDialogCreator
3. Created a class GOMidiDialogCreatorProxy that calls ShowMIDIEventDialog of another GOMidiDialogCreator
4. Made GOOrganModel as a subclass of GOMidiDialogCreatorProxy
5. Removed GOOrganController::GetDocument because it was used only for ShowMIDIEventDialog

It is hust a refactoring. No GO behavior should be changed.
