### PR TITLE
Added FindXXXByName methods for all objects used in combinations

### DIFF
--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -81,8 +81,6 @@ bool GOButtonControl::IsDisplayed() { return m_Displayed; }
 
 bool GOButtonControl::IsReadOnly() { return m_ReadOnly; }
 
-const wxString &GOButtonControl::GetName() { return m_Name; }
-
 void GOButtonControl::HandleKey(int key) {
   if (m_ReadOnly)
     return;

--- a/src/grandorgue/control/GOButtonControl.h
+++ b/src/grandorgue/control/GOButtonControl.h
@@ -62,7 +62,7 @@ public:
   bool IsDisplayed();
   void SetDisplayed(bool displayed) { m_Displayed = displayed; }
   bool IsReadOnly();
-  const wxString &GetName();
+  const wxString &GetName() const { return m_Name; }
   bool IsPiston() const { return m_IsPiston; }
 
   virtual void Push();

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -348,6 +348,17 @@ GOStop *GOManual::GetStop(unsigned index) {
   return m_stops[index];
 }
 
+int GOManual::FindStopByName(const wxString &stopName) const {
+  int stopIndex = -1;
+
+  for (unsigned l = m_stops.size(), i = 0; i < l; i++)
+    if (m_stops[i]->GetName() == stopName) {
+      stopIndex = i;
+      break;
+    }
+  return stopIndex;
+}
+
 unsigned GOManual::GetCouplerCount() { return m_couplers.size(); }
 
 unsigned GOManual::GetODFCouplerCount() { return m_ODFCouplerCount; }

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -17,6 +17,8 @@
 #include "GODocument.h"
 #include "GOOrganController.h"
 #include "GOStop.h"
+#include "GOSwitch.h"
+#include "GOTremulant.h"
 
 GOManual::GOManual(GOOrganController *organController)
   : m_group(wxT("---")),
@@ -341,31 +343,36 @@ int GOManual::GetFirstLogicalKeyMIDINoteNumber() {
     + 1;
 }
 
-unsigned GOManual::GetStopCount() { return m_stops.size(); }
-
 GOStop *GOManual::GetStop(unsigned index) {
   assert(index < m_stops.size());
   return m_stops[index];
 }
 
-int GOManual::FindStopByName(const wxString &stopName) const {
-  int stopIndex = -1;
+int GOManual::FindStopByName(const wxString &name) const {
+  int resIndex = -1;
 
   for (unsigned l = m_stops.size(), i = 0; i < l; i++)
-    if (m_stops[i]->GetName() == stopName) {
-      stopIndex = i;
+    if (m_stops[i]->GetName() == name) {
+      resIndex = i;
       break;
     }
-  return stopIndex;
+  return resIndex;
 }
-
-unsigned GOManual::GetCouplerCount() { return m_couplers.size(); }
-
-unsigned GOManual::GetODFCouplerCount() { return m_ODFCouplerCount; }
 
 GOCoupler *GOManual::GetCoupler(unsigned index) {
   assert(index < m_couplers.size());
   return m_couplers[index];
+}
+
+int GOManual::FindCouplerByName(const wxString &name) const {
+  int resIndex = -1;
+
+  for (unsigned l = m_couplers.size(), i = 0; i < l; i++)
+    if (m_couplers[i]->GetName() == name) {
+      resIndex = i;
+      break;
+    }
+  return resIndex;
 }
 
 void GOManual::AddCoupler(GOCoupler *coupler) { m_couplers.push_back(coupler); }
@@ -385,18 +392,46 @@ GOCombinationDefinition &GOManual::GetDivisionalTemplate() {
   return m_DivisionalTemplate;
 }
 
-unsigned GOManual::GetTremulantCount() { return m_tremulant_ids.size(); }
-
 GOTremulant *GOManual::GetTremulant(unsigned index) {
   assert(index < m_tremulant_ids.size());
   return m_OrganController->GetTremulant(m_tremulant_ids[index] - 1);
 }
 
-unsigned GOManual::GetSwitchCount() { return m_switch_ids.size(); }
+int GOManual::FindTremulantByName(const wxString &name) const {
+  int resIndex = -1;
+
+  for (unsigned l = m_tremulant_ids.size(), i = 0; i < l; i++) {
+    int globalIndex = m_tremulant_ids[i] - 1;
+
+    if (
+      globalIndex >= 0
+      && m_OrganController->GetTremulant(globalIndex)->GetName() == name) {
+      resIndex = globalIndex;
+      break;
+    }
+  }
+  return resIndex;
+}
 
 GOSwitch *GOManual::GetSwitch(unsigned index) {
   assert(index < m_switch_ids.size());
   return m_OrganController->GetSwitch(m_switch_ids[index] - 1);
+}
+
+int GOManual::FindSwitchByName(const wxString &name) const {
+  int resIndex = -1;
+
+  for (unsigned l = m_switch_ids.size(), i = 0; i < l; i++) {
+    int globalIndex = m_switch_ids[i] - 1;
+
+    if (
+      globalIndex >= 0
+      && m_OrganController->GetSwitch(globalIndex)->GetName() == name) {
+      resIndex = globalIndex;
+      break;
+    }
+  }
+  return resIndex;
 }
 
 void GOManual::AllNotesOff() {

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -110,26 +110,46 @@ public:
   void AllNotesOff();
   bool IsKeyDown(unsigned midiNoteNumber);
 
-  unsigned GetStopCount();
+  unsigned GetStopCount() const { return m_stops.size(); };
   GOStop *GetStop(unsigned index);
 
   /**
    * Find a stop by it's name
-   * @param stopName - the name of stop to find
+   * @param name - the name of stop to find
    * @return the stop index or -1 if the stop is not found
    */
-  int FindStopByName(const wxString &stopName) const;
-  unsigned GetCouplerCount();
-  unsigned GetODFCouplerCount();
+  int FindStopByName(const wxString &name) const;
+  unsigned GetCouplerCount() const { return m_couplers.size(); }
+  unsigned GetODFCouplerCount() const { return m_ODFCouplerCount; }
   GOCoupler *GetCoupler(unsigned index);
+  /**
+   * Find a coupler by it's name
+   * @param name - the name of coupler to find
+   * @return the stop index or -1 if the stop is not found
+   */
+  int FindCouplerByName(const wxString &name) const;
   void AddCoupler(GOCoupler *coupler);
   unsigned GetDivisionalCount();
   GODivisionalButtonControl *GetDivisional(unsigned index);
   void AddDivisional(GODivisionalButtonControl *divisional);
-  unsigned GetTremulantCount();
+  unsigned GetTremulantCount() const { return m_tremulant_ids.size(); }
   GOTremulant *GetTremulant(unsigned index);
-  unsigned GetSwitchCount();
+  /**
+   * Find a tremulant belonging to this manual by it's name
+   * @param name - the name of tremulant to find
+   * @return the tremulant index in the OrganModel (not in the manual) or -1
+   *   if the tremulant is not found
+   */
+  int FindTremulantByName(const wxString &name) const;
+  unsigned GetSwitchCount() const { return m_switch_ids.size(); }
   GOSwitch *GetSwitch(unsigned index);
+  /**
+   * Find a switch belonging to this manual by it's name
+   * @param name - the name of switch to find
+   * @return the switch index in the OrganModel (not in the manual) or -1
+   *   if the switch is not found
+   */
+  int FindSwitchByName(const wxString &name) const;
 
   GOCombinationDefinition &GetDivisionalTemplate();
   const wxString &GetName();

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -112,6 +112,13 @@ public:
 
   unsigned GetStopCount();
   GOStop *GetStop(unsigned index);
+
+  /**
+   * Find a stop by it's name
+   * @param stopName - the name of stop to find
+   * @return the stop index or -1 if the stop is not found
+   */
+  int FindStopByName(const wxString &stopName) const;
   unsigned GetCouplerCount();
   unsigned GetODFCouplerCount();
   GOCoupler *GetCoupler(unsigned index);

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -214,14 +214,26 @@ unsigned GOOrganModel::AddEnclosure(GOEnclosure *enclosure) {
   return m_enclosures.size() - 1;
 }
 
-unsigned GOOrganModel::GetSwitchCount() { return m_switches.size(); }
+int GOOrganModel::FindSwitchByName(const wxString &name) const {
+  int resIndex = -1;
 
-GOSwitch *GOOrganModel::GetSwitch(unsigned index) { return m_switches[index]; }
+  for (unsigned l = m_switches.size(), i = 0; i < l; i++)
+    if (m_switches[i]->GetName() == name) {
+      resIndex = i;
+      break;
+    }
+  return resIndex;
+}
 
-unsigned GOOrganModel::GetTremulantCount() { return m_tremulants.size(); }
+int GOOrganModel::FindTremulantByName(const wxString &name) const {
+  int resIndex = -1;
 
-GOTremulant *GOOrganModel::GetTremulant(unsigned index) {
-  return m_tremulants[index];
+  for (unsigned l = m_tremulants.size(), i = 0; i < l; i++)
+    if (m_tremulants[i]->GetName() == name) {
+      resIndex = i;
+      break;
+    }
+  return resIndex;
 }
 
 GORank *GOOrganModel::GetRank(unsigned index) { return m_ranks[index]; }
@@ -238,12 +250,15 @@ GOPistonControl *GOOrganModel::GetPiston(unsigned index) {
   return m_pistons[index];
 }
 
-unsigned GOOrganModel::GetDivisionalCouplerCount() {
-  return m_DivisionalCoupler.size();
-}
+int GOOrganModel::FindDivisionalCouplerByName(const wxString &name) const {
+  int resIndex = -1;
 
-GODivisionalCoupler *GOOrganModel::GetDivisionalCoupler(unsigned index) {
-  return m_DivisionalCoupler[index];
+  for (unsigned l = m_DivisionalCoupler.size(), i = 0; i < l; i++)
+    if (m_DivisionalCoupler[i]->GetName() == name) {
+      resIndex = i;
+      break;
+    }
+  return resIndex;
 }
 
 unsigned GOOrganModel::GetGeneralCount() { return m_generals.size(); }

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -87,11 +87,23 @@ public:
   unsigned GetEnclosureCount();
   unsigned AddEnclosure(GOEnclosure *enclosure);
 
-  unsigned GetSwitchCount();
-  GOSwitch *GetSwitch(unsigned index);
+  unsigned GetSwitchCount() const { return m_switches.size(); }
+  GOSwitch *GetSwitch(unsigned index) { return m_switches[index]; }
+  /**
+   * Find a switch by it's name
+   * @param name - the name of switch to find
+   * @return the switch index or -1 if the tremulant is not found
+   */
+  int FindSwitchByName(const wxString &name) const;
 
-  unsigned GetTremulantCount();
-  GOTremulant *GetTremulant(unsigned index);
+  unsigned GetTremulantCount() const { return m_tremulants.size(); }
+  GOTremulant *GetTremulant(unsigned index) { return m_tremulants[index]; }
+  /**
+   * Find a tremulant by it's name
+   * @param name - the name of tremulant to find
+   * @return the tremulant index or -1 if the tremulant is not found
+   */
+  int FindTremulantByName(const wxString &name) const;
 
   unsigned GetManualAndPedalCount();
   unsigned GetODFManualCount();
@@ -105,8 +117,19 @@ public:
   unsigned GetNumberOfReversiblePistons();
   GOPistonControl *GetPiston(unsigned index);
 
-  unsigned GetDivisionalCouplerCount();
-  GODivisionalCoupler *GetDivisionalCoupler(unsigned index);
+  unsigned GetDivisionalCouplerCount() const {
+    return m_DivisionalCoupler.size();
+  }
+  GODivisionalCoupler *GetDivisionalCoupler(unsigned index) {
+    return m_DivisionalCoupler[index];
+  }
+
+  /**
+   * Find a divisional coupler by it's name
+   * @param name - the name of the divisional coupler to find
+   * @return the divisional coupler index or -1 if the coupler is not found
+   */
+  int FindDivisionalCouplerByName(const wxString &name) const;
 
   unsigned GetGeneralCount();
   GOGeneralButtonControl *GetGeneral(unsigned index);


### PR DESCRIPTION
For import combinations from yaml (#1195  file sometimes I have to match objects by name instead of by number. So I added the method ``FindXXXByName()``.

No GO behavior should be changed.
