### PR TITLE
Added capability of importing yaml combinations https://github.com/GrandOrgue/grandorgue/issues/1195

### DIFF
--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -420,13 +420,27 @@ currently in use is <emphasis>deleted</emphasis>.
           <indexterm>
             <primary>Import Combinations</primary>
           </indexterm>
-          <para>Apply only the combination settings from a  previously exported settings file to the currently loaded
-sample set. All other settings that might have previously been changed are preserved.</para>
-          <para>Note that settings may only be applied to a matching sample
-set, and you will receive a warning if you try to do otherwise. The
-location where the combinations were imported from will be remembered for the next time.</para>
-          <para>A settings file matches a sample set when the <emphasis>ChurchName</emphasis> property of the settings file
-matches the <emphasis>ChurchName</emphasis> property of the definition file.</para>
+	  <para>
+	    This menu item opens the file selection dialog that allows the user
+	    to select either a yaml-file, created with <emphasis>Export
+	    Combinations</emphasis>, or a .cmb-file, created with <emphasis>
+	    Export Settings</emphasis>. In the second case apply only the
+	    combination part of settings from a  previously exported settings
+	    file to the currently loaded sample set. All other settings that
+	    might have previously been changed are preserved.
+	  </para>
+          <para>
+	    Note The file selection dialog is opened at the directory where
+	    exported combination are stored, not where the settings files
+	    are. For selecting a .cmb file you have to navigate to the
+	    Export/import directory that is named <emphasis>Settings</emphasis>
+	    by default.
+	  </para>
+          <para>
+	    A settings file matches a sample set when the <emphasis>ChurchName
+	    </emphasis> property of the settings file matches the <emphasis>
+	      ChurchName</emphasis> property of the definition file.
+	  </para>
         </sect3>
         <sect3 id="export_combinations">
           <title>Export Combinations</title>
@@ -435,7 +449,8 @@ matches the <emphasis>ChurchName</emphasis> property of the definition file.</pa
           </indexterm>
           <para>
 	    Saves current combination settings to a text file in YAML format.
-	    The user can view this file.
+	    The user can view this file and can import it later with <emphasis>
+	    Import Combinations</emphasis>
 	  </para>
         </sect3>
         <sect3 id="import_settings">

--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -816,7 +816,8 @@
                  commonFlags="-mtune=generic -march=x86-64 -std=c++11 -fPIC"/>
         <element flagsID="4" commonFlags="-std=c++11 -O3 -ffast-math -fPIC"/>
         <element flagsID="5" commonFlags="-std=c++11 -fPIC"/>
-        <element flagsID="6" commonFlags="-std=c++14"/>
+        <element flagsID="6" commonFlags="-std=c++11 -msse3"/>
+        <element flagsID="7" commonFlags="-std=c++14"/>
       </flagsDictionary>
       <codeAssistance>
       </codeAssistance>
@@ -826,7 +827,7 @@
           <buildCommand>${MAKE} -f Makefile -j 16 -k</buildCommand>
           <cleanCommand>${MAKE} -f Makefile clean</cleanCommand>
           <executablePath>../../build/current/bin/GrandOrgue</executablePath>
-          <ccTool flags="-std=c++11 -msse3">
+          <ccTool flags="6">
           </ccTool>
         </makeTool>
         <preBuild>
@@ -843,7 +844,7 @@
             ex="false"
             tool="1"
             flavor2="11">
-        <ccTool flags="6">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <item path="../../build/current/src/images/ASIO.cpp"
@@ -8158,87 +8159,26 @@
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOApp.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/help</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8320,88 +8260,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8480,86 +8358,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8640,79 +8458,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/core/archive</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8865,96 +8630,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>../../src/grandorgue/help</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9100,103 +8795,26 @@
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOFrame.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/dialogs</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/help</pElem>
-            <pElem>../../src/core/archive</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9204,85 +8822,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9435,85 +8994,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9521,88 +9021,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9610,103 +9048,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/archive</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/core/contrib</pElem>
-            <pElem>../../src/grandorgue/dialogs</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
             <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9791,44 +9152,576 @@
             ex="false"
             tool="1"
             flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/combinations/GODivisionalSetter.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/combinations/GOSetter.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/combinations/control/GODivisionalButtonControl.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/combinations/control/GOGeneralButtonControl.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/combinations/model/GOCombination.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/combinations/model/GOCombinationDefinition.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.0/wx/unix</pElem>
             <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/gui</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
             <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/combinations/model/GODivisionalCombination.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/combinations/model/GOGeneralCombination.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/config/GOConfig.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/config/GOMidiDeviceConfig.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/config/GOMidiDeviceConfigList.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/config/GOPortFactory.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/config/GOPortsConfig.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/control/GOButtonControl.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/control/GOCallbackButtonControl.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -9867,560 +9760,9 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/combinations/GODivisionalSetter.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/combinations/GOSetter.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/combinations/control/GODivisionalButtonControl.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/combinations/control/GOGeneralButtonControl.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/combinations/model/GOCombination.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/combinations/model/GOCombinationDefinition.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/combinations/model/GODivisionalCombination.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/combinations/model/GOGeneralCombination.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/config/GOConfig.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/core/archive</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/config/GOMidiDeviceConfig.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/config/GOMidiDeviceConfigList.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/config/GOPortFactory.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/config/GOPortsConfig.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/control/GOButtonControl.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/control/GOCallbackButtonControl.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOElementCreator.cpp"
@@ -10429,6 +9771,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
@@ -10450,6 +9793,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOEventDistributor.cpp"
@@ -10458,6 +9843,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -10478,86 +9864,100 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOLabelControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPistonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPushbuttonControl.cpp"
@@ -10566,6 +9966,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -10587,6 +9988,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOMidiListDialog.cpp"
@@ -10618,53 +10061,73 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOOrganDialog.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/dialogs</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10693,6 +10156,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSelectOrganDialog.cpp"
@@ -10723,6 +10228,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSplash.cpp"
@@ -10753,6 +10300,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/common/GODialogCloser.cpp"
@@ -10841,6 +10430,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -10865,6 +10455,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventKeyTab.cpp"
@@ -10873,6 +10505,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/include/c++/12</pElem>
@@ -10888,56 +10521,78 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/unix</pElem>
             <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10945,70 +10600,44 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsAudio.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11017,37 +10646,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11058,6 +10668,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -11080,38 +10691,70 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiDevices.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11122,6 +10765,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -11143,39 +10787,70 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiMessage.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11184,31 +10859,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>../../src/core/settings</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11217,81 +10879,38 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/core/midi</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/archive</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPaths.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/midi</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11302,6 +10921,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -11322,37 +10942,70 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsReverb.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11361,30 +11014,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11443,35 +11084,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11482,6 +11106,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
@@ -11506,42 +11131,70 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11550,35 +11203,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11587,35 +11223,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11626,6 +11245,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/grandorgue</pElem>
@@ -11645,8 +11265,50 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11654,40 +11316,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11698,6 +11338,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -11723,46 +11364,70 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIFloatingPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11773,6 +11438,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -11794,8 +11460,50 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11805,6 +11513,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -11826,8 +11535,50 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11837,6 +11588,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue</pElem>
@@ -11859,8 +11611,50 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11868,39 +11662,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11911,6 +11684,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
@@ -11932,8 +11706,50 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11943,6 +11759,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -11970,6 +11787,52 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIManualBackground.cpp"
@@ -11978,6 +11841,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue</pElem>
@@ -12004,41 +11868,70 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIMasterPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12047,35 +11940,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12084,44 +11960,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/config</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12132,6 +11982,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -12154,8 +12005,50 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -12163,35 +12056,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12200,35 +12076,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12237,36 +12096,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12326,32 +12167,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/archive</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoadThread.cpp"
@@ -12360,6 +12195,8 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12</pElem>
@@ -12379,6 +12216,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoadWorker.cpp"
@@ -12387,6 +12266,8 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
@@ -12406,6 +12287,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoaderFilename.cpp"
@@ -12414,6 +12337,8 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/12</pElem>
@@ -12440,39 +12365,74 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidi.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/core/midi</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiInputMerger.cpp"
@@ -12500,6 +12460,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiListener.cpp"
@@ -12531,6 +12533,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiOutputMerger.cpp"
@@ -12558,50 +12602,73 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiPlayer.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -12630,92 +12697,99 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiReceiver.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiRecorder.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -12723,42 +12797,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -13003,770 +13060,9 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOCoupler.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GODivisionalCoupler.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GODrawStop.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GODummyPipe.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOEnclosure.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOEventHandlerList.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOManual.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOOrganModel.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOPipe.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GORank.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOReferencePipe.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOSoundingPipe.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/core/contrib</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOStop.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOSwitch.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOTremulant.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOWindchest.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfig.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/sound/GOSound.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
@@ -13809,6 +13105,619 @@
             <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOCoupler.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GODivisionalCoupler.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GODrawStop.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GODummyPipe.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOEnclosure.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOEventHandlerList.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOManual.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOOrganModel.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOPipe.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GORank.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOReferencePipe.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOSoundingPipe.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOStop.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOSwitch.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOTremulant.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOWindchest.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfig.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/sound/GOSound.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -13891,85 +13800,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/core/threading</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -14420,81 +14270,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -15029,54 +14824,14 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+        <ccTool flags="6">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/yaml/go-wx-yaml.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+        <ccTool flags="6">
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA00.cpp" ex="false" tool="1" flavor2="8">
@@ -15999,41 +15754,13 @@
         </ccTool>
       </item>
       <item path="../../src/tools/GOPerfTest.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/tools</pElem>
           </incDir>
         </ccTool>
@@ -16041,6 +15768,7 @@
       <item path="../../src/tools/GOTool.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/tools</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -16064,8 +15792,49 @@
             <pElem>../../build/current/src/tools</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -16074,15 +15843,7 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
-          <incDir>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16125,15 +15886,7 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
-          <incDir>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16176,15 +15929,7 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
-          <incDir>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16229,13 +15974,8 @@
         <cTool flags="1">
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16278,14 +16018,7 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/portaudio</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16329,15 +16062,9 @@
             flavor2="3">
         <cTool flags="1">
           <incDir>
-            <pElem>../../submodules/PortAudio/include</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16382,14 +16109,8 @@
         <cTool flags="1">
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16434,13 +16155,8 @@
         <cTool flags="1">
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16483,15 +16199,7 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
-          <incDir>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>HAVE_SYS_SOUNDCARD_H=1</Elem>
-            <Elem>PA_USE_ALSA=1</Elem>
-            <Elem>PA_USE_JACK=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16536,8 +16244,6 @@
         <cTool flags="1">
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
           </incDir>
         </cTool>
       </item>
@@ -16560,11 +16266,6 @@
             tool="0"
             flavor2="3">
         <cTool flags="1">
-          <incDir>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/PortAudio/src/common</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
-          </incDir>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/os/unix/pa_unix_util.c"
@@ -16574,9 +16275,6 @@
         <cTool flags="1">
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/PortAudio/src/common</pElem>
-            <pElem>../../build/current/src/portaudio</pElem>
           </incDir>
         </cTool>
       </item>
