### PR TITLE
Fixed some warnings when compiling with GCC 13

### DIFF
--- a/src/core/GOOrgan.cpp
+++ b/src/core/GOOrgan.cpp
@@ -138,7 +138,10 @@ const wxString GOOrgan::GetOrganHash() const {
     hash.Update(m_ODF);
   } else {
     wxFileName odf(m_ODF);
-    odf.Normalize(wxPATH_NORM_ALL | wxPATH_NORM_CASE);
+
+    odf.Normalize(
+      wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE
+      | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT);
     wxString filename = odf.GetFullPath();
 
     hash.Update(filename);

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -60,7 +60,7 @@ const struct IniFileEnumEntry GOMidiReceiverBase::m_MidiTypes[] = {
 };
 
 void GOMidiReceiverBase::Load(
-  GOConfigReader &cfg, wxString group, GOMidiMap &map) {
+  GOConfigReader &cfg, const wxString &group, GOMidiMap &map) {
   m_events.resize(0);
 
   int event_cnt = cfg.ReadInteger(

--- a/src/core/midi/GOMidiReceiverBase.h
+++ b/src/core/midi/GOMidiReceiverBase.h
@@ -42,7 +42,7 @@ protected:
 public:
   GOMidiReceiverBase(GOMidiReceiverType type);
 
-  virtual void Load(GOConfigReader &cfg, wxString group, GOMidiMap &map);
+  virtual void Load(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
   void Save(GOConfigWriter &cfg, wxString group, GOMidiMap &map);
   void PreparePlayback();
 


### PR DESCRIPTION
Resolves: #1508 

This PR eliminates the compiler warnings when compiling with the recent GCC.

The warnings when compilling portaudio are still here.
