### PR TITLE
Moving controlling buttons from GOCombination::Push derivatives to GOSetter

### DIFF
--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -783,7 +783,7 @@ void GOFrame::OnUpdateLoaded(wxUpdateUIEvent &event) {
   if (event.GetId() == ID_AUDIO_MEMSET)
     event.Check(
       organController && organController->GetSetter()
-      && organController->GetSetter()->IsSetterActive());
+      && organController->GetSetter()->GetState().m_IsActive);
   else if (event.GetId() == ID_ORGAN_EDIT)
     event.Check(m_doc && m_doc->WindowExists(GODocument::ORGAN_DIALOG, NULL));
   else if (event.GetId() == ID_MIDI_LIST)

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -263,7 +263,7 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
     m_tremulants[i]->SetElementID(
       GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
 
-  m_DivisionalSetter = new GODivisionalSetter(this);
+  m_DivisionalSetter = new GODivisionalSetter(this, m_setter->GetState());
   m_elementcreators.push_back(m_DivisionalSetter);
   m_AudioRecorder = new GOAudioRecorder(this);
   m_MidiRecorder = new GOMidiRecorder(this);

--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -15,6 +15,7 @@
 #include "control/GOLabelControl.h"
 #include "model/GODivisionalCombination.h"
 #include "model/GOManual.h"
+#include "model/GOSetterState.h"
 #include "yaml/go-wx-yaml.h"
 
 #include "GOOrganController.h"
@@ -84,8 +85,10 @@ wxString GODivisionalSetter::GetDivisionalBankNextLabelName(
   return wxString::Format(wxT("Setter%03dDivisionalNextBank"), manualIndex);
 }
 
-GODivisionalSetter::GODivisionalSetter(GOOrganController *organController)
+GODivisionalSetter::GODivisionalSetter(
+  GOOrganController *organController, const GOSetterState &setterState)
   : m_OrganController(organController),
+    r_SetterState(setterState),
     m_FirstManualIndex(m_OrganController->GetFirstManualIndex()),
     m_OdfManualCount(m_OrganController->GetODFManualCount()),
     m_NManuals(m_OdfManualCount - m_FirstManualIndex),
@@ -351,9 +354,8 @@ void GODivisionalSetter::SwitchDivisionalTo(
     // whether the combination is defined
     bool isExist = divMap.find(divisionalIdx) != divMap.end();
     GODivisionalCombination *pCmb = isExist ? divMap[divisionalIdx] : nullptr;
-    GOSetter &setter = *m_OrganController->GetSetter();
 
-    if (!isExist && setter.IsSetterActive()) {
+    if (!isExist && r_SetterState.m_IsActive) {
       // create a new combination
       const unsigned manualIndex = m_FirstManualIndex + manualN;
       GOCombinationDefinition &divTemplate
@@ -369,7 +371,7 @@ void GODivisionalSetter::SwitchDivisionalTo(
 
     if (pCmb) {
       // the combination was existing or has just been created
-      setter.NotifyCmbPushed(pCmb->Push());
+      m_OrganController->GetSetter()->PushDivisional(*pCmb);
 
       // reflect the ne state of the combination buttons
       for (unsigned firstButtonIdx = N_BUTTONS * manualN, k = 0;

--- a/src/grandorgue/combinations/GODivisionalSetter.h
+++ b/src/grandorgue/combinations/GODivisionalSetter.h
@@ -23,6 +23,7 @@
 class GOOrganController;
 class GODivisionalCombination;
 class GOLabelControl;
+class GOSetterState;
 
 class GODivisionalSetter : public GOElementCreator,
                            GOSaveableObject,
@@ -34,6 +35,7 @@ private:
   using DivisionalMap = std::map<unsigned, GODivisionalCombination *>;
 
   GOOrganController *m_OrganController;
+  const GOSetterState &r_SetterState;
 
   // the setter starts manuals from 0 but m_OrganController may start from
   // m_FirstManualIndex
@@ -80,7 +82,8 @@ public:
   // calculates the setter element name for the next-bank button
   static wxString GetDivisionalBankNextLabelName(unsigned manualIndex);
 
-  GODivisionalSetter(GOOrganController *organController);
+  GODivisionalSetter(
+    GOOrganController *organController, const GOSetterState &setterState);
   virtual ~GODivisionalSetter();
 
   // saves all combinations to the preset file

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -18,7 +18,10 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 #include "control/GOCallbackButtonControl.h"
+#include "control/GODivisionalButtonControl.h"
 #include "control/GOGeneralButtonControl.h"
+#include "model/GODivisionalCoupler.h"
+#include "model/GOManual.h"
 #include "yaml/go-wx-yaml.h"
 
 #include "GOEvent.h"
@@ -293,8 +296,7 @@ GOSetter::GOSetter(GOOrganController *organController)
     m_CrescendoDisplay(organController),
     m_TransposeDisplay(organController),
     m_NameDisplay(organController),
-    m_swell(*organController),
-    m_SetterType(GOCombination::SETTER_REGULAR) {
+    m_swell(*organController) {
   CreateButtons(m_OrganController);
 
   m_buttons[ID_SETTER_PREV]->SetPreconfigIndex(0);
@@ -327,7 +329,7 @@ GOSetter::GOSetter(GOOrganController *organController)
   m_buttons[ID_SETTER_NEXT]->SetShortcutKey(39);
   m_buttons[ID_SETTER_CURRENT]->SetShortcutKey(40);
 
-  SetSetterType(m_SetterType);
+  SetSetterType(GOSetterState::SETTER_REGULAR);
   SetCrescendoType(m_crescendobank);
 
   m_OrganController->RegisterSoundStateHandler(this);
@@ -483,7 +485,7 @@ void GOSetter::DisplayCmbFile(const wxString &fileName) {
     isValid ? wxFileName(fileName).GetName() : wxString());
   m_buttons[ID_SETTER_LOAD_FILE]->Display(isValid && !isTheSameAsLoaded);
   m_buttons[ID_SETTER_SAVE_FILE]->Display(
-    isValid && isTheSameAsLoaded && m_IsCmbChanged);
+    isValid && isTheSameAsLoaded && m_state.m_IsModified);
 }
 
 int GOSetter::FindCmbFilePosFor(const wxString &yamlFile) {
@@ -524,8 +526,8 @@ void GOSetter::NotifyCmbChanged() {
 }
 
 void GOSetter::NotifyCmbPushed(bool isChanged) {
-  if (isChanged && IsSetterActive() && !m_IsCmbChanged) {
-    m_IsCmbChanged = true;
+  if (isChanged && m_state.m_IsActive && !m_state.m_IsModified) {
+    m_state.m_IsModified = true;
     // light the save button if the last loaded combination file  is displayed
     if (
       !m_CmbFileDisplayed.IsEmpty()
@@ -698,7 +700,11 @@ void GOSetter::ButtonStateChanged(int id, bool newState) {
   case ID_SETTER_NEXT:
     Next();
     break;
+  case ID_SETTER_FULL:
+    m_state.m_IsStoreInvisible = newState;
+    break;
   case ID_SETTER_SET:
+    m_state.m_IsActive = newState;
     wxTheApp->GetTopWindow()->UpdateWindowUI();
     break;
   case ID_SETTER_M1:
@@ -807,9 +813,7 @@ void GOSetter::ButtonStateChanged(int id, bool newState) {
   case ID_SETTER_GENERAL47:
   case ID_SETTER_GENERAL48:
   case ID_SETTER_GENERAL49:
-    NotifyCmbPushed(
-      m_general[id - ID_SETTER_GENERAL00 + m_bank * GENERALS]->Push(
-        GetCrescendoAddSet(elementSet)));
+    PushGeneral(*m_general[id - ID_SETTER_GENERAL00 + m_bank * GENERALS]);
     ResetDisplay();
     m_buttons[id]->Display(true);
     break;
@@ -824,13 +828,13 @@ void GOSetter::ButtonStateChanged(int id, bool newState) {
     break;
 
   case ID_SETTER_REGULAR:
-    SetSetterType(GOCombination::SETTER_REGULAR);
+    SetSetterType(GOSetterState::SETTER_REGULAR);
     break;
   case ID_SETTER_SCOPE:
-    SetSetterType(GOCombination::SETTER_SCOPE);
+    SetSetterType(GOSetterState::SETTER_SCOPE);
     break;
   case ID_SETTER_SCOPED:
-    SetSetterType(GOCombination::SETTER_SCOPED);
+    SetSetterType(GOSetterState::SETTER_SCOPED);
     break;
   case ID_SETTER_CRESCENDO_A:
   case ID_SETTER_CRESCENDO_B:
@@ -846,17 +850,13 @@ void GOSetter::ButtonStateChanged(int id, bool newState) {
     Crescendo(m_crescendopos + 1, true);
     break;
   case ID_SETTER_CRESCENDO_CURRENT:
-    NotifyCmbPushed(
-      m_crescendo[m_crescendopos + m_crescendobank * CRESCENDO_STEPS]->Push());
+    PushGeneral(
+      *m_crescendo[m_crescendopos + m_crescendobank * CRESCENDO_STEPS]);
     break;
 
-  case ID_SETTER_CRESCENDO_OVERRIDE: {
-    GOButtonControl *btn = m_buttons[ID_SETTER_CRESCENDO_OVERRIDE];
-    bool newIsOverride = !btn->IsEngaged();
-
-    m_CrescendoOverrideMode[m_crescendobank] = newIsOverride;
-    btn->Display(newIsOverride);
-  } break;
+  case ID_SETTER_CRESCENDO_OVERRIDE:
+    m_CrescendoOverrideMode[m_crescendobank] = newState;
+    m_buttons[ID_SETTER_CRESCENDO_OVERRIDE]->Display(newState);
 
   case ID_SETTER_PITCH_M1:
     m_OrganController->GetRootPipeConfigNode().ModifyManualTuning(-1);
@@ -954,37 +954,93 @@ void GOSetter::OnCombinationsLoaded(
       : -1;
   }
   m_CmbFileLastLoaded = yamlFile;
-  m_IsCmbChanged = false;
+  m_state.m_IsModified = false;
   DisplayCmbFile(m_CmbFileLastLoaded);
 }
 
 void GOSetter::OnCombinationsSaved(const wxString &yamlFile) {
   if (yamlFile == m_CmbFileLastLoaded)
-    m_IsCmbChanged = false;
+    m_state.m_IsModified = false;
   else if (wxFileName(yamlFile).GetPath() == m_CmbFilesDir) {
     // Possible a new file has been created in the same directory, so we need to
     // refresh
     m_IsCmbFileListPopulated = false;
     // switch to the new file
     m_CmbFileLastLoaded = yamlFile;
-    m_IsCmbChanged = false;
+    m_state.m_IsModified = false;
   }
   DisplayCmbFile(m_CmbFileLastLoaded);
 }
 
 void GOSetter::Update() {}
 
-bool GOSetter::IsSetterActive() {
-  return m_buttons[ID_SETTER_SET]->IsEngaged();
-}
-
-bool GOSetter::StoreInvisibleObjects() {
-  return m_buttons[ID_SETTER_FULL]->IsEngaged();
-}
-
 void GOSetter::SetterActive(bool on) { m_buttons[ID_SETTER_SET]->Set(on); }
 
 void GOSetter::ToggleSetter() { m_buttons[ID_SETTER_SET]->Push(); }
+
+void GOSetter::PushGeneral(GOGeneralCombination &cmb) {
+  GOCombination::ExtraElementsSet elementSet;
+  const GOCombination::ExtraElementsSet *pExtraSet
+    = GetCrescendoAddSet(elementSet);
+
+  NotifyCmbPushed(cmb.Push(m_state, pExtraSet));
+  if (!pExtraSet) { // Otherwise the crescendo in add mode:
+                    // not to switch off combination buttons
+    ResetDisplay(); // disable buttons
+
+    for (unsigned k = 0; k < m_OrganController->GetGeneralCount(); k++) {
+      GOGeneralButtonControl *general = m_OrganController->GetGeneral(k);
+      general->Display(&general->GetCombination() == &cmb);
+    }
+
+    for (unsigned j = m_OrganController->GetFirstManualIndex();
+         j <= m_OrganController->GetManualAndPedalCount();
+         j++) {
+      for (unsigned k = 0;
+           k < m_OrganController->GetManual(j)->GetDivisionalCount();
+           k++)
+        m_OrganController->GetManual(j)->GetDivisional(k)->Display(false);
+    }
+  }
+}
+
+void GOSetter::PushDivisional(GODivisionalCombination &cmb) {
+  GOCombination::ExtraElementsSet elementSet;
+
+  NotifyCmbPushed(cmb.Push(m_state, GetCrescendoAddSet(elementSet)));
+  /* only use divisional couples, if not in setter mode */
+  if (!m_state.m_IsActive) {
+    unsigned cmbManualNumber = cmb.GetManualNumber();
+    unsigned divisionalNumber = cmb.GetDivisionalNumber();
+
+    for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
+         k++) {
+      GODivisionalCoupler *coupler = m_OrganController->GetDivisionalCoupler(k);
+      if (!coupler->IsEngaged())
+        continue;
+
+      for (unsigned i = 0; i < coupler->GetNumberOfManuals(); i++) {
+        if (coupler->GetManual(i) != cmbManualNumber)
+          continue;
+
+        for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++)
+          m_OrganController->GetManual(coupler->GetManual(j))
+            ->GetDivisional(divisionalNumber)
+            ->Push();
+
+        if (coupler->IsBidirectional())
+          for (unsigned j = 0; j < coupler->GetNumberOfManuals(); j++) {
+            if (coupler->GetManual(j) == cmbManualNumber)
+              break;
+            m_OrganController->GetManual(coupler->GetManual(j))
+              ->GetDivisional(divisionalNumber)
+              ->Push();
+          }
+        break;
+      }
+    }
+  }
+}
 
 void GOSetter::Next() { SetPosition(m_pos + 1); }
 
@@ -994,11 +1050,11 @@ void GOSetter::Push() { SetPosition(m_pos); }
 
 unsigned GOSetter::GetPosition() { return m_pos; }
 
-void GOSetter::SetSetterType(GOCombination::SetterType type) {
-  m_SetterType = type;
-  m_buttons[ID_SETTER_REGULAR]->Display(type == GOCombination::SETTER_REGULAR);
-  m_buttons[ID_SETTER_SCOPE]->Display(type == GOCombination::SETTER_SCOPE);
-  m_buttons[ID_SETTER_SCOPED]->Display(type == GOCombination::SETTER_SCOPED);
+void GOSetter::SetSetterType(GOSetterState::SetterType type) {
+  m_state.m_SetterType = type;
+  m_buttons[ID_SETTER_REGULAR]->Display(type == GOSetterState::SETTER_REGULAR);
+  m_buttons[ID_SETTER_SCOPE]->Display(type == GOSetterState::SETTER_SCOPE);
+  m_buttons[ID_SETTER_SCOPED]->Display(type == GOSetterState::SETTER_SCOPED);
 }
 
 void GOSetter::SetCrescendoType(unsigned no) {
@@ -1045,11 +1101,7 @@ void GOSetter::SetPosition(int pos, bool push) {
     pos -= m_framegeneral.size();
   m_pos = pos;
   if (push) {
-    GOCombination::ExtraElementsSet elementSet;
-
-    NotifyCmbPushed(
-      m_framegeneral[m_pos]->Push(GetCrescendoAddSet(elementSet)));
-
+    PushGeneral(*m_framegeneral[m_pos]);
     m_buttons[ID_SETTER_HOME]->Display(m_pos == 0);
     for (unsigned i = 0; i < 10; i++)
       m_buttons[ID_SETTER_L0 + i]->Display((m_pos % 10) == i);
@@ -1071,7 +1123,7 @@ void GOSetter::Crescendo(int newpos, bool force) {
     newpos = 0;
   if (newpos > CRESCENDO_STEPS - 1)
     newpos = CRESCENDO_STEPS - 1;
-  if (IsSetterActive() && !force)
+  if (m_state.m_IsActive && !force)
     return;
   unsigned pos = newpos;
   if (pos == m_crescendopos)
@@ -1091,7 +1143,7 @@ void GOSetter::Crescendo(int newpos, bool force) {
     ++m_crescendopos;
     changed = changed
       || m_crescendo[newIdx]->Push(
-        crescendoAddMode ? &m_CrescendoExtraSets[oldIdx] : nullptr, true);
+        m_state, crescendoAddMode ? &m_CrescendoExtraSets[oldIdx] : nullptr);
   }
 
   while (pos < m_crescendopos) {
@@ -1101,8 +1153,11 @@ void GOSetter::Crescendo(int newpos, bool force) {
 
     changed = changed
       || m_crescendo[newIdx]->Push(
-        crescendoAddMode ? &m_CrescendoExtraSets[newIdx] : nullptr, true);
+        m_state, crescendoAddMode ? &m_CrescendoExtraSets[newIdx] : nullptr);
   }
+  // switch combination buttons off in the crescendo override mode
+  if (changed && !crescendoAddMode)
+    ResetDisplay();
   NotifyCmbPushed(changed);
 
   wxString buffer;

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -17,12 +17,15 @@
 #include "control/GOLabelControl.h"
 #include "model/GOCombination.h"
 #include "model/GOEnclosure.h"
+#include "model/GOGeneralCombination.h"
+#include "model/GOSetterState.h"
 #include "sound/GOSoundStateHandler.h"
 #include "yaml/GOSaveableToYaml.h"
 
 #define N_CRESCENDOS 4
 
 class GOGeneralCombination;
+class GODivisionalCombination;
 
 class GOSetter : private GOSoundStateHandler,
                  private GOControlChangedHandler,
@@ -38,11 +41,9 @@ private:
   bool m_IsCmbFileListPopulated;
   // current loaded cmb file name (with dir and extension)
   wxString m_CmbFileLastLoaded;
-  // has the current combinations been changed after last loaded or saved
-  // used for lighting the save button
-  bool m_IsCmbChanged;
   // current displayed cmb file name (with dir and extension)
   wxString m_CmbFileDisplayed;
+  GOSetterState m_state;
   int m_CmbFilePos; // current displayed position or -1 or the list is not
                     // populated yet or no file are loaded
 
@@ -62,7 +63,6 @@ private:
   GOLabelControl m_TransposeDisplay;
   GOLabelControl m_NameDisplay;
   GOEnclosure m_swell;
-  GOCombination::SetterType m_SetterType;
 
   // Show the combination file name
   void DisplayCmbFile(const wxString &fileName);
@@ -73,7 +73,7 @@ private:
   // Display the prev/next cmb file
   void MoveToCmbFile(int offset);
 
-  void SetSetterType(GOCombination::SetterType type);
+  void SetSetterType(GOSetterState::SetterType type);
   void SetCrescendoType(unsigned no);
   void Crescendo(int pos, bool force = false);
 
@@ -85,6 +85,18 @@ private:
   void ControlChanged(void *control);
 
   void PreparePlayback();
+
+  /**
+   * Called after at least one combination is changed
+   * Temporary it calls mOrganController->SetModified()
+   */
+  void NotifyCmbChanged();
+  /**
+   * Called after a combination is pushed
+   * When Set is active then marks the cpmbinations as modified
+   * Temporary it calls mOrganController->SetModified()
+   */
+  void NotifyCmbPushed(bool isChanged = true);
 
 public:
   static const wxString KEY_REFRESH_FILES;
@@ -106,19 +118,8 @@ public:
   GOSetter(GOOrganController *organController);
   virtual ~GOSetter();
 
-  bool IsCmbModified() const { return m_IsCmbChanged; }
-
-  /**
-   * Called after at least one combination is changed
-   * Temporary it calls mOrganController->SetModified()
-   */
-  void NotifyCmbChanged();
-  /**
-   * Called after a combination is pushed
-   * When Set is active then marks the cpmbinations as modified
-   * Temporary it calls mOrganController->SetModified()
-   */
-  void NotifyCmbPushed(bool isChanged = true);
+  const GOSetterState &GetState() const { return m_state; }
+  bool IsCmbModified() const { return m_state.m_IsModified; }
 
   /**
    * Save all combinations to yaml as a map
@@ -157,11 +158,20 @@ public:
 
   void Update();
 
-  bool StoreInvisibleObjects();
-  bool IsSetterActive();
   void ToggleSetter();
   void SetterActive(bool on);
-  GOCombination::SetterType GetSetterType() const { return m_SetterType; }
+
+  /*
+   * Activate cmb
+   * If the crescendo in add mode then not to disable stops that are present in
+   * extraSet
+   * If isFromCrescendo and it is in add mode then then does not depress other
+   * buttons
+   *
+   * return if anything is changed
+   */
+  void PushGeneral(GOGeneralCombination &cmb);
+  void PushDivisional(GODivisionalCombination &cmb);
 
   /*
    * If current crescendo is in override mode then returns nullptr

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -52,14 +52,10 @@ void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
 }
 
 void GODivisionalButtonControl::Push() {
-  GOCombination::ExtraElementsSet elementSet;
-  const GOCombination::ExtraElementsSet *pAddSet
-    = r_setter.GetCrescendoAddSet(elementSet);
   GOManual *pManual
     = m_OrganController->GetManual(m_combination.GetManualNumber());
 
-  r_setter.NotifyCmbPushed(m_combination.Push(pAddSet));
-
+  r_setter.PushDivisional(m_combination);
   for (unsigned l = pManual->GetDivisionalCount(), k = 0; k < l; k++) {
     GODivisionalButtonControl *pDivisionalControl = pManual->GetDivisional(k);
 

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -27,10 +27,7 @@ void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
 }
 
 void GOGeneralButtonControl::Push() {
-  GOCombination::ExtraElementsSet elementSet;
-
-  r_setter.NotifyCmbPushed(
-    m_combination.Push(r_setter.GetCrescendoAddSet(elementSet)));
+  r_setter.PushGeneral(m_combination);
 }
 
 GOGeneralCombination &GOGeneralButtonControl::GetCombination() {

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -26,9 +26,7 @@ void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
   GOPushbuttonControl::Load(cfg, group);
 }
 
-void GOGeneralButtonControl::Push() {
-  r_setter.PushGeneral(m_combination);
-}
+void GOGeneralButtonControl::Push() { r_setter.PushGeneral(m_combination); }
 
 GOGeneralCombination &GOGeneralButtonControl::GetCombination() {
   return m_combination;

--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -17,12 +17,12 @@
 
 #include "GOCombinationDefinition.h"
 #include "GOSaveableObject.h"
+#include "GOSetterState.h"
 
 class GOOrganController;
 
 class GOCombination : public GOSaveableObject, public GOSaveableToYaml {
 public:
-  enum SetterType { SETTER_REGULAR, SETTER_SCOPE, SETTER_SCOPED };
   using ExtraElementsSet = std::unordered_set<unsigned>;
 
 private:
@@ -119,7 +119,6 @@ protected:
    * @param yamlMap
    */
   virtual void FromYamlMap(const YAML::Node &yamlMap) = 0;
-  virtual bool PushLocal(ExtraElementsSet const *extraSet = nullptr);
 
 public:
   GOCombination(
@@ -143,7 +142,8 @@ public:
   /**
    * Fills the combination from the current organ elements
    */
-  bool FillWithCurrent(SetterType setterType, bool isToStoreInvisibleObjects);
+  bool FillWithCurrent(
+    GOSetterState::SetterType setterType, bool isToStoreInvisibleObjects);
 
   void ToYaml(YAML::Node &yamlMap) const override;
 
@@ -164,6 +164,10 @@ public:
     YAML::Node &container, const wxString &key, const GOCombination *pCmb);
 
   void FromYaml(const YAML::Node &yamlNode) override;
+
+  bool Push(
+    const GOSetterState &setterState,
+    const ExtraElementsSet *extraSet = nullptr);
 };
 
 #endif

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -10,9 +10,6 @@
 #include <wx/intl.h>
 #include <wx/log.h>
 
-#include "combinations/control/GODivisionalButtonControl.h"
-
-#include "combinations/GOSetter.h"
 #include "config/GOConfigWriter.h"
 #include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
@@ -242,44 +239,6 @@ void GODivisionalCombination::FromYamlMap(const YAML::Node &yamlMap) {
     m_odfManualNumber,
     GOCombinationDefinition::COMBINATION_SWITCH);
 }
-
-bool GODivisionalCombination::Push(ExtraElementsSet const *extraSet) {
-  bool changed = PushLocal(extraSet);
-
-  /* only use divisional couples, if not in setter mode */
-  if (!m_OrganController->GetSetter()->IsSetterActive()) {
-    for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
-         k++) {
-      GODivisionalCoupler *coupler = m_OrganController->GetDivisionalCoupler(k);
-      if (!coupler->IsEngaged())
-        continue;
-
-      for (unsigned i = 0; i < coupler->GetNumberOfManuals(); i++) {
-        if (coupler->GetManual(i) != m_odfManualNumber)
-          continue;
-
-        for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++)
-          m_OrganController->GetManual(coupler->GetManual(j))
-            ->GetDivisional(m_DivisionalNumber)
-            ->Push();
-
-        if (coupler->IsBidirectional()) {
-          for (unsigned j = 0; j < coupler->GetNumberOfManuals(); j++) {
-            if (coupler->GetManual(j) == m_odfManualNumber)
-              break;
-            m_OrganController->GetManual(coupler->GetManual(j))
-              ->GetDivisional(m_DivisionalNumber)
-              ->Push();
-          }
-        }
-        break;
-      }
-    }
-  }
-  return changed;
-}
-
-wxString GODivisionalCombination::GetMidiType() { return _("Divisional"); }
 
 GODivisionalCombination *GODivisionalCombination::LoadFrom(
   GOOrganController *organController,

--- a/src/grandorgue/combinations/model/GODivisionalCombination.h
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.h
@@ -15,6 +15,7 @@
 class GOConfigReader;
 class GOConfigWriter;
 class GOOrganController;
+class GOSetterState;
 
 class GODivisionalCombination : public GOCombination {
 protected:
@@ -55,10 +56,6 @@ public:
     wxString group,
     int manualNumber,
     int divisionalNumber);
-
-  bool Push(ExtraElementsSet const *extraSet = nullptr);
-
-  wxString GetMidiType();
 
   // checks if the combination exists in the config file
   // returns the loaded combination if it exists else returns nullptr

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -11,9 +11,6 @@
 #include <wx/log.h>
 #include <yaml-cpp/yaml.h>
 
-#include "combinations/GOSetter.h"
-#include "combinations/control/GODivisionalButtonControl.h"
-#include "combinations/control/GOGeneralButtonControl.h"
 #include "config/GOConfigWriter.h"
 #include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
@@ -144,31 +141,6 @@ void GOGeneralCombination::LoadCombinationInt(
       cfg.ReadInteger(srcType, m_group, buffer, -cnt, cnt),
       buffer);
   }
-}
-
-bool GOGeneralCombination::Push(
-  ExtraElementsSet const *extraSet, bool isFromCrescendo) {
-  bool changed = GOCombination::PushLocal(extraSet);
-
-  if (!isFromCrescendo || !extraSet) { // Otherwise the crescendo in add mode:
-                                       // not to switch off combination buttons
-    m_OrganController->GetSetter()->ResetDisplay(); // disable buttons
-
-    for (unsigned k = 0; k < m_OrganController->GetGeneralCount(); k++) {
-      GOGeneralButtonControl *general = m_OrganController->GetGeneral(k);
-      general->Display(&general->GetCombination() == this);
-    }
-
-    for (unsigned j = m_OrganController->GetFirstManualIndex();
-         j <= m_OrganController->GetManualAndPedalCount();
-         j++) {
-      for (unsigned k = 0;
-           k < m_OrganController->GetManual(j)->GetDivisionalCount();
-           k++)
-        m_OrganController->GetManual(j)->GetDivisional(k)->Display(false);
-    }
-  }
-  return changed;
 }
 
 void GOGeneralCombination::SaveInt(GOConfigWriter &cfg) {

--- a/src/grandorgue/combinations/model/GOGeneralCombination.h
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.h
@@ -15,6 +15,7 @@
 class GOConfigReader;
 class GOConfigWriter;
 class GOOrganController;
+class GOSetter;
 
 class GOGeneralCombination : public GOCombination {
 private:
@@ -42,17 +43,6 @@ public:
     GOOrganController *organController,
     bool is_setter);
   void Load(GOConfigReader &cfg, wxString group);
-
-  /*
-   * Activate this combination
-   * If extraSet is passed then not to disable stops that are present in
-   * extraSet
-   * If isFromCrescendo and extraSet is passed then does not depress other
-   * buttons
-   * return if anything is changed
-   */
-  bool Push(
-    ExtraElementsSet const *extraSet = nullptr, bool isFromCrescendo = false);
 };
 
 #endif /* GOGENERALCOMBINATION_H */

--- a/src/grandorgue/combinations/model/GOSetterState.h
+++ b/src/grandorgue/combinations/model/GOSetterState.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSETTERSTATE_H
+#define GOSETTERSTATE_H
+
+struct GOSetterState {
+  enum SetterType { SETTER_REGULAR, SETTER_SCOPE, SETTER_SCOPED };
+
+  // Is the Set button pushed now
+  bool m_IsActive = false;
+  // What type button is pushed now: Regular, Scope or Scoped
+  SetterType m_SetterType = SETTER_REGULAR;
+  // Is the Full button is pushed now
+  bool m_IsStoreInvisible = false;
+  // has the current combinations been changed after last loaded or saved
+  // used for lighting the save button
+  bool m_IsModified = false;
+};
+
+#endif /* GOSETTERSTATE_H */


### PR DESCRIPTION
This PR has been opened instead of #1501 that was closed by error.

It makes a next step towards the MVC paradigm.

Earlier GOCombination had the PushLocal method that activated the combination. And both GOGeneralCombination and GODivisionalCombination had the methods Push that called PushLocal and then switched general and divisional buttons' light on and off.

But it contradicted the idea of model. Combinations should know what elements (stops, couplers, tremulant and switches) to snable and disable, but they do not know, what UI elements (general and divisional buttons) use the combinations. This knowledge is more for GOSetter than for the combinations.

So this PR:

Moves the code controlling button light from Push of combinations to the new methods of GOSetter: PushGeneral and PushDivisional.
Removes the methods GOGeneralCombination::Push and GODivisionalCombination::Push.
Renames GOCombination::PushLocal to Push.
Addes a new GOSetterState class and moves the setter state from GOSetter there.
Passes the GOSetterState instance to GOCombination::Push. It allows to stop using GOSetter in GOCOmbination.
It is just refactoring. No GO behavior should be changed.