@@ -16607,7 +16305,7 @@
             ex="false"
             tool="1"
             flavor2="11">
-        <ccTool flags="6">
+        <ccTool flags="7">
         </ccTool>
       </item>
       <folder path="0/build">
@@ -17148,176 +16846,50 @@
       <folder path="0/src/grandorgue/combinations">
         <ccTool>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/combinations/control">
         <ccTool>
           <incDir>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-          </incDir>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/combinations/model">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/config">
         <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/config</pElem>
-          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
             <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/control">
         <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/control</pElem>
-          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
             <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -17328,6 +16900,16 @@
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs/common">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+          </incDir>
+          <preprocessorList>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -17366,31 +16948,19 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
-      <folder path="0/src/grandorgue/dialogs/common">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-          </incDir>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/dialogs/midi-event">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
-          </incDir>
-        </ccTool>
-      </folder>
       <folder path="0/src/grandorgue/dialogs/settings">
         <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
-          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/document-base">
@@ -17451,55 +17021,12 @@
       </folder>
       <folder path="0/src/grandorgue/gui">
         <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -17561,56 +17088,12 @@
       </folder>
       <folder path="0/src/grandorgue/loader">
         <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
             <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -17621,6 +17104,66 @@
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/midi/dialog-creator">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/midi/ports">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+          </incDir>
+          <preprocessorList>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -17659,87 +17202,30 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/midi/dialog-creator">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/midi/ports">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-          </incDir>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/model">
         <ccTool>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/model/pipe-config">
         <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
+          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/sound/ports">
@@ -17853,54 +17339,24 @@
       <folder path="0/src/grandorgue/yaml">
         <ccTool>
           <incDir>
-            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -18091,54 +17547,11 @@
       </folder>
       <folder path="0/src/tools">
         <ccTool>
-          <incDir>
-            <pElem>../../src/tools</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </folder>

--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -5872,12 +5872,12 @@
           <incDir>
             <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/core/contrib</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -7062,9 +7062,9 @@
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/core/contrib</pElem>
             <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
@@ -7236,8 +7236,8 @@
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.0/wx/unix</pElem>
@@ -8299,7 +8299,7 @@
             <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
             <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
             <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
             <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
             <Elem>__GNUC__=12</Elem>
             <Elem>__GNUG__=12</Elem>
@@ -8310,7 +8310,7 @@
             <Elem>__STDCPP_THREADS__=1</Elem>
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
             <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
@@ -8699,7 +8699,7 @@
             <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
             <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
             <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
             <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
             <Elem>__GNUC__=12</Elem>
             <Elem>__GNUG__=12</Elem>
@@ -8710,7 +8710,7 @@
             <Elem>__STDCPP_THREADS__=1</Elem>
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
             <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
@@ -9129,6 +9129,7 @@
             <pElem>../../src/core/archive</pElem>
             <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/core/config</pElem>
             <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/core/files</pElem>
             <pElem>../../src/grandorgue/sound/scheduler</pElem>
@@ -9611,26 +9612,103 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/core/contrib</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9804,21 +9882,22 @@
         <ccTool flags="0">
           <incDir>
             <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
             <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>../../src/grandorgue/combinations/control</pElem>
             <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
@@ -9861,8 +9940,8 @@
             <pElem>/usr/include/yaml-cpp/node/detail</pElem>
             <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/core/settings</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -9898,7 +9977,6 @@
           <incDir>
             <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -9907,6 +9985,7 @@
             <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node/detail</pElem>
             <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>../../src/grandorgue/combinations</pElem>
@@ -9936,7 +10015,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
@@ -9947,6 +10025,7 @@
             <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node/detail</pElem>
             <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>../../src/grandorgue/combinations</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
@@ -9980,33 +10059,35 @@
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>../../src/grandorgue/yaml</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/core/config</pElem>
             <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/gui</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
             <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
@@ -10065,12 +10146,13 @@
             <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node</pElem>
             <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>../../src/grandorgue/combinations</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
@@ -10081,7 +10163,6 @@
             <pElem>../../src/grandorgue/combinations/control</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/gui</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
@@ -10110,13 +10191,13 @@
             <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node</pElem>
             <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
@@ -10455,13 +10536,13 @@
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/threading</pElem>
@@ -10542,6 +10623,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOOrganDialog.cpp"
@@ -10587,8 +10710,46 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10617,6 +10778,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSelectOrganDialog.cpp"
@@ -10647,6 +10850,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSplash.cpp"
@@ -10677,6 +10922,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/common/GODialogCloser.cpp"
@@ -10905,6 +11192,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -10935,6 +11223,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsDialog.cpp"
@@ -10943,6 +11273,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -10974,6 +11305,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiDeviceList.cpp"
@@ -10982,6 +11355,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -11004,6 +11378,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiDevices.cpp"
@@ -11012,6 +11428,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -11038,6 +11455,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiMatchDialog.cpp"
@@ -11046,6 +11505,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -11067,6 +11527,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiMessage.cpp"
@@ -11075,6 +11577,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -11102,6 +11605,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsOptions.cpp"
@@ -11110,6 +11655,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -11135,6 +11681,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp"
@@ -11143,6 +11731,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -11183,8 +11772,46 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11192,32 +11819,26 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="6">
           <incDir>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/midi</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPorts.cpp"
@@ -11226,6 +11847,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -11246,6 +11868,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsReverb.cpp"
@@ -11254,6 +11918,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -11279,6 +11944,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsTemperaments.cpp"
@@ -11287,6 +11994,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -11311,6 +12019,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/document-base/GODocumentBase.cpp"
@@ -11409,6 +12159,7 @@
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -11417,7 +12168,6 @@
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/unix</pElem>
             <pElem>/usr/include/c++/12/backward</pElem>
@@ -12017,6 +12767,7 @@
             <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
@@ -12024,7 +12775,6 @@
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
@@ -13154,6 +13904,7 @@
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
@@ -13163,9 +13914,10 @@
             <pElem>/usr/include/yaml-cpp</pElem>
             <pElem>/usr/include/yaml-cpp/node/detail</pElem>
             <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.0/wx/unix</pElem>
@@ -13177,9 +13929,7 @@
             <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue/document-base</pElem>
             <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
             <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
@@ -13199,6 +13949,7 @@
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
@@ -13206,7 +13957,6 @@
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/combinations/control</pElem>
@@ -13323,13 +14073,13 @@
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/threading</pElem>
@@ -13362,10 +14112,11 @@
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
@@ -13373,10 +14124,8 @@
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/core</pElem>
             <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
             <pElem>../../src/core/contrib</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>../../src/core/settings</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -13384,17 +14133,20 @@
             <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>/usr/include/wx-3.0/wx/meta</pElem>
-            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOStop.cpp"
@@ -13488,10 +14240,10 @@
             <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/threading</pElem>
@@ -13526,12 +14278,12 @@
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/12/debug</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/threading</pElem>
@@ -13822,6 +14574,7 @@
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/core/threading</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
@@ -13829,7 +14582,6 @@
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/grandorgue/sound/scheduler</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
             <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -14955,7 +15707,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/yaml</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>/usr/include/yaml-cpp</pElem>
@@ -14975,74 +15726,33 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/yaml/go-wx-yaml.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA00.cpp" ex="false" tool="1" flavor2="8">
@@ -16442,6 +17152,12 @@
           <incDir>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>HAVE_SYS_SOUNDCARD_H</Elem>
+            <Elem>PA_USE_ALSA</Elem>
+            <Elem>PA_USE_JACK</Elem>
+            <Elem>_REENTRANT</Elem>
+          </preprocessorList>
         </cTool>
       </item>
       <item path="../../submodules/PortAudio/src/hostapi/alsa/pa_linux_alsa.c"
@@ -17098,6 +17814,7 @@
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
           </incDir>
         </ccTool>
       </folder>
@@ -17223,6 +17940,16 @@
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs/common">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+          </incDir>
+          <preprocessorList>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -17261,17 +17988,9 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/dialogs/common">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-          </incDir>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/dialogs/midi-event">
@@ -17279,13 +17998,48 @@
           <incDir>
             <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
           </incDir>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/dialogs/settings">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
-          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/document-base">
@@ -17747,12 +18501,55 @@
       </folder>
       <folder path="0/src/grandorgue/yaml">
         <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/yaml</pElem>
+          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
             <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>

--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -8159,26 +8159,87 @@
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOApp.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/help</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8260,26 +8321,88 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8358,26 +8481,86 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8458,26 +8641,79 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8630,26 +8866,96 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>../../src/grandorgue/help</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8795,26 +9101,103 @@
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOFrame.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/help</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8822,26 +9205,85 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -8994,26 +9436,85 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9021,26 +9522,88 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9152,26 +9715,85 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9179,18 +9801,42 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -9199,18 +9845,47 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -9219,32 +9894,120 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/control/GOGeneralButtonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOCombination.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -9255,7 +10018,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -9284,50 +10046,8 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -9335,18 +10055,43 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -9355,18 +10100,43 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -9375,26 +10145,37 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOMidiDeviceConfig.cpp"
@@ -9403,7 +10184,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/config</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -9420,48 +10200,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOMidiDeviceConfigList.cpp"
@@ -9470,7 +10208,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/config</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core</pElem>
@@ -9489,48 +10226,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOPortFactory.cpp"
@@ -9539,7 +10234,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/config</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -9556,48 +10250,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOPortsConfig.cpp"
@@ -9606,7 +10258,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/config</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -9623,74 +10274,48 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOButtonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOCallbackButtonControl.cpp"
@@ -9699,7 +10324,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
@@ -9721,48 +10345,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOElementCreator.cpp"
@@ -9771,7 +10353,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
@@ -9793,48 +10374,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOEventDistributor.cpp"
@@ -9843,7 +10382,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -9864,100 +10402,86 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOLabelControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPistonControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPushbuttonControl.cpp"
@@ -9966,7 +10490,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -9988,48 +10511,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOMidiListDialog.cpp"
@@ -10061,73 +10542,53 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOOrganDialog.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/dialogs</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10156,48 +10617,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSelectOrganDialog.cpp"
@@ -10228,48 +10647,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSplash.cpp"
@@ -10300,48 +10677,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/common/GODialogCloser.cpp"
@@ -10430,7 +10765,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -10455,48 +10789,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventKeyTab.cpp"
@@ -10505,7 +10797,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/include/c++/12</pElem>
@@ -10526,73 +10817,51 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -10600,44 +10869,70 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsAudio.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -10646,18 +10941,37 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -10668,7 +10982,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -10691,70 +11004,38 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiDevices.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -10765,7 +11046,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -10787,70 +11067,39 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiMessage.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -10859,18 +11108,31 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/core/settings</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -10879,38 +11141,81 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPaths.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -10921,7 +11226,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/generic</pElem>
@@ -10942,70 +11246,37 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsReverb.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11014,18 +11285,30 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/settings</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11084,18 +11367,35 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11106,7 +11406,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
@@ -11131,70 +11430,42 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIControl.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11203,18 +11474,35 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11223,18 +11511,35 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11245,7 +11550,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/grandorgue</pElem>
@@ -11265,50 +11569,8 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11316,18 +11578,40 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11338,7 +11622,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -11364,70 +11647,46 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIFloatingPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11438,7 +11697,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -11460,50 +11718,8 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11513,7 +11729,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -11535,50 +11750,8 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11588,7 +11761,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue</pElem>
@@ -11611,50 +11783,8 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11662,18 +11792,39 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11684,7 +11835,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
@@ -11706,50 +11856,8 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -11759,7 +11867,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -11787,52 +11894,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIManualBackground.cpp"
@@ -11841,7 +11902,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue</pElem>
@@ -11868,70 +11928,41 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIMasterPanel.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11940,18 +11971,35 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11960,18 +12008,44 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -11982,7 +12056,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
@@ -12005,50 +12078,8 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -12056,18 +12087,35 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12076,18 +12124,35 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12096,18 +12161,36 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -12167,26 +12250,32 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/archive</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoadThread.cpp"
@@ -12195,8 +12284,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>/usr/include/c++/12</pElem>
@@ -12216,48 +12303,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoadWorker.cpp"
@@ -12266,8 +12311,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
@@ -12287,48 +12330,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/GOLoaderFilename.cpp"
@@ -12337,8 +12338,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/12</pElem>
@@ -12365,74 +12364,39 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidi.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiInputMerger.cpp"
@@ -12460,48 +12424,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiListener.cpp"
@@ -12533,48 +12455,6 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiOutputMerger.cpp"
@@ -12602,73 +12482,50 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiPlayer.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -12697,99 +12554,92 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiReceiver.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiRecorder.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -12797,25 +12647,42 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -13060,70 +12927,46 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOCoupler.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -13132,18 +12975,37 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -13152,18 +13014,37 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -13193,70 +13074,47 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOEnclosure.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -13280,9 +13138,559 @@
             <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOManual.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOOrganModel.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOPipe.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GORank.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/document-base</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOReferencePipe.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOSoundingPipe.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/core/contrib</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOStop.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOSwitch.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOTremulant.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/GOWindchest.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfig.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>../../src/core/config</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/sound/GOSound.cpp"
