### PR TITLE
Default implementation of   GOSoundStateHandler::AbortPlaybook and GOSoundStateHandler::PrepareRecording

### DIFF
--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -232,8 +232,6 @@ void GOMetronome::PreparePlayback() {
 
 void GOMetronome::StartPlayback() {}
 
-void GOMetronome::PrepareRecording() {}
-
 GOEnclosure *GOMetronome::GetEnclosure(const wxString &name, bool is_panel) {
   return NULL;
 }

--- a/src/grandorgue/GOMetronome.h
+++ b/src/grandorgue/GOMetronome.h
@@ -45,7 +45,6 @@ private:
   void AbortPlayback();
   void PreparePlayback();
   void StartPlayback();
-  void PrepareRecording();
 
   void Save(GOConfigWriter &cfg);
 

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -670,8 +670,6 @@ void GOSetter::ButtonStateChanged(int id) {
   }
 }
 
-void GOSetter::AbortPlayback() {}
-
 void GOSetter::PreparePlayback() {
   wxString buffer;
   buffer.Printf(wxT("%03d"), m_pos);
@@ -693,8 +691,6 @@ void GOSetter::PreparePlayback() {
 }
 
 void GOSetter::StartPlayback() {}
-
-void GOSetter::PrepareRecording() {}
 
 void GOSetter::Update() {}
 

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -58,10 +58,8 @@ private:
 
   void ControlChanged(void *control);
 
-  void AbortPlayback();
   void PreparePlayback();
   void StartPlayback();
-  void PrepareRecording();
 
 public:
   GOSetter(GOOrganController *organController);

--- a/src/grandorgue/model/GOPipe.cpp
+++ b/src/grandorgue/model/GOPipe.cpp
@@ -29,8 +29,6 @@ unsigned GOPipe::RegisterReference(GOPipe *pipe) {
   return id;
 }
 
-void GOPipe::AbortPlayback() {}
-
 void GOPipe::PreparePlayback() {
   m_Velocity = 0;
   for (unsigned i = 0; i < m_Velocities.size(); i++)
@@ -38,8 +36,6 @@ void GOPipe::PreparePlayback() {
 }
 
 void GOPipe::StartPlayback() {}
-
-void GOPipe::PrepareRecording() {}
 
 void GOPipe::SetTemperament(const GOTemperament &temperament) {}
 

--- a/src/grandorgue/model/GOPipe.h
+++ b/src/grandorgue/model/GOPipe.h
@@ -30,10 +30,8 @@ protected:
 
   virtual void Change(unsigned velocity, unsigned old_velocity) = 0;
 
-  void AbortPlayback();
   void StartPlayback();
   void PreparePlayback();
-  void PrepareRecording();
 
 public:
   GOPipe(

--- a/src/grandorgue/model/GORank.cpp
+++ b/src/grandorgue/model/GORank.cpp
@@ -213,8 +213,6 @@ void GORank::PreparePlayback() {
 
 void GORank::StartPlayback() {}
 
-void GORank::PrepareRecording() {}
-
 void GORank::SendKey(unsigned note, unsigned velocity) {
   m_sender.SetKey(note, velocity);
 }

--- a/src/grandorgue/model/GORank.h
+++ b/src/grandorgue/model/GORank.h
@@ -49,7 +49,6 @@ private:
   void AbortPlayback();
   void PreparePlayback();
   void StartPlayback();
-  void PrepareRecording();
 
 public:
   GORank(GOOrganController *organController);

--- a/src/grandorgue/model/GOWindchest.cpp
+++ b/src/grandorgue/model/GOWindchest.cpp
@@ -125,10 +125,6 @@ void GOWindchest::UpdateTremulant(GOTremulant *tremulant) {
     }
 }
 
-void GOWindchest::AbortPlayback() {}
-
 void GOWindchest::StartPlayback() {}
 
 void GOWindchest::PreparePlayback() { UpdateVolume(); }
-
-void GOWindchest::PrepareRecording() {}

--- a/src/grandorgue/model/GOWindchest.h
+++ b/src/grandorgue/model/GOWindchest.h
@@ -33,10 +33,8 @@ private:
   std::vector<GOPipeWindchestCallback *> m_pipes;
   GOPipeConfigTreeNode m_PipeConfig;
 
-  void AbortPlayback();
   void StartPlayback();
   void PreparePlayback();
-  void PrepareRecording();
 
 public:
   GOWindchest(GOOrganController *organController);

--- a/src/grandorgue/sound/GOSoundStateHandler.h
+++ b/src/grandorgue/sound/GOSoundStateHandler.h
@@ -12,10 +12,10 @@ class GOSoundStateHandler {
 public:
   virtual ~GOSoundStateHandler() {}
 
-  virtual void AbortPlayback() = 0;
   virtual void PreparePlayback() = 0;
+  virtual void AbortPlayback() {}
   virtual void StartPlayback() = 0;
-  virtual void PrepareRecording() = 0;
+  virtual void PrepareRecording() {}
 };
 
 #endif


### PR DESCRIPTION
Because most of subclasses have trivial implementations of GOSoundStateHandler::AbortPlaybook and GOSoundStateHandler::PrepareRecording, I made a default implementation of them in GOSoundStateHandler and removed all trivial implementatons from the subclasses.

No GO behavior should be changed