### PR TITLE
Fixed build for macos

### DIFF
--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -24,3 +24,10 @@ for F in $(grep -l '(, weak)\?'  /usr/local/Cellar/cmake/*/share/cmake/Modules/G
   sed -e 's/(, weak)\?/(, (weak|reexport))?/' $F >${F}.new
   mv ${F}.new $F
 done
+
+# wxwidgets has been built against libtiff.5.dylib but it is not more available
+if [ ! -f /usr/local/opt/libtiff/lib/libtiff.5.dylib ]; then
+  pushd /usr/local/opt/libtiff/lib
+  sudo ln -s `readlink libtiff.dylib` libtiff.5.dylib
+  popd
+fi


### PR DESCRIPTION
Some days ago all builds for mac os started failing. 

The reason: for comatibility with mac os 10.15 I use the prebuld wxWidgets that has been linked against `libtiff.5.dylib`, but since a time brew has started installing `libtiff.6.dylib`.

This PR creates a symlink `libtiff.5.dylib` to an existing `libtiff` library.