+            ex="false"
+            tool="1"
+            flavor2="8">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
@@ -13325,399 +13733,6 @@
             <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOManual.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOOrganModel.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOPipe.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GORank.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOReferencePipe.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOSoundingPipe.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOStop.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOSwitch.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOTremulant.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/GOWindchest.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfig.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/c++/12</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/12/bits</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/12/debug</pElem>
-            <pElem>/usr/include/c++/12/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
-            <pElem>/usr/include/wx-3.0/wx</pElem>
-            <pElem>/usr/include/c++/12/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
-            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
-            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
-        </ccTool>
-      </item>
-      <item path="../../src/grandorgue/sound/GOSound.cpp"
-            ex="false"
-            tool="1"
-            flavor2="8">
-        <ccTool flags="6">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -13800,26 +13815,85 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>../../src/core/threading</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -14270,26 +14344,81 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/files</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -14824,7 +14953,70 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
+          <incDir>
+            <pElem>../../src/grandorgue/yaml</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/yaml-cpp</pElem>
+            <pElem>/usr/include/yaml-cpp/node</pElem>
+            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/yaml/go-wx-yaml.cpp"
@@ -14832,6 +15024,25 @@
             tool="1"
             flavor2="8">
         <ccTool flags="6">
+          <incDir>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/images/EnclosureA00.cpp" ex="false" tool="1" flavor2="8">
@@ -15754,13 +15965,41 @@
         </ccTool>
       </item>
       <item path="../../src/tools/GOPerfTest.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="6">
+        <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/gtk</pElem>
+            <pElem>../../src/grandorgue/loader</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
+            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/include/c++/12/ext</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux/bits</pElem>
+            <pElem>/usr/include/c++/12/debug</pElem>
+            <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
+            <pElem>../../src/core/midi</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../src/core/threading</pElem>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
+            <pElem>/usr/include/c++/12/backward</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0/wx</pElem>
+            <pElem>/usr/include/wx-3.0/wx/unix</pElem>
+            <pElem>/usr/include/wx-3.0/wx/meta</pElem>
+            <pElem>/usr/include/wx-3.0/wx/generic</pElem>
+            <pElem>../../src/core/settings</pElem>
+            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
+            <pElem>../../src/grandorgue/control</pElem>
+            <pElem>../../src/grandorgue/midi</pElem>
+            <pElem>../../src/grandorgue/gui</pElem>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
+            <pElem>/usr/include/c++/12/x86_64-redhat-linux</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>../../build/current/src/tools</pElem>
           </incDir>
         </ccTool>
@@ -15768,7 +16007,6 @@
       <item path="../../src/tools/GOTool.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/tools</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
             <pElem>/usr/include/c++/12</pElem>
             <pElem>/usr/include/c++/12/bits</pElem>
@@ -15792,49 +16030,8 @@
             <pElem>../../build/current/src/tools</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=2</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -16846,70 +17043,81 @@
       <folder path="0/src/grandorgue/combinations">
         <ccTool>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/combinations/control">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+            <pElem>/usr/include/c++/12/bits</pElem>
+            <pElem>/usr/include/c++/12</pElem>
+          </incDir>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/combinations/model">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/combinations/model</pElem>
           </incDir>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/config">
         <ccTool>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__WXGTK__=1</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/control">
-        <ccTool>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__WXGTK__=1</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/dialogs">
-        <ccTool>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__WXGTK__=1</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/dialogs/common">
-        <ccTool>
           <incDir>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
+            <pElem>../../src/grandorgue/config</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -16948,19 +17156,136 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
-      <folder path="0/src/grandorgue/dialogs/settings">
+      <folder path="0/src/grandorgue/control">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/control</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs">
         <ccTool>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs/common">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+          </incDir>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs/midi-event">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
+          </incDir>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs/settings">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
+          </incDir>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/document-base">
@@ -17021,12 +17346,55 @@
       </folder>
       <folder path="0/src/grandorgue/gui">
         <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/gui</pElem>
+          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -17088,82 +17456,15 @@
       </folder>
       <folder path="0/src/grandorgue/loader">
         <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>/usr/include/wx-3.0/wx</pElem>
+          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
-            <Elem>__WXGTK__=1</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/midi">
-        <ccTool>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__WXGTK__=1</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/midi/dialog-creator">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>__DBL_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
-            <Elem>__FLT_IS_IEC_60559__=2</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=4</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=12</Elem>
-            <Elem>__GNUG__=12</Elem>
-            <Elem>__GXX_ABI_VERSION=1017</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/midi/ports">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-          </incDir>
-          <preprocessorList>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -17202,30 +17503,138 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
+      <folder path="0/src/grandorgue/midi">
+        <ccTool>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=2</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20220819 (Red Hat 12.2.1-2)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/midi/dialog-creator">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/midi/ports">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/midi/ports</pElem>
+          </incDir>
+        </ccTool>
+      </folder>
       <folder path="0/src/grandorgue/model">
         <ccTool>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/model/pipe-config">
         <ccTool>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__WXGTK__=1</Elem>
-          </preprocessorList>
+          <incDir>
+            <pElem>../../src/grandorgue/model/pipe-config</pElem>
+          </incDir>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/sound/ports">
@@ -17338,25 +17747,12 @@
       </folder>
       <folder path="0/src/grandorgue/yaml">
         <ccTool>
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
-            <pElem>/usr/include/wx-3.0</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -17547,11 +17943,54 @@
       </folder>
       <folder path="0/src/tools">
         <ccTool>
+          <incDir>
+            <pElem>../../src/tools</pElem>
+          </incDir>
           <preprocessorList>
-            <Elem>WXUSINGDLL</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__DBL_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=2</Elem>
+            <Elem>__FLT_IS_IEC_60559__=2</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=12</Elem>
+            <Elem>__GNUG__=12</Elem>
+            <Elem>__GXX_ABI_VERSION=1017</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="12.2.1 20221121 (Red Hat 12.2.1-4)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>

--- a/ide-projects/NetBeans12/nbproject/project.xml
+++ b/ide-projects/NetBeans12/nbproject/project.xml
@@ -6,7 +6,7 @@
             <name>GrandOrgue</name>
             <c-extensions>c</c-extensions>
             <cpp-extensions>cc,cpp,cxx</cpp-extensions>
