### PR TITLE
Renamed combination fields in GODivisionalButtonControl and GOGeneralButtonControl

### DIFF
--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -19,7 +19,7 @@ GODivisionalButtonControl::GODivisionalButtonControl(
   GOCombinationDefinition &divisionalTemplate,
   bool isSetter)
   : GOPushbuttonControl(organController),
-    m_divisional(organController, divisionalTemplate, isSetter) {}
+    m_combination(organController, divisionalTemplate, isSetter) {}
 
 wxString GODivisionalButtonControl::GetMidiType() { return _("Divisional"); };
 
@@ -30,7 +30,7 @@ void GODivisionalButtonControl::Init(
   int divisionalNumber,
   const wxString &name) {
   GOPushbuttonControl::Init(cfg, group, name);
-  m_divisional.Init(group, manualNumber, divisionalNumber);
+  m_combination.Init(group, manualNumber, divisionalNumber);
 }
 void GODivisionalButtonControl::Load(
   GOConfigReader &cfg,
@@ -38,16 +38,16 @@ void GODivisionalButtonControl::Load(
   int manualNumber,
   int divisionalNumber) {
   GOPushbuttonControl::Load(cfg, group);
-  m_divisional.Load(cfg, group, manualNumber, divisionalNumber);
+  m_combination.Load(cfg, group, manualNumber, divisionalNumber);
 }
 
 void GODivisionalButtonControl::LoadCombination(GOConfigReader &cfg) {
-  m_divisional.LoadCombination(cfg);
+  m_combination.LoadCombination(cfg);
 }
 
 void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
   GOPushbuttonControl::Save(cfg);
-  m_divisional.Save(cfg);
+  m_combination.Save(cfg);
 }
 
 void GODivisionalButtonControl::Push() {
@@ -55,9 +55,9 @@ void GODivisionalButtonControl::Push() {
   const GOCombination::ExtraElementsSet *pAddSet
     = m_OrganController->GetSetter()->GetCrescendoAddSet(elementSet);
   GOManual *pManual
-    = m_OrganController->GetManual(m_divisional.GetManualNumber());
+    = m_OrganController->GetManual(m_combination.GetManualNumber());
 
-  m_divisional.Push(pAddSet);
+  m_combination.Push(pAddSet);
 
   for (unsigned l = pManual->GetDivisionalCount(), k = 0; k < l; k++) {
     GODivisionalButtonControl *pDivisionalControl = pManual->GetDivisional(k);

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.h
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.h
@@ -15,7 +15,7 @@ class GOConfigReader;
 
 class GODivisionalButtonControl : public GOPushbuttonControl {
 private:
-  GODivisionalCombination m_divisional;
+  GODivisionalCombination m_combination;
 
 public:
   GODivisionalButtonControl(
@@ -23,7 +23,7 @@ public:
     GOCombinationDefinition &divisionalTemplate,
     bool isSetter);
 
-  GODivisionalCombination &GetGeneral() { return m_divisional; }
+  GODivisionalCombination &GetCombination() { return m_combination; }
   wxString GetMidiType() override;
 
   void Init(

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -18,20 +18,22 @@ GOGeneralButtonControl::GOGeneralButtonControl(
   GOOrganController *organController,
   bool is_setter)
   : GOPushbuttonControl(organController),
-    m_general(general_template, organController, is_setter) {}
+    m_combination(general_template, organController, is_setter) {}
 
 void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
-  m_general.Load(cfg, group);
+  m_combination.Load(cfg, group);
   GOPushbuttonControl::Load(cfg, group);
 }
 
 void GOGeneralButtonControl::Push() {
   GOCombination::ExtraElementsSet elementSet;
 
-  m_general.Push(
+  m_combination.Push(
     m_OrganController->GetSetter()->GetCrescendoAddSet(elementSet));
 }
 
-GOGeneralCombination &GOGeneralButtonControl::GetGeneral() { return m_general; }
+GOGeneralCombination &GOGeneralButtonControl::GetCombination() {
+  return m_combination;
+}
 
 wxString GOGeneralButtonControl::GetMidiType() { return _("General"); }

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.h
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.h
@@ -15,7 +15,7 @@ class GOConfigReader;
 
 class GOGeneralButtonControl : public GOPushbuttonControl {
 private:
-  GOGeneralCombination m_general;
+  GOGeneralCombination m_combination;
 
 public:
   GOGeneralButtonControl(
@@ -24,7 +24,7 @@ public:
     bool is_setter);
   void Load(GOConfigReader &cfg, wxString group);
   void Push();
-  GOGeneralCombination &GetGeneral();
+  GOGeneralCombination &GetCombination();
 
   wxString GetMidiType();
 };

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -391,7 +391,7 @@ void GOGeneralCombination::Push(
 
     for (unsigned k = 0; k < m_OrganController->GetGeneralCount(); k++) {
       GOGeneralButtonControl *general = m_OrganController->GetGeneral(k);
-      general->Display(&general->GetGeneral() == this);
+      general->Display(&general->GetCombination() == this);
     }
 
     for (unsigned j = m_OrganController->GetFirstManualIndex();


### PR DESCRIPTION
I named the combination field in both GODivisionalButtonControl and GOGeneralButtonControl as `m_combination` and the method returning them as `GetCombination()`.

It is just renaming. No GO behavior should be changed.