### PR TITLE
Fixed warning "temperament would retune pipe by more than 600 cents" for retuned pipes https://github.com/GrandOrgue/ODFEdit/discussions/11#discussioncomment-5877020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed warning "temperament would retune pipe by more than 600 cents" for retuned pipes https://github.com/GrandOrgue/ODFEdit/discussions/11#discussioncomment-5877020
 - Increased the maximum value of Enclosures from 50 to 999 https://github.com/GrandOrgue/grandorgue/issues/1484
 # 3.11.2 (2023-05-08)
 - Fixed crash on loading organ with general of divisional buttons https://github.com/GrandOrgue/grandorgue/issues/1512

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -421,7 +421,9 @@ void GOSoundingPipe::Validate() {
       GetLoadTitle().c_str());
     return;
   }
-  float offset = m_RetunePipe ? GetAutoTuningPitchOffset() : 0.0;
+  float offset = m_RetunePipe
+    ? (GetAutoTuningPitchOffset() - GetManualTuningPitchOffset())
+    : 0.0;
 
   if (offset < -1800 || offset > 1800) {
     wxLogError(


### PR DESCRIPTION
Earlier when the "Strict ODF checking" was selected if a pipe was borrowed from another pipe with retuning more than 600 cents, the warning appeared.

Now the warning appear only if the retuning with original temperament differs to the retuning from oter temperaments more than 600 cents.
