### PR TITLE
Removed GODocument::ImportCombination

### DIFF
--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -109,14 +109,6 @@ bool GODocument::LoadOrgan(
   return true;
 }
 
-bool GODocument::ImportCombination(const wxString &cmb) {
-  if (!m_OrganController)
-    return false;
-  m_OrganController->LoadCombination(cmb);
-  m_OrganController->SetOrganModified();
-  return true;
-}
-
 bool GODocument::UpdateCache(GOProgressDialog *dlg, bool compress) {
   if (!m_OrganController)
     return false;

--- a/src/grandorgue/GODocument.h
+++ b/src/grandorgue/GODocument.h
@@ -59,7 +59,6 @@ public:
   bool Export(const wxString &cmb);
   bool LoadOrgan(
     GOProgressDialog *dlg, const GOOrgan &organ, const wxString &cmb);
-  bool ImportCombination(const wxString &cmb);
   bool UpdateCache(GOProgressDialog *dlg, bool compress);
 
   void ShowMIDIEventDialog(

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -879,6 +879,23 @@ void GOFrame::OnInstall(wxCommandEvent &event) {
     }
 }
 
+void GOFrame::OnImportCombinations(wxCommandEvent &event) {
+  GOOrganController *pOrganController = GetOrganController();
+
+  if (pOrganController) {
+    wxFileDialog dlg(
+      this,
+      _("Import Combinations"),
+      m_config.ExportImportPath(),
+      wxEmptyString,
+      _("Settings files (*.cmb)|*.cmb"),
+      wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+
+    if (dlg.ShowModal() == wxID_OK)
+      pOrganController->LoadCombination(dlg.GetPath());
+  }
+}
+
 void GOFrame::OnImportSettings(wxCommandEvent &event) {
   GOOrganController *organController = GetOrganController();
 
@@ -898,22 +915,6 @@ void GOFrame::OnImportSettings(wxCommandEvent &event) {
       if (m_locker.IsLocked()) {
         LoadOrgan(organ, dlg.GetPath());
       }
-    }
-  }
-}
-
-void GOFrame::OnImportCombinations(wxCommandEvent &event) {
-  if (GetOrganController()) {
-    wxFileDialog dlg(
-      this,
-      _("Import Combinations"),
-      m_config.ExportImportPath(),
-      wxEmptyString,
-      _("Settings files (*.cmb)|*.cmb"),
-      wxFD_OPEN | wxFD_FILE_MUST_EXIST);
-
-    if (dlg.ShowModal() == wxID_OK) {
-      m_doc->ImportCombination(dlg.GetPath());
     }
   }
 }

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -663,6 +663,7 @@ void GOOrganController::LoadCombination(const wxString &file) {
     cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ODFPath"), false);
 
     ReadCombinations(cfg);
+    SetOrganModified();
   } catch (wxString error) {
     wxLogError(wxT("%s\n"), error.c_str());
     GOMessageBox(error, _("Load error"), wxOK | wxICON_ERROR, NULL);


### PR DESCRIPTION
Towards to support importing yaml combinations I removed the extra proxy call to GODocument.

No GO behavior should be changed.