### PR TITLE
Moved GOOrganController::MarkSectionInUse to GOConfigReader

### DIFF
--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -7,6 +7,7 @@
 
 #include "config/GOConfigReader.h"
 
+#include <unordered_set>
 #include <wx/intl.h>
 #include <wx/log.h>
 
@@ -621,4 +622,10 @@ int GOConfigReader::ReadEnum(
   unsigned count,
   bool required) {
   return ReadEnum(type, group, key, entry, count, required, entry[0].value);
+}
+
+void GOConfigReader::MarkGroupInUse(const wxString &group) {
+  if (m_GroupsInUse.find(group) != m_GroupsInUse.end())
+    throw wxString::Format(_("Section %s already in use"), group);
+  m_GroupsInUse.insert(group);
 }

--- a/src/core/config/GOConfigReader.h
+++ b/src/core/config/GOConfigReader.h
@@ -8,6 +8,9 @@
 #ifndef GOCONFIGREADER_H
 #define GOCONFIGREADER_H
 
+#include <unordered_set>
+
+#include <wx/hashmap.h>
 #include <wx/string.h>
 
 #include "GOLogicalColour.h"
@@ -23,7 +26,10 @@ typedef enum { ODFSetting, CMBSetting } GOSettingType;
 
 class GOConfigReader {
 private:
+  using StringSet = std::unordered_set<wxString, wxStringHash, wxStringEqual>;
+
   GOConfigReaderDB &m_Config;
+  StringSet m_GroupsInUse;
   bool m_Strict;
   bool m_IsHw1Check;
 
@@ -169,6 +175,13 @@ public:
     unsigned count,
     bool required,
     int defaultValue);
+
+  /**
+   * Mark the group as used. Throws an exception if the group has already been
+   * marked as in use
+   * @param group the group name
+   */
+  void MarkGroupInUse(const wxString &group);
 };
 
 #endif

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -111,7 +111,6 @@ GOOrganController::GOOrganController(
     m_panels(),
     m_panelcreators(),
     m_elementcreators(),
-    m_UsedSections(),
     m_soundengine(0),
     m_midi(0),
     m_MidiSamplesetMatch(),
@@ -1102,10 +1101,4 @@ GOLabelControl *GOOrganController::GetTemperamentLabel() {
 
 GOMainWindowData *GOOrganController::GetMainWindowData() {
   return &m_MainWindowData;
-}
-
-void GOOrganController::MarkSectionInUse(wxString name) {
-  if (m_UsedSections[name])
-    throw wxString::Format(_("Section %s already in use"), name.c_str());
-  m_UsedSections[name] = true;
 }

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -8,10 +8,9 @@
 #ifndef GOORGANCONTROLLER_H
 #define GOORGANCONTROLLER_H
 
-#include <wx/hashmap.h>
-#include <wx/string.h>
-
 #include <vector>
+
+#include <wx/string.h>
 
 #include "ptrvector.h"
 
@@ -56,8 +55,6 @@ class GOOrganController : public GOEventDistributor,
                           public GOTimer,
                           public GOOrganModel,
                           public GOModificationProxy {
-  WX_DECLARE_STRING_HASH_MAP(bool, GOStringBoolMap);
-
 private:
   GOConfig &m_config;
   wxString m_odf;
@@ -92,7 +89,6 @@ private:
   ptr_vector<GOGUIPanel> m_panels;
   ptr_vector<GOGUIPanelCreator> m_panelcreators;
   ptr_vector<GOElementCreator> m_elementcreators;
-  GOStringBoolMap m_UsedSections;
 
   GOSoundEngine *m_soundengine;
   GOMidi *m_midi;
@@ -185,7 +181,6 @@ public:
   GOBitmapCache &GetBitmapCache();
   void SetTemperament(wxString name);
   wxString GetTemperament();
-  void MarkSectionInUse(wxString name);
 
   int GetRecorderElementID(wxString name);
   GOCombinationDefinition &GetGeneralTemplate();

--- a/src/grandorgue/gui/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/GOGUIPanel.cpp
@@ -310,7 +310,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           this, m_OrganController->GetEnclosureElement(enclosure_nb - 1)),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(panel_prefix + buffer);
+      cfg.MarkGroupInUse(panel_prefix + buffer);
     }
 
     unsigned NumberOfSetterElements = cfg.ReadInteger(
@@ -345,7 +345,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           this, m_OrganController->GetTremulant(tremulant_nb - 1)),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(panel_prefix + buffer);
+      cfg.MarkGroupInUse(panel_prefix + buffer);
     }
 
     unsigned NumberOfDivisionalCouplers = cfg.ReadInteger(
@@ -368,7 +368,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           this, m_OrganController->GetDivisionalCoupler(coupler_nb - 1)),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(panel_prefix + buffer);
+      cfg.MarkGroupInUse(panel_prefix + buffer);
     }
 
     unsigned NumberOfGenerals = cfg.ReadInteger(
@@ -391,7 +391,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           this, m_OrganController->GetGeneral(general_nb - 1), true),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(panel_prefix + buffer);
+      cfg.MarkGroupInUse(panel_prefix + buffer);
     }
 
     unsigned NumberOfReversiblePistons = cfg.ReadInteger(
@@ -414,7 +414,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           this, m_OrganController->GetPiston(piston_nb - 1), true),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(panel_prefix + buffer);
+      cfg.MarkGroupInUse(panel_prefix + buffer);
     }
 
     unsigned NumberOfSwitches = cfg.ReadInteger(
@@ -439,7 +439,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           this, m_OrganController->GetSwitch(switch_nb - 1), false),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(panel_prefix + buffer);
+      cfg.MarkGroupInUse(panel_prefix + buffer);
     }
 
     unsigned nb_manuals = cfg.ReadInteger(
@@ -466,7 +466,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           m_layout->GetManualNumber()),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(panel_prefix + buffer);
+      cfg.MarkGroupInUse(panel_prefix + buffer);
     }
 
     unsigned NumberOfCouplers = cfg.ReadInteger(
@@ -493,7 +493,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           m_OrganController->GetManual(manual_nb)->GetCoupler(coupler_nb - 1)),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(
+      cfg.MarkGroupInUse(
         panel_prefix
         + wxString::Format(
           wxT("Manual%03dCoupler%03d"), manual_nb, coupler_nb));
@@ -522,7 +522,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           this, m_OrganController->GetManual(manual_nb)->GetStop(stop_nb - 1)),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(
+      cfg.MarkGroupInUse(
         panel_prefix
         + wxString::Format(wxT("Manual%03dStop%03d"), manual_nb, stop_nb));
     }
