### PR TITLE
Added passing the new button state to GOButtonCallback::ButtonStateChanged and GOElementCreator::ButtonStateChanged

### DIFF
--- a/src/grandorgue/GOAudioRecorder.cpp
+++ b/src/grandorgue/GOAudioRecorder.cpp
@@ -70,7 +70,7 @@ void GOAudioRecorder::Load(GOConfigReader &cfg) {
   m_RecordingTime.Init(cfg, wxT("AudioRecordTime"), _("Audio recording time"));
 }
 
-void GOAudioRecorder::ButtonStateChanged(int id) {
+void GOAudioRecorder::ButtonStateChanged(int id, bool newState) {
   switch (id) {
   case ID_AUDIO_RECORDER_STOP:
     StopRecording();

--- a/src/grandorgue/GOAudioRecorder.h
+++ b/src/grandorgue/GOAudioRecorder.h
@@ -30,7 +30,7 @@ private:
   static const struct ButtonDefinitionEntry m_element_types[];
   const struct ButtonDefinitionEntry *GetButtonDefinitionList();
 
-  void ButtonStateChanged(int id);
+  void ButtonStateChanged(int id, bool newState) override;
 
   void UpdateDisplay();
   void HandleTimer();

--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -132,7 +132,7 @@ void GOMetronome::Save(GOConfigWriter &cfg) {
   cfg.WriteInteger(m_group, wxT("MeasureLength"), m_MeasureLength);
 }
 
-void GOMetronome::ButtonStateChanged(int id) {
+void GOMetronome::ButtonStateChanged(int id, bool newState) {
   switch (id) {
   case ID_METRONOME_ON:
     if (m_Running)

--- a/src/grandorgue/GOMetronome.h
+++ b/src/grandorgue/GOMetronome.h
@@ -40,7 +40,7 @@ private:
 
   void HandleTimer();
 
-  void ButtonStateChanged(int id);
+  void ButtonStateChanged(int id, bool newState) override;
 
   void AbortPlayback();
   void PreparePlayback();

--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -405,7 +405,7 @@ void GODivisionalSetter::SwitchBankToNext(unsigned manualN) {
   }
 }
 
-void GODivisionalSetter::ButtonStateChanged(int id) {
+void GODivisionalSetter::ButtonStateChanged(int id, bool newState) {
   // dispatch button press to the actual button
 
   int manualN = id / N_BUTTONS;

--- a/src/grandorgue/combinations/GODivisionalSetter.h
+++ b/src/grandorgue/combinations/GODivisionalSetter.h
@@ -67,7 +67,7 @@ protected:
   GetButtonDefinitionList() override;
 
   // called on pressing any button. id is mapped to manualN and divisionalN
-  void ButtonStateChanged(int id) override;
+  void ButtonStateChanged(int id, bool newState) override;
 
 public:
   // calculates the setter element name for a divisional button

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -661,7 +661,7 @@ void GOSetter::FromYaml(const YAML::Node &yamlNode) {
       >> *m_framegeneral[i];
 }
 
-void GOSetter::ButtonStateChanged(int id) {
+void GOSetter::ButtonStateChanged(int id, bool newState) {
   GOCombination::ExtraElementsSet elementSet;
 
   switch (id) {

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -80,7 +80,7 @@ private:
   static const struct ButtonDefinitionEntry m_element_types[];
   const struct ButtonDefinitionEntry *GetButtonDefinitionList();
 
-  void ButtonStateChanged(int id);
+  void ButtonStateChanged(int id, bool newState) override;
 
   void ControlChanged(void *control);
 

--- a/src/grandorgue/control/GOButtonCallback.h
+++ b/src/grandorgue/control/GOButtonCallback.h
@@ -14,7 +14,13 @@ class GOButtonCallback {
 public:
   virtual ~GOButtonCallback() {}
 
-  virtual void ButtonStateChanged(GOButtonControl *button) = 0;
+  /**
+   * Called when the button is pushed of it's state is changed
+   * @param button the button that is changed
+   * @param newState is the button goes to be pushed or not.
+   *   For pushbuttons it is always true
+   */
+  virtual void ButtonStateChanged(GOButtonControl *button, bool newState) = 0;
 };
 
 #endif

--- a/src/grandorgue/control/GOCallbackButtonControl.cpp
+++ b/src/grandorgue/control/GOCallbackButtonControl.cpp
@@ -21,7 +21,7 @@ GOCallbackButtonControl::GOCallbackButtonControl(
 
 void GOCallbackButtonControl::Push() {
   if (m_Pushbutton)
-    m_callback->ButtonStateChanged(this);
+    m_callback->ButtonStateChanged(this, true);
   else
     GOButtonControl::Push();
 }
@@ -29,7 +29,7 @@ void GOCallbackButtonControl::Push() {
 void GOCallbackButtonControl::Set(bool on) {
   if (IsEngaged() == on)
     return;
-  m_callback->ButtonStateChanged(this);
+  m_callback->ButtonStateChanged(this, on);
   Display(on);
 }
 

--- a/src/grandorgue/control/GOElementCreator.cpp
+++ b/src/grandorgue/control/GOElementCreator.cpp
@@ -40,8 +40,9 @@ GOButtonControl *GOElementCreator::GetButtonControl(
   return NULL;
 }
 
-void GOElementCreator::ButtonStateChanged(GOButtonControl *button) {
+void GOElementCreator::ButtonStateChanged(
+  GOButtonControl *button, bool newState) {
   for (unsigned i = 0; i < m_buttons.size(); i++)
     if (m_buttons[i] == button)
-      ButtonStateChanged(i);
+      ButtonStateChanged(i, newState);
 }

--- a/src/grandorgue/control/GOElementCreator.h
+++ b/src/grandorgue/control/GOElementCreator.h
@@ -33,7 +33,7 @@ protected:
   ptr_vector<GOButtonControl> m_buttons;
 
   virtual const struct ButtonDefinitionEntry *GetButtonDefinitionList() = 0;
-  virtual void ButtonStateChanged(int id) = 0;
+  virtual void ButtonStateChanged(int id, bool newState) = 0;
   void CreateButtons(GOOrganController *organController);
 
 public:
@@ -48,7 +48,7 @@ public:
   virtual GOButtonControl *GetButtonControl(
     const wxString &name, bool is_panel);
 
-  void ButtonStateChanged(GOButtonControl *button);
+  void ButtonStateChanged(GOButtonControl *button, bool newState) override;
 };
 
 #endif

--- a/src/grandorgue/midi/GOMidiPlayer.cpp
+++ b/src/grandorgue/midi/GOMidiPlayer.cpp
@@ -65,7 +65,7 @@ void GOMidiPlayer::Load(GOConfigReader &cfg) {
   m_PlayingTime.Init(cfg, wxT("MidiPlayerTime"), _("MIDI playing time"));
 }
 
-void GOMidiPlayer::ButtonStateChanged(int id) {
+void GOMidiPlayer::ButtonStateChanged(int id, bool newState) {
   switch (id) {
   case ID_MIDI_PLAYER_STOP:
     StopPlaying();

--- a/src/grandorgue/midi/GOMidiPlayer.h
+++ b/src/grandorgue/midi/GOMidiPlayer.h
@@ -40,7 +40,7 @@ private:
   const struct GOElementCreator::ButtonDefinitionEntry *
   GetButtonDefinitionList();
 
-  void ButtonStateChanged(int id);
+  void ButtonStateChanged(int id, bool newState) override;
 
   void UpdateDisplay();
   void HandleTimer();

--- a/src/grandorgue/midi/GOMidiRecorder.cpp
+++ b/src/grandorgue/midi/GOMidiRecorder.cpp
@@ -79,7 +79,7 @@ void GOMidiRecorder::Load(GOConfigReader &cfg) {
   m_RecordingTime.Init(cfg, wxT("MidiRecordTime"), _("MIDI recording time"));
 }
 
-void GOMidiRecorder::ButtonStateChanged(int id) {
+void GOMidiRecorder::ButtonStateChanged(int id, bool newState) {
   switch (id) {
   case ID_MIDI_RECORDER_STOP:
     StopRecording();

--- a/src/grandorgue/midi/GOMidiRecorder.h
+++ b/src/grandorgue/midi/GOMidiRecorder.h
@@ -53,7 +53,7 @@ private:
   const struct GOElementCreator::ButtonDefinitionEntry *
   GetButtonDefinitionList();
 
-  void ButtonStateChanged(int id);
+  void ButtonStateChanged(int id, bool newState) override;
 
   void UpdateDisplay();
   void HandleTimer();


### PR DESCRIPTION
Passing the new button state to ButtonStateChanged allows to write handlers not only for pushbuttons but also for regular buttons.

It is just passing a new parameter that is not used yet, so GO behavior should not be changed.