### PR TITLE
Added capability of specifying a size of the label

### DIFF
--- a/src/grandorgue/gui/GOGUILabel.cpp
+++ b/src/grandorgue/gui/GOGUILabel.cpp
@@ -224,7 +224,7 @@ void GOGUILabel::Load(GOConfigReader &cfg, wxString group) {
       false,
       0),
     cfg.ReadStringTrim(ODFSetting, group, WX_IMAGE, false),
-    cfg.ReadInteger(ODFSetting, group, WX_DISP_IMAGE_NUM, 0, 12, false, 1),
+    cfg.ReadInteger(ODFSetting, group, WX_DISP_IMAGE_NUM, 0, 15, false, 1),
     cfg.ReadStringTrim(ODFSetting, group, WX_MASK, false));
   InitFont(
     cfg.ReadStringTrim(

--- a/src/grandorgue/gui/GOGUILabel.h
+++ b/src/grandorgue/gui/GOGUILabel.h
@@ -35,6 +35,8 @@ private:
   void InitBackgroundBitmap(
     unsigned x,
     unsigned y,
+    unsigned w,
+    unsigned h,
     wxString imageFileName,
     unsigned imageNum,
     const wxString &imageMaskFileneme);
@@ -57,7 +59,9 @@ public:
     unsigned x_pos = 0,
     unsigned y_pos = 0,
     wxString name = wxT(""),
-    unsigned imageno = 1);
+    unsigned imageno = 1,
+    unsigned w = 0,
+    unsigned h = 0);
   void Load(GOConfigReader &cfg, wxString group);
   void Layout();
 


### PR DESCRIPTION
In order to using lars' label images #1465  in the sequencer panel I need a capability of specifying a label size different from the label size.

It is a capability for future use in #1196. No GO behavior should b changed now.
