### PR TITLE
Renamed GOCombinationDefinition inner types fields an methods

### DIFF
--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -43,8 +43,8 @@ void GOCombination::SetState(unsigned no, int value) { m_State[no] = value; }
 
 void GOCombination::GetExtraSetState(
   GOCombination::ExtraElementsSet &extraSet) {
-  const std::vector<GOCombinationDefinition::CombinationSlot> &elements
-    = m_Template.GetCombinationElements();
+  const std::vector<GOCombinationDefinition::Element> &elements
+    = m_Template.GetElements();
 
   extraSet.clear();
   for (unsigned i = 0; i < elements.size(); i++) {
@@ -55,8 +55,8 @@ void GOCombination::GetExtraSetState(
 
 void GOCombination::GetEnabledElements(
   GOCombination::ExtraElementsSet &enabledElements) {
-  const std::vector<GOCombinationDefinition::CombinationSlot> &elements
-    = m_Template.GetCombinationElements();
+  const std::vector<GOCombinationDefinition::Element> &elements
+    = m_Template.GetElements();
 
   enabledElements.clear();
   for (unsigned i = 0; i < elements.size(); i++) {
@@ -66,8 +66,8 @@ void GOCombination::GetEnabledElements(
 }
 
 void GOCombination::UpdateState() {
-  const std::vector<GOCombinationDefinition::CombinationSlot> &elements
-    = m_Template.GetCombinationElements();
+  const std::vector<GOCombinationDefinition::Element> &elements
+    = m_Template.GetElements();
   if (m_State.size() > elements.size())
     m_State.resize(elements.size());
   else if (m_State.size() < elements.size()) {
@@ -82,8 +82,8 @@ GOCombinationDefinition *GOCombination::GetTemplate() { return &m_Template; }
 
 bool GOCombination::PushLocal(GOCombination::ExtraElementsSet const *extraSet) {
   bool used = false;
-  const std::vector<GOCombinationDefinition::CombinationSlot> &elements
-    = m_Template.GetCombinationElements();
+  const std::vector<GOCombinationDefinition::Element> &elements
+    = m_Template.GetElements();
   UpdateState();
 
   if (m_OrganFile->GetSetter()->IsSetterActive()) {

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -16,29 +16,29 @@
 #include "model/GOTremulant.h"
 
 GOCombinationDefinition::GOCombinationDefinition(GOOrganModel &organModel)
-  : r_OrganModel(organModel), m_Content(0) {}
+  : r_OrganModel(organModel), m_elements(0) {}
 
 GOCombinationDefinition::~GOCombinationDefinition() {}
 
 void GOCombinationDefinition::AddGeneral(
-  GODrawstop *control, CombinationType type, int manual, unsigned index) {
+  GODrawstop *control, ElementType type, int manual, unsigned index) {
   Add(control, type, manual, index, control->GetStoreGeneral());
 }
 
 void GOCombinationDefinition::AddDivisional(
-  GODrawstop *control, CombinationType type, int manual, unsigned index) {
+  GODrawstop *control, ElementType type, int manual, unsigned index) {
   Add(control, type, manual, index, control->GetStoreDivisional());
 }
 
 void GOCombinationDefinition::Add(
   GODrawstop *control,
-  CombinationType type,
+  ElementType type,
   int manual,
   unsigned index,
   bool store_unconditional) {
   if (control->IsReadOnly())
     return;
-  CombinationSlot def;
+  Element def;
   def.type = type;
   def.manual = manual;
   def.index = index;
@@ -48,11 +48,11 @@ void GOCombinationDefinition::Add(
     def.group = wxEmptyString;
   else
     def.group = r_OrganModel.GetManual(manual)->GetName();
-  m_Content.push_back(def);
+  m_elements.push_back(def);
 }
 
 void GOCombinationDefinition::InitGeneral() {
-  m_Content.resize(0);
+  m_elements.resize(0);
 
   for (unsigned j = r_OrganModel.GetFirstManualIndex();
        j <= r_OrganModel.GetManualAndPedalCount();
@@ -89,7 +89,7 @@ void GOCombinationDefinition::InitGeneral() {
 
 void GOCombinationDefinition::InitDivisional(unsigned manual_number) {
   GOManual *associatedManual = r_OrganModel.GetManual(manual_number);
-  m_Content.resize(0);
+  m_elements.resize(0);
 
   for (unsigned i = 0; i < associatedManual->GetStopCount(); i++)
     AddDivisional(
@@ -114,17 +114,12 @@ void GOCombinationDefinition::InitDivisional(unsigned manual_number) {
       associatedManual->GetSwitch(i), COMBINATION_SWITCH, manual_number, i + 1);
 }
 
-const std::vector<GOCombinationDefinition::CombinationSlot>
-  &GOCombinationDefinition::GetCombinationElements() {
-  return m_Content;
-}
-
-int GOCombinationDefinition::findEntry(
-  CombinationType type, int manual, unsigned index) {
-  for (unsigned i = 0; i < m_Content.size(); i++) {
+int GOCombinationDefinition::FindElement(
+  ElementType type, int manual, unsigned index) {
+  for (unsigned i = 0; i < m_elements.size(); i++) {
     if (
-      m_Content[i].type == type && m_Content[i].manual == manual
-      && m_Content[i].index == index)
+      m_elements[i].type == type && m_elements[i].manual == manual
+      && m_elements[i].index == index)
       return i;
   }
   return -1;

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.h
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.h
@@ -19,33 +19,33 @@ class GOOrganModel;
 
 class GOCombinationDefinition {
 public:
-  typedef enum {
+  enum ElementType {
     COMBINATION_STOP = 0,
     COMBINATION_COUPLER = 1,
     COMBINATION_TREMULANT = 2,
     COMBINATION_DIVISIONALCOUPLER = 3,
     COMBINATION_SWITCH = 4
-  } CombinationType;
-  typedef struct {
-    CombinationType type;
+  };
+  struct Element {
+    ElementType type;
     int manual;
     unsigned index;
     bool store_unconditional;
     wxString group;
     GOCombinationElement *control;
-  } CombinationSlot;
+  };
 
 private:
   GOOrganModel &r_OrganModel;
-  std::vector<CombinationSlot> m_Content;
+  std::vector<Element> m_elements;
 
   void AddGeneral(
-    GODrawstop *control, CombinationType type, int manual, unsigned index);
+    GODrawstop *control, ElementType type, int manual, unsigned index);
   void AddDivisional(
-    GODrawstop *control, CombinationType type, int manual, unsigned index);
+    GODrawstop *control, ElementType type, int manual, unsigned index);
   void Add(
     GODrawstop *control,
-    CombinationType type,
+    ElementType type,
     int manual,
     unsigned index,
     bool store_unconditional);
@@ -57,9 +57,9 @@ public:
   void InitGeneral();
   void InitDivisional(unsigned manual_number);
 
-  int findEntry(CombinationType type, int manual, unsigned index);
+  int FindElement(ElementType type, int manual, unsigned index);
 
-  const std::vector<CombinationSlot> &GetCombinationElements();
+  const std::vector<Element> &GetElements() const { return m_elements; };
 };
 
 #endif

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -102,7 +102,7 @@ void GODivisionalCombination::Load(
       buffer.Printf(wxT("Stop%03d"), i + 1);
       unsigned cnt = associatedManual->GetStopCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_STOP, m_odfManualNumber, abs(s));
       if (pos >= 0) {
         if (used[pos]) {
@@ -124,7 +124,7 @@ void GODivisionalCombination::Load(
       buffer.Printf(wxT("Coupler%03d"), i + 1);
       unsigned cnt = associatedManual->GetODFCouplerCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_COUPLER,
         m_odfManualNumber,
         abs(s));
@@ -148,7 +148,7 @@ void GODivisionalCombination::Load(
       buffer.Printf(wxT("Tremulant%03d"), i + 1);
       unsigned cnt = associatedManual->GetTremulantCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt, false, 0);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_TREMULANT,
         m_odfManualNumber,
         abs(s));
@@ -172,7 +172,7 @@ void GODivisionalCombination::Load(
       buffer.Printf(wxT("Switch%03d"), i + 1);
       unsigned cnt = associatedManual->GetSwitchCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt, false, 0);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_SWITCH, m_odfManualNumber, abs(s));
       if (pos >= 0) {
         if (used[pos]) {
@@ -235,7 +235,7 @@ void GODivisionalCombination::LoadCombination(GOConfigReader &cfg) {
     buffer.Printf(wxT("Stop%03d"), i + 1);
     unsigned cnt = associatedManual->GetStopCount();
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_STOP, m_odfManualNumber, abs(s));
     if (pos >= 0) {
       if (m_State[pos] != -1) {
@@ -258,7 +258,7 @@ void GODivisionalCombination::LoadCombination(GOConfigReader &cfg) {
     unsigned cnt = type == CMBSetting ? associatedManual->GetCouplerCount()
                                       : associatedManual->GetODFCouplerCount();
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_COUPLER, m_odfManualNumber, abs(s));
     if (pos >= 0) {
       if (m_State[pos] != -1) {
@@ -280,7 +280,7 @@ void GODivisionalCombination::LoadCombination(GOConfigReader &cfg) {
     buffer.Printf(wxT("Tremulant%03d"), i + 1);
     unsigned cnt = associatedManual->GetTremulantCount();
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt, false, 0);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_TREMULANT,
       m_odfManualNumber,
       abs(s));
@@ -304,7 +304,7 @@ void GODivisionalCombination::LoadCombination(GOConfigReader &cfg) {
     buffer.Printf(wxT("Switch%03d"), i + 1);
     unsigned cnt = associatedManual->GetSwitchCount();
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt, false, 0);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_SWITCH, m_odfManualNumber, abs(s));
     if (pos >= 0) {
       if (m_State[pos] != -1) {
@@ -325,8 +325,8 @@ void GODivisionalCombination::LoadCombination(GOConfigReader &cfg) {
 
 void GODivisionalCombination::Save(GOConfigWriter &cfg) {
   wxString buffer;
-  const std::vector<GOCombinationDefinition::CombinationSlot> &elements
-    = m_Template.GetCombinationElements();
+  const std::vector<GOCombinationDefinition::Element> &elements
+    = m_Template.GetElements();
 
   UpdateState();
 

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -85,7 +85,7 @@ void GOGeneralCombination::Load(GOConfigReader &cfg, wxString group) {
       buffer.Printf(wxT("StopNumber%03d"), i + 1);
       unsigned cnt = m_OrganController->GetManual(m)->GetStopCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_STOP, m, abs(s));
       if (pos >= 0) {
         if (used[pos]) {
@@ -114,7 +114,7 @@ void GOGeneralCombination::Load(GOConfigReader &cfg, wxString group) {
       buffer.Printf(wxT("CouplerNumber%03d"), i + 1);
       unsigned cnt = m_OrganController->GetManual(m)->GetODFCouplerCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_COUPLER, m, abs(s));
       if (pos >= 0) {
         if (used[pos]) {
@@ -136,7 +136,7 @@ void GOGeneralCombination::Load(GOConfigReader &cfg, wxString group) {
       buffer.Printf(wxT("TremulantNumber%03d"), i + 1);
       unsigned cnt = m_OrganController->GetTremulantCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_TREMULANT, -1, abs(s));
       if (pos >= 0) {
         if (used[pos]) {
@@ -158,7 +158,7 @@ void GOGeneralCombination::Load(GOConfigReader &cfg, wxString group) {
       buffer.Printf(wxT("SwitchNumber%03d"), i + 1);
       unsigned cnt = m_OrganController->GetSwitchCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_SWITCH, -1, abs(s));
       if (pos >= 0) {
         if (used[pos]) {
@@ -180,7 +180,7 @@ void GOGeneralCombination::Load(GOConfigReader &cfg, wxString group) {
       buffer.Printf(wxT("DivisionalCouplerNumber%03d"), i + 1);
       unsigned cnt = m_OrganController->GetDivisionalCouplerCount();
       int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.findEntry(
+      pos = m_Template.FindElement(
         GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER, -1, abs(s));
       if (pos >= 0) {
         if (used[pos]) {
@@ -265,7 +265,7 @@ void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
      */
     int s = cfg.ReadInteger(type, m_group, buffer, -999, 999);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_STOP, m, abs(s));
     if (pos >= 0) {
       if (m_State[pos] != -1) {
@@ -296,7 +296,7 @@ void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
       ? m_OrganController->GetManual(m)->GetCouplerCount()
       : m_OrganController->GetManual(m)->GetODFCouplerCount();
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_COUPLER, m, abs(s));
     if (pos >= 0) {
       if (m_State[pos] != -1) {
@@ -318,7 +318,7 @@ void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
     buffer.Printf(wxT("TremulantNumber%03d"), i + 1);
     unsigned cnt = m_OrganController->GetTremulantCount();
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_TREMULANT, -1, abs(s));
     if (pos >= 0) {
       if (m_State[pos] != -1) {
@@ -340,7 +340,7 @@ void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
     buffer.Printf(wxT("SwitchNumber%03d"), i + 1);
     unsigned cnt = m_OrganController->GetSwitchCount();
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_SWITCH, -1, abs(s));
     if (pos >= 0) {
       if (m_State[pos] != -1) {
@@ -362,7 +362,7 @@ void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
     buffer.Printf(wxT("DivisionalCouplerNumber%03d"), i + 1);
     unsigned cnt = m_OrganController->GetDivisionalCouplerCount();
     int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.findEntry(
+    pos = m_Template.FindElement(
       GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER, -1, abs(s));
     if (pos >= 0) {
       if (m_State[pos] != -1) {
@@ -407,8 +407,8 @@ void GOGeneralCombination::Push(
 
 void GOGeneralCombination::Save(GOConfigWriter &cfg) {
   UpdateState();
-  const std::vector<GOCombinationDefinition::CombinationSlot> &elements
-    = m_Template.GetCombinationElements();
+  const std::vector<GOCombinationDefinition::Element> &elements
+    = m_Template.GetElements();
 
   wxString buffer;
   unsigned stop_count = 0;


### PR DESCRIPTION
I replaced several terms inside the GOCombinationDefinition with the single term `Element`

No GO behavior should be changed