### PR TITLE
Removed support of old linux distros (with libc6 versions before 2.31) https://github.com/GrandOrgue/grandorgue/discussions/1334

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,22 +75,22 @@ jobs:
     strategy:
       matrix:
         include:
-          - run_on: ubuntu-18.04
+          - run_on: ubuntu-20.04
             for: linux
             prepare: "debian-based"
             build_on: linux
 
-          - run_on: ubuntu-18.04
+          - run_on: ubuntu-20.04
             for: appimage-x86_64
             prepare: "debian-based"
             build_on: linux
 
-          - run_on: ubuntu-18.04
+          - run_on: ubuntu-20.04
             for: linux-armhf
             prepare: "debian-based"
             build_on: linux
     
-          - run_on: ubuntu-18.04
+          - run_on: ubuntu-20.04
             for: linux-aarch64
             prepare: "debian-based"
             build_on: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed support of old linux distros (with libc6 versions before 2.31) https://github.com/GrandOrgue/grandorgue/discussions/1334
 - Fixed the translation of the desktop icon on Linux https://github.com/GrandOrgue/grandorgue/issues/1429
 - Added support of labels without a background image by specifying DispImageNum=0 https://github.com/GrandOrgue/grandorgue/issues/1386
 - Added capability of overriding wav MIDIPitchFraction with the Pipe999MIDIPitchFraction key https://github.com/GrandOrgue/grandorgue/issues/1378

--- a/build-scripts/for-linux/prepare-debian-based-align-libs.sh
+++ b/build-scripts/for-linux/prepare-debian-based-align-libs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#rem $1 - target architecture: ex arm64, amd64, armhf or i386
+
+set -e
+
+DIR=`dirname $0`
+
+TARGET_ARCH="${1:-$(dpkg --print-architecture)}"
+
+# remove an odd version of libpcre2-8-0 and libgd3 that prevents installing
+# packages for foreign archs
+LIBPCRE_VERSION=`apt-cache policy libpcre2-8-0:$TARGET_ARCH | awk '/Candidate:/ { print $2; }'`
+LIBDG3_VERSION=`apt-cache policy libgd3:$TARGET_ARCH | awk '/Candidate:/ { print $2; }'`
+sudo DEBIAN_FRONTEND=noninteractive apt-get --allow-downgrades -y install \
+  libpcre2-8-0=$LIBPCRE_VERSION libgd3=$LIBDG3_VERSION

--- a/build-scripts/for-linux/prepare-debian-based.sh
+++ b/build-scripts/for-linux/prepare-debian-based.sh
@@ -19,6 +19,10 @@ else
   # ubuntu has different urls for different architectures
   [[ "$OS_DISTR" == "ubuntu" ]] && $DIR/prepare-ubuntu-multiarch-repos.sh
   sudo apt update
+
+  # remove an odd version of packages that prevents installing same packages for foreign arch
+  $DIR/prepare-debian-based-align-libs.sh $TARGET_ARCH
+
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y dpkg-dev
   GCC_SUFFIX=-$(dpkg-architecture -A $TARGET_ARCH -q DEB_TARGET_MULTIARCH)
 fi

--- a/build-scripts/for-win64/prepare-debian-based.sh
+++ b/build-scripts/for-win64/prepare-debian-based.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 set -e
+
+BASE_DIR=$(dirname $0)
+
 sudo dpkg --add-architecture i386
 sudo apt-get update
 
 # remove an odd version of packages that prevents installing wine32
-LIBPCRE_VERSION=`apt-cache policy libpcre2-8-0:i386 | awk '/Candidate:/ { print $2; }'`
-LIBDG3_VERSION=`apt-cache policy libgd3:i386 | awk '/Candidate:/ { print $2; }'`
-sudo DEBIAN_FRONTEND=noninteractive apt-get --allow-downgrades -y install \
-  libpcre2-8-0=$LIBPCRE_VERSION libgd3=$LIBDG3_VERSION
+$BASE_DIR/../for-linux/prepare-debian-based-align-libs.sh $TARGET_ARCH i386
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   wget unzip cmake g++ pkg-config g++-mingw-w64-x86-64 nsis \


### PR DESCRIPTION
As discussed in #1334 we won't be able to build on Github on ubuntu 18 since 2023-04-01. So I switched builds to Ubuntu 20.

But there was a problem: odd versions of `libpcre2-8-0` and `libgd3` hat had been installed on github runner machines were preventing installing the same packages from the standard repositories for non-amd64 architectures. So I need to switch them to the standard versions. Earlier the same problem had been solved with windows builds at #1127.