### PR TITLE
Reworked marking the current organ as changed on midi-event settings

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,6 +32,8 @@ midi/GOMidiFileReader.cpp
 midi/GOMidiMap.cpp
 midi/GOMidiEventPattern.cpp
 midi/GOMidiReceiverBase.cpp
+midi/GOMidiReceiverEventPattern.cpp
+midi/GOMidiSenderEventPattern.cpp
 midi/GOMidiWXEvent.cpp
 settings/GOSetting.cpp
 settings/GOSettingBool.cpp

--- a/src/core/midi/GOMidiEventPattern.cpp
+++ b/src/core/midi/GOMidiEventPattern.cpp
@@ -10,6 +10,12 @@
 #include <algorithm>
 #include <math.h>
 
+bool GOMidiEventPattern::operator==(const GOMidiEventPattern &other) const {
+  return deviceId == other.deviceId && channel == other.channel
+    && key == other.key && low_value == other.low_value
+    && high_value == other.high_value;
+}
+
 int GOMidiEventPattern::convertValueBetweenRanges(
   int srcValue, int srcLow, int srcHigh, int dstLow, int dstHigh) {
   const int dstAbsLow = std::min(dstLow, dstHigh);

--- a/src/core/midi/GOMidiEventPattern.h
+++ b/src/core/midi/GOMidiEventPattern.h
@@ -29,6 +29,8 @@ struct GOMidiEventPattern {
       low_value(iLowValue),
       high_value(iHighValue) {}
 
+  bool operator==(const GOMidiEventPattern &other) const;
+
   /**
    * Convert a midi value between ranges: from [srcLow, srcHigh] to
    *   [dstLow, dstHigh]. All ranges must be between 0 and 127. They may be

--- a/src/core/midi/GOMidiEventPatternList.h
+++ b/src/core/midi/GOMidiEventPatternList.h
@@ -35,6 +35,20 @@ public:
   }
 
   void DeleteEvent(unsigned index) { m_events.erase(m_events.begin() + index); }
+
+  /**
+   * Assign the new list to the current one
+   * @param newList the lnew list to assign
+   * @return whether the list is changed
+   */
+
+  bool RenewFrom(const GOMidiEventPatternList &newList) {
+    bool result = newList.m_type != m_type || newList.m_events != m_events;
+
+    if (result)
+      *this = newList;
+    return result;
+  }
 };
 
 #endif /* GOMIDIEVENTPATTERNLIST_H */

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -903,8 +903,4 @@ GOMidiMatchType GOMidiReceiverBase::Match(
   return MIDI_MATCH_NONE;
 }
 
-void GOMidiReceiverBase::Assign(const GOMidiReceiverEventPatternList &data) {
-  *(GOMidiReceiverEventPatternList *)this = data;
-}
-
 void GOMidiReceiverBase::PreparePlayback() { m_Internal.resize(0); }

--- a/src/core/midi/GOMidiReceiverBase.h
+++ b/src/core/midi/GOMidiReceiverBase.h
@@ -63,8 +63,6 @@ public:
   unsigned KeyLimit(GOMidiReceiverMessageType type);
   unsigned LowerValueLimit(GOMidiReceiverMessageType type);
   unsigned UpperValueLimit(GOMidiReceiverMessageType type);
-
-  virtual void Assign(const GOMidiReceiverEventPatternList &data);
 };
 
 #endif

--- a/src/core/midi/GOMidiReceiverEventPattern.cpp
+++ b/src/core/midi/GOMidiReceiverEventPattern.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOMidiReceiverEventPattern.h"
+
+bool GOMidiReceiverEventPattern::operator==(
+  const GOMidiReceiverEventPattern &other) const {
+  return (const GOMidiEventPattern &)*this == (const GOMidiEventPattern &)other
+    && type == other.type && low_key == other.low_key
+    && high_key == other.high_key && debounce_time == other.debounce_time;
+}

