### PR TITLE
Bugfix/build on osx

### DIFF
--- a/cmake/CopyDependencies.cmake
+++ b/cmake/CopyDependencies.cmake
@@ -30,8 +30,8 @@ function(CopyDependencies app instpath)
   string(REPLACE ";" "$<SEMICOLON>" cmd_searchdirs "${searchdirs}")
 
   add_custom_command(TARGET ${app} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -Dstatusfile="${statusfile}" -Dtarget="${targetfile}" -Dsearchdirs="${cmd_searchdirs}" -P "${CMAKE_SOURCE_DIR}/cmake/FixupBundle.cmake"
+    COMMAND ${CMAKE_COMMAND} -Dstatusfile="${statusfile}" -Dbundledtarget="${targetfile}" -Dsearchdirs="${cmd_searchdirs}" -P "${CMAKE_SOURCE_DIR}/cmake/FixupBundle.cmake"
     DEPENDS ${targetfile} "${CMAKE_SOURCE_DIR}/cmake/FixupBundle.cmake" "${statusfile}")
 
-  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" \"-Dstatusfile=${statusfile}\" \"-Dtarget=\$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${instpath}\" \"-Dsearchdirs=${searchdirs}\" -P \"${CMAKE_SOURCE_DIR}/cmake/FixupBundle.cmake\")")
+  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" \"-Dstatusfile=${statusfile}\" \"-Dbundledtarget=\$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${instpath}\" \"-Dsearchdirs=${searchdirs}\" -P \"${CMAKE_SOURCE_DIR}/cmake/FixupBundle.cmake\")")
 endfunction()

--- a/cmake/CopyDependencies.cmake
+++ b/cmake/CopyDependencies.cmake
@@ -1,21 +1,10 @@
 # GrandOrgue - free pipe organ simulator
 # 
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Copyright 2006 Milan Digital Audio LLC
+# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# License GPL-2.0 or later
+# (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 include(${CMAKE_SOURCE_DIR}/cmake/ExtractLibraryDirs.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/WriteStatus.cmake)

--- a/cmake/FixupBundle.cmake
+++ b/cmake/FixupBundle.cmake
@@ -31,4 +31,4 @@ set(WIN32  )
 include("${statusfile}")
 set(BU_CHMOD_BUNDLE_ITEMS ON)
 
-fixup_bundle("${target}"  ""  "${searchdirs}")
+fixup_bundle("${bundledtarget}"  ""  "${searchdirs}")

--- a/cmake/FixupBundle.cmake
+++ b/cmake/FixupBundle.cmake
@@ -1,21 +1,7 @@
-# GrandOrgue - free pipe organ simulator
-# 
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
-# 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# License GPL-2.0 or later
+# (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 include(BundleUtilities)
 include(CMakeParseArguments)


### PR DESCRIPTION
After changing something in CMakeLists.txt, I experienced some difficults when building GrandOrgue for OSx: https://github.com/oleg68/GrandOrgue-official/actions/runs/4384854530

The reason was using the variable name `target` that may be conlicting with other places.

I renamed this variable to `bundledtarget`.
