### PR TITLE
Fixed installing dependencies for osx and windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed support of MacOs 10.15. Now MacOs 11 or above is required https://github.com/GrandOrgue/grandorgue/discussions/1149
 - Fixed warning "temperament would retune pipe by more than 600 cents" for retuned pipes https://github.com/GrandOrgue/ODFEdit/discussions/11#discussioncomment-5877020
 - Increased the maximum value of Enclosures from 50 to 999 https://github.com/GrandOrgue/grandorgue/issues/1484
 # 3.11.2 (2023-05-08)

--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -23,7 +23,7 @@ pushd build/osx
 rm -rf *
 export LANG=C
 
-OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15"
+OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl"
 GO_PRMS="-DCMAKE_BUILD_TYPE=Release $CMAKE_VERSION_PRMS"
 cmake -G "Unix Makefiles" $OS_PRMS $GO_PRMS . $SRC_DIR
 make -k $PARALLEL_PRMS VERBOSE=1 package

--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -9,13 +9,9 @@ brew install \
   imagemagick \
   jack \
   pkg-config \
+  wxwidgets \
   yaml-cpp
 brew link gettext --force
-
-# install wx for 10.15 in order to using the GrandOrgue bundle with 10.15
-# prevent upgrading wxwidgets just afrer installing
-export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-brew install -f --formula https://github.com/GrandOrgue/WxOsX/releases/download/3.2.0-1/90dab952e7e1c26dba572e1b19b7f97728cbbd4d5580a020aee0ff36eebe9138--wxwidgets--3.2.0.catalina.bottle.tar.gz
 
 # A workaround of https://gitlab.kitware.com/cmake/cmake/-/issues/23826
 for F in $(grep -l '(, weak)\?'  /usr/local/Cellar/cmake/*/share/cmake/Modules/GetPrerequisites.cmake); do
@@ -24,10 +20,3 @@ for F in $(grep -l '(, weak)\?'  /usr/local/Cellar/cmake/*/share/cmake/Modules/G
   sed -e 's/(, weak)\?/(, (weak|reexport))?/' $F >${F}.new
   mv ${F}.new $F
 done
-
-# wxwidgets has been built against libtiff.5.dylib but it is not more available
-if [ ! -f /usr/local/opt/libtiff/lib/libtiff.5.dylib ]; then
-  pushd /usr/local/opt/libtiff/lib
-  sudo ln -s `readlink libtiff.dylib` libtiff.5.dylib
-  popd
-fi

--- a/build-scripts/for-win64/prepare-debian-based.sh
+++ b/build-scripts/for-win64/prepare-debian-based.sh
@@ -10,6 +10,10 @@ sudo apt-get update
 # remove an odd version of packages that prevents installing wine32
 $BASE_DIR/../for-linux/prepare-debian-based-align-libs.sh $TARGET_ARCH i386
 
+# install dependencies for wine32
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  libgcc-s1:i386 libstdc++6:i386
+
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   wget unzip cmake g++ pkg-config g++-mingw-w64-x86-64 nsis \
   docbook-xsl xsltproc gettext po4a imagemagick zip libz-mingw-w64-dev \

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -296,8 +296,7 @@ GOSetter::GOSetter(GOOrganController *organController)
     m_CrescendoDisplay(organController),
     m_TransposeDisplay(organController),
     m_NameDisplay(organController),
-    m_swell(*organController),
-    m_SetterType(GOCombination::SETTER_REGULAR) {
+    m_swell(*organController) {
   CreateButtons(*m_OrganController);
 
   m_buttons[ID_SETTER_PREV]->SetPreconfigIndex(0);


### PR DESCRIPTION
Some time ago GitHub builds stopped working. The reasons was unability to install dependencies.

- MacOS: as discussed at #1149, this PR removes support of MacOS 10.15 beacause we can not more install necessary depensdencies.
- Windows: added installing libgcc-s1:i386 libstdc++6:i386
This PR should restore the capabuility of building on GitHub.