--- a/src/core/midi/GOMidiReceiverEventPattern.h
+++ b/src/core/midi/GOMidiReceiverEventPattern.h
@@ -24,6 +24,8 @@ struct GOMidiReceiverEventPattern : public GOMidiEventPattern {
       high_key(0),
       debounce_time(0) {}
 
+  bool operator==(const GOMidiReceiverEventPattern &other) const;
+
   /**
    * Convert a source midi value (from low_value to high_value) to an internal
    *   one (from MIN_VALUE to MAX_VALUE)

--- a/src/core/midi/GOMidiSenderEventPattern.cpp
+++ b/src/core/midi/GOMidiSenderEventPattern.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOMidiSenderEventPattern.h"
+
+bool GOMidiSenderEventPattern::operator==(
+  const GOMidiSenderEventPattern &other) const {
+  return (const GOMidiEventPattern &)*this == (const GOMidiEventPattern &)other
+    && type == other.type && start == other.start && length == other.length;
+}

--- a/src/core/midi/GOMidiSenderEventPattern.h
+++ b/src/core/midi/GOMidiSenderEventPattern.h
@@ -22,6 +22,8 @@ struct GOMidiSenderEventPattern : public GOMidiEventPattern {
       start(0),
       length(0) {}
 
+  bool operator==(const GOMidiSenderEventPattern &other) const;
+
   /**
    * Convert an internal midi value (from MIN_VALUE to MAX_VALUE) to a
    * destination one (from low_value to high_value)

--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -210,6 +210,7 @@ void GODocument::ShowMIDIEventDialog(
       key,
       division);
     dlg->RegisterMIDIListener(m_OrganController->GetMidi());
+    dlg->SetModificationListener(m_OrganController);
     registerWindow(GODocument::MIDI_EVENT, element, dlg);
   }
 }

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventDialog.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventDialog.cpp
@@ -32,11 +32,13 @@ GOMidiEventDialog::GOMidiEventDialog(
 
   if (event) {
     m_recvPage = new GOMidiEventRecvTab(notebook, event, settings);
+    m_recvPage->SetModificationListener(this);
     AddTab(m_recvPage, "Receive", _("Receive"));
   }
   if (sender) {
     m_sendPage
       = new GOMidiEventSendTab(this, _("Send"), sender, m_recvPage, settings);
+    m_sendPage->SetModificationListener(this);
     AddTab(m_sendPage);
   }
   if (key) {

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventDialog.h
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventDialog.h
@@ -12,6 +12,7 @@
 
 #include "dialogs/common/GOTabbedDialog.h"
 #include "document-base/GOView.h"
+#include "modification/GOModificationProxy.h"
 
 class GOKeyReceiver;
 class GOMidi;
@@ -23,7 +24,9 @@ class GOMidiEventKeyTab;
 class GOMidiEventRecvTab;
 class GOMidiEventSendTab;
 
-class GOMidiEventDialog : public GOTabbedDialog, public GOView {
+class GOMidiEventDialog : public GOTabbedDialog,
+                          public GOView,
+                          public GOModificationProxy {
 private:
   GOMidiEventRecvTab *m_recvPage;
   GOMidiEventSendTab *m_sendPage;

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp
@@ -320,7 +320,8 @@ bool GOMidiEventRecvTab::TransferDataFromWindow() {
       }
   } while (empty_event);
 
-  m_original->Assign(m_midi);
+  if (m_original->RenewFrom(m_midi))
+    GOModificationProxy::OnIsModifiedChanged(true);
   return true;
 }
 

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.h
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.h
@@ -16,6 +16,7 @@
 #include "midi/GOMidiCallback.h"
 #include "midi/GOMidiListener.h"
 #include "midi/GOMidiReceiverBase.h"
+#include "modification/GOModificationProxy.h"
 
 #include "GOChoice.h"
 
@@ -28,7 +29,9 @@ class wxToggleButton;
 class GOConfig;
 class GOMidiDeviceConfigList;
 
-class GOMidiEventRecvTab : public wxPanel, protected GOMidiCallback {
+class GOMidiEventRecvTab : public wxPanel,
+                           public GOModificationProxy,
+                           protected GOMidiCallback {
 private:
   GOMidiDeviceConfigList &m_MidiIn;
   GOMidiMap &m_MidiMap;

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
@@ -274,7 +274,8 @@ bool GOMidiEventSendTab::TransferDataFromWindow() {
   } while (empty_event);
   // The event with index 0 is also deleted so the dialog can't be used more
 
-  m_original->Assign(m_midi);
+  if (m_original->RenewFrom(m_midi))
+    OnIsModifiedChanged(true);
   return true;
 }
 

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.h
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.h
@@ -10,6 +10,7 @@
 
 #include "dialogs/common/GODialogTab.h"
 #include "midi/GOMidiSender.h"
+#include "modification/GOModificationProxy.h"
 
 #include "GOChoice.h"
 
@@ -24,7 +25,7 @@ class GOMidiMap;
 class GOMidiEventRecvTab;
 class GOTabbedDialog;
 
-class GOMidiEventSendTab : public GODialogTab {
+class GOMidiEventSendTab : public GODialogTab, public GOModificationProxy {
 private:
   GOMidiDeviceConfigList &m_MidiIn;
   GOMidiDeviceConfigList &m_MidiOut;

--- a/src/grandorgue/midi/GOMidiReceiver.cpp
+++ b/src/grandorgue/midi/GOMidiReceiver.cpp
@@ -62,8 +62,3 @@ void GOMidiReceiver::Preconfigure(GOConfigReader &cfg, wxString group) {
 }
 
 int GOMidiReceiver::GetTranspose() { return r_config.Transpose(); }
-
-void GOMidiReceiver::Assign(const GOMidiReceiverEventPatternList &data) {
-  GOMidiReceiverBase::Assign(data);
-  r_OrganModel.SetOrganModelModified();
-}

--- a/src/grandorgue/midi/GOMidiReceiver.h
+++ b/src/grandorgue/midi/GOMidiReceiver.h
@@ -29,8 +29,6 @@ public:
   void Load(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
 
   void SetIndex(int index) { m_Index = index; }
-
-  void Assign(const GOMidiReceiverEventPatternList &data);
 };
 
 #endif

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -667,9 +667,3 @@ void GOMidiSender::SetName(const wxString &text) {
     }
   }
 }
-
-void GOMidiSender::Assign(const GOMidiSenderEventPatternList &data) {
-  *(GOMidiSenderEventPatternList *)this = data;
-  if (m_OrganController)
-    m_OrganController->SetOrganModified();
-}

--- a/src/grandorgue/midi/GOMidiSender.h
+++ b/src/grandorgue/midi/GOMidiSender.h
@@ -51,8 +51,6 @@ public:
   unsigned HighValueLimit(GOMidiSenderMessageType type);
   unsigned StartLimit(GOMidiSenderMessageType type);
   unsigned LengthLimit(GOMidiSenderMessageType type);
-
-  void Assign(const GOMidiSenderEventPatternList &data);
 };
 
 #endif


### PR DESCRIPTION
Earlier GOMidiReceiver and GOMidiSender notified GOController when the midi-event settings are changed.

I moved this notification to the MidiEventDialog, where these settings are actually changed.

Earlier the current organ was marked as modified every time when the midi event dialog was closed. Now the current organ is marked as modified only if the midi settings have been actually changed. So I introdoced a comparing `operator==` for midi event patterns.
