### PR TITLE
Added using yaml-cpp in GrandOrgue Builds https://github.com/GrandOrgue/grandorgue/issues/1195

### DIFF
--- a/build-scripts/for-linux/prepare-debian-based.sh
+++ b/build-scripts/for-linux/prepare-debian-based.sh
@@ -45,7 +45,19 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   libudev-dev:$TARGET_ARCH \
   libwavpack-dev:$TARGET_ARCH \
   libwxgtk3.0-gtk3-dev:$TARGET_ARCH \
+  libyaml-cpp-dev:$TARGET_ARCH \
   zlib1g-dev:$TARGET_ARCH
+
+# download and install additional packages
+mkdir -p deb
+pushd deb
+
+wget \
+  https://github.com/GrandOrgue/YamlCppAdd/releases/download/0.6.2-5.go/libyaml-cpp-static_0.6.2-5.go_all.deb
+
+sudo apt-get install -y \
+  ./libyaml-cpp-static_0.6.2-5.go_all.deb
+popd
 
 # old linux versions have libgcc1 instead of libgcc-s1
 # prevent generating dependencies on libgcc-s1

--- a/build-scripts/for-linux/prepare-fedora.sh
+++ b/build-scripts/for-linux/prepare-fedora.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
-sudo dnf install -y cmake gcc-c++ make gettext docbook-style-xsl zip po4a \
-  pipewire-jack-audio-connection-kit-devel fftw-devel zlib-devel wavpack-devel wxGTK3-devel \
-  alsa-lib-devel systemd-devel ImageMagick
+sudo dnf install -y \
+  cmake gcc-c++ make gettext docbook-style-xsl zip po4a ImageMagick rpm-build \
+  pipewire-jack-audio-connection-kit-devel fftw-devel zlib-devel wavpack-devel \
+  wxGTK3-devel alsa-lib-devel systemd-devel yaml-cpp-static

--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
 set -e
-brew install gettext jack docbook-xsl cmake pkg-config fftw wavpack imagemagick
+brew install \
+  cmake \
+  docbook-xsl \
+  fftw wavpack \
+  gettext \
+  imagemagick \
+  jack \
+  pkg-config \
+  yaml-cpp
 brew link gettext --force
 
 # install wx for 10.15 in order to using the GrandOrgue bundle with 10.15

--- a/build-scripts/for-win64/prepare-debian-based.sh
+++ b/build-scripts/for-win64/prepare-debian-based.sh
@@ -23,14 +23,16 @@ wget \
   https://launchpad.net/~tobydox/+archive/ubuntu/mingw-w64/+files/fftw-mingw-w64_3.3.6-3_all.deb \
   https://github.com/GrandOrgue/JackCross/releases/download/1.9.19-1.os/jack-mingw-w64_1.9.19-1.os_all.deb \
   https://github.com/GrandOrgue/WavPackCross/releases/download/5.4.0-1.go/wavpack-mingw-w64_5.4.0-1.go_all.deb \
-  https://github.com/GrandOrgue/WxWidgetsCross/releases/download/3.1.5-2.go/wxwidgets3.0-mingw-w64_3.1.5-2.go_all.deb
+  https://github.com/GrandOrgue/WxWidgetsCross/releases/download/3.1.5-2.go/wxwidgets3.0-mingw-w64_3.1.5-2.go_all.deb \
+  https://github.com/GrandOrgue/YamlCppAdd/releases/download/0.6.2-6.go/libyaml-cpp-mingw-w64_0.6.2-6.go_all.deb
 
 sudo apt-get install -y \
   ./libgnurx-mingw-w64_2.6.1-1.os_all.deb \
   ./fftw-mingw-w64_3.3.6-3_all.deb \
   ./jack-mingw-w64_1.9.19-1.os_all.deb \
   ./wavpack-mingw-w64_5.4.0-1.go_all.deb \
-  ./wxwidgets3.0-mingw-w64_3.1.5-2.go_all.deb
+  ./wxwidgets3.0-mingw-w64_3.1.5-2.go_all.deb \
+  ./libyaml-cpp-mingw-w64_0.6.2-6.go_all.deb
 
 popd
 

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -15,6 +15,20 @@ add_option(-mstackrealign)
 
 find_package(wxWidgets REQUIRED html net adv core base)
 include(${wxWidgets_USE_FILE})
+if (APPLE)
+  # /usr/local/share/cmake/yaml-cpp/yaml-cpp-config.cmake sets
+  # empty YAML_CPP_INCLUDE_DIR and YAML_CPP_LIBRARIES, so we use pkg_config
+  pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
+else()
+  # but pkg_config does not support static linking for yaml-cpp, so use cmake config
+  find_package(yaml-cpp REQUIRED)
+  include("${yaml-cpp_CONFIG}")
+  # the variables are different in both methods
+  set(YAML_CPP_INCLUDE_DIRS "${YAML_CPP_INCLUDE_DIR}")
+endif()
+
+message("YAML_CPP_INCLUDE_DIRS=${YAML_CPP_INCLUDE_DIRS}")
+message("YAML_CPP_LIBRARIES=${YAML_CPP_LIBRARIES}")
 
 include_directories(${CMAKE_BINARY_DIR}/src/core/go_defs.h ${CMAKE_CURRENT_SOURCE_DIR}/resource ${CMAKE_SOURCE_DIR}/src/core)
 include_directories(${RT_INCLUDE_DIRS})
@@ -23,6 +37,7 @@ include_directories(${ZITACONVOLVER_INCLUDE_DIRS})
 include_directories(${FFTW_INCLUDE_DIRS})
 include_directories(${wxWidgets_INCLUDE_DIRS})
 include_directories(${JACK_INCLUDE_DIRS})
+include_directories(${YAML_CPP_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(grandorgue_src
@@ -192,7 +207,7 @@ if (USE_INTERNAL_ZITACONVOLVER)
 endif()
 
 add_library(golib STATIC ${grandorgue_src})
-set(go_libs ${wxWidgets_LIBRARIES} ${RT_LIBRARIES} ${PORTAUDIO_LIBRARIES} ${FFTW_LIBRARIES} ${ZITACONVOLVER_LIBRARIES})
+set(go_libs ${wxWidgets_LIBRARIES} ${YAML_CPP_LIBRARIES} ${RT_LIBRARIES} ${PORTAUDIO_LIBRARIES} ${FFTW_LIBRARIES} ${ZITACONVOLVER_LIBRARIES})
 set(go_libdir ${wxWidgets_LIBRARY_DIRS} ${RT_LIBDIR} ${PORTAUDIO_LIBDIR} ${FFTW_LIBDIR})
 target_link_libraries(golib GrandOrgueImages GrandOrgueCore ${go_libs})
 link_directories(${go_libdir})


### PR DESCRIPTION
This is the first PR related to #1195

I added the yaml-cpp library to GrandOrgue build, but I haven't use it in this PR.

No GO behavior should be changed. Exporting combinations to yaml will be submitted in the next PR after merging this.

