### PR TITLE
Moved GOEventDistributor::ControlChanged to GOEventHandlerList::SendControlChanged

### DIFF
--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -146,7 +146,7 @@ void GOButtonControl::Display(bool onoff) {
     return;
   m_sender.SetDisplay(onoff);
   m_Engaged = onoff;
-  m_OrganController->ControlChanged(this);
+  m_OrganController->SendControlChanged(this);
 }
 
 bool GOButtonControl::IsEngaged() const { return m_Engaged; }

--- a/src/grandorgue/control/GOEventDistributor.cpp
+++ b/src/grandorgue/control/GOEventDistributor.cpp
@@ -59,9 +59,3 @@ void GOEventDistributor::PrepareRecording() {
   for (auto handler : p_model->GetSoundStateHandlers())
     handler->PrepareRecording();
 }
-
-void GOEventDistributor::ControlChanged(void *control) {
-  if (control)
-    for (auto handler : p_model->GetControlChangedHandlers())
-      handler->ControlChanged(control);
-}

--- a/src/grandorgue/control/GOEventDistributor.h
+++ b/src/grandorgue/control/GOEventDistributor.h
@@ -38,7 +38,6 @@ public:
   ~GOEventDistributor() { p_model = nullptr; }
 
   void HandleKey(int key);
-  void ControlChanged(void *control);
 };
 
 #endif

--- a/src/grandorgue/control/GOLabelControl.cpp
+++ b/src/grandorgue/control/GOLabelControl.cpp
@@ -49,7 +49,7 @@ const wxString &GOLabelControl::GetContent() { return m_Content; }
 void GOLabelControl::SetContent(wxString name) {
   m_Content = name;
   m_sender.SetLabel(m_Content);
-  m_OrganController->ControlChanged(this);
+  m_OrganController->SendControlChanged(this);
 }
 
 void GOLabelControl::AbortPlayback() {

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -82,7 +82,7 @@ void GOEnclosure::Set(int n) {
     m_sender.SetValue(m_MIDIValue);
   }
   m_OrganController->UpdateVolume();
-  m_OrganController->ControlChanged(this);
+  m_OrganController->SendControlChanged(this);
 }
 
 int GOEnclosure::GetMIDIInputNumber() { return m_MIDIInputNumber; }

--- a/src/grandorgue/model/GOEventHandlerList.cpp
+++ b/src/grandorgue/model/GOEventHandlerList.cpp
@@ -9,6 +9,8 @@
 
 #include <algorithm>
 
+#include "control/GOControlChangedHandler.h"
+
 void GOEventHandlerList::RegisterCacheObject(GOCacheObject *obj) {
   m_CacheObjects.push_back(obj);
 }
@@ -45,6 +47,11 @@ void GOEventHandlerList::UnregisterSaveableObject(GOSaveableObject *obj) {
     *it = nullptr;
     m_SaveableObjects.erase(it);
   }
+}
+
+void GOEventHandlerList::SendControlChanged(void *pControl) {
+  for (auto handler : m_ControlChangedHandlers)
+    handler->ControlChanged(pControl);
 }
 
 void GOEventHandlerList::Cleanup() {

--- a/src/grandorgue/model/GOEventHandlerList.h
+++ b/src/grandorgue/model/GOEventHandlerList.h
@@ -30,10 +30,6 @@ public:
   const std::vector<GOCacheObject *> &GetCacheObjects() const {
     return m_CacheObjects;
   }
-  const std::vector<GOControlChangedHandler *> &GetControlChangedHandlers()
-    const {
-    return m_ControlChangedHandlers;
-  }
   const std::vector<GOMidiConfigurator *> &GetMidiConfigurators() const {
     return m_MidiConfigurators;
   }
@@ -54,6 +50,12 @@ public:
   void RegisterSoundStateHandler(GOSoundStateHandler *handler);
   void RegisterSaveableObject(GOSaveableObject *obj);
   void UnregisterSaveableObject(GOSaveableObject *obj);
+
+  /**
+   * Calls ControlChanged for all ControlChanged handlers
+   * @param pControl - the control that state is changed
+   */
+  void SendControlChanged(void *pControl);
 
   void Cleanup();
 };

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -287,7 +287,7 @@ void GOManual::SetKey(
   if (
     m_first_accessible_logical_key_nb <= note + 1
     && note <= m_first_accessible_logical_key_nb + m_nb_accessible_keys)
-    m_OrganController->ControlChanged(this);
+    m_OrganController->SendControlChanged(this);
 }
 
 void GOManual::Set(unsigned note, unsigned velocity) {


### PR DESCRIPTION
Toward to removing dependencies on GOOrganController from model I removed the method GOEventDistributor::ControlChanged and replaced it with GOEventHandlerList::SendControlChanged.

No GO behavior should be changed.