### PR TITLE
Moving controlling buttons from GOCombination::Push derivatives to GOSetter

### DIFF
--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -783,7 +783,7 @@ void GOFrame::OnUpdateLoaded(wxUpdateUIEvent &event) {
   if (event.GetId() == ID_AUDIO_MEMSET)
     event.Check(
       organController && organController->GetSetter()
-      && organController->GetSetter()->IsSetterActive());
+      && organController->GetSetter()->GetState().m_IsActive);
   else if (event.GetId() == ID_ORGAN_EDIT)
     event.Check(m_doc && m_doc->WindowExists(GODocument::ORGAN_DIALOG, NULL));
   else if (event.GetId() == ID_MIDI_LIST)

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -261,7 +261,7 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   m_setter = new GOSetter(this);
   m_elementcreators.push_back(m_setter);
-  m_DivisionalSetter = new GODivisionalSetter(this);
+  m_DivisionalSetter = new GODivisionalSetter(this, m_setter->GetState());
   m_elementcreators.push_back(m_DivisionalSetter);
   m_AudioRecorder = new GOAudioRecorder(this);
   m_MidiRecorder = new GOMidiRecorder(this);

--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -15,6 +15,7 @@
 #include "control/GOLabelControl.h"
 #include "model/GODivisionalCombination.h"
 #include "model/GOManual.h"
+#include "model/GOSetterState.h"
 #include "yaml/go-wx-yaml.h"
 
 #include "GOOrganController.h"
@@ -84,8 +85,10 @@ wxString GODivisionalSetter::GetDivisionalBankNextLabelName(
   return wxString::Format(wxT("Setter%03dDivisionalNextBank"), manualIndex);
 }
 
-GODivisionalSetter::GODivisionalSetter(GOOrganController *organController)
+GODivisionalSetter::GODivisionalSetter(
+  GOOrganController *organController, const GOSetterState &setterState)
   : m_OrganController(organController),
+    r_SetterState(setterState),
     m_FirstManualIndex(m_OrganController->GetFirstManualIndex()),
     m_OdfManualCount(m_OrganController->GetODFManualCount()),
     m_NManuals(m_OdfManualCount - m_FirstManualIndex),
