### PR TITLE
Added the filename to an error message when the file not found

### DIFF
--- a/src/grandorgue/loader/GOLoaderFilename.cpp
+++ b/src/grandorgue/loader/GOLoaderFilename.cpp
@@ -41,7 +41,8 @@ std::unique_ptr<GOOpenedFile> GOLoaderFilename::Open(
     GOArchive *const archive = fileStore.FindArchiveContaining(m_path);
 
     if (!archive)
-      throw _("File is not found in the organ package archives");
+      throw wxString::Format(
+        _("File %s is not found in the organ package archives"), m_path);
     file = archive->OpenFile(m_path);
   } else {
     wxString baseDir;


### PR DESCRIPTION
If an ODF or a built-in panel references to an image filename that does not exist, GO displays an error message without a filename, so troubleshooting is quite difficult.

I added the filename to the error message.
