### PR TITLE
Removed usage of GOOrganController from GOMidiSender

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -133,6 +133,7 @@ midi/GOMidiInputMerger.cpp
 midi/GOMidiOutputMerger.cpp
 midi/GOMidiPlayer.cpp
 midi/GOMidiPlayerContent.cpp
+midi/GOMidiSendProxy.cpp
 midi/GOMidiSender.cpp
 midi/GOMidiReceiver.cpp
 midi/GOMidiRecorder.cpp

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -981,16 +981,6 @@ GOConfig &GOOrganController::GetSettings() { return m_config; }
 
 GOBitmapCache &GOOrganController::GetBitmapCache() { return m_bitmaps; }
 
-void GOOrganController::SendMidiMessage(GOMidiEvent &e) {
-  if (m_midi)
-    m_midi->Send(e);
-}
-
-void GOOrganController::SendMidiRecorderMessage(GOMidiEvent &e) {
-  if (m_MidiRecorder)
-    m_MidiRecorder->SendMidiRecorderMessage(e);
-}
-
 GOMidi *GOOrganController::GetMidi() { return m_midi; }
 
 void GOOrganController::LoadMIDIFile(wxString const &filename) {
@@ -1007,6 +997,7 @@ void GOOrganController::Abort() {
   m_MidiRecorder->StopRecording();
   m_AudioRecorder->StopRecording();
   m_AudioRecorder->SetAudioRecorder(NULL);
+  GOOrganModel::SetMidi(nullptr, nullptr);
   m_midi = NULL;
 }
 
@@ -1030,6 +1021,7 @@ void GOOrganController::PreparePlayback(
   PreconfigRecorder();
 
   m_MidiSamplesetMatch.clear();
+  GOOrganModel::SetMidi(midi, m_MidiRecorder);
   GOEventDistributor::PreparePlayback(engine);
 
   m_setter->UpdateModified(m_OrganModified);

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -242,8 +242,6 @@ public:
   const wxString &GetRecordingDetails();
   const wxString &GetInfoFilename();
 
-  void SendMidiMessage(GOMidiEvent &e);
-  void SendMidiRecorderMessage(GOMidiEvent &e);
   GOMidi *GetMidi();
 
   GOGUIMouseState &GetMouseState() { return m_MouseState; }

--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -21,7 +21,7 @@ GOButtonControl::GOButtonControl(
   bool isPiston)
   : m_OrganController(organController),
     m_midi(*organController, midi_type),
-    m_sender(organController, MIDI_SEND_BUTTON),
+    m_sender(*organController, MIDI_SEND_BUTTON),
     m_shortcut(organController, KEY_RECV_BUTTON),
     m_Pushbutton(pushbutton),
     m_Displayed(false),

--- a/src/grandorgue/control/GOLabelControl.cpp
+++ b/src/grandorgue/control/GOLabelControl.cpp
@@ -17,7 +17,7 @@ GOLabelControl::GOLabelControl(GOOrganController *organController)
   : m_Name(),
     m_Content(),
     m_OrganController(organController),
-    m_sender(organController, MIDI_SEND_LABEL) {
+    m_sender(*organController, MIDI_SEND_LABEL) {
   m_OrganController->RegisterMidiConfigurator(this);
   m_OrganController->RegisterSoundStateHandler(this);
 }

--- a/src/grandorgue/midi/GOMidiSendProxy.cpp
+++ b/src/grandorgue/midi/GOMidiSendProxy.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOMidiSendProxy.h"
+
+#include "GOMidi.h"
+#include "GOMidiRecorder.h"
+
+void GOMidiSendProxy::SetMidi(GOMidi *pMidi, GOMidiRecorder *pMidiRecorder) {
+  p_midi = pMidi;
+  p_MidiRecorder = pMidiRecorder;
+}
+
+void GOMidiSendProxy::SendMidiMessage(const GOMidiEvent &e) {
+  if (p_midi)
+    p_midi->Send(e);
+}
+
+void GOMidiSendProxy::SendMidiRecorderMessage(GOMidiEvent &e) {
+  if (p_MidiRecorder)
+    p_MidiRecorder->SendMidiRecorderMessage(e);
+}

--- a/src/grandorgue/midi/GOMidiSendProxy.h
+++ b/src/grandorgue/midi/GOMidiSendProxy.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDISENDPROXY_H
+#define GOMIDISENDPROXY_H
+
+class GOMidi;
+class GOMidiEvent;
+class GOMidiRecorder;
+
+class GOMidiSendProxy {
+  GOMidi *p_midi = nullptr;
+  GOMidiRecorder *p_MidiRecorder = nullptr;
+
+public:
+  void SetMidi(GOMidi *pMidi, GOMidiRecorder *pMidiRecorder);
+  void SendMidiMessage(const GOMidiEvent &e);
+  void SendMidiRecorderMessage(GOMidiEvent &e);
+};
+
+#endif /* GOMIDISENDPROXY_H */

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -9,17 +9,15 @@
 
 #include <wx/intl.h>
 
-#include "GOOrganController.h"
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 #include "midi/GOMidiEvent.h"
 #include "midi/GOMidiMap.h"
 
-GOMidiSender::GOMidiSender(
-  GOOrganController *organController, GOMidiSenderType type)
-  : GOMidiSenderEventPatternList(type),
-    m_OrganController(organController),
-    m_ElementID(-1) {}
+#include "GOMidiSendProxy.h"
+
+GOMidiSender::GOMidiSender(GOMidiSendProxy &proxy, GOMidiSenderType type)
+  : GOMidiSenderEventPatternList(type), r_proxy(proxy), m_ElementID(-1) {}
 
 GOMidiSender::~GOMidiSender() {}
 
@@ -309,7 +307,7 @@ void GOMidiSender::SetDisplay(bool state) {
     e.SetMidiType(MIDI_NRPN);
     e.SetDevice(m_ElementID);
     e.SetValue(state ? 0x7F : 0x00);
-    m_OrganController->SendMidiRecorderMessage(e);
+    r_proxy.SendMidiRecorderMessage(e);
   }
 
   for (unsigned i = 0; i < m_events.size(); i++) {
@@ -320,7 +318,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(state ? m_events[i].high_value : m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_CTRL) {
       GOMidiEvent e;
@@ -329,7 +327,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(state ? m_events[i].high_value : m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_RPN) {
       GOMidiEvent e;
@@ -338,7 +336,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(state ? m_events[i].high_value : m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_NRPN) {
       GOMidiEvent e;
@@ -347,7 +345,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(state ? m_events[i].high_value : m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_PGM_RANGE) {
       GOMidiEvent e;
@@ -355,7 +353,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetMidiType(MIDI_PGM_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(state ? m_events[i].high_value : m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_RPN_RANGE) {
       GOMidiEvent e;
@@ -364,7 +362,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetValue(m_events[i].key);
       e.SetKey(state ? m_events[i].high_value : m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_NRPN_RANGE) {
       GOMidiEvent e;
@@ -373,7 +371,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetValue(m_events[i].key);
       e.SetKey(state ? m_events[i].high_value : m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_PGM_ON && state) {
       GOMidiEvent e;
@@ -381,7 +379,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetMidiType(MIDI_PGM_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_PGM_OFF && !state) {
       GOMidiEvent e;
@@ -389,7 +387,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetMidiType(MIDI_PGM_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_NOTE_ON && state) {
       GOMidiEvent e;
@@ -398,7 +396,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].high_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_NOTE_OFF && !state) {
       GOMidiEvent e;
@@ -407,7 +405,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_CTRL_ON && state) {
       GOMidiEvent e;
@@ -416,7 +414,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].high_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_CTRL_OFF && !state) {
       GOMidiEvent e;
@@ -425,7 +423,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_RPN_ON && state) {
       GOMidiEvent e;
@@ -434,7 +432,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].high_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_RPN_OFF && !state) {
       GOMidiEvent e;
@@ -443,7 +441,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_NRPN_ON && state) {
       GOMidiEvent e;
@@ -452,7 +450,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].high_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_NRPN_OFF && !state) {
       GOMidiEvent e;
@@ -461,7 +459,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_HW_LCD) {
       GOMidiEvent e;
@@ -471,7 +469,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(state ? _("ON") : _("OFF"), m_events[i].length);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_HW_STRING) {
       GOMidiEvent e;
@@ -480,7 +478,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(state ? _("ON") : _("OFF"), m_events[i].length);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_RODGERS_STOP_CHANGE) {
       GOMidiEvent e;
@@ -489,7 +487,7 @@ void GOMidiSender::SetDisplay(bool state) {
       e.SetChannel(m_events[i].key);
       e.SetKey(m_events[i].low_value);
       e.SetValue(state);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
   }
 }
@@ -501,7 +499,7 @@ void GOMidiSender::ResetKey() {
     e.SetDevice(m_ElementID);
     e.SetKey(MIDI_CTRL_NOTES_OFF);
     e.SetValue(0);
-    m_OrganController->SendMidiRecorderMessage(e);
+    r_proxy.SendMidiRecorderMessage(e);
   }
 
   for (unsigned i = 0; i < m_events.size(); i++) {
@@ -514,7 +512,7 @@ void GOMidiSender::ResetKey() {
       e.SetChannel(m_events[i].channel);
       e.SetKey(MIDI_CTRL_NOTES_OFF);
       e.SetValue(0);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
   }
 }
@@ -526,7 +524,7 @@ void GOMidiSender::SetKey(unsigned key, unsigned velocity) {
     e.SetDevice(m_ElementID);
     e.SetKey(key & 0x7F);
     e.SetValue(velocity & 0x7F);
-    m_OrganController->SendMidiRecorderMessage(e);
+    r_proxy.SendMidiRecorderMessage(e);
   }
 
   for (unsigned i = 0; i < m_events.size(); i++) {
@@ -537,7 +535,7 @@ void GOMidiSender::SetKey(unsigned key, unsigned velocity) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(key);
       e.SetValue(m_events[i].ConvertIntValueToDst(velocity));
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_NOTE_NO_VELOCITY) {
       GOMidiEvent e;
@@ -546,7 +544,7 @@ void GOMidiSender::SetKey(unsigned key, unsigned velocity) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(key);
       e.SetValue(velocity ? m_events[i].high_value : m_events[i].low_value);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
   }
 }
@@ -557,7 +555,7 @@ void GOMidiSender::SetValue(unsigned value) {
     e.SetMidiType(MIDI_NRPN);
     e.SetDevice(m_ElementID);
     e.SetValue(value & 0x7F);
-    m_OrganController->SendMidiRecorderMessage(e);
+    r_proxy.SendMidiRecorderMessage(e);
   }
 
   for (unsigned i = 0; i < m_events.size(); i++) {
@@ -568,7 +566,7 @@ void GOMidiSender::SetValue(unsigned value) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].ConvertIntValueToDst(value));
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_RPN) {
       GOMidiEvent e;
@@ -577,7 +575,7 @@ void GOMidiSender::SetValue(unsigned value) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].ConvertIntValueToDst(value));
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_NRPN) {
       GOMidiEvent e;
@@ -586,7 +584,7 @@ void GOMidiSender::SetValue(unsigned value) {
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].ConvertIntValueToDst(value));
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_PGM_RANGE) {
       GOMidiEvent e;
@@ -594,7 +592,7 @@ void GOMidiSender::SetValue(unsigned value) {
       e.SetMidiType(MIDI_PGM_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].ConvertIntValueToDst(value));
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_HW_LCD) {
       GOMidiEvent e;
@@ -605,7 +603,7 @@ void GOMidiSender::SetValue(unsigned value) {
       e.SetValue(m_events[i].start);
       e.SetString(
         wxString::Format(_("%d %%"), value * 100 / 127), m_events[i].length);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_HW_STRING) {
       GOMidiEvent e;
@@ -615,7 +613,7 @@ void GOMidiSender::SetValue(unsigned value) {
       e.SetValue(m_events[i].start);
       e.SetString(
         wxString::Format(_("%d %%"), value * 100 / 127), m_events[i].length);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
   }
 }
@@ -630,7 +628,7 @@ void GOMidiSender::SetLabel(const wxString &text) {
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(text, m_events[i].length);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_HW_STRING) {
       GOMidiEvent e;
@@ -639,7 +637,7 @@ void GOMidiSender::SetLabel(const wxString &text) {
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(text, m_events[i].length);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
   }
 }
@@ -654,7 +652,7 @@ void GOMidiSender::SetName(const wxString &text) {
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(text, m_events[i].length);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
     if (m_events[i].type == MIDI_S_HW_NAME_STRING) {
       GOMidiEvent e;
@@ -663,7 +661,7 @@ void GOMidiSender::SetName(const wxString &text) {
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(text, m_events[i].length);
-      m_OrganController->SendMidiMessage(e);
+      r_proxy.SendMidiMessage(e);
     }
   }
 }

--- a/src/grandorgue/midi/GOMidiSender.h
+++ b/src/grandorgue/midi/GOMidiSender.h
@@ -15,17 +15,17 @@
 class GOConfigReader;
 class GOConfigWriter;
 class GOMidiMap;
-class GOOrganController;
+class GOMidiSendProxy;
 struct IniFileEnumEntry;
 
 class GOMidiSender : public GOMidiSenderEventPatternList {
 private:
   static const struct IniFileEnumEntry m_MidiTypes[];
-  GOOrganController *m_OrganController;
+  GOMidiSendProxy &r_proxy;
   int m_ElementID;
 
 public:
-  GOMidiSender(GOOrganController *organController, GOMidiSenderType type);
+  GOMidiSender(GOMidiSendProxy &proxy, GOMidiSenderType type);
   ~GOMidiSender();
 
   void SetElementID(int id);

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -17,7 +17,7 @@
 
 GOEnclosure::GOEnclosure(GOOrganController *organController)
   : m_midi(*organController, MIDI_RECV_ENCLOSURE),
-    m_sender(organController, MIDI_SEND_ENCLOSURE),
+    m_sender(*organController, MIDI_SEND_ENCLOSURE),
     m_shortcut(organController, KEY_RECV_ENCLOSURE),
     m_OrganController(organController),
     m_AmpMinimumLevel(0),

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -23,8 +23,8 @@
 GOManual::GOManual(GOOrganController *organController)
   : m_group(wxT("---")),
     m_midi(*organController, MIDI_RECV_MANUAL),
-    m_sender(organController, MIDI_SEND_MANUAL),
-    m_division(organController, MIDI_SEND_MANUAL),
+    m_sender(*organController, MIDI_SEND_MANUAL),
+    m_division(*organController, MIDI_SEND_MANUAL),
     m_OrganController(organController),
     m_InputCouplers(),
     m_KeyVelocity(0),

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -10,6 +10,7 @@
 
 #include "ptrvector.h"
 
+#include "midi/GOMidiSendProxy.h"
 #include "midi/dialog-creator/GOMidiDialogCreatorProxy.h"
 #include "modification/GOModificationProxy.h"
 #include "pipe-config/GOPipeConfigTreeNode.h"
@@ -30,7 +31,8 @@ class GOTremulant;
 class GOWindchest;
 
 class GOOrganModel : public GOEventHandlerList,
-                     public GOMidiDialogCreatorProxy {
+                     public GOMidiDialogCreatorProxy,
+                     public GOMidiSendProxy {
 private:
   GOModificationProxy m_ModificationProxy;
 

--- a/src/grandorgue/model/GORank.cpp
+++ b/src/grandorgue/model/GORank.cpp
@@ -34,7 +34,7 @@ GORank::GORank(GOOrganController *organController)
     m_MinVolume(100),
     m_MaxVolume(100),
     m_RetuneRank(true),
-    m_sender(organController, MIDI_SEND_MANUAL),
+    m_sender(*organController, MIDI_SEND_MANUAL),
     m_PipeConfig(NULL, organController, NULL) {
   m_OrganController->RegisterMidiConfigurator(this);
   m_OrganController->RegisterSoundStateHandler(this);


### PR DESCRIPTION
This PR continues eliminating usage GOOrganController anywhere.

Now I've introdoced a new class `GOMidiSendProxy` with two methods `SendMidiMessage` and `SendMidiRecorderMessage` and I've added inheritance of `GOMidiSendProxy` to `GOOrganModel`.

It has allowed to remove reference from GOMidiSender to GOOrganController.

It is just refactoring. No GO behavior should be changed.