### PR TITLE
Fixed saving empty and scoped combinations to yaml https://github.com/GrandOrgue/grandorgue/issues/1531

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed saving empty and scoped combinations to yaml https://github.com/GrandOrgue/grandorgue/issues/1531
 - Fixed bug of GC not working on manual with only a single stop https://github.com/GrandOrgue/grandorgue/issues/1556
 - Fixed installation on linux with another yaml-cpp version than 6.2 https://github.com/GrandOrgue/grandorgue/issues/1548
 # 3.12.0 (2023-05-25)

--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -45,6 +45,13 @@ private:
    */
   bool m_IsFull;
 
+  /**
+   * Whether the combination has been captured when `Scope` or `Scoped` engaged
+   */
+  bool m_HasScope;
+
+  void PutElementsToYaml(YAML::Node &yamlMap, int stateFrom) const;
+
 protected:
   const std::vector<GOCombinationDefinition::Element> &r_ElementDefinitions;
   bool m_Protected;

--- a/src/grandorgue/yaml/GOSaveableToYaml.cpp
+++ b/src/grandorgue/yaml/GOSaveableToYaml.cpp
@@ -10,7 +10,7 @@
 #include <yaml-cpp/yaml.h>
 
 YAML::Node GOSaveableToYaml::ToYamlNode() const {
-  YAML::Node yamlNode;
+  YAML::Node yamlNode(YAML::NodeType::Map);
 
   ToYaml(yamlNode);
   return yamlNode;


### PR DESCRIPTION
Resolves: #1531

1. Added saving empty combinations to yaml
2. Added saving the scope of scope/scoped combination to yaml in the `scope` subelement
3. Introduced the GOCombination::m_HasScope member and it's saving to .cmb