### PR TITLE
Removed unnecessary inclusion of GOOrganModel from some model files

### DIFF
--- a/src/grandorgue/model/GOCoupler.cpp
+++ b/src/grandorgue/model/GOCoupler.cpp
@@ -13,7 +13,7 @@
 #include "config/GOConfigReader.h"
 
 #include "GOManual.h"
-#include "GOOrganController.h"
+#include "GOOrganModel.h"
 
 GOCoupler::GOCoupler(GOOrganModel &organModel, unsigned sourceManual)
   : GODrawstop(organModel),

--- a/src/grandorgue/model/GOCoupler.h
+++ b/src/grandorgue/model/GOCoupler.h
@@ -14,7 +14,6 @@
 
 class GOConfigReader;
 class GOConfigWriter;
-class GOOrganController;
 struct IniFileEnumEntry;
 
 class GOCoupler : public GODrawstop {

--- a/src/grandorgue/model/GODivisionalCoupler.cpp
+++ b/src/grandorgue/model/GODivisionalCoupler.cpp
@@ -11,7 +11,7 @@
 
 #include "config/GOConfigReader.h"
 
-#include "GOOrganController.h"
+#include "GOOrganModel.h"
 
 GODivisionalCoupler::GODivisionalCoupler(GOOrganModel &organModel)
   : GODrawstop(organModel), m_BiDirectionalCoupling(false), m_manuals(0) {}

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -12,7 +12,7 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
-#include "GOOrganController.h"
+#include "GOOrganModel.h"
 #include "GOSwitch.h"
 
 const struct IniFileEnumEntry GODrawstop::m_function_types[] = {

--- a/src/grandorgue/model/GOPipe.cpp
+++ b/src/grandorgue/model/GOPipe.cpp
@@ -9,7 +9,7 @@
 
 #include <wx/intl.h>
 
-#include "GOOrganController.h"
+#include "GOEventHandlerList.h"
 #include "GORank.h"
 
 GOPipe::GOPipe(

--- a/src/grandorgue/model/GOReferencePipe.cpp
+++ b/src/grandorgue/model/GOReferencePipe.cpp
@@ -13,7 +13,6 @@
 #include "config/GOConfigReader.h"
 
 #include "GOManual.h"
-#include "GOOrganController.h"
 #include "GOOrganModel.h"
 #include "GORank.h"
 #include "GOStop.h"


### PR DESCRIPTION
After removing usage of GOOrganController from some model files, including "GOOrganController.h" became no more necessary.

This PR removes these includes or replacles it with another smaller inclusion.

No GO behavior should be changed.