### PR TITLE
Added GrandOrgueTool and GrandOrguePerfTest man pages for linux https://github.com/GrandOrgue/grandorgue/issues/1419

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -49,6 +49,13 @@ endforeach()
 # ========================
 # Install resources
 # ========================
+function(add_man_page EXECUTABLE_NAME)
+  ADD_CUSTOM_COMMAND(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${EXECUTABLE_NAME}.1" COMMAND ${XSLTPROC} -o "${CMAKE_CURRENT_BINARY_DIR}/" ${DOCBOOK_PATH}/manpages/docbook.xsl "${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}Man.xml" DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${EXECUTABLE_NAME}Man.xml)
+  LIST(APPEND DEPLIST "${CMAKE_CURRENT_BINARY_DIR}/${EXECUTABLE_NAME}.1")
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${EXECUTABLE_NAME}.1" DESTINATION share/man/man1)
+  set(DEPLIST ${DEPLIST} PARENT_SCOPE)
+endfunction()
+
 if (APPLE)
    ADD_CUSTOM_COMMAND(OUTPUT "${RESOURCEDIR}/GrandOrgue.icns" COMMAND iconutil -c icns ${GENERATED_ICONS_DIR} DEPENDS ${GENERATED_ICONS})
    INSTALL(FILES "${RESOURCEDIR}/GrandOrgue.icns" DESTINATION "${RESOURCEINSTDIR}")
@@ -71,9 +78,9 @@ elseif(UNIX)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/GrandOrgue.desktop" DESTINATION share/applications)
 
   if(XSLTPROC AND DOCBOOK_PATH)
-    ADD_CUSTOM_COMMAND(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/GrandOrgue.1" COMMAND ${XSLTPROC} -o "${CMAKE_CURRENT_BINARY_DIR}/" ${DOCBOOK_PATH}/manpages/docbook.xsl "${CMAKE_CURRENT_SOURCE_DIR}/man.xml" DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/man.xml)
-    LIST(APPEND DEPLIST "${CMAKE_CURRENT_BINARY_DIR}/GrandOrgue.1")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/GrandOrgue.1" DESTINATION share/man/man1)
+    add_man_page(GrandOrgue)
+    add_man_page(GrandOrguePerfTest)
+    add_man_page(GrandOrgueTool)
   else()
     MESSAGE(STATUS "Not build manpage - some programs are missing")
   endif()
@@ -82,5 +89,7 @@ elseif(UNIX)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/GrandOrgue.appdata.xml.in" "${CMAKE_CURRENT_BINARY_DIR}/GrandOrgue.appdata.xml/GrandOrgue.appdata.xml")
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/GrandOrgue.appdata.xml/GrandOrgue.appdata.xml" DESTINATION share/metainfo)
 endif()
+
+message(STATUS "DEPLIST=${DEPLIST}")
 
 ADD_CUSTOM_TARGET(resources ALL DEPENDS ${DEPLIST})

--- a/resources/GrandOrgueMan.xml
+++ b/resources/GrandOrgueMan.xml
@@ -1,24 +1,12 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
 <!--
- GrandOrgue - free pipe organ simulator
+  GrandOrgue - free pipe organ simulator
 
- Copyright 2006 Milan Digital Audio LLC
- Copyright 2009-2019 GrandOrgue contributors (see AUTHORS)
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License as
- published by the Free Software Foundation; either version 2 of the
- License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful, but
- WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+  Copyright 2006 Milan Digital Audio LLC
+  Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+  License GPL-2.0 or later
+  (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 -->
 <refentry lang="en">
   <refentryinfo>

--- a/resources/GrandOrgueMan.xml
+++ b/resources/GrandOrgueMan.xml
@@ -13,11 +13,6 @@
     <title>GrandOrgue man page</title>
     <author>
       <surname>GrandOrgue contributors (see AUTHORS)</surname>
-      <affiliation>
-        <address>
-          <email>ourorgan-developers@lists.sourceforge.net</email>
-        </address>
-      </affiliation>
     </author>
     <productname>GrandOrgue</productname>
   </refentryinfo>

--- a/resources/GrandOrguePerfTestMan.xml
+++ b/resources/GrandOrguePerfTestMan.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
+<!--
+  GrandOrgue - free pipe organ simulator
+
+  Copyright 2006 Milan Digital Audio LLC
+  Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+  License GPL-2.0 or later
+  (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+-->
+<refentry lang="en">
+  <refentryinfo>
+    <title>GrandOrguePerfTest man page</title>
+    <author>
+      <surname>GrandOrgue contributors (see AUTHORS)</surname>
+      <affiliation>
+        <address>
+          <email>ourorgan-developers@lists.sourceforge.net</email>
+        </address>
+      </affiliation>
+    </author>
+    <productname>GrandOrgue</productname>
+  </refentryinfo>
+  <refmeta>
+    <refentrytitle>GrandOrguePerfTest</refentrytitle>
+    <manvolnum>1</manvolnum>
+  </refmeta>
+  <refnamediv>
+    <title>NAME</title>
+    <refname>GrandOrguePerfTest</refname>
+    <refentrytitle>
+      <command>GrandOrguePerfTest</command>
+    </refentrytitle>
+    <refpurpose>Virtual Pipe Organ Software. Testing performance</refpurpose>
+    <manvolnum>1</manvolnum>
+  </refnamediv>
+  <refsynopsisdiv>
+    <title>SYNOPSIS</title>
+    <cmdsynopsis>
+      <command>GrandOrguePerfTest</command>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+  <refsect1>
+    <title>DESCRIPTION</title>
+    <para>
+      GrandOrguePerfTest is a commandline tool built together with GrandOrgue to
+      test performance of the computer with different settings: Bits per sample,
+      Sample Rate, Loseless compression, Linear/Polyphase interpolation and
+      Sampes per buffer.
+    </para>
+    <para>
+      It outputs one line for each parameter set to the standard output. This
+      line contains the 'limit:' value. It is the recommended maximum value for
+      the Polyphony field in the GrandOrgan toolbar.
+    </para>
+  </refsect1>
+</refentry>

--- a/resources/GrandOrguePerfTestMan.xml
+++ b/resources/GrandOrguePerfTestMan.xml
@@ -13,11 +13,6 @@
     <title>GrandOrguePerfTest man page</title>
     <author>
       <surname>GrandOrgue contributors (see AUTHORS)</surname>
-      <affiliation>
-        <address>
-          <email>ourorgan-developers@lists.sourceforge.net</email>
-        </address>
-      </affiliation>
     </author>
     <productname>GrandOrgue</productname>
   </refentryinfo>

--- a/resources/GrandOrgueToolMan.xml
+++ b/resources/GrandOrgueToolMan.xml
@@ -13,11 +13,6 @@
     <title>GrandOrgue Tool man page</title>
     <author>
       <surname>GrandOrgue contributors (see AUTHORS)</surname>
-      <affiliation>
-        <address>
-          <email>ourorgan-developers@lists.sourceforge.net</email>
-        </address>
-      </affiliation>
     </author>
     <productname>GrandOrgue</productname>
   </refentryinfo>

--- a/resources/GrandOrgueToolMan.xml
+++ b/resources/GrandOrgueToolMan.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
+<!--
+  GrandOrgue - free pipe organ simulator
+
+  Copyright 2006 Milan Digital Audio LLC
+  Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+  License GPL-2.0 or later
+  (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+-->
+<refentry lang="en">
+  <refentryinfo>
+    <title>GrandOrgue Tool man page</title>
+    <author>
+      <surname>GrandOrgue contributors (see AUTHORS)</surname>
+      <affiliation>
+        <address>
+          <email>ourorgan-developers@lists.sourceforge.net</email>
+        </address>
+      </affiliation>
+    </author>
+    <productname>GrandOrgue</productname>
+  </refentryinfo>
+  <refmeta>
+    <refentrytitle>GrandOrgueTool</refentrytitle>
+    <manvolnum>1</manvolnum>
+  </refmeta>
+  <refnamediv>
+    <title>NAME</title>
+    <refname>GrandOrgueTool</refname>
+    <refentrytitle>
+      <command>GrandOrgueTool</command>
+    </refentrytitle>
+    <refpurpose>Virtual Pipe Organ Software. Organ package creation</refpurpose>
+    <manvolnum>1</manvolnum>
+  </refnamediv>
+  <refsynopsisdiv>
+    <title>SYNOPSIS</title>
+    <cmdsynopsis>
+      <command>GrandOrgueTool</command>
+      <arg choice="opt">
+        <option>-h</option>
+      </arg>
+      <arg choice="opt">
+        <option>-c</option>
+      </arg>
+      <arg choice="opt">
+        <option>-o <replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-i <replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-t <replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-p1:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-p2:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-p3:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-p4:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-p5:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o1:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o2:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o3:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o4:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o5:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o6:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o7:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o8:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o9:<replaceable>str</replaceable></option>
+      </arg>
+      <arg choice="opt">
+        <option>-o10:<replaceable>str</replaceable></option>
+      </arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+  <refsect1>
+    <title>DESCRIPTION</title>
+    <para>
+      GrandOrgueTool is a commandline tool built together with GrandOrgue to
+      make the .orgue package creation process easier.
+    </para>
+  </refsect1>
+  <refsect1>
+    <title>OPTIONS</title>
+    <variablelist>
+      <varlistentry>
+        <term><option>-h</option>, <option>--help</option></term>
+        <listitem>
+          <para>
+display usage message
+</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-c</option>, <option>--create</option></term>
+        <listitem>
+          <para>
+	    create an organ package
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o <parameter>str</parameter></option>, <option>--organ-package=<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    specify generated organ package filename
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-i <parameter>str</parameter></option>, <option>--input-directory=<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    specify input directory
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-t <parameter>str</parameter></option>, <option>--title=<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    organ package title
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-p1:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    depend on organ package
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-p2:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    depend on organ package
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-p3:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    depend on organ package
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-p4:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    depend on organ package
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-p5:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    depend on organ package
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o1:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o2:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o3:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o4:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o5:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o6:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o7:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o8:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o9:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>-o10:<parameter>str</parameter></option></term>
+        <listitem>
+          <para>
+	    provide odf-file-name
+	  </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+</refentry>


### PR DESCRIPTION
I added man pages for two additional command line utilities: `GrandOrgueTool` and `GrandOrguePerfTest`. Also I renamed the source of the GrandOrgue man page.