### PR TITLE
Fixed copyright in cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,7 @@
-# GrandOrgue - free pipe organ simulator
-# 
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# License GPL-2.0 or later
+# (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 cmake_minimum_required(VERSION 3.10)
 

--- a/help/CMakeLists.txt
+++ b/help/CMakeLists.txt
@@ -1,21 +1,7 @@
-# GrandOrgue - free pipe organ simulator
-# 
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# License GPL-2.0 or later
+# (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 include(${CMAKE_SOURCE_DIR}/cmake/BuildHelp.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/GetText.cmake)

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -3,7 +3,7 @@
 <book lang="en">
 <!--
 Copyright 2006 Milan Digital Audio LLC
-Copyright 2009-2021 GrandOrgue contributors (see AUTHORS)
+Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
 License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 -->
   <title>GrandOrgue Help</title>

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -1,21 +1,7 @@
-# GrandOrgue - free pipe organ simulator
-# 
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# License GPL-2.0 or later
+# (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 include(${CMAKE_SOURCE_DIR}/cmake/GetText.cmake)
 

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -1,21 +1,7 @@
-# GrandOrgue - free pipe organ simulator
-# 
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# License GPL-2.0 or later
+# (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 set(DEPLIST)
 

--- a/sounds/CMakeLists.txt
+++ b/sounds/CMakeLists.txt
@@ -1,21 +1,7 @@
-# GrandOrgue - free pipe organ simulator
-# 
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# License GPL-2.0 or later
+# (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 include(${CMAKE_SOURCE_DIR}/cmake/CopyStructure.cmake)
 COPY_STRUCTURE(sounds "sounds" resources)


### PR DESCRIPTION
Some cmake files were still containing the old copyright header.

See also #1409.