@@ -553,7 +553,7 @@ void GOGUIPanel::Load(GOConfigReader &cfg, wxString group) {
           true),
         cfg,
         panel_prefix + buffer);
-      m_OrganController->MarkSectionInUse(
+      cfg.MarkGroupInUse(
         panel_prefix
         + wxString::Format(
           wxT("Manual%03dDivisional%03d"), manual_nb, divisional_nb));

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -174,7 +174,7 @@ void GOManual::Load(GOConfigReader &cfg, wxString group, int manualNumber) {
     buffer.Printf(wxT("Stop%03d"), i + 1);
     buffer.Printf(
       wxT("Stop%03d"), cfg.ReadInteger(ODFSetting, group, buffer, 1, 999));
-    m_OrganController->MarkSectionInUse(buffer);
+    cfg.MarkGroupInUse(buffer);
     m_stops[i]->Load(cfg, buffer);
     m_stops[i]->SetElementID(m_OrganController->GetRecorderElementID(
       wxString::Format(wxT("M%dS%d"), m_manual_number, i)));
@@ -186,7 +186,7 @@ void GOManual::Load(GOConfigReader &cfg, wxString group, int manualNumber) {
     buffer.Printf(wxT("Coupler%03d"), i + 1);
     buffer.Printf(
       wxT("Coupler%03d"), cfg.ReadInteger(ODFSetting, group, buffer, 1, 999));
-    m_OrganController->MarkSectionInUse(buffer);
+    cfg.MarkGroupInUse(buffer);
     m_couplers[i]->Load(cfg, buffer);
     m_couplers[i]->SetElementID(m_OrganController->GetRecorderElementID(
       wxString::Format(wxT("M%dC%d"), m_manual_number, i)));
@@ -227,7 +227,7 @@ void GOManual::Load(GOConfigReader &cfg, wxString group, int manualNumber) {
     buffer.Printf(
       wxT("Divisional%03d"),
       cfg.ReadInteger(ODFSetting, group, buffer, 1, 999));
-    m_OrganController->MarkSectionInUse(buffer);
+    cfg.MarkGroupInUse(buffer);
     m_divisionals[i]->Load(cfg, buffer, m_manual_number, i);
   }
   m_midi.Load(cfg, group, m_OrganController->GetSettings().GetMidiMap());


### PR DESCRIPTION
In order to eleminate usage of GOOrganController I moved it's method `MarkSectionInUse` to the `GOConfigReader` class and renamed it to `MarkGroupInUse`

No GO behavior should be changed