### PR TITLE
Moved notification on combination change from combinations to the controls and the setters

### DIFF
--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -351,8 +351,9 @@ void GODivisionalSetter::SwitchDivisionalTo(
     // whether the combination is defined
     bool isExist = divMap.find(divisionalIdx) != divMap.end();
     GODivisionalCombination *pCmb = isExist ? divMap[divisionalIdx] : nullptr;
+    GOSetter &setter = *m_OrganController->GetSetter();
 
-    if (!isExist && m_OrganController->GetSetter()->IsSetterActive()) {
+    if (!isExist && setter.IsSetterActive()) {
       // create a new combination
       const unsigned manualIndex = m_FirstManualIndex + manualN;
       GOCombinationDefinition &divTemplate
@@ -368,7 +369,7 @@ void GODivisionalSetter::SwitchDivisionalTo(
 
     if (pCmb) {
       // the combination was existing or has just been created
-      pCmb->Push();
+      setter.NotifyCmbPushed(pCmb->Push());
 
       // reflect the ne state of the combination buttons
       for (unsigned firstButtonIdx = N_BUTTONS * manualN, k = 0;

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -435,14 +435,17 @@ void GOSetter::Load(GOConfigReader &cfg) {
     cfg, wxT("SetterGeneralNext"), _("Next"));
 }
 
+void GOSetter::NotifyCmbChanged() {
+  // Temporary we mark the organ modified when a combination is changed for
+  // the user would save the preset.
+  // But we intend to split combinations and organ settings, so in the future
+  // we will only mark the combinations as modified, not the organ settings
+  m_OrganController->SetOrganModified();
+}
+
 void GOSetter::NotifyCmbPushed(bool isChanged) {
-  if (isChanged && IsSetterActive()) {
-    // Temporary we mark the organ modified when a combination is changed for
-    // the user would save the preset.
-    // But we intend to split combinations and organ settings, so in the future
-    // we will only mark the combinations as modified, not the organ settings
-    m_OrganController->SetOrganModified();
-  }
+  if (isChanged && IsSetterActive())
+    NotifyCmbChanged();
 }
 
 void GOSetter::Save(GOConfigWriter &cfg) {
@@ -620,13 +623,13 @@ void GOSetter::ButtonStateChanged(int id) {
     for (unsigned j = m_pos; j < m_framegeneral.size() - 1; j++)
       m_framegeneral[j]->Copy(m_framegeneral[j + 1]);
     ResetDisplay();
-    NotifyCmbPushed(true);
+    NotifyCmbChanged();
     break;
   case ID_SETTER_INSERT:
     for (unsigned j = m_framegeneral.size() - 1; j > m_pos; j--)
       m_framegeneral[j]->Copy(m_framegeneral[j - 1]);
     SetPosition(m_pos);
-    NotifyCmbPushed(true);
+    NotifyCmbChanged();
     break;
   case ID_SETTER_L0:
   case ID_SETTER_L1:

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -939,8 +939,9 @@ void GOSetter::Crescendo(int newpos, bool force) {
     else
       m_CrescendoExtraSets[oldIdx].clear();
     ++m_crescendopos;
-    changed |= m_crescendo[newIdx]->Push(
-      crescendoAddMode ? &m_CrescendoExtraSets[oldIdx] : nullptr, true);
+    changed = changed
+      || m_crescendo[newIdx]->Push(
+        crescendoAddMode ? &m_CrescendoExtraSets[oldIdx] : nullptr, true);
   }
 
   while (pos < m_crescendopos) {
@@ -948,8 +949,9 @@ void GOSetter::Crescendo(int newpos, bool force) {
 
     const unsigned newIdx = m_crescendopos + m_crescendobank * CRESCENDO_STEPS;
 
-    changed |= m_crescendo[newIdx]->Push(
-      crescendoAddMode ? &m_CrescendoExtraSets[newIdx] : nullptr, true);
+    changed = changed
+      || m_crescendo[newIdx]->Push(
+        crescendoAddMode ? &m_CrescendoExtraSets[newIdx] : nullptr, true);
   }
   NotifyCmbPushed(changed);
 

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -435,6 +435,16 @@ void GOSetter::Load(GOConfigReader &cfg) {
     cfg, wxT("SetterGeneralNext"), _("Next"));
 }
 
+void GOSetter::NotifyCmbPushed(bool isChanged) {
+  if (isChanged && IsSetterActive()) {
+    // Temporary we mark the organ modified when a combination is changed for
+    // the user would save the preset.
+    // But we intend to split combinations and organ settings, so in the future
+    // we will only mark the combinations as modified, not the organ settings
+    m_OrganController->SetOrganModified();
+  }
+}
+
 void GOSetter::Save(GOConfigWriter &cfg) {
   for (unsigned i = 0; i < N_CRESCENDOS; i++) {
     cfg.WriteBoolean(
@@ -610,11 +620,13 @@ void GOSetter::ButtonStateChanged(int id) {
     for (unsigned j = m_pos; j < m_framegeneral.size() - 1; j++)
       m_framegeneral[j]->Copy(m_framegeneral[j + 1]);
     ResetDisplay();
+    NotifyCmbPushed(true);
     break;
   case ID_SETTER_INSERT:
     for (unsigned j = m_framegeneral.size() - 1; j > m_pos; j--)
       m_framegeneral[j]->Copy(m_framegeneral[j - 1]);
     SetPosition(m_pos);
+    NotifyCmbPushed(true);
     break;
   case ID_SETTER_L0:
   case ID_SETTER_L1:
@@ -678,8 +690,9 @@ void GOSetter::ButtonStateChanged(int id) {
   case ID_SETTER_GENERAL47:
   case ID_SETTER_GENERAL48:
   case ID_SETTER_GENERAL49:
-    m_general[id - ID_SETTER_GENERAL00 + m_bank * GENERALS]->Push(
-      GetCrescendoAddSet(elementSet));
+    NotifyCmbPushed(
+      m_general[id - ID_SETTER_GENERAL00 + m_bank * GENERALS]->Push(
+        GetCrescendoAddSet(elementSet)));
     ResetDisplay();
     m_buttons[id]->Display(true);
     break;
@@ -716,7 +729,8 @@ void GOSetter::ButtonStateChanged(int id) {
     Crescendo(m_crescendopos + 1, true);
     break;
   case ID_SETTER_CRESCENDO_CURRENT:
-    m_crescendo[m_crescendopos + m_crescendobank * CRESCENDO_STEPS]->Push();
+    NotifyCmbPushed(
+      m_crescendo[m_crescendopos + m_crescendobank * CRESCENDO_STEPS]->Push());
     break;
 
   case ID_SETTER_CRESCENDO_OVERRIDE: {
@@ -883,7 +897,8 @@ void GOSetter::SetPosition(int pos, bool push) {
   if (push) {
     GOCombination::ExtraElementsSet elementSet;
 
-    m_framegeneral[m_pos]->Push(GetCrescendoAddSet(elementSet));
+    NotifyCmbPushed(
+      m_framegeneral[m_pos]->Push(GetCrescendoAddSet(elementSet)));
 
     m_buttons[ID_SETTER_HOME]->Display(m_pos == 0);
     for (unsigned i = 0; i < 10; i++)
@@ -913,6 +928,7 @@ void GOSetter::Crescendo(int newpos, bool force) {
     return;
 
   bool crescendoAddMode = !m_CrescendoOverrideMode[m_crescendobank];
+  bool changed = false;
 
   while (pos > m_crescendopos) {
     const unsigned oldIdx = m_crescendopos + m_crescendobank * CRESCENDO_STEPS;
@@ -923,7 +939,7 @@ void GOSetter::Crescendo(int newpos, bool force) {
     else
       m_CrescendoExtraSets[oldIdx].clear();
     ++m_crescendopos;
-    m_crescendo[newIdx]->Push(
+    changed |= m_crescendo[newIdx]->Push(
       crescendoAddMode ? &m_CrescendoExtraSets[oldIdx] : nullptr, true);
   }
 
@@ -932,9 +948,10 @@ void GOSetter::Crescendo(int newpos, bool force) {
 
     const unsigned newIdx = m_crescendopos + m_crescendobank * CRESCENDO_STEPS;
 
-    m_crescendo[newIdx]->Push(
+    changed |= m_crescendo[newIdx]->Push(
       crescendoAddMode ? &m_CrescendoExtraSets[newIdx] : nullptr, true);
   }
+  NotifyCmbPushed(changed);
 
   wxString buffer;
   buffer.Printf(wxT("%d"), m_crescendopos + 1);

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -65,7 +65,12 @@ public:
   virtual ~GOSetter();
 
   /**
-   * Called when after combination is pushed
+   * Called after at least one combination is changed
+   * Temporary it calls mOrganController->SetModified()
+   */
+  void NotifyCmbChanged();
+  /**
+   * Called after a combination is pushed
    * When Set is active then marks the cpmbinations as modified
    * Temporary it calls mOrganController->SetModified()
    */

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -65,6 +65,13 @@ public:
   virtual ~GOSetter();
 
   /**
+   * Called when after combination is pushed
+   * When Set is active then marks the cpmbinations as modified
+   * Temporary it calls mOrganController->SetModified()
+   */
+  void NotifyCmbPushed(bool isChanged = true);
+
+  /**
    * Save all combinations to yaml as a map
    * @param outYaml - a yaml emitter to save combinations as a map
    */

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -52,12 +52,13 @@ void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
 
 void GODivisionalButtonControl::Push() {
   GOCombination::ExtraElementsSet elementSet;
+  GOSetter &setter = *m_OrganController->GetSetter();
   const GOCombination::ExtraElementsSet *pAddSet
-    = m_OrganController->GetSetter()->GetCrescendoAddSet(elementSet);
+    = setter.GetCrescendoAddSet(elementSet);
   GOManual *pManual
     = m_OrganController->GetManual(m_combination.GetManualNumber());
 
-  m_combination.Push(pAddSet);
+  setter.NotifyCmbPushed(m_combination.Push(pAddSet));
 
   for (unsigned l = pManual->GetDivisionalCount(), k = 0; k < l; k++) {
     GODivisionalButtonControl *pDivisionalControl = pManual->GetDivisional(k);

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -26,10 +26,11 @@ void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
 }
 
 void GOGeneralButtonControl::Push() {
+  GOSetter &setter = *m_OrganController->GetSetter();
   GOCombination::ExtraElementsSet elementSet;
 
-  m_combination.Push(
-    m_OrganController->GetSetter()->GetCrescendoAddSet(elementSet));
+  setter.NotifyCmbPushed(
+    m_combination.Push(setter.GetCrescendoAddSet(elementSet)));
 }
 
 GOGeneralCombination &GOGeneralButtonControl::GetCombination() {

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -47,7 +47,6 @@ void GOCombination::Copy(GOCombination *combination) {
   assert(&m_Template == &combination->m_Template);
   m_State = combination->m_State;
   UpdateState();
-  m_OrganFile->SetOrganModified();
 }
 
 bool GOCombination::IsEmpty() const {
@@ -364,10 +363,8 @@ bool GOCombination::PushLocal(GOCombination::ExtraElementsSet const *extraSet) {
 
   if (setter.IsSetterActive()) {
     if (!m_Protected) {
-
       used = FillWithCurrent(
         setter.GetSetterType(), setter.StoreInvisibleObjects());
-      m_OrganFile->SetOrganModified();
     }
   } else {
     UpdateState();

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -245,40 +245,40 @@ void GODivisionalCombination::FromYamlMap(const YAML::Node &yamlMap) {
     GOCombinationDefinition::COMBINATION_SWITCH);
 }
 
-void GODivisionalCombination::Push(ExtraElementsSet const *extraSet) {
-  PushLocal(extraSet);
+bool GODivisionalCombination::Push(ExtraElementsSet const *extraSet) {
+  bool changed = PushLocal(extraSet);
 
   /* only use divisional couples, if not in setter mode */
-  if (m_OrganController->GetSetter()->IsSetterActive())
-    return;
-
-  for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
-       k++) {
-    GODivisionalCoupler *coupler = m_OrganController->GetDivisionalCoupler(k);
-    if (!coupler->IsEngaged())
-      continue;
-
-    for (unsigned i = 0; i < coupler->GetNumberOfManuals(); i++) {
-      if (coupler->GetManual(i) != m_odfManualNumber)
+  if (!m_OrganController->GetSetter()->IsSetterActive()) {
+    for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
+         k++) {
+      GODivisionalCoupler *coupler = m_OrganController->GetDivisionalCoupler(k);
+      if (!coupler->IsEngaged())
         continue;
 
-      for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++)
-        m_OrganController->GetManual(coupler->GetManual(j))
-          ->GetDivisional(m_DivisionalNumber)
-          ->Push();
+      for (unsigned i = 0; i < coupler->GetNumberOfManuals(); i++) {
+        if (coupler->GetManual(i) != m_odfManualNumber)
+          continue;
 
-      if (coupler->IsBidirectional()) {
-        for (unsigned j = 0; j < coupler->GetNumberOfManuals(); j++) {
-          if (coupler->GetManual(j) == m_odfManualNumber)
-            break;
+        for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++)
           m_OrganController->GetManual(coupler->GetManual(j))
             ->GetDivisional(m_DivisionalNumber)
             ->Push();
+
+        if (coupler->IsBidirectional()) {
+          for (unsigned j = 0; j < coupler->GetNumberOfManuals(); j++) {
+            if (coupler->GetManual(j) == m_odfManualNumber)
+              break;
+            m_OrganController->GetManual(coupler->GetManual(j))
+              ->GetDivisional(m_DivisionalNumber)
+              ->Push();
+          }
         }
+        break;
       }
-      break;
     }
   }
+  return changed;
 }
 
 wxString GODivisionalCombination::GetMidiType() { return _("Divisional"); }

--- a/src/grandorgue/combinations/model/GODivisionalCombination.h
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.h
@@ -56,7 +56,7 @@ public:
     int divisionalNumber);
   void Save(GOConfigWriter &cfg);
 
-  void Push(ExtraElementsSet const *extraSet = nullptr);
+  bool Push(ExtraElementsSet const *extraSet = nullptr);
 
   wxString GetMidiType();
 

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -148,9 +148,9 @@ void GOGeneralCombination::LoadCombinationInt(
   }
 }
 
-void GOGeneralCombination::Push(
+bool GOGeneralCombination::Push(
   ExtraElementsSet const *extraSet, bool isFromCrescendo) {
-  GOCombination::PushLocal(extraSet);
+  bool changed = GOCombination::PushLocal(extraSet);
 
   if (!isFromCrescendo || !extraSet) { // Otherwise the crescendo in add mode:
                                        // not to switch off combination buttons
@@ -170,6 +170,7 @@ void GOGeneralCombination::Push(
         m_OrganController->GetManual(j)->GetDivisional(k)->Display(false);
     }
   }
+  return changed;
 }
 
 void GOGeneralCombination::Save(GOConfigWriter &cfg) {

--- a/src/grandorgue/combinations/model/GOGeneralCombination.h
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.h
@@ -49,8 +49,9 @@ public:
    * extraSet
    * If isFromCrescendo and extraSet is passed then does not depress other
    * buttons
+   * return if anything is changed
    */
-  void Push(
+  bool Push(
     ExtraElementsSet const *extraSet = nullptr, bool isFromCrescendo = false);
 };
 


### PR DESCRIPTION
Earlier any combination (either General or Divisional) notified OrganController on change.

That
1. Contradicted the model/controller paradigm, where the model should only return change status, but not to call the controller
2. Did not allow to separate changing in combinations from changing the organ setting

In this PR 
1. I removed calling SetOrganNotified from GOCombination::PushLocal().
2. I introduced the method GOSetter::NotifyCmbPushed() .
3. I aded calling GOSetter::NotifyCmbPushed() to the code where GOCombination::PushLocal() is called from.

It is just refactoring. No GO behavior should be changed.