@@ -351,9 +354,8 @@ void GODivisionalSetter::SwitchDivisionalTo(
     // whether the combination is defined
     bool isExist = divMap.find(divisionalIdx) != divMap.end();
     GODivisionalCombination *pCmb = isExist ? divMap[divisionalIdx] : nullptr;
-    GOSetter &setter = *m_OrganController->GetSetter();
 
-    if (!isExist && setter.IsSetterActive()) {
+    if (!isExist && r_SetterState.m_IsActive) {
       // create a new combination
       const unsigned manualIndex = m_FirstManualIndex + manualN;
       GOCombinationDefinition &divTemplate
@@ -369,7 +371,7 @@ void GODivisionalSetter::SwitchDivisionalTo(
 
     if (pCmb) {
       // the combination was existing or has just been created
-      setter.NotifyCmbPushed(pCmb->Push());
+      m_OrganController->GetSetter()->PushDivisional(*pCmb);
 
       // reflect the ne state of the combination buttons
       for (unsigned firstButtonIdx = N_BUTTONS * manualN, k = 0;

--- a/src/grandorgue/combinations/GODivisionalSetter.h
+++ b/src/grandorgue/combinations/GODivisionalSetter.h
@@ -23,6 +23,7 @@
 class GOOrganController;
 class GODivisionalCombination;
 class GOLabelControl;
+class GOSetterState;
 
 class GODivisionalSetter : public GOElementCreator,
                            GOSaveableObject,
@@ -34,6 +35,7 @@ private:
   using DivisionalMap = std::map<unsigned, GODivisionalCombination *>;
 
   GOOrganController *m_OrganController;
+  const GOSetterState &r_SetterState;
 
   // the setter starts manuals from 0 but m_OrganController may start from
   // m_FirstManualIndex
@@ -80,7 +82,8 @@ public:
   // calculates the setter element name for the next-bank button
   static wxString GetDivisionalBankNextLabelName(unsigned manualIndex);
 
-  GODivisionalSetter(GOOrganController *organController);
+  GODivisionalSetter(
+    GOOrganController *organController, const GOSetterState &setterState);
   virtual ~GODivisionalSetter();
 
   // saves all combinations to the preset file

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -17,12 +17,15 @@
 #include "control/GOLabelControl.h"
 #include "model/GOCombination.h"
 #include "model/GOEnclosure.h"
+#include "model/GOGeneralCombination.h"
+#include "model/GOSetterState.h"
 #include "sound/GOSoundStateHandler.h"
 #include "yaml/GOSaveableToYaml.h"
 
 #define N_CRESCENDOS 4
 
 class GOGeneralCombination;
+class GODivisionalCombination;
 
 class GOSetter : private GOSoundStateHandler,
                  private GOControlChangedHandler,
@@ -38,11 +41,9 @@ private:
   bool m_IsCmbFileListPopulated;
   // current loaded cmb file name (with dir and extension)
   wxString m_CmbFileLastLoaded;
-  // has the current combinations been changed after last loaded or saved
-  // used for lighting the save button
-  bool m_IsCmbChanged;
   // current displayed cmb file name (with dir and extension)
   wxString m_CmbFileDisplayed;
+  GOSetterState m_state;
   int m_CmbFilePos; // current displayed position or -1 or the list is not
                     // populated yet or no file are loaded
 
@@ -62,7 +63,6 @@ private:
   GOLabelControl m_TransposeDisplay;
   GOLabelControl m_NameDisplay;
   GOEnclosure m_swell;
-  GOCombination::SetterType m_SetterType;
 
   // Show the combination file name
   void DisplayCmbFile(const wxString &fileName);
@@ -73,7 +73,7 @@ private:
   // Display the prev/next cmb file
   void MoveToCmbFile(int offset);
 
-  void SetSetterType(GOCombination::SetterType type);
+  void SetSetterType(GOSetterState::SetterType type);
   void SetCrescendoType(unsigned no);
   void Crescendo(int pos, bool force = false);
 
@@ -85,6 +85,18 @@ private:
   void ControlChanged(void *control);
 
   void PreparePlayback();
+
+  /**
+   * Called after at least one combination is changed
+   * Temporary it calls mOrganController->SetModified()
+   */
+  void NotifyCmbChanged();
+  /**
+   * Called after a combination is pushed
+   * When Set is active then marks the cpmbinations as modified
+   * Temporary it calls mOrganController->SetModified()
+   */
+  void NotifyCmbPushed(bool isChanged = true);
 
 public:
   static const wxString KEY_REFRESH_FILES;
@@ -106,19 +118,8 @@ public:
   GOSetter(GOOrganController *organController);
   virtual ~GOSetter();
 
-  bool IsCmbModified() const { return m_IsCmbChanged; }
-
-  /**
-   * Called after at least one combination is changed
-   * Temporary it calls mOrganController->SetModified()
-   */
-  void NotifyCmbChanged();
-  /**
-   * Called after a combination is pushed
-   * When Set is active then marks the cpmbinations as modified
-   * Temporary it calls mOrganController->SetModified()
-   */
-  void NotifyCmbPushed(bool isChanged = true);
+  const GOSetterState &GetState() const { return m_state; }
+  bool IsCmbModified() const { return m_state.m_IsModified; }
 
   /**
    * Save all combinations to yaml as a map
@@ -157,11 +158,20 @@ public:
 
   void Update();
 
-  bool StoreInvisibleObjects();
-  bool IsSetterActive();
   void ToggleSetter();
   void SetterActive(bool on);
-  GOCombination::SetterType GetSetterType() const { return m_SetterType; }
+
+  /*
+   * Activate cmb
+   * If the crescendo in add mode then not to disable stops that are present in
+   * extraSet
+   * If isFromCrescendo and it is in add mode then then does not depress other
+   * buttons
+   *
+   * return if anything is changed
+   */
+  void PushGeneral(GOGeneralCombination &cmb);
+  void PushDivisional(GODivisionalCombination &cmb);
 
   /*
    * If current crescendo is in override mode then returns nullptr

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -51,14 +51,9 @@ void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
 }
 
 void GODivisionalButtonControl::Push() {
-  GOCombination::ExtraElementsSet elementSet;
-  GOSetter &setter = *m_OrganController->GetSetter();
-  const GOCombination::ExtraElementsSet *pAddSet
-    = setter.GetCrescendoAddSet(elementSet);
+  m_OrganController->GetSetter()->PushDivisional(m_combination);
   GOManual *pManual
     = m_OrganController->GetManual(m_combination.GetManualNumber());
-
-  setter.NotifyCmbPushed(m_combination.Push(pAddSet));
 
   for (unsigned l = pManual->GetDivisionalCount(), k = 0; k < l; k++) {
     GODivisionalButtonControl *pDivisionalControl = pManual->GetDivisional(k);

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -26,11 +26,7 @@ void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
 }
 
 void GOGeneralButtonControl::Push() {
-  GOSetter &setter = *m_OrganController->GetSetter();
-  GOCombination::ExtraElementsSet elementSet;
-
-  setter.NotifyCmbPushed(
-    m_combination.Push(setter.GetCrescendoAddSet(elementSet)));
+  m_OrganController->GetSetter()->PushGeneral(m_combination);
 }
 
 GOGeneralCombination &GOGeneralButtonControl::GetCombination() {

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -12,20 +12,19 @@
 #include <wx/intl.h>
 #include <wx/log.h>
 
-#include "combinations/GOSetter.h"
 #include "config/GOConfigWriter.h"
+#include "model/GOCoupler.h"
+#include "model/GODivisionalCoupler.h"
 #include "model/GODrawStop.h"
+#include "model/GOManual.h"
+#include "model/GOStop.h"
+#include "model/GOSwitch.h"
+#include "model/GOTremulant.h"
 #include "yaml/go-wx-yaml.h"
 
 #include "GOCombinationDefinition.h"
 #include "GOCombinationElement.h"
 #include "GOOrganController.h"
-#include "model/GOCoupler.h"
-#include "model/GODivisionalCoupler.h"
-#include "model/GOManual.h"
-#include "model/GOStop.h"
-#include "model/GOSwitch.h"
-#include "model/GOTremulant.h"
 
 GOCombination::GOCombination(
   const GOCombinationDefinition &combination_template,
@@ -346,12 +345,13 @@ void GOCombination::FromYaml(const YAML::Node &yamlNode) {
 }
 
 bool GOCombination::FillWithCurrent(
-  SetterType setterType, bool isToStoreInvisibleObjects) {
+  GOSetterState::SetterType setterType, bool isToStoreInvisibleObjects) {
   bool used = false;
 
   UpdateState();
   m_IsFull = isToStoreInvisibleObjects;
-  if (setterType == SETTER_REGULAR) {
+  switch (setterType) {
+  case GOSetterState::SETTER_REGULAR:
     for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
       if (
         !isToStoreInvisibleObjects
@@ -363,8 +363,8 @@ bool GOCombination::FillWithCurrent(
       } else
         m_State[i] = 0;
     }
-  }
-  if (setterType == SETTER_SCOPE) {
+    break;
+  case GOSetterState::SETTER_SCOPE:
     for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
       if (
         !isToStoreInvisibleObjects
@@ -376,9 +376,9 @@ bool GOCombination::FillWithCurrent(
       } else
         m_State[i] = -1;
     }
-  }
-  if (setterType == SETTER_SCOPED) {
-    for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
+    break;
+  case GOSetterState::SETTER_SCOPED:
+    for (unsigned i = 0; i < r_ElementDefinitions.size(); i++)
       if (m_State[i] != -1) {
         if (r_ElementDefinitions[i].control->GetCombinationState()) {
           m_State[i] = 1;
@@ -386,19 +386,20 @@ bool GOCombination::FillWithCurrent(
         } else
           m_State[i] = 0;
       }
-    }
+    break;
   }
   return used;
 }
 
-bool GOCombination::PushLocal(GOCombination::ExtraElementsSet const *extraSet) {
+bool GOCombination::Push(
+  const GOSetterState &setterState,
+  const GOCombination::ExtraElementsSet *extraSet) {
   bool used = false;
-  GOSetter &setter = *m_OrganFile->GetSetter();
 
-  if (setter.IsSetterActive()) {
+  if (setterState.m_IsActive) {
     if (!m_Protected) {
       used = FillWithCurrent(
-        setter.GetSetterType(), setter.StoreInvisibleObjects());
+        setterState.m_SetterType, setterState.m_IsStoreInvisible);
     }
   } else {
     UpdateState();

--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -17,12 +17,12 @@
 
 #include "GOCombinationDefinition.h"
 #include "GOSaveableObject.h"
+#include "GOSetterState.h"
 
 class GOOrganController;
 
 class GOCombination : public GOSaveableObject, public GOSaveableToYaml {
 public:
-  enum SetterType { SETTER_REGULAR, SETTER_SCOPE, SETTER_SCOPED };
   using ExtraElementsSet = std::unordered_set<unsigned>;
 
 private:
@@ -119,7 +119,6 @@ protected:
    * @param yamlMap
    */
   virtual void FromYamlMap(const YAML::Node &yamlMap) = 0;
-  virtual bool PushLocal(ExtraElementsSet const *extraSet = nullptr);
 
 public:
   GOCombination(
@@ -143,7 +142,8 @@ public:
   /**
    * Fills the combination from the current organ elements
    */
-  bool FillWithCurrent(SetterType setterType, bool isToStoreInvisibleObjects);
+  bool FillWithCurrent(
+    GOSetterState::SetterType setterType, bool isToStoreInvisibleObjects);
 
   void ToYaml(YAML::Node &yamlMap) const override;
 
@@ -164,6 +164,10 @@ public:
     YAML::Node &container, const wxString &key, const GOCombination *pCmb);
 
   void FromYaml(const YAML::Node &yamlNode) override;
+
+  bool Push(
+    const GOSetterState &setterState,
+    const ExtraElementsSet *extraSet = nullptr);
 };
 
 #endif

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -10,9 +10,6 @@
 #include <wx/intl.h>
 #include <wx/log.h>
 
-#include "combinations/control/GODivisionalButtonControl.h"
-
-#include "combinations/GOSetter.h"
 #include "config/GOConfigWriter.h"
 #include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
@@ -242,44 +239,6 @@ void GODivisionalCombination::FromYamlMap(const YAML::Node &yamlMap) {
     m_odfManualNumber,
     GOCombinationDefinition::COMBINATION_SWITCH);
 }
-
-bool GODivisionalCombination::Push(ExtraElementsSet const *extraSet) {
-  bool changed = PushLocal(extraSet);
-
-  /* only use divisional couples, if not in setter mode */
-  if (!m_OrganController->GetSetter()->IsSetterActive()) {
-    for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
-         k++) {
-      GODivisionalCoupler *coupler = m_OrganController->GetDivisionalCoupler(k);
-      if (!coupler->IsEngaged())
-        continue;
-
-      for (unsigned i = 0; i < coupler->GetNumberOfManuals(); i++) {
-        if (coupler->GetManual(i) != m_odfManualNumber)
-          continue;
-
-        for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++)
-          m_OrganController->GetManual(coupler->GetManual(j))
-            ->GetDivisional(m_DivisionalNumber)
-            ->Push();
-
-        if (coupler->IsBidirectional()) {
-          for (unsigned j = 0; j < coupler->GetNumberOfManuals(); j++) {
-            if (coupler->GetManual(j) == m_odfManualNumber)
-              break;
-            m_OrganController->GetManual(coupler->GetManual(j))
-              ->GetDivisional(m_DivisionalNumber)
-              ->Push();
-          }
-        }
-        break;
-      }
-    }
-  }
-  return changed;
-}
-
-wxString GODivisionalCombination::GetMidiType() { return _("Divisional"); }
 
 GODivisionalCombination *GODivisionalCombination::LoadFrom(
   GOOrganController *organController,

--- a/src/grandorgue/combinations/model/GODivisionalCombination.h
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.h
@@ -15,6 +15,7 @@
 class GOConfigReader;
 class GOConfigWriter;
 class GOOrganController;
+class GOSetterState;
 
 class GODivisionalCombination : public GOCombination {
 protected:
@@ -55,10 +56,6 @@ public:
     wxString group,
     int manualNumber,
     int divisionalNumber);
-
-  bool Push(ExtraElementsSet const *extraSet = nullptr);
-
-  wxString GetMidiType();
 
   // checks if the combination exists in the config file
   // returns the loaded combination if it exists else returns nullptr

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -11,9 +11,6 @@
 #include <wx/log.h>
 #include <yaml-cpp/yaml.h>
 
-#include "combinations/GOSetter.h"
-#include "combinations/control/GODivisionalButtonControl.h"
-#include "combinations/control/GOGeneralButtonControl.h"
 #include "config/GOConfigWriter.h"
 #include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
@@ -144,31 +141,6 @@ void GOGeneralCombination::LoadCombinationInt(
       cfg.ReadInteger(srcType, m_group, buffer, -cnt, cnt),
       buffer);
   }
-}
-
-bool GOGeneralCombination::Push(
-  ExtraElementsSet const *extraSet, bool isFromCrescendo) {
-  bool changed = GOCombination::PushLocal(extraSet);
-
-  if (!isFromCrescendo || !extraSet) { // Otherwise the crescendo in add mode:
-                                       // not to switch off combination buttons
-    m_OrganController->GetSetter()->ResetDisplay(); // disable buttons
-
-    for (unsigned k = 0; k < m_OrganController->GetGeneralCount(); k++) {
-      GOGeneralButtonControl *general = m_OrganController->GetGeneral(k);
-      general->Display(&general->GetCombination() == this);
-    }
-
-    for (unsigned j = m_OrganController->GetFirstManualIndex();
-         j <= m_OrganController->GetManualAndPedalCount();
-         j++) {
-      for (unsigned k = 0;
-           k < m_OrganController->GetManual(j)->GetDivisionalCount();
-           k++)
-        m_OrganController->GetManual(j)->GetDivisional(k)->Display(false);
-    }
-  }
-  return changed;
 }
 
 void GOGeneralCombination::SaveInt(GOConfigWriter &cfg) {

--- a/src/grandorgue/combinations/model/GOGeneralCombination.h
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.h
@@ -15,6 +15,7 @@
 class GOConfigReader;
 class GOConfigWriter;
 class GOOrganController;
+class GOSetter;
 
 class GOGeneralCombination : public GOCombination {
 private:
@@ -42,17 +43,6 @@ public:
     GOOrganController *organController,
     bool is_setter);
   void Load(GOConfigReader &cfg, wxString group);
-
-  /*
-   * Activate this combination
-   * If extraSet is passed then not to disable stops that are present in
-   * extraSet
-   * If isFromCrescendo and extraSet is passed then does not depress other
-   * buttons
-   * return if anything is changed
-   */
-  bool Push(
-    ExtraElementsSet const *extraSet = nullptr, bool isFromCrescendo = false);
 };
 
 #endif /* GOGENERALCOMBINATION_H */

--- a/src/grandorgue/combinations/model/GOSetterState.h
+++ b/src/grandorgue/combinations/model/GOSetterState.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSETTERSTATE_H
+#define GOSETTERSTATE_H
+
+struct GOSetterState {
+  enum SetterType { SETTER_REGULAR, SETTER_SCOPE, SETTER_SCOPED };
+
+  // Is the Set button pushed now
+  bool m_IsActive = false;
+  // What type button is pushed now: Regular, Scope or Scoped
+  SetterType m_SetterType = SETTER_REGULAR;
+  // Is the Full button is pushed now
+  bool m_IsStoreInvisible = false;
+  // has the current combinations been changed after last loaded or saved
+  // used for lighting the save button
+  bool m_IsModified = false;
+};
+
+#endif /* GOSETTERSTATE_H */


### PR DESCRIPTION
This PR makes a next step towards the MVC paradigm.

Earlier `GOCombination` had the `PushLocal` method that activated the combination. And both `GOGeneralCombination` and `GODivisionalCombination` had the methods `Push` that called `PushLocal` and then switched general and divisional buttons' light on and off.

But it contradicted the idea of model. Combinations should know what elements (stops, couplers, tremulant and switches) to snable and disable, but they do not know, what UI elements (general and divisional buttons) use the combinations. This knowledge is more for GOSetter than for the combinations.

So this PR:
1. Moves the code controlling button light from `Push` of combinations to the new methods of `GOSetter`: `PushGeneral` and `PushDivisional`.
2. Removes the methods `GOGeneralCombination::Push` and `GODivisionalCombination::Push`.
3. Renames `GOCombination::PushLocal` to `Push`.
4. Addes a new `GOSetterState` class and moves the setter state from GOSetter there.
5. Passes the `GOSetterState` instance to `GOCombination::Push`. It allows to stop using GOSetter in GOCOmbination.

It is just refactoring. No GO behavior should be changed.