### PR TITLE
Moved CmbProperties from GOOrganController to GOOrganModel

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -101,11 +101,6 @@ GOOrganController::GOOrganController(
     m_b_customized(false),
     m_CurrentPitch(999999.0), // for enforcing updating the label first time
     m_OrganModified(false),
-    m_DivisionalsStoreIntermanualCouplers(false),
-    m_DivisionalsStoreIntramanualCouplers(false),
-    m_DivisionalsStoreTremulants(false),
-    m_GeneralsStoreDivisionalCouplers(false),
-    m_CombinationsStoreNonDisplayedDrawstops(false),
     m_ChurchName(),
     m_ChurchAddress(),
     m_OrganBuilder(),
@@ -241,20 +236,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   /* load basic organ information */
   unsigned NumberOfPanels = cfg.ReadInteger(
     ODFSetting, WX_ORGAN, wxT("NumberOfPanels"), 0, 100, false);
-  m_DivisionalsStoreIntermanualCouplers = cfg.ReadBoolean(
-    ODFSetting, WX_ORGAN, wxT("DivisionalsStoreIntermanualCouplers"));
-  m_DivisionalsStoreIntramanualCouplers = cfg.ReadBoolean(
-    ODFSetting, WX_ORGAN, wxT("DivisionalsStoreIntramanualCouplers"));
-  m_DivisionalsStoreTremulants
-    = cfg.ReadBoolean(ODFSetting, WX_ORGAN, wxT("DivisionalsStoreTremulants"));
-  m_GeneralsStoreDivisionalCouplers = cfg.ReadBoolean(
-    ODFSetting, WX_ORGAN, wxT("GeneralsStoreDivisionalCouplers"));
-  m_CombinationsStoreNonDisplayedDrawstops = cfg.ReadBoolean(
-    ODFSetting,
-    WX_ORGAN,
-    wxT("CombinationsStoreNonDisplayedDrawstops"),
-    false,
-    true);
   cfg.ReadString(CMBSetting, WX_ORGAN, WX_GRANDORGUE_VERSION, false);
   m_volume = cfg.ReadInteger(
     CMBSetting, WX_ORGAN, wxT("Volume"), -120, 100, false, m_config.Volume());
@@ -888,26 +869,6 @@ GOButtonControl *GOOrganController::GetButtonControl(
 void GOOrganController::SetVolume(int volume) { m_volume = volume; }
 
 int GOOrganController::GetVolume() { return m_volume; }
-
-bool GOOrganController::DivisionalsStoreIntermanualCouplers() {
-  return m_DivisionalsStoreIntermanualCouplers;
-}
-
-bool GOOrganController::DivisionalsStoreIntramanualCouplers() {
-  return m_DivisionalsStoreIntramanualCouplers;
-}
-
-bool GOOrganController::DivisionalsStoreTremulants() {
-  return m_DivisionalsStoreTremulants;
-}
-
-bool GOOrganController::CombinationsStoreNonDisplayedDrawstops() {
-  return m_CombinationsStoreNonDisplayedDrawstops;
-}
-
-bool GOOrganController::GeneralsStoreDivisionalCouplers() {
-  return m_GeneralsStoreDivisionalCouplers;
-}
 
 GOSetter *GOOrganController::GetSetter() { return m_setter; }
 

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -80,11 +80,6 @@ private:
   bool m_b_customized;
   float m_CurrentPitch; // organ pitch
   bool m_OrganModified; // always m_IsOrganModified >= IsModelModified()
-  bool m_DivisionalsStoreIntermanualCouplers;
-  bool m_DivisionalsStoreIntramanualCouplers;
-  bool m_DivisionalsStoreTremulants;
-  bool m_GeneralsStoreDivisionalCouplers;
-  bool m_CombinationsStoreNonDisplayedDrawstops;
 
   wxString m_ChurchName;
   wxString m_ChurchAddress;
@@ -199,13 +194,6 @@ public:
   GOMainWindowData *GetMainWindowData();
 
   void LoadMIDIFile(const wxString &filename);
-
-  /* ODF general properties */
-  bool DivisionalsStoreIntermanualCouplers();
-  bool DivisionalsStoreIntramanualCouplers();
-  bool DivisionalsStoreTremulants();
-  bool CombinationsStoreNonDisplayedDrawstops();
-  bool GeneralsStoreDivisionalCouplers();
 
   void SetVolume(int volume);
   int GetVolume();

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -23,6 +23,11 @@
 
 GOOrganModel::GOOrganModel(const GOConfig &config)
   : m_config(config),
+    m_DivisionalsStoreIntermanualCouplers(false),
+    m_DivisionalsStoreIntramanualCouplers(false),
+    m_DivisionalsStoreTremulants(false),
+    m_GeneralsStoreDivisionalCouplers(false),
+    m_CombinationsStoreNonDisplayedDrawstops(false),
     m_RootPipeConfigNode(nullptr, this, nullptr),
     m_OrganModelModified(false),
     m_FirstManual(0),
@@ -34,8 +39,23 @@ GOOrganModel::~GOOrganModel() {}
 void GOOrganModel::Load(
   GOConfigReader &cfg, GOOrganController *organController) {
   wxString group = wxT("Organ");
-  unsigned NumberOfWindchestGroups = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfWindchestGroups"), 1, 999);
+  m_DivisionalsStoreIntermanualCouplers = cfg.ReadBoolean(
+    ODFSetting, group, wxT("DivisionalsStoreIntermanualCouplers"));
+  m_DivisionalsStoreIntramanualCouplers = cfg.ReadBoolean(
+    ODFSetting, group, wxT("DivisionalsStoreIntramanualCouplers"));
+  m_DivisionalsStoreTremulants
+    = cfg.ReadBoolean(ODFSetting, group, wxT("DivisionalsStoreTremulants"));
+  m_GeneralsStoreDivisionalCouplers = cfg.ReadBoolean(
+    ODFSetting, group, wxT("GeneralsStoreDivisionalCouplers"));
+  m_CombinationsStoreNonDisplayedDrawstops = cfg.ReadBoolean(
+    ODFSetting,
+    group,
+    wxT("CombinationsStoreNonDisplayedDrawstops"),
+    false,
+    true);
+
+  unsigned NumberOfWindchestGroups
+    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfWindchestGroups"), 1, 999);
 
   m_RootPipeConfigNode.Load(cfg, group, wxEmptyString);
   m_windchests.resize(0);

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -54,8 +54,8 @@ void GOOrganModel::Load(
     false,
     true);
 
-  unsigned NumberOfWindchestGroups
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfWindchestGroups"), 1, 999);
+  unsigned NumberOfWindchestGroups = cfg.ReadInteger(
+    ODFSetting, group, wxT("NumberOfWindchestGroups"), 1, 999);
 
   m_RootPipeConfigNode.Load(cfg, group, wxEmptyString);
   m_windchests.resize(0);

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -38,6 +38,12 @@ private:
 
   const GOConfig &m_config;
 
+  bool m_DivisionalsStoreIntermanualCouplers;
+  bool m_DivisionalsStoreIntramanualCouplers;
+  bool m_DivisionalsStoreTremulants;
+  bool m_GeneralsStoreDivisionalCouplers;
+  bool m_CombinationsStoreNonDisplayedDrawstops;
+
   GOPipeConfigTreeNode m_RootPipeConfigNode;
 
   bool m_OrganModelModified;
@@ -63,6 +69,27 @@ public:
   ~GOOrganModel();
 
   const GOConfig &GetConfig() const { return m_config; }
+
+  /* combinations properties */
+  bool DivisionalsStoreIntermanualCouplers() const {
+    return m_DivisionalsStoreIntermanualCouplers;
+  }
+
+  bool DivisionalsStoreIntramanualCouplers() const {
+    return m_DivisionalsStoreIntramanualCouplers;
+  }
+
+  bool DivisionalsStoreTremulants() const {
+    return m_DivisionalsStoreTremulants;
+  }
+
+  bool CombinationsStoreNonDisplayedDrawstops() const {
+    return m_CombinationsStoreNonDisplayedDrawstops;
+  }
+
+  bool GeneralsStoreDivisionalCouplers() const {
+    return m_GeneralsStoreDivisionalCouplers;
+  }
 
   GOPipeConfigNode &GetRootPipeConfigNode() { return m_RootPipeConfigNode; }
 


### PR DESCRIPTION
Toward to removing usages of GOOrganController from combinations/model, I moved some properties controlling combinations setting from GOOrganController to GOOrganModel.

It is just refactoring. No GO behavior should be changed.