### PR TITLE
Beautified GORank::SetKey and renamed GORank

### DIFF
--- a/src/grandorgue/model/GORank.h
+++ b/src/grandorgue/model/GORank.h
@@ -29,9 +29,18 @@ private:
   GOOrganController *m_OrganController;
   wxString m_Name;
   ptr_vector<GOPipe> m_Pipes;
+  /**
+   * Number of stops using this rank
+   */
   unsigned m_StopCount;
-  std::vector<unsigned> m_Velocity;
-  std::vector<std::vector<unsigned>> m_Velocities;
+  /**
+   * last pressed velocity of notes and stop
+   */
+  std::vector<std::vector<unsigned>> m_NoteStopVelocities;
+  /**
+   * maximum last velocity of notes over all stops
+   */
+  std::vector<unsigned> m_MaxNoteVelocities;
   unsigned m_FirstMidiNoteNumber;
   bool m_Percussive;
   unsigned m_WindchestGroup;


### PR DESCRIPTION
While working with [the bug mentioned by @larspalo](https://github.com/GrandOrgue/grandorgue/pull/1421#issuecomment-1455074846) I made the code of GORank::SetKey  more understandable.

No GO behavior should be changed.