### PR TITLE
Fixed bug of GC not working on manual with only a single stop https://github.com/GrandOrgue/grandorgue/issues/1556

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed bug of GC not working on manual with only a single stop https://github.com/GrandOrgue/grandorgue/issues/1556
 - Fixed installation on linux with another yaml-cpp version than 6.2 https://github.com/GrandOrgue/grandorgue/issues/1548
 # 3.12.0 (2023-05-25)
 - Reverted back default display of GeneralPrev and GeneralNext https://github.com/GrandOrgue/grandorgue/issues/1538

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -538,9 +538,6 @@ void GOManual::Reset() {
   for (unsigned j = 0; j < GetDivisionalCount(); j++)
     GetDivisional(j)->Display(false);
 
-  if (GetStopCount() == 1 && !GetStop(0)->IsDisplayed())
-    return;
-
   for (unsigned j = 0; j < GetStopCount(); j++)
     GetStop(j)->Reset();
 }


### PR DESCRIPTION
Resolves #1556 by removing the if check that a single stop on a manual must be displayed according to the old panel format for GC to actually work on it.