-            <header-extensions>h,hxx</header-extensions>
+            <header-extensions>h,hxx,linux</header-extensions>
             <sourceEncoding>UTF-8</sourceEncoding>
             <make-dep-projects/>
             <sourceRootList>

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -889,9 +889,9 @@ void GOFrame::OnImportCombinations(wxCommandEvent &event) {
     wxFileDialog dlg(
       this,
       _("Import Combinations"),
-      m_config.ExportImportPath(),
+      pOrganController->GetCombinationsDir(),
       wxEmptyString,
-      _("Settings files (*.cmb)|*.cmb"),
+      _("Combinations files (*.yaml)|*.yaml|Settings files (*.cmb)|*.cmb"),
       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
 
     if (dlg.ShowModal() == wxID_OK)
@@ -903,10 +903,7 @@ void GOFrame::OnExportCombinations(wxCommandEvent &event) {
   GOOrganController *pOrganController = GetOrganController();
 
   if (pOrganController) {
-    const wxString organCmbDir
-      = wxFileName(
-          m_config.OrganCombinationsPath(), pOrganController->GetChurchName())
-          .GetFullPath();
+    const wxString organCmbDir = pOrganController->GetCombinationsDir();
 
     wxFileName::Mkdir(organCmbDir, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -922,6 +922,11 @@ const wxString GOOrganController::GetSettingFilename() {
 
 const wxString GOOrganController::GetCacheFilename() { return m_CacheFilename; }
 
+wxString GOOrganController::GetCombinationsDir() const {
+  return wxFileName(m_config.OrganCombinationsPath(), m_ChurchName)
+    .GetFullPath();
+}
+
 GOMemoryPool &GOOrganController::GetMemoryPool() { return m_pool; }
 
 GOConfig &GOOrganController::GetSettings() { return m_config; }

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -630,6 +630,8 @@ wxString GOOrganController::Load(
   return errMsg;
 }
 
+// const wxString &WX_CMB = wxT(".cmb");
+const wxString &WX_YAML = wxT("yaml");
 const char *const INFO = "info";
 const char *const CONTENT_TYPE = "content-type";
 const wxString WX_GRANDORGUE_COMBINATIONS = "GrandOrgue Combinations";
@@ -665,46 +667,95 @@ wxString GOOrganController::ExportCombination(const wxString &fileName) {
   return errMsg;
 }
 
+/**
+ * Check the churchName of the imported combination file. If it differs from the
+ * current organ m_ChurchName then ask for the user
+ * @param churchName the organ the combination file was saved of
+ * @return true if the churchNames are the same or the user agree with importing
+ *   the combination file
+ */
+bool GOOrganController::IsToImportCombinationsFor(
+  const wxString &fileName, const wxString &churchName) const {
+  bool isToImport = true;
+
+  if (churchName != m_ChurchName) {
+    wxLogWarning(
+      _("This combination file '%s' was originally made for another organ "
+        "'%s'"),
+      fileName,
+      churchName);
+    isToImport = wxMessageBox(
+                   wxString::Format(
+                     _("This combination file '%s' was originally made for "
+                       "another organ '%s'. Importing it can cause various "
+                       "problems. Should it really be imported?"),
+                     fileName,
+                     churchName),
+                   _("Import Combinations"),
+                   wxYES_NO,
+                   NULL)
+      == wxYES;
+  }
+  return isToImport;
+}
+
 void GOOrganController::LoadCombination(const wxString &file) {
+  wxString errMsg;
+
   try {
-    GOConfigFileReader odf_ini_file;
+    const wxString fileExt = wxFileName(file).GetExt();
 
-    if (!odf_ini_file.Read(file))
-      throw wxString::Format(_("Unable to read '%s'"), file.c_str());
+    if (fileExt == WX_YAML) {
+      YAML::Node cmbNode = YAML::LoadFile(file.c_str().AsChar());
+      YAML::Node cmbInfoNode = cmbNode[INFO];
+      const wxString contentType = cmbInfoNode[CONTENT_TYPE].as<wxString>();
 
-    GOConfigReaderDB ini;
-    ini.ReadData(odf_ini_file, CMBSetting, false);
-    GOConfigReader cfg(ini);
+      if (contentType != WX_GRANDORGUE_COMBINATIONS)
+        throw wxString::Format(
+          _("The file '%s' is not a GrandOrgue Combination file"), file);
+      if (IsToImportCombinationsFor(
+            file, cmbInfoNode[ORGAN_NAME].as<wxString>())) {
+        cmbNode >> *m_setter;
+        cmbNode >> *m_DivisionalSetter;
+      }
+    } else {
+      GOConfigFileReader odf_ini_file;
 
-    wxString church_name
-      = cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ChurchName"));
-    if (church_name != m_ChurchName)
-      if (
-        wxMessageBox(
-          _("This combination file was originally made for "
-            "another organ. Importing it can cause various "
-            "problems. Should it really be imported?"),
-          _("Import"),
-          wxYES_NO,
-          NULL)
-        == wxNO)
+      if (!odf_ini_file.Read(file))
+        throw wxString::Format(_("Unable to read '%s'"), file.c_str());
+
+      GOConfigReaderDB ini;
+      ini.ReadData(odf_ini_file, CMBSetting, false);
+      GOConfigReader cfg(ini);
+
+      wxString church_name
+        = cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ChurchName"));
+      if (!IsToImportCombinationsFor(file, church_name))
         return;
 
-    wxString hash = odf_ini_file.getEntry(WX_ORGAN, wxT("ODFHash"));
-    if (hash != wxEmptyString)
-      if (hash != m_ODFHash) {
-        wxLogWarning(
-          _("The combination file does not exactly match the current ODF."));
-      }
-    /* skip informational items */
-    cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ChurchAddress"), false);
-    cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ODFPath"), false);
+      wxString hash = odf_ini_file.getEntry(WX_ORGAN, wxT("ODFHash"));
+      if (hash != wxEmptyString)
+        if (hash != m_ODFHash) {
+          wxLogWarning(
+            _("The combination file does not exactly match the current ODF."));
+        }
+      /* skip informational items */
+      cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ChurchAddress"), false);
+      cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ODFPath"), false);
 
-    ReadCombinations(cfg);
+      ReadCombinations(cfg);
+    }
     SetOrganModified();
-  } catch (wxString error) {
-    wxLogError(wxT("%s\n"), error.c_str());
-    GOMessageBox(error, _("Load error"), wxOK | wxICON_ERROR, NULL);
+  } catch (const wxString &error) {
+    errMsg = error;
+  } catch (const std::exception &e) {
+    errMsg = e.what();
+  } catch (...) { // We must not allow unhandled exceptions here
+    errMsg.Printf("Unknown exception");
+  }
+  if (!errMsg.IsEmpty()) {
+    wxLogError(errMsg);
+    GOMessageBox(errMsg, _("Load error"), wxOK | wxICON_ERROR, NULL);
   }
 }
 

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -234,6 +234,7 @@ public:
   GOOrgan GetOrganInfo();
   const wxString GetSettingFilename();
   const wxString GetCacheFilename();
+  wxString GetCombinationsDir() const;
 
   /* Organ and Building general information */
   const wxString &GetChurchName();

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -127,6 +127,8 @@ private:
   void PreconfigRecorder();
 
   wxString GetOrganHash();
+  bool IsToImportCombinationsFor(
+    const wxString &fileName, const wxString &churchName) const;
 
 public:
   GOOrganController(
@@ -158,7 +160,6 @@ public:
     GOProgressDialog *dlg,
     const GOOrgan &organ,
     const wxString &cmb = wxEmptyString);
-
   /**
    * Exports organ combinations in the yaml file
    * @param fileName - the path to the taml file to export

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -304,8 +304,12 @@ void GOCombination::ToYaml(YAML::Node &yamlMap) const {
 void GOCombination::FromYaml(const YAML::Node &yamlNode) {
   if (!m_Protected) {
     Clear();
-    if (yamlNode.IsDefined() && yamlNode.IsMap())
+    if (yamlNode.IsDefined() && yamlNode.IsMap()) {
       FromYamlMap(yamlNode);
+      // clear all non mentioned elements. Otherwise they won't be disabled when
+      // this combination is switched on
+      std::replace(m_State.begin(), m_State.end(), -1, 0);
+    }
   }
 }
 

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -155,6 +155,28 @@ void GOCombination::LoadCombination(GOConfigReader &cfg) {
     Clear();
 }
 
+const wxString WX_P03D = wxT("%03d");
+
+void GOCombination::ToYaml(YAML::Node &yamlMap) const {
+  for (unsigned i = 0; i < r_ElementDefinitions.size(); i++)
+    if (GetState(i) > 0) {
+      const auto &e = r_ElementDefinitions[i];
+      unsigned value = e.index;
+
+      assert(value > 0);
+      PutElementToYamlMap(
+        e, wxString::Format(WX_P03D, value), value - 1, yamlMap);
+    }
+}
+
+void GOCombination::FromYaml(const YAML::Node &yamlNode) {
+  if (!m_Protected) {
+    Clear();
+    if (yamlNode.IsDefined() && yamlNode.IsMap())
+      FromYamlMap(yamlNode);
+  }
+}
+
 bool GOCombination::FillWithCurrent(
   SetterType setterType, bool isToStoreInvisibleObjects) {
   bool used = false;

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -9,7 +9,11 @@
 
 #include <algorithm>
 
+#include <wx/intl.h>
+#include <wx/log.h>
+
 #include "combinations/GOSetter.h"
+#include "config/GOConfigWriter.h"
 #include "model/GODrawStop.h"
 #include "yaml/go-wx-yaml.h"
 
@@ -18,11 +22,11 @@
 #include "GOOrganController.h"
 
 GOCombination::GOCombination(
-  GOCombinationDefinition &combination_template,
+  const GOCombinationDefinition &combination_template,
   GOOrganController *organController)
-  : m_OrganFile(organController),
-    m_Template(combination_template),
-    m_State(0),
+  : m_Template(combination_template),
+    m_OrganFile(organController),
+    r_ElementDefinitions(combination_template.GetElements()),
     m_Protected(false) {}
 
 GOCombination::~GOCombination() {}
@@ -34,7 +38,7 @@ void GOCombination::Clear() {
 }
 
 void GOCombination::Copy(GOCombination *combination) {
-  assert(GetTemplate() == combination->GetTemplate());
+  assert(&m_Template == &combination->m_Template);
   m_State = combination->m_State;
   UpdateState();
   m_OrganFile->SetOrganModified();
@@ -46,61 +50,123 @@ bool GOCombination::IsEmpty() const {
     == m_State.end();
 }
 
-int GOCombination::GetState(unsigned no) { return m_State[no]; }
+void GOCombination::SetLoadedState(
+  int manualNumber,
+  GOCombinationDefinition::ElementType elementType,
+  int elementNumber,
+  const wxString &elementName) {
+  int pos
+    = m_Template.FindElement(elementType, manualNumber, abs(elementNumber));
 
-void GOCombination::SetState(unsigned no, int value) { m_State[no] = value; }
+  if (pos >= 0) {
+    int &state = m_State[pos];
+
+    if (state < 0) // has not yet been set
+      state = (elementNumber > 0) ? 1 : 0;
+    else // has already been set
+      wxLogError(
+        _("Duplicate combination entry %s in %s"), elementName, m_group);
+  } else
+    wxLogError(_("Invalid combination entry %s in %s"), elementName, m_group);
+}
 
 void GOCombination::GetExtraSetState(
   GOCombination::ExtraElementsSet &extraSet) {
-  const std::vector<GOCombinationDefinition::Element> &elements
-    = m_Template.GetElements();
-
   extraSet.clear();
-  for (unsigned i = 0; i < elements.size(); i++) {
-    if (m_State[i] == 0 && elements[i].control->GetCombinationState())
+  for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
+    if (
+      m_State[i] == 0 && r_ElementDefinitions[i].control->GetCombinationState())
       extraSet.insert(i);
   }
 }
 
 void GOCombination::GetEnabledElements(
   GOCombination::ExtraElementsSet &enabledElements) {
-  const std::vector<GOCombinationDefinition::Element> &elements
-    = m_Template.GetElements();
-
   enabledElements.clear();
-  for (unsigned i = 0; i < elements.size(); i++) {
+  for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
     if (m_State[i] > 0)
       enabledElements.insert(i);
   }
 }
 
 void GOCombination::UpdateState() {
-  const std::vector<GOCombinationDefinition::Element> &elements
-    = m_Template.GetElements();
-  if (m_State.size() > elements.size())
-    m_State.resize(elements.size());
-  else if (m_State.size() < elements.size()) {
+  unsigned defSize = r_ElementDefinitions.size();
+
+  if (m_State.size() > defSize)
+    m_State.resize(defSize);
+  else if (m_State.size() < defSize) {
     unsigned current = m_State.size();
-    m_State.resize(elements.size());
-    while (current < elements.size())
+    m_State.resize(defSize);
+    while (current < defSize)
       m_State[current++] = -1;
   }
 }
 
-GOCombinationDefinition *GOCombination::GetTemplate() { return &m_Template; }
+static const wxString WX_NUMBER_OF_STOPS = wxT("NumberOfStops");
+
+int read_number_of_stops(
+  GOSettingType settingType,
+  GOConfigReader &cfg,
+  const wxString &group,
+  unsigned maxStopN,
+  bool isRequired) {
+  return cfg.ReadInteger(
+    settingType,
+    group,
+    WX_NUMBER_OF_STOPS,
+    0,
+    maxStopN,
+    isRequired,
+    isRequired ? 0 : -1);
+}
+
+// checks if a combinatiom exists in the file with the group
+bool is_cmb_on_file(
+  GOConfigReader &cfg, GOSettingType settingType, const wxString &group) {
+  int nOfStops = read_number_of_stops(settingType, cfg, group, 999, false);
+
+  return nOfStops >= 0;
+}
+
+bool GOCombination::isCmbOnFile(GOConfigReader &cfg, const wxString &group) {
+  return is_cmb_on_file(cfg, ODFSetting, group)
+    || is_cmb_on_file(cfg, CMBSetting, group);
+}
+
+unsigned GOCombination::ReadNumberOfStops(
+  GOConfigReader &cfg, GOSettingType srcType, unsigned maxStops) const {
+  int nOfStopsInt = read_number_of_stops(srcType, cfg, m_group, maxStops, true);
+
+  assert(nOfStopsInt >= 0);
+  return (unsigned)nOfStopsInt;
+}
+
+void GOCombination::WriteNumberOfStops(
+  GOConfigWriter &cfg, unsigned stopCount) const {
+  cfg.WriteInteger(m_group, WX_NUMBER_OF_STOPS, stopCount);
+}
+
+void GOCombination::LoadCombination(GOConfigReader &cfg) {
+  if (is_cmb_on_file(cfg, CMBSetting, m_group))
+    LoadCombinationInt(cfg, CMBSetting);
+  else if (is_cmb_on_file(cfg, ODFSetting, m_group))
+    LoadCombinationInt(cfg, ODFSetting);
+  else
+    Clear();
+}
 
 bool GOCombination::FillWithCurrent(
   SetterType setterType, bool isToStoreInvisibleObjects) {
   bool used = false;
-  const std::vector<GOCombinationDefinition::Element> &elements
-    = m_Template.GetElements();
 
   UpdateState();
   if (setterType == SETTER_REGULAR) {
-    for (unsigned i = 0; i < elements.size(); i++) {
-      if (!isToStoreInvisibleObjects && !elements[i].store_unconditional)
+    for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
+      if (
+        !isToStoreInvisibleObjects
+        && !r_ElementDefinitions[i].store_unconditional)
         m_State[i] = -1;
-      else if (elements[i].control->GetCombinationState()) {
+      else if (r_ElementDefinitions[i].control->GetCombinationState()) {
         m_State[i] = 1;
         used |= 1;
       } else
@@ -108,10 +174,12 @@ bool GOCombination::FillWithCurrent(
     }
   }
   if (setterType == SETTER_SCOPE) {
-    for (unsigned i = 0; i < elements.size(); i++) {
-      if (!isToStoreInvisibleObjects && !elements[i].store_unconditional)
+    for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
+      if (
+        !isToStoreInvisibleObjects
+        && !r_ElementDefinitions[i].store_unconditional)
         m_State[i] = -1;
-      else if (elements[i].control->GetCombinationState()) {
+      else if (r_ElementDefinitions[i].control->GetCombinationState()) {
         m_State[i] = 1;
         used |= 1;
       } else
@@ -119,9 +187,9 @@ bool GOCombination::FillWithCurrent(
     }
   }
   if (setterType == SETTER_SCOPED) {
-    for (unsigned i = 0; i < elements.size(); i++) {
+    for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
       if (m_State[i] != -1) {
-        if (elements[i].control->GetCombinationState()) {
+        if (r_ElementDefinitions[i].control->GetCombinationState()) {
           m_State[i] = 1;
           used |= 1;
         } else
@@ -144,15 +212,12 @@ bool GOCombination::PushLocal(GOCombination::ExtraElementsSet const *extraSet) {
       m_OrganFile->SetOrganModified();
     }
   } else {
-    const std::vector<GOCombinationDefinition::Element> &elements
-      = m_Template.GetElements();
-
     UpdateState();
-    for (unsigned i = 0; i < elements.size(); i++) {
+    for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
       if (
         m_State[i] != -1
         && (!extraSet || extraSet->find(i) == extraSet->end())) {
-        elements[i].control->SetCombination(m_State[i] == 1);
+        r_ElementDefinitions[i].control->SetCombination(m_State[i] == 1);
         used |= m_State[i] == 1;
       }
     }

--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -68,6 +68,39 @@ protected:
   virtual void LoadCombinationInt(GOConfigReader &cfg, GOSettingType srcType)
     = 0;
 
+  /**
+   * Encode one combination element to yaml map. Called internally from ToYaml()
+   * only for elements with enabled state
+   */
+  virtual void PutElementToYamlMap(
+    const GOCombinationDefinition::Element &e,
+    const wxString &valueLabel,
+    const unsigned objectIndex,
+    YAML::Node &yamlMap) const = 0;
+
+  /**
+   * Set states of all elements of a specified type from the yaml node. The yaml
+   *   node must be a map (Number: Name). The elements may be matched by names
+   *   as well by numbers. The name has a higher priority than the number.
+   *   If only of them is matched then log a warning. If no
+   *   of them is matched then log an error.
+   * @param yamlNode the source yaml node with number-name pairs
+   * @param manualNumber in the odf. -1 means that the element does not relate
+   *   to any manual
+   * @param elementType The element type
+   */
+  void SetStatesFromYaml(
+    const YAML::Node &yamlNode,
+    int manualNumber,
+    GOCombinationDefinition::ElementType elementType);
+
+  /**
+   * Fill up the combination from yaml map. It is called internally from
+   * FromYaml after cleaning the combination only when yamlMap is not empty
+   * @param yamlMap
+   */
+  virtual void FromYamlMap(const YAML::Node &yamlMap) = 0;
+
   virtual bool PushLocal(ExtraElementsSet const *extraSet = nullptr);
 
 public:
@@ -92,6 +125,8 @@ public:
    */
   bool FillWithCurrent(SetterType setterType, bool isToStoreInvisibleObjects);
 
+  void ToYaml(YAML::Node &yamlMap) const override;
+
   /**
    * If the combination is not empty, put it into the YAML map a a key value
    * pair
@@ -107,6 +142,8 @@ public:
   }
   static void putToYamlMap(
     YAML::Node &container, const wxString &key, const GOCombination *pCmb);
+
+  void FromYaml(const YAML::Node &yamlNode) override;
 };
 
 #endif

--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -13,45 +13,84 @@
 
 #include "yaml/GOSaveableToYaml.h"
 
-class GOCombinationDefinition;
+#include "config/GOConfigReader.h"
+
+#include "GOCombinationDefinition.h"
+#include "GOSaveableObject.h"
+
 class GOOrganController;
 
-class GOCombination : public GOSaveableToYaml {
+class GOCombination : public GOSaveableObject, public GOSaveableToYaml {
 public:
   enum SetterType { SETTER_REGULAR, SETTER_SCOPE, SETTER_SCOPED };
   using ExtraElementsSet = std::unordered_set<unsigned>;
 
 private:
+  const GOCombinationDefinition &m_Template;
   GOOrganController *m_OrganFile;
+  std::vector<int> m_State;
 
 protected:
-  GOCombinationDefinition &m_Template;
-  std::vector<int> m_State;
+  const std::vector<GOCombinationDefinition::Element> &r_ElementDefinitions;
   bool m_Protected;
 
   void UpdateState();
+
+  // Read the NumberOfStops key from the given config source
+  unsigned ReadNumberOfStops(
+    GOConfigReader &cfg, GOSettingType srcType, unsigned maxStops) const;
+  void WriteNumberOfStops(GOConfigWriter &cfg, unsigned stopCount) const;
+
+  static bool isCmbOnFile(GOConfigReader &cfg, const wxString &group);
+
+  /**
+   * Set the combination element state when loading. If the element is not found
+   * or it's state has already been set the logs an error
+   * @param manualNumber in the odf. -1 means that the element does not relate
+   *   to a manual
+   * @param elementType The element type
+   * @param elementNumber May be positive or negative. abs(elementNumber) means
+   *   the element number  among elements of the same type
+   *   in the ODF (starting from 1). If elementNumber is positive then the
+   *   element is  enabled in the combination. If elementNumber is negative then
+   *   the element is disabled in the combination
+   * @param elementName The element name for logging an error
+   * @param containerName Where the element is specified. Used for logging an
+   * error
+   */
+  void SetLoadedState(
+    int manualNumber,
+    GOCombinationDefinition::ElementType elementType,
+    int elementNumber,
+    const wxString &elementName);
+
+  // Load the combination either from the odf or from the cmb
+  virtual void LoadCombinationInt(GOConfigReader &cfg, GOSettingType srcType)
+    = 0;
+
   virtual bool PushLocal(ExtraElementsSet const *extraSet = nullptr);
 
 public:
   GOCombination(
-    GOCombinationDefinition &combination_template,
+    const GOCombinationDefinition &combination_template,
     GOOrganController *organController);
   virtual ~GOCombination();
 
   bool IsEmpty() const;
-  int GetState(unsigned no);
-  void SetState(unsigned no, int value);
+  int GetState(unsigned no) const { return m_State[no]; }
   void GetExtraSetState(ExtraElementsSet &extraSet);
   void GetEnabledElements(GOCombination::ExtraElementsSet &enabledElements);
 
   void Copy(GOCombination *combination);
   void Clear();
 
+  // if present, read from CMB, else read from ODF, else clear
+  void LoadCombination(GOConfigReader &cfg) override;
+
   /**
    * Fills the combination from the current organ elements
    */
   bool FillWithCurrent(SetterType setterType, bool isToStoreInvisibleObjects);
-  GOCombinationDefinition *GetTemplate();
 
   /**
    * If the combination is not empty, put it into the YAML map a a key value

--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -100,7 +100,6 @@ protected:
    * @param yamlMap
    */
   virtual void FromYamlMap(const YAML::Node &yamlMap) = 0;
-
   virtual bool PushLocal(ExtraElementsSet const *extraSet = nullptr);
 
 public:

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -115,7 +115,7 @@ void GOCombinationDefinition::InitDivisional(unsigned manual_number) {
 }
 
 int GOCombinationDefinition::FindElement(
-  ElementType type, int manual, unsigned index) {
+  ElementType type, int manual, unsigned index) const {
   for (unsigned i = 0; i < m_elements.size(); i++) {
     if (
       m_elements[i].type == type && m_elements[i].manual == manual

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -7,6 +7,8 @@
 
 #include "GOCombinationDefinition.h"
 
+#include <wx/intl.h>
+
 #include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
 #include "model/GOManual.h"
@@ -14,6 +16,13 @@
 #include "model/GOStop.h"
 #include "model/GOSwitch.h"
 #include "model/GOTremulant.h"
+
+const wxString GOCombinationDefinition::ELEMENT_TYPE_NAMES[] = {
+  _("stop"),
+  _("coupler"),
+  _("tremulant"),
+  _("divisional coupler"),
+  _("switch")};
 
 GOCombinationDefinition::GOCombinationDefinition(GOOrganModel &organModel)
   : r_OrganModel(organModel), m_elements(0) {}

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.h
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.h
@@ -57,9 +57,8 @@ public:
   void InitGeneral();
   void InitDivisional(unsigned manual_number);
 
-  int FindElement(ElementType type, int manual, unsigned index);
-
   const std::vector<Element> &GetElements() const { return m_elements; };
+  int FindElement(ElementType type, int manual, unsigned index) const;
 };
 
 #endif

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.h
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.h
@@ -35,6 +35,11 @@ public:
     GOCombinationElement *control;
   };
 
+  /**
+   * array of localised names of ElementTypes
+   */
+  static const wxString ELEMENT_TYPE_NAMES[];
+
 private:
   GOOrganModel &r_OrganModel;
   std::vector<Element> m_elements;

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -220,7 +220,29 @@ void GODivisionalCombination::PutElementToYamlMap(
 }
 
 void GODivisionalCombination::FromYamlMap(const YAML::Node &yamlMap) {
-  throw wxT("Not implemented yet");
+  // stops
+  SetStatesFromYaml(
+    yamlMap[STOPS],
+    m_odfManualNumber,
+    GOCombinationDefinition::COMBINATION_STOP);
+
+  // couplers
+  SetStatesFromYaml(
+    yamlMap[COUPLERS],
+    m_odfManualNumber,
+    GOCombinationDefinition::COMBINATION_COUPLER);
+
+  // tremulants
+  SetStatesFromYaml(
+    yamlMap[TREMULANTS],
+    m_odfManualNumber,
+    GOCombinationDefinition::COMBINATION_TREMULANT);
+
+  // switches
+  SetStatesFromYaml(
+    yamlMap[SWITCHES],
+    m_odfManualNumber,
+    GOCombinationDefinition::COMBINATION_SWITCH);
 }
 
 void GODivisionalCombination::Push(ExtraElementsSet const *extraSet) {

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -188,42 +188,39 @@ const char *const COUPLERS = "couplers";
 const char *const TREMULANTS = "tremulants";
 const char *const SWITCHES = "switches";
 
-void GODivisionalCombination::ToYaml(YAML::Node &yamlNode) const {
+void GODivisionalCombination::PutElementToYamlMap(
+  const GOCombinationDefinition::Element &e,
+  const wxString &valueLabel,
+  const unsigned objectIndex,
+  YAML::Node &yamlMap) const {
   GOManual &manual = *m_OrganController->GetManual(m_odfManualNumber);
 
-  for (unsigned i = 0; i < r_ElementDefinitions.size(); i++)
-    if (GetState(i) > 0) {
-      const auto &e = r_ElementDefinitions[i];
-      unsigned value = e.index;
-      const wxString valueLabel = wxString::Format(WX_P03D, value);
+  switch (e.type) {
+  case GOCombinationDefinition::COMBINATION_STOP:
+    yamlMap[STOPS][valueLabel] = manual.GetStop(objectIndex)->GetName();
+    break;
 
-      assert(value > 0);
+  case GOCombinationDefinition::COMBINATION_COUPLER:
+    yamlMap[COUPLERS][valueLabel] = manual.GetCoupler(objectIndex)->GetName();
+    break;
 
-      unsigned index = value - 1;
+  case GOCombinationDefinition::COMBINATION_TREMULANT:
+    yamlMap[TREMULANTS][valueLabel]
+      = m_OrganController->GetTremulant(objectIndex)->GetName();
+    break;
 
-      switch (e.type) {
-      case GOCombinationDefinition::COMBINATION_STOP:
-        yamlNode[STOPS][valueLabel] = manual.GetStop(index)->GetName();
-        break;
+  case GOCombinationDefinition::COMBINATION_SWITCH:
+    yamlMap[SWITCHES][valueLabel]
+      = m_OrganController->GetSwitch(objectIndex)->GetName();
+    break;
 
-      case GOCombinationDefinition::COMBINATION_COUPLER:
-        yamlNode[COUPLERS][valueLabel] = manual.GetCoupler(index)->GetName();
-        break;
+  case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:
+    break;
+  }
+}
 
-      case GOCombinationDefinition::COMBINATION_TREMULANT:
-        yamlNode[TREMULANTS][valueLabel]
-          = m_OrganController->GetTremulant(index)->GetName();
-        break;
-
-      case GOCombinationDefinition::COMBINATION_SWITCH:
-        yamlNode[SWITCHES][valueLabel]
-          = m_OrganController->GetSwitch(index)->GetName();
-        break;
-
-      case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:
-        break;
-      }
-    }
+void GODivisionalCombination::FromYamlMap(const YAML::Node &yamlMap) {
+  throw wxT("Not implemented yet");
 }
 
 void GODivisionalCombination::Push(ExtraElementsSet const *extraSet) {
@@ -292,8 +289,4 @@ GODivisionalCombination *GODivisionalCombination::LoadFrom(
     }
   }
   return pCmb;
-}
-
-void GODivisionalCombination::FromYaml(const YAML::Node &node) {
-  throw wxT("Not implemented yet");
 }

--- a/src/grandorgue/combinations/model/GODivisionalCombination.h
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.h
@@ -23,9 +23,21 @@ protected:
   int m_DivisionalNumber;
   bool m_IsSetter;
 
-  // It is not registered as saveable objectb ecause
+  // It is not registered as saveable object because
   // GOdivisionalSetter::LoadCombination creates the combinations dynamically
   void LoadCombinationInt(GOConfigReader &cfg, GOSettingType srcType) override;
+
+  void PutElementToYamlMap(
+    const GOCombinationDefinition::Element &e,
+    const wxString &valueLabel,
+    const unsigned objectIndex,
+    YAML::Node &yamlMap) const override;
+
+  /**
+   * Loads the combination from the Yaml Node
+   * @param yamlNode - a YAML node to load from
+   */
+  void FromYamlMap(const YAML::Node &yamlMap) override;
 
 public:
   GODivisionalCombination(
@@ -43,17 +55,6 @@ public:
     int manualNumber,
     int divisionalNumber);
   void Save(GOConfigWriter &cfg);
-
-  /**
-   * Save the combination to the YAML object
-   */
-  void ToYaml(YAML::Node &yamlNode) const override;
-
-  /**
-   * Loads the combination from the Yaml Node
-   * @param yamlNode - a YAML node to load from
-   */
-  void FromYaml(const YAML::Node &yamlNode) override;
 
   void Push(ExtraElementsSet const *extraSet = nullptr);
 

--- a/src/grandorgue/combinations/model/GODivisionalCombination.h
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.h
@@ -19,12 +19,14 @@ class GOOrganController;
 class GODivisionalCombination : public GOCombination {
 protected:
   GOOrganController *m_OrganController;
-  wxString m_group;
   unsigned m_odfManualNumber;
   int m_DivisionalNumber;
   bool m_IsSetter;
 
-private:
+  // It is not registered as saveable objectb ecause
+  // GOdivisionalSetter::LoadCombination creates the combinations dynamically
+  void LoadCombinationInt(GOConfigReader &cfg, GOSettingType srcType) override;
+
 public:
   GODivisionalCombination(
     GOOrganController *organController,
@@ -40,9 +42,6 @@ public:
     wxString group,
     int manualNumber,
     int divisionalNumber);
-  // It does not inherit GOSaveableOblect because
-  // GOdivisionalSetter::LoadCombination creates the combinations dynamically
-  void LoadCombination(GOConfigReader &cfg);
   void Save(GOConfigWriter &cfg);
 
   /**

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -287,6 +287,43 @@ void GOGeneralCombination::PutElementToYamlMap(
   }
 }
 
-void GOGeneralCombination::FromYaml(const YAML::Node &node) {
-  throw wxT("Not implemented yet");
+void GOGeneralCombination::FromYamlMap(const YAML::Node &yamlMap) {
+  // manuals
+  const int minManualNum = m_OrganController->GetFirstManualIndex();
+  const int upperManualNum
+    = minManualNum + m_OrganController->GetManualAndPedalCount();
+
+  for (const auto &manualEntry : get_from_map_or_null(yamlMap, MANUALS)) {
+    const wxString manualNumStr = manualEntry.first.as<wxString>();
+    int manualNum = wxAtoi(manualNumStr);
+
+    if (manualNum >= minManualNum && manualNum < upperManualNum) {
+      // stops
+      SetStatesFromYaml(
+        manualEntry.second[STOPS],
+        manualNum,
+        GOCombinationDefinition::COMBINATION_STOP);
+
+      // couplers
+      SetStatesFromYaml(
+        manualEntry.second[COUPLERS],
+        manualNum,
+        GOCombinationDefinition::COMBINATION_COUPLER);
+    } else
+      wxLogError(_("Invalid manual number %s"), manualNumStr);
+  }
+
+  // tremulants
+  SetStatesFromYaml(
+    yamlMap[TREMULANTS], -1, GOCombinationDefinition::COMBINATION_TREMULANT);
+
+  // switches
+  SetStatesFromYaml(
+    yamlMap[SWITCHES], -1, GOCombinationDefinition::COMBINATION_SWITCH);
+
+  // divisional couplers
+  SetStatesFromYaml(
+    yamlMap[DIVISIONAL_COUPLERS],
+    -1,
+    GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER);
 }

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -14,7 +14,6 @@
 #include "combinations/GOSetter.h"
 #include "combinations/control/GODivisionalButtonControl.h"
 #include "combinations/control/GOGeneralButtonControl.h"
-#include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 #include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
@@ -41,204 +40,31 @@ void GOGeneralCombination::Load(GOConfigReader &cfg, wxString group) {
   m_Protected
     = cfg.ReadBoolean(ODFSetting, group, wxT("Protected"), false, false);
 
-  /* skip ODF settings */
-  UpdateState();
-  if (!m_IsSetter) {
-    wxString buffer;
-    int pos;
-    std::vector<bool> used(m_State.size());
-    unsigned NumberOfStops = cfg.ReadInteger(
-      ODFSetting,
-      m_group,
-      wxT("NumberOfStops"),
-      0,
-      m_OrganController->GetStopCount());
-    unsigned NumberOfCouplers = cfg.ReadInteger(
-      ODFSetting,
-      m_group,
-      wxT("NumberOfCouplers"),
-      0,
-      m_OrganController->GetODFCouplerCount());
-    unsigned NumberOfTremulants = cfg.ReadInteger(
-      ODFSetting,
-      m_group,
-      wxT("NumberOfTremulants"),
-      0,
-      m_OrganController->GetTremulantCount());
-    unsigned NumberOfSwitches = cfg.ReadInteger(
-      ODFSetting,
-      m_group,
-      wxT("NumberOfSwitches"),
-      0,
-      m_OrganController->GetSwitchCount(),
-      false,
-      0);
-    unsigned NumberOfDivisionalCouplers = cfg.ReadInteger(
-      ODFSetting,
-      m_group,
-      wxT("NumberOfDivisionalCouplers"),
-      0,
-      m_OrganController->GetDivisionalCouplerCount(),
-      m_OrganController->GeneralsStoreDivisionalCouplers());
-
-    for (unsigned i = 0; i < NumberOfStops; i++) {
-      buffer.Printf(wxT("StopManual%03d"), i + 1);
-      unsigned m = cfg.ReadInteger(
-        ODFSetting,
-        m_group,
-        buffer,
-        m_OrganController->GetFirstManualIndex(),
-        m_OrganController->GetManualAndPedalCount());
-      buffer.Printf(wxT("StopNumber%03d"), i + 1);
-      unsigned cnt = m_OrganController->GetManual(m)->GetStopCount();
-      int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.FindElement(
-        GOCombinationDefinition::COMBINATION_STOP, m, abs(s));
-      if (pos >= 0) {
-        if (used[pos]) {
-          wxLogError(
-            _("Duplicate combination entry %s in %s"),
-            buffer.c_str(),
-            m_group.c_str());
-        }
-        used[pos] = true;
-      } else {
-        wxLogError(
-          _("Invalid combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-    }
-
-    for (unsigned i = 0; i < NumberOfCouplers; i++) {
-      buffer.Printf(wxT("CouplerManual%03d"), i + 1);
-      unsigned m = cfg.ReadInteger(
-        ODFSetting,
-        m_group,
-        buffer,
-        m_OrganController->GetFirstManualIndex(),
-        m_OrganController->GetManualAndPedalCount());
-      buffer.Printf(wxT("CouplerNumber%03d"), i + 1);
-      unsigned cnt = m_OrganController->GetManual(m)->GetODFCouplerCount();
-      int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.FindElement(
-        GOCombinationDefinition::COMBINATION_COUPLER, m, abs(s));
-      if (pos >= 0) {
-        if (used[pos]) {
-          wxLogError(
-            _("Duplicate combination entry %s in %s"),
-            buffer.c_str(),
-            m_group.c_str());
-        }
-        used[pos] = true;
-      } else {
-        wxLogError(
-          _("Invalid combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-    }
-
-    for (unsigned i = 0; i < NumberOfTremulants; i++) {
-      buffer.Printf(wxT("TremulantNumber%03d"), i + 1);
-      unsigned cnt = m_OrganController->GetTremulantCount();
-      int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.FindElement(
-        GOCombinationDefinition::COMBINATION_TREMULANT, -1, abs(s));
-      if (pos >= 0) {
-        if (used[pos]) {
-          wxLogError(
-            _("Duplicate combination entry %s in %s"),
-            buffer.c_str(),
-            m_group.c_str());
-        }
-        used[pos] = true;
-      } else {
-        wxLogError(
-          _("Invalid combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-    }
-
-    for (unsigned i = 0; i < NumberOfSwitches; i++) {
-      buffer.Printf(wxT("SwitchNumber%03d"), i + 1);
-      unsigned cnt = m_OrganController->GetSwitchCount();
-      int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.FindElement(
-        GOCombinationDefinition::COMBINATION_SWITCH, -1, abs(s));
-      if (pos >= 0) {
-        if (used[pos]) {
-          wxLogError(
-            _("Duplicate combination entry %s in %s"),
-            buffer.c_str(),
-            m_group.c_str());
-        }
-        used[pos] = true;
-      } else {
-        wxLogError(
-          _("Invalid combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-    }
-
-    for (unsigned i = 0; i < NumberOfDivisionalCouplers; i++) {
-      buffer.Printf(wxT("DivisionalCouplerNumber%03d"), i + 1);
-      unsigned cnt = m_OrganController->GetDivisionalCouplerCount();
-      int s = cfg.ReadInteger(ODFSetting, m_group, buffer, -cnt, cnt);
-      pos = m_Template.FindElement(
-        GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER, -1, abs(s));
-      if (pos >= 0) {
-        if (used[pos]) {
-          wxLogError(
-            _("Duplicate combination entry %s in %s"),
-            buffer.c_str(),
-            m_group.c_str());
-        }
-        used[pos] = true;
-      } else {
-        wxLogError(
-          _("Invalid combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-    }
-  }
+  /* check ODF settings */
+  if (!m_IsSetter)
+    LoadCombinationInt(cfg, ODFSetting);
 }
 
-void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
-  GOSettingType type = CMBSetting;
-  if (!m_IsSetter)
-    if (
-      cfg.ReadInteger(
-        CMBSetting,
-        m_group,
-        wxT("NumberOfStops"),
-        -1,
-        m_OrganController->GetStopCount(),
-        false,
-        -1)
-      == -1)
-      type = ODFSetting;
+void GOGeneralCombination::LoadCombinationInt(
+  GOConfigReader &cfg, GOSettingType srcType) {
   wxString buffer;
-  unsigned NumberOfStops = cfg.ReadInteger(
-    type, m_group, wxT("NumberOfStops"), 0, m_OrganController->GetStopCount());
+  unsigned NumberOfStops
+    = ReadNumberOfStops(cfg, srcType, m_OrganController->GetStopCount());
   unsigned NumberOfCouplers = cfg.ReadInteger(
-    type,
+    srcType,
     m_group,
     wxT("NumberOfCouplers"),
     0,
-    type == CMBSetting ? m_OrganController->GetCouplerCount()
-                       : m_OrganController->GetODFCouplerCount());
+    srcType == CMBSetting ? m_OrganController->GetCouplerCount()
+                          : m_OrganController->GetODFCouplerCount());
   unsigned NumberOfTremulants = cfg.ReadInteger(
-    type,
+    srcType,
     m_group,
     wxT("NumberOfTremulants"),
     0,
     m_OrganController->GetTremulantCount());
   unsigned NumberOfSwitches = cfg.ReadInteger(
-    type,
+    srcType,
     m_group,
     wxT("NumberOfSwitches"),
     0,
@@ -246,145 +72,79 @@ void GOGeneralCombination::LoadCombination(GOConfigReader &cfg) {
     false,
     0);
   unsigned NumberOfDivisionalCouplers = cfg.ReadInteger(
-    type,
+    srcType,
     m_group,
     wxT("NumberOfDivisionalCouplers"),
     0,
     m_OrganController->GetDivisionalCouplerCount(),
     m_OrganController->GeneralsStoreDivisionalCouplers());
 
-  int pos;
-  UpdateState();
-  for (unsigned i = 0; i < m_State.size(); i++)
-    m_State[i] = -1;
+  Clear();
 
   for (unsigned i = 0; i < NumberOfStops; i++) {
-    buffer.Printf(wxT("StopManual%03d"), i + 1);
     unsigned m = cfg.ReadInteger(
-      type,
+      srcType,
       m_group,
-      buffer,
+      wxString::Format(wxT("StopManual%03d"), i + 1),
       m_OrganController->GetFirstManualIndex(),
       m_OrganController->GetManualAndPedalCount());
+
     buffer.Printf(wxT("StopNumber%03d"), i + 1);
-    /*
-    unsigned cnt = m_OrganController->GetManual(m)->GetStopCount();
-    int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-     */
-    int s = cfg.ReadInteger(type, m_group, buffer, -999, 999);
-    pos = m_Template.FindElement(
-      GOCombinationDefinition::COMBINATION_STOP, m, abs(s));
-    if (pos >= 0) {
-      if (m_State[pos] != -1) {
-        wxLogError(
-          _("Duplicate combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-      m_State[pos] = (s > 0) ? 1 : 0;
-    } else {
-      wxLogError(
-        _("Invalid combination entry %s in %s"),
-        buffer.c_str(),
-        m_group.c_str());
-    }
+    SetLoadedState(
+      m,
+      GOCombinationDefinition::COMBINATION_STOP,
+      cfg.ReadInteger(srcType, m_group, buffer, -999, 999),
+      buffer);
   }
 
   for (unsigned i = 0; i < NumberOfCouplers; i++) {
-    buffer.Printf(wxT("CouplerManual%03d"), i + 1);
     unsigned m = cfg.ReadInteger(
-      type,
+      srcType,
       m_group,
-      buffer,
+      wxString::Format(wxT("CouplerManual%03d"), i + 1),
       m_OrganController->GetFirstManualIndex(),
       m_OrganController->GetManualAndPedalCount());
-    buffer.Printf(wxT("CouplerNumber%03d"), i + 1);
-    unsigned cnt = type == CMBSetting
+    unsigned cnt = srcType == CMBSetting
       ? m_OrganController->GetManual(m)->GetCouplerCount()
       : m_OrganController->GetManual(m)->GetODFCouplerCount();
-    int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.FindElement(
-      GOCombinationDefinition::COMBINATION_COUPLER, m, abs(s));
-    if (pos >= 0) {
-      if (m_State[pos] != -1) {
-        wxLogError(
-          _("Duplicate combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-      m_State[pos] = (s > 0) ? 1 : 0;
-    } else {
-      wxLogError(
-        _("Invalid combination entry %s in %s"),
-        buffer.c_str(),
-        m_group.c_str());
-    }
+
+    buffer.Printf(wxT("CouplerNumber%03d"), i + 1);
+    SetLoadedState(
+      m,
+      GOCombinationDefinition::COMBINATION_COUPLER,
+      cfg.ReadInteger(srcType, m_group, buffer, -cnt, cnt),
+      buffer);
   }
+
+  unsigned cnt = m_OrganController->GetTremulantCount();
 
   for (unsigned i = 0; i < NumberOfTremulants; i++) {
     buffer.Printf(wxT("TremulantNumber%03d"), i + 1);
-    unsigned cnt = m_OrganController->GetTremulantCount();
-    int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.FindElement(
-      GOCombinationDefinition::COMBINATION_TREMULANT, -1, abs(s));
-    if (pos >= 0) {
-      if (m_State[pos] != -1) {
-        wxLogError(
-          _("Duplicate combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-      m_State[pos] = (s > 0) ? 1 : 0;
-    } else {
-      wxLogError(
-        _("Invalid combination entry %s in %s"),
-        buffer.c_str(),
-        m_group.c_str());
-    }
+    SetLoadedState(
+      -1,
+      GOCombinationDefinition::COMBINATION_TREMULANT,
+      cfg.ReadInteger(srcType, m_group, buffer, -cnt, cnt),
+      buffer);
   }
 
+  cnt = m_OrganController->GetSwitchCount();
   for (unsigned i = 0; i < NumberOfSwitches; i++) {
     buffer.Printf(wxT("SwitchNumber%03d"), i + 1);
-    unsigned cnt = m_OrganController->GetSwitchCount();
-    int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.FindElement(
-      GOCombinationDefinition::COMBINATION_SWITCH, -1, abs(s));
-    if (pos >= 0) {
-      if (m_State[pos] != -1) {
-        wxLogError(
-          _("Duplicate combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-      m_State[pos] = (s > 0) ? 1 : 0;
-    } else {
-      wxLogError(
-        _("Invalid combination entry %s in %s"),
-        buffer.c_str(),
-        m_group.c_str());
-    }
+    SetLoadedState(
+      -1,
+      GOCombinationDefinition::COMBINATION_SWITCH,
+      cfg.ReadInteger(srcType, m_group, buffer, -cnt, cnt),
+      buffer);
   }
 
+  cnt = m_OrganController->GetDivisionalCouplerCount();
   for (unsigned i = 0; i < NumberOfDivisionalCouplers; i++) {
     buffer.Printf(wxT("DivisionalCouplerNumber%03d"), i + 1);
-    unsigned cnt = m_OrganController->GetDivisionalCouplerCount();
-    int s = cfg.ReadInteger(type, m_group, buffer, -cnt, cnt);
-    pos = m_Template.FindElement(
-      GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER, -1, abs(s));
-    if (pos >= 0) {
-      if (m_State[pos] != -1) {
-        wxLogError(
-          _("Duplicate combination entry %s in %s"),
-          buffer.c_str(),
-          m_group.c_str());
-      }
-      m_State[pos] = (s > 0) ? 1 : 0;
-    } else {
-      wxLogError(
-        _("Invalid combination entry %s in %s"),
-        buffer.c_str(),
-        m_group.c_str());
-    }
+    SetLoadedState(
+      -1,
+      GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER,
+      cfg.ReadInteger(srcType, m_group, buffer, -cnt, cnt),
+      buffer);
   }
 }
 
@@ -392,7 +152,7 @@ void GOGeneralCombination::Push(
   ExtraElementsSet const *extraSet, bool isFromCrescendo) {
   GOCombination::PushLocal(extraSet);
 
-  if (!isFromCrescendo || !extraSet) { // Otherwise the rescendo in add mode:
+  if (!isFromCrescendo || !extraSet) { // Otherwise the crescendo in add mode:
                                        // not to switch off combination buttons
     m_OrganController->GetSetter()->ResetDisplay(); // disable buttons
 
@@ -414,8 +174,6 @@ void GOGeneralCombination::Push(
 
 void GOGeneralCombination::Save(GOConfigWriter &cfg) {
   UpdateState();
-  const std::vector<GOCombinationDefinition::Element> &elements
-    = m_Template.GetElements();
 
   wxString buffer;
   unsigned stop_count = 0;
@@ -424,49 +182,52 @@ void GOGeneralCombination::Save(GOConfigWriter &cfg) {
   unsigned switch_count = 0;
   unsigned divisional_coupler_count = 0;
 
-  for (unsigned i = 0; i < elements.size(); i++) {
-    if (m_State[i] == -1)
-      continue;
-    int value = m_State[i] == 1 ? elements[i].index : -elements[i].index;
-    switch (elements[i].type) {
-    case GOCombinationDefinition::COMBINATION_STOP:
-      stop_count++;
-      buffer.Printf(wxT("StopManual%03d"), stop_count);
-      cfg.WriteInteger(m_group, buffer, elements[i].manual);
-      buffer.Printf(wxT("StopNumber%03d"), stop_count);
-      cfg.WriteInteger(m_group, buffer, value);
-      break;
+  for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
+    const GOCombinationDefinition::Element &e = r_ElementDefinitions[i];
+    int state = GetState(i);
 
-    case GOCombinationDefinition::COMBINATION_COUPLER:
-      coupler_count++;
-      buffer.Printf(wxT("CouplerManual%03d"), coupler_count);
-      cfg.WriteInteger(m_group, buffer, elements[i].manual);
-      buffer.Printf(wxT("CouplerNumber%03d"), coupler_count);
-      cfg.WriteInteger(m_group, buffer, value);
-      break;
+    if (state >= 0) {
+      int value = state == 1 ? e.index : -e.index;
+      switch (e.type) {
+      case GOCombinationDefinition::COMBINATION_STOP:
+        stop_count++;
+        buffer.Printf(wxT("StopManual%03d"), stop_count);
+        cfg.WriteInteger(m_group, buffer, e.manual);
+        buffer.Printf(wxT("StopNumber%03d"), stop_count);
+        cfg.WriteInteger(m_group, buffer, value);
+        break;
 
-    case GOCombinationDefinition::COMBINATION_TREMULANT:
-      tremulant_count++;
-      buffer.Printf(wxT("TremulantNumber%03d"), tremulant_count);
-      cfg.WriteInteger(m_group, buffer, value);
-      break;
+      case GOCombinationDefinition::COMBINATION_COUPLER:
+        coupler_count++;
+        buffer.Printf(wxT("CouplerManual%03d"), coupler_count);
+        cfg.WriteInteger(m_group, buffer, e.manual);
+        buffer.Printf(wxT("CouplerNumber%03d"), coupler_count);
+        cfg.WriteInteger(m_group, buffer, value);
+        break;
 
-    case GOCombinationDefinition::COMBINATION_SWITCH:
-      switch_count++;
-      buffer.Printf(wxT("SwitchNumber%03d"), switch_count);
-      cfg.WriteInteger(m_group, buffer, value);
-      break;
+      case GOCombinationDefinition::COMBINATION_TREMULANT:
+        tremulant_count++;
+        buffer.Printf(wxT("TremulantNumber%03d"), tremulant_count);
+        cfg.WriteInteger(m_group, buffer, value);
+        break;
 
-    case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:
-      divisional_coupler_count++;
-      buffer.Printf(
-        wxT("DivisionalCouplerNumber%03d"), divisional_coupler_count);
-      cfg.WriteInteger(m_group, buffer, value);
-      break;
+      case GOCombinationDefinition::COMBINATION_SWITCH:
+        switch_count++;
+        buffer.Printf(wxT("SwitchNumber%03d"), switch_count);
+        cfg.WriteInteger(m_group, buffer, value);
+        break;
+
+      case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:
+        divisional_coupler_count++;
+        buffer.Printf(
+          wxT("DivisionalCouplerNumber%03d"), divisional_coupler_count);
+        cfg.WriteInteger(m_group, buffer, value);
+        break;
+      }
     }
   }
 
-  cfg.WriteInteger(m_group, wxT("NumberOfStops"), stop_count);
+  WriteNumberOfStops(cfg, stop_count);
   cfg.WriteInteger(m_group, wxT("NumberOfCouplers"), coupler_count);
   cfg.WriteInteger(m_group, wxT("NumberOfTremulants"), tremulant_count);
   cfg.WriteInteger(m_group, wxT("NumberOfSwitches"), switch_count);
@@ -485,12 +246,9 @@ const char *const NAME = "name";
 const wxString WX_P03D = wxT("%03d");
 
 void GOGeneralCombination::ToYaml(YAML::Node &yamlNode) const {
-  const std::vector<GOCombinationDefinition::Element> &elements
-    = m_Template.GetElements();
-
-  for (unsigned i = 0; i < elements.size(); i++)
-    if (m_State[i] > 0) {
-      const GOCombinationDefinition::Element &e = elements[i];
+  for (unsigned i = 0; i < r_ElementDefinitions.size(); i++)
+    if (GetState(i) > 0) {
+      const GOCombinationDefinition::Element &e = r_ElementDefinitions[i];
       unsigned value = e.index;
       int manualIndex = e.manual;
       const wxString manualLabel = wxString::Format(WX_P03D, manualIndex);

--- a/src/grandorgue/combinations/model/GOGeneralCombination.h
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.h
@@ -24,23 +24,24 @@ private:
   void Save(GOConfigWriter &cfg);
   void LoadCombinationInt(GOConfigReader &cfg, GOSettingType srcType) override;
 
+  void PutElementToYamlMap(
+    const GOCombinationDefinition::Element &e,
+    const wxString &valueLabel,
+    const unsigned objectIndex,
+    YAML::Node &yamlMap) const override;
+
+  /**
+   * Loads the combination from the Yaml Node. Called from FromYaml
+   * @param node
+   */
+  void FromYamlMap(const YAML::Node &yamlMap) override;
+
 public:
   GOGeneralCombination(
     GOCombinationDefinition &general_template,
     GOOrganController *organController,
     bool is_setter);
   void Load(GOConfigReader &cfg, wxString group);
-
-  /**
-   * Save the combination to the YAML object
-   */
-  void ToYaml(YAML::Node &yamlNode) const override;
-
-  /**
-   * Loads the combination from the Yaml Node
-   * @param node
-   */
-  void FromYaml(const YAML::Node &node) override;
 
   /*
    * Activate this combination

--- a/src/grandorgue/combinations/model/GOGeneralCombination.h
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.h
@@ -11,19 +11,18 @@
 #include <wx/string.h>
 
 #include "GOCombination.h"
-#include "GOSaveableObject.h"
 
 class GOConfigReader;
 class GOConfigWriter;
 class GOOrganController;
 
-class GOGeneralCombination : public GOCombination, private GOSaveableObject {
+class GOGeneralCombination : public GOCombination {
 private:
   GOOrganController *m_OrganController;
   bool m_IsSetter;
 
   void Save(GOConfigWriter &cfg);
-  void LoadCombination(GOConfigReader &cfg);
+  void LoadCombinationInt(GOConfigReader &cfg, GOSettingType srcType) override;
 
 public:
   GOGeneralCombination(

--- a/src/grandorgue/yaml/go-wx-yaml.cpp
+++ b/src/grandorgue/yaml/go-wx-yaml.cpp
@@ -20,7 +20,7 @@ Node convert<wxString>::encode(const wxString &rhs) {
 }
 
 bool convert<wxString>::decode(const Node &node, wxString &rhs) {
-  const bool isNull = node.IsNull() || !node.IsDefined();
+  const bool isNull = !node.IsDefined() || node.IsNull();
   bool isValid = isNull || node.IsScalar();
 
   if (isValid) {
@@ -33,6 +33,18 @@ bool convert<wxString>::decode(const Node &node, wxString &rhs) {
 }
 
 } // namespace YAML
+
+YAML::Node get_from_map_or_null(const YAML::Node &container, const char *key) {
+  YAML::Node resultNode;
+
+  if (container.IsDefined() && container.IsMap()) {
+    YAML::Node valueNode = container[key];
+
+    if (valueNode.IsDefined())
+      resultNode = valueNode;
+  }
+  return resultNode;
+}
 
 void put_to_map_if_not_null(
   YAML::Node &container, const char *key, const YAML::Node &value) {

--- a/src/grandorgue/yaml/go-wx-yaml.h
+++ b/src/grandorgue/yaml/go-wx-yaml.h
@@ -24,7 +24,21 @@ template <> struct convert<wxString> {
 
 } // namespace YAML
 
-// utility functions non empty YAML nodes into maps
+// utility functions for special processing empty YAML nodes and maps
+/**
+ * if the container is a map and contains the key, return it. Otherwise return
+ * a null mode
+ * @param container
+ * @param key
+ * @return
+ */
+extern YAML::Node get_from_map_or_null(
+  const YAML::Node &container, const char *key);
+inline YAML::Node get_from_map_or_null(
+  const YAML::Node &container, const wxString &key) {
+  return get_from_map_or_null(container, key.mbc_str().data());
+}
+
 /**
  * Put the key-value pair into the container map only if the value is not
  *   empty:
@@ -68,5 +82,4 @@ inline void put_to_map_with_name(
   put_to_map_with_name(
     container, key.mbc_str().data(), nameValue, valueLabel, value);
 }
-
 #endif /* GOWXYAML_H */


### PR DESCRIPTION
Resolves: #1195

This is the last PR on export/import yaml combination

Now the menu entry ``File->Import Combinations``
1. Open a file selection dialog at Combination/ChurchName directory (where Export Combinations creates files).
2. By default lists the `.yaml` file in this directory, but the user is able to choose the `.cmb` file filter instead.
3. Supports importing combinations from both the new yaml and from the old .cmb (settings) file formats.
4. For importing combinations from the old .cmb files the user has to navigate the file open dialog to the Export/Import (`Settings`) directory.