### PR TITLE
Removed dependency on GOOrganController from GORank

### DIFF
--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -106,7 +106,7 @@ void GOMetronome::Load(GOConfigReader &cfg) {
   windchest->Init(cfg, wxT("MetronomeWindchest"), _("Metronome"));
   unsigned samplegroup = m_OrganController->AddWindchest(windchest);
 
-  m_rank = new GORank(m_OrganController);
+  m_rank = new GORank(*m_OrganController);
   m_rank->Init(cfg, wxT("MetronomSounds"), _("Metronome"), 36, samplegroup);
   m_StopID = m_rank->RegisterStop(NULL);
   m_OrganController->AddRank(m_rank);

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -21,7 +21,7 @@
 #include "GOTremulant.h"
 #include "GOWindchest.h"
 
-GOOrganModel::GOOrganModel(const GOConfig &config)
+GOOrganModel::GOOrganModel(GOConfig &config)
   : m_config(config),
     m_DivisionalsStoreIntermanualCouplers(false),
     m_DivisionalsStoreIntramanualCouplers(false),
@@ -106,7 +106,7 @@ void GOOrganModel::Load(
   m_ODFRankCount
     = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfRanks"), 0, 999, false);
   for (unsigned i = 0; i < m_ODFRankCount; i++) {
-    m_ranks.push_back(new GORank(organController));
+    m_ranks.push_back(new GORank(*organController));
     m_ranks[i]->Load(cfg, wxString::Format(wxT("Rank%03d"), i + 1), -1);
   }
 

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -36,7 +36,7 @@ class GOOrganModel : public GOEventHandlerList,
 private:
   GOModificationProxy m_ModificationProxy;
 
-  const GOConfig &m_config;
+  GOConfig &m_config;
 
   bool m_DivisionalsStoreIntermanualCouplers;
   bool m_DivisionalsStoreIntramanualCouplers;
@@ -65,10 +65,11 @@ protected:
   void Load(GOConfigReader &cfg, GOOrganController *organController);
 
 public:
-  GOOrganModel(const GOConfig &config);
+  GOOrganModel(GOConfig &config);
   ~GOOrganModel();
 
   const GOConfig &GetConfig() const { return m_config; }
+  GOConfig &GetConfig() { return m_config; }
 
   /* combinations properties */
   bool DivisionalsStoreIntermanualCouplers() const {

--- a/src/grandorgue/model/GORank.h
+++ b/src/grandorgue/model/GORank.h
@@ -17,16 +17,18 @@
 
 #include "GOSaveableObject.h"
 
+class GOMidiMap;
+class GOOrganModel;
 class GOPipe;
 class GOStop;
 class GOTemperament;
-class GOOrganController;
 
 class GORank : private GOSaveableObject,
                public GOMidiConfigurator,
                private GOSoundStateHandler {
 private:
-  GOOrganController *m_OrganController;
+  GOOrganModel &r_OrganModel;
+  GOMidiMap &r_MidiMap;
   wxString m_Name;
   ptr_vector<GOPipe> m_Pipes;
   /**
@@ -59,7 +61,7 @@ private:
   void PreparePlayback();
 
 public:
-  GORank(GOOrganController *organController);
+  GORank(GOOrganModel &organModel);
   ~GORank();
   void Init(
     GOConfigReader &cfg,

--- a/src/grandorgue/model/GOStop.cpp
+++ b/src/grandorgue/model/GOStop.cpp
@@ -77,7 +77,7 @@ void GOStop::Load(GOConfigReader &cfg, wxString group) {
     }
   } else {
     RankInfo info;
-    info.Rank = new GORank(m_OrganController);
+    info.Rank = new GORank(*m_OrganController);
     m_OrganController->AddRank(info.Rank);
     info.FirstPipeNumber = cfg.ReadInteger(
       ODFSetting, group, wxT("FirstAccessiblePipeLogicalPipeNumber"), 1, 192);


### PR DESCRIPTION
This is a next PR towards removing references to GOOrganController from model

GORank stops using GOOrganController.

No GO behavior should be changed.