### PR TITLE
Fixed displaying light of various combination buttons https://githubcom/GrandOrgue/grandorgue/issues/1536

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed displaying light of various combination buttons https://github.com/GrandOrgue/grandorgue/issues/1536 
 - Fixed saving empty and scoped combinations to yaml https://github.com/GrandOrgue/grandorgue/issues/1531
 - Fixed bug of GC not working on manual with only a single stop https://github.com/GrandOrgue/grandorgue/issues/1556
 - Fixed installation on linux with another yaml-cpp version than 6.2 https://github.com/GrandOrgue/grandorgue/issues/1548

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -45,6 +45,7 @@ include_directories(${YAML_CPP_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(grandorgue_src
+combinations/control/GOCombinationButtonSet.cpp
 combinations/control/GOGeneralButtonControl.cpp
 combinations/control/GODivisionalButtonControl.cpp
 combinations/model/GOCombination.cpp

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -1062,7 +1062,7 @@ void GOOrganController::Reset() {
     GetDivisionalCoupler(j)->Reset();
   for (unsigned k = 0; k < GetGeneralCount(); k++)
     GetGeneral(k)->Display(false);
-  m_setter->ResetDisplay();
+  m_setter->ResetCmbButtons();
 }
 
 void GOOrganController::SetTemperament(const GOTemperament &temperament) {

--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -422,7 +422,7 @@ void GODivisionalSetter::UpdateAllButtonsLight(
     if (
       manualIndexOnlyFor < 0
       || (unsigned)manualIndexOnlyFor == odfManualIndex) {
-      // reflect the ne state of the combination buttons
+      // reflect the new state of the combination buttons
       for (unsigned firstButtonIdx = N_BUTTONS * manualN, k = 0;
            k < N_DIVISIONALS;
            k++) {

--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -116,7 +116,7 @@ GODivisionalSetter::GODivisionalSetter(
   // create button conrols for all buttons. It calls the GetButtonDefinitionList
   // callback
   CreateButtons(*organController);
-
+  organController->RegisterCombinationButtonSet(this);
   for (unsigned manualN = 0; manualN < m_NManuals; manualN++) {
     m_manualBanks.push_back(0);
     m_BankLabels.push_back(new GOLabelControl(organController));
@@ -369,19 +369,10 @@ void GODivisionalSetter::SwitchDivisionalTo(
       divMap[divisionalIdx] = pCmb;
     }
 
-    if (pCmb) {
+    if (pCmb)
       // the combination was existing or has just been created
-      m_OrganController->GetSetter()->PushDivisional(*pCmb);
-
-      // reflect the ne state of the combination buttons
-      for (unsigned firstButtonIdx = N_BUTTONS * manualN, k = 0;
-           k < N_DIVISIONALS;
-           k++) {
-        GOButtonControl *divisional = m_buttons[firstButtonIdx + k];
-
-        divisional->Display(k == divisionalN);
-      }
-    }
+      m_OrganController->GetSetter()->PushDivisional(
+        *pCmb, m_buttons[N_BUTTONS * manualN + divisionalN]);
   }
 }
 
@@ -420,5 +411,25 @@ void GODivisionalSetter::ButtonStateChanged(int id, bool newState) {
       SwitchBankToPrev(manualN);
     else if (buttonId == ID_NEXT_BANK)
       SwitchBankToNext(manualN);
+  }
+}
+
+void GODivisionalSetter::UpdateAllButtonsLight(
+  GOButtonControl *buttonToLight, int manualIndexOnlyFor) {
+  for (unsigned manualN = 0; manualN < m_NManuals; manualN++) {
+    unsigned odfManualIndex = m_FirstManualIndex + manualN;
+
+    if (
+      manualIndexOnlyFor < 0
+      || (unsigned)manualIndexOnlyFor == odfManualIndex) {
+      // reflect the ne state of the combination buttons
+      for (unsigned firstButtonIdx = N_BUTTONS * manualN, k = 0;
+           k < N_DIVISIONALS;
+           k++) {
+        GOButtonControl *pDivisional = m_buttons[firstButtonIdx + k];
+
+        pDivisional->Display(pDivisional == buttonToLight);
+      }
+    }
   }
 }

--- a/src/grandorgue/combinations/GODivisionalSetter.h
+++ b/src/grandorgue/combinations/GODivisionalSetter.h
@@ -66,7 +66,7 @@ private:
   void ClearCombinations();
 
   /**
-   * Ubdate all divisional buttons light.
+   * Update all divisional buttons light.
    * @param buttonToLight - the button that should be lighted on. All other
    *   divisionals are lighted off
    * @param manualIndexOnlyFor - if >= 0 change lighting of this manual only

--- a/src/grandorgue/combinations/GODivisionalSetter.h
+++ b/src/grandorgue/combinations/GODivisionalSetter.h
@@ -15,6 +15,7 @@
 
 #include "ptrvector.h"
 
+#include "control/GOCombinationButtonSet.h"
 #include "control/GOElementCreator.h"
 #include "yaml/GOSaveableToYaml.h"
 
@@ -26,6 +27,7 @@ class GOLabelControl;
 class GOSetterState;
 
 class GODivisionalSetter : public GOElementCreator,
+                           private GOCombinationButtonSet,
                            GOSaveableObject,
                            public GOSaveableToYaml {
 private:
@@ -62,6 +64,15 @@ private:
   void UpdateBankDisplay(unsigned manualN);
   // delete all combinations from m_DivisionalMaps
   void ClearCombinations();
+
+  /**
+   * Ubdate all divisional buttons light.
+   * @param buttonToLight - the button that should be lighted on. All other
+   *   divisionals are lighted off
+   * @param manualIndexOnlyFor - if >= 0 change lighting of this manual only
+   */
+  void UpdateAllButtonsLight(
+    GOButtonControl *buttonToLight, int manualIndexOnlyFor) override;
 
 protected:
   // called from GOElementCreator::CreateButtons()

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -985,11 +985,13 @@ void GOSetter::ToggleSetter() { m_buttons[ID_SETTER_SET]->Push(); }
 
 void GOSetter::UpdateAllButtonsLight(
   GOButtonControl *buttonToLight, int manualIndexOnlyFor) {
-  UpdateOneButtonLight(m_buttons[ID_SETTER_HOME], buttonToLight);
-  for (unsigned i = 0; i < 10; i++)
-    UpdateOneButtonLight(m_buttons[ID_SETTER_L0 + i], buttonToLight);
-  for (unsigned i = 0; i < GENERALS; i++)
-    UpdateOneButtonLight(m_buttons[ID_SETTER_GENERAL00 + i], buttonToLight);
+  if (manualIndexOnlyFor < 0) {
+    UpdateOneButtonLight(m_buttons[ID_SETTER_HOME], buttonToLight);
+    for (unsigned i = 0; i < 10; i++)
+      UpdateOneButtonLight(m_buttons[ID_SETTER_L0 + i], buttonToLight);
+    for (unsigned i = 0; i < GENERALS; i++)
+      UpdateOneButtonLight(m_buttons[ID_SETTER_GENERAL00 + i], buttonToLight);
+  }
 }
 
 void GOSetter::UpdateAllSetsButtonsLight(

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -986,11 +986,11 @@ void GOSetter::ToggleSetter() { m_buttons[ID_SETTER_SET]->Push(); }
 void GOSetter::UpdateAllButtonsLight(
   GOButtonControl *buttonToLight, int manualIndexOnlyFor) {
   if (manualIndexOnlyFor < 0) {
-    UpdateOneButtonLight(m_buttons[ID_SETTER_HOME], buttonToLight);
+    updateOneButtonLight(m_buttons[ID_SETTER_HOME], buttonToLight);
     for (unsigned i = 0; i < 10; i++)
-      UpdateOneButtonLight(m_buttons[ID_SETTER_L0 + i], buttonToLight);
+      updateOneButtonLight(m_buttons[ID_SETTER_L0 + i], buttonToLight);
     for (unsigned i = 0; i < GENERALS; i++)
-      UpdateOneButtonLight(m_buttons[ID_SETTER_GENERAL00 + i], buttonToLight);
+      updateOneButtonLight(m_buttons[ID_SETTER_GENERAL00 + i], buttonToLight);
   }
 }
 

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -101,7 +101,7 @@ private:
   void NotifyCmbPushed(bool isChanged = true);
 
   /**
-   * Ubdate all setter combination buttons light.
+   * Update all setter combination buttons light.
    * If the button
    * @param buttonToLight
    * @param manualIndexOnlyFor
@@ -110,7 +110,7 @@ private:
     GOButtonControl *buttonToLight, int manualIndexOnlyFor) override;
 
   /**
-   * Ubdate buttons light in all combination button set.
+   * Update buttons light in all combination button set.
    * If the button
    * @param buttonToLight
    * @param manualIndexOnlyFor

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -12,6 +12,7 @@
 
 #include "ptrvector.h"
 
+#include "control/GOCombinationButtonSet.h"
 #include "control/GOControlChangedHandler.h"
 #include "control/GOElementCreator.h"
 #include "control/GOLabelControl.h"
@@ -28,6 +29,7 @@ class GOGeneralCombination;
 class GODivisionalCombination;
 
 class GOSetter : private GOSoundStateHandler,
+                 private GOCombinationButtonSet,
                  private GOControlChangedHandler,
                  public GOElementCreator,
                  public GOSaveableObject,
@@ -98,6 +100,24 @@ private:
    */
   void NotifyCmbPushed(bool isChanged = true);
 
+  /**
+   * Ubdate all setter combination buttons light.
+   * If the button
+   * @param buttonToLight
+   * @param manualIndexOnlyFor
+   */
+  void UpdateAllButtonsLight(
+    GOButtonControl *buttonToLight, int manualIndexOnlyFor) override;
+
+  /**
+   * Ubdate buttons light in all combination button set.
+   * If the button
+   * @param buttonToLight
+   * @param manualIndexOnlyFor
+   */
+  void UpdateAllSetsButtonsLight(
+    GOButtonControl *buttonToLight, int manualIndexOnlyFor);
+
 public:
   static const wxString KEY_REFRESH_FILES;
   static const wxString KEY_PREV_FILE;
@@ -167,11 +187,13 @@ public:
    * extraSet
    * If isFromCrescendo and it is in add mode then then does not depress other
    * buttons
-   *
+   * @param cmb the cmb to activate or to set
+   * @param pButton the button to light on
    * return if anything is changed
    */
-  void PushGeneral(GOGeneralCombination &cmb);
-  void PushDivisional(GODivisionalCombination &cmb);
+  void PushGeneral(GOGeneralCombination &cmb, GOButtonControl *pButtonToLight);
+  void PushDivisional(
+    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight);
 
   /*
    * If current crescendo is in override mode then returns nullptr
@@ -187,7 +209,11 @@ public:
   unsigned GetPosition();
   void UpdatePosition(int pos);
   void SetPosition(int pos, bool push = true);
-  void ResetDisplay();
+
+  /**
+   * Switch the light of all combination buttons off
+   */
+  void ResetCmbButtons() { UpdateAllSetsButtonsLight(nullptr, -1); }
   void SetTranspose(int value);
   void UpdateTranspose();
   void UpdateModified(bool modified);

--- a/src/grandorgue/combinations/control/GOCombinationButtonSet.cpp
+++ b/src/grandorgue/combinations/control/GOCombinationButtonSet.cpp
@@ -9,7 +9,7 @@
 
 #include "control/GOButtonControl.h"
 
-void GOCombinationButtonSet::UpdateOneButtonLight(
+void GOCombinationButtonSet::updateOneButtonLight(
   GOButtonControl *pButton, GOButtonControl *buttonToLight) {
   if (pButton) {
     // switch off and then on is necessary for sending midi events

--- a/src/grandorgue/combinations/control/GOCombinationButtonSet.cpp
+++ b/src/grandorgue/combinations/control/GOCombinationButtonSet.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOCombinationButtonSet.h"
+
+#include "control/GOButtonControl.h"
+
+void GOCombinationButtonSet::UpdateOneButtonLight(
+  GOButtonControl *pButton, GOButtonControl *buttonToLight) {
+  if (pButton) {
+    // switch off and then on is necessary for sending midi events
+    pButton->Display(false);
+    if (pButton == buttonToLight)
+      pButton->Display(true);
+  }
+}

--- a/src/grandorgue/combinations/control/GOCombinationButtonSet.h
+++ b/src/grandorgue/combinations/control/GOCombinationButtonSet.h
@@ -17,7 +17,7 @@ protected:
    * @param pButton - the button to control
    * @param buttonToLight - the button to light
    */
-  void UpdateOneButtonLight(
+  static void updateOneButtonLight(
     GOButtonControl *pButton, GOButtonControl *buttonToLight);
 
 public:

--- a/src/grandorgue/combinations/control/GOCombinationButtonSet.h
+++ b/src/grandorgue/combinations/control/GOCombinationButtonSet.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOCOMBINATIONBUTTONSET_H
+#define GOCOMBINATIONBUTTONSET_H
+
+class GOButtonControl;
+
+class GOCombinationButtonSet {
+protected:
+  /**
+   * Ubdate light of one button.
+   * @param pButton - the button to control
+   * @param buttonToLight - the button to light
+   */
+  void UpdateOneButtonLight(
+    GOButtonControl *pButton, GOButtonControl *buttonToLight);
+
+public:
+  /**
+   * Ubdate all combination buttons light.
+   * If the button
+   * @param buttonToLight
+   * @param manualIndexOnlyFor
+   */
+  virtual void UpdateAllButtonsLight(
+    GOButtonControl *buttonToLight, int manualIndexOnlyFor)
+    = 0;
+};
+
+#endif /* GOCOMBINATIONBUTTONSET_H */

--- a/src/grandorgue/combinations/control/GOCombinationButtonSet.h
+++ b/src/grandorgue/combinations/control/GOCombinationButtonSet.h
@@ -13,7 +13,7 @@ class GOButtonControl;
 class GOCombinationButtonSet {
 protected:
   /**
-   * Ubdate light of one button.
+   * Update light of one button.
    * @param pButton - the button to control
    * @param buttonToLight - the button to light
    */
@@ -22,7 +22,7 @@ protected:
 
 public:
   /**
-   * Ubdate all combination buttons light.
+   * Update all combination buttons light.
    * If the button
    * @param buttonToLight
    * @param manualIndexOnlyFor

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -52,12 +52,5 @@ void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
 }
 
 void GODivisionalButtonControl::Push() {
-  GOManual *pManual = r_OrganModel.GetManual(m_combination.GetManualNumber());
-
-  r_setter.PushDivisional(m_combination);
-  for (unsigned l = pManual->GetDivisionalCount(), k = 0; k < l; k++) {
-    GODivisionalButtonControl *pDivisionalControl = pManual->GetDivisional(k);
-
-    pDivisionalControl->Display(pDivisionalControl == this);
-  }
+  r_setter.PushDivisional(m_combination, this);
 }

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.h
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.h
@@ -44,7 +44,7 @@ public:
   void LoadCombination(GOConfigReader &cfg);
   void Save(GOConfigWriter &cfg);
 
-  void Push();
+  void Push() override;
 };
 
 #endif /* GODIVISIONALBUTTONCONTROL_H */

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -26,7 +26,9 @@ void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
   GOPushbuttonControl::Load(cfg, group);
 }
 
-void GOGeneralButtonControl::Push() { r_setter.PushGeneral(m_combination); }
+void GOGeneralButtonControl::Push() {
+  r_setter.PushGeneral(m_combination, this);
+}
 
 GOGeneralCombination &GOGeneralButtonControl::GetCombination() {
   return m_combination;

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.h
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.h
@@ -25,7 +25,7 @@ public:
     GOOrganController *organController,
     bool is_setter);
   void Load(GOConfigReader &cfg, wxString group);
-  void Push();
+  void Push() override;
   GOGeneralCombination &GetCombination();
 
   wxString GetMidiType();

--- a/src/grandorgue/model/GOEventHandlerList.cpp
+++ b/src/grandorgue/model/GOEventHandlerList.cpp
@@ -15,6 +15,11 @@ void GOEventHandlerList::RegisterCacheObject(GOCacheObject *obj) {
   m_CacheObjects.push_back(obj);
 }
 
+void GOEventHandlerList::RegisterCombinationButtonSet(
+  GOCombinationButtonSet *obj) {
+  m_CombinationButtonSets.push_back(obj);
+}
+
 void GOEventHandlerList::RegisterControlChangedHandler(
   GOControlChangedHandler *handler) {
   m_ControlChangedHandlers.push_back(handler);
@@ -56,6 +61,7 @@ void GOEventHandlerList::SendControlChanged(void *pControl) {
 
 void GOEventHandlerList::Cleanup() {
   m_CacheObjects.clear();
+  m_CombinationButtonSets.clear();
   m_ControlChangedHandlers.clear();
   m_MidiConfigurators.clear();
   m_MidiEventHandlers.clear();

--- a/src/grandorgue/model/GOEventHandlerList.h
+++ b/src/grandorgue/model/GOEventHandlerList.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 class GOCacheObject;
+class GOCombinationButtonSet;
 class GOControlChangedHandler;
 class GOEventHandler;
 class GOMidiConfigurator;
@@ -20,6 +21,7 @@ class GOSaveableObject;
 class GOEventHandlerList {
 private:
   std::vector<GOCacheObject *> m_CacheObjects;
+  std::vector<GOCombinationButtonSet *> m_CombinationButtonSets;
   std::vector<GOControlChangedHandler *> m_ControlChangedHandlers;
   std::vector<GOMidiConfigurator *> m_MidiConfigurators;
   std::vector<GOEventHandler *> m_MidiEventHandlers;
@@ -29,6 +31,10 @@ private:
 public:
   const std::vector<GOCacheObject *> &GetCacheObjects() const {
     return m_CacheObjects;
+  }
+  const std::vector<GOCombinationButtonSet *> &GetCombinationButtonSets()
+    const {
+    return m_CombinationButtonSets;
   }
   const std::vector<GOMidiConfigurator *> &GetMidiConfigurators() const {
     return m_MidiConfigurators;
@@ -44,6 +50,7 @@ public:
   }
 
   void RegisterCacheObject(GOCacheObject *obj);
+  void RegisterCombinationButtonSet(GOCombinationButtonSet *obj);
   void RegisterControlChangedHandler(GOControlChangedHandler *handler);
   void RegisterMidiConfigurator(GOMidiConfigurator *obj);
   void RegisterEventHandler(GOEventHandler *handler);

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -49,6 +49,7 @@ GOManual::GOManual(GOOrganController *organController)
     m_displayed(false),
     m_DivisionalTemplate(*organController) {
   m_InputCouplers.push_back(NULL);
+  m_OrganController->RegisterCombinationButtonSet(this);
   m_OrganController->RegisterEventHandler(this);
   m_OrganController->RegisterMidiConfigurator(this);
   m_OrganController->RegisterSoundStateHandler(this);
@@ -570,4 +571,11 @@ std::vector<wxString> GOManual::GetElementActions() {
 
 void GOManual::TriggerElementActions(unsigned no) {
   // Never called
+}
+
+void GOManual::UpdateAllButtonsLight(
+  GOButtonControl *buttonToLight, int manualIndexOnlyFor) {
+  if (manualIndexOnlyFor < 0 || (unsigned)manualIndexOnlyFor == m_manual_number)
+    for (GOButtonControl *pDivisional : m_divisionals)
+      UpdateOneButtonLight(pDivisional, buttonToLight);
 }

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -577,5 +577,5 @@ void GOManual::UpdateAllButtonsLight(
   GOButtonControl *buttonToLight, int manualIndexOnlyFor) {
   if (manualIndexOnlyFor < 0 || (unsigned)manualIndexOnlyFor == m_manual_number)
     for (GOButtonControl *pDivisional : m_divisionals)
-      UpdateOneButtonLight(pDivisional, buttonToLight);
+      updateOneButtonLight(pDivisional, buttonToLight);
 }

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -12,6 +12,7 @@
 
 #include "ptrvector.h"
 
+#include "combinations/control/GOCombinationButtonSet.h"
 #include "combinations/model/GOCombinationDefinition.h"
 #include "midi/GOMidiConfigurator.h"
 #include "midi/GOMidiReceiver.h"
@@ -32,6 +33,7 @@ class GOTremulant;
 class GOOrganController;
 
 class GOManual : private GOEventHandler,
+                 private GOCombinationButtonSet,
                  private GOSaveableObject,
                  private GOSoundStateHandler,
                  public GOMidiConfigurator {
@@ -82,6 +84,14 @@ private:
   void AbortPlayback();
   void PreparePlayback();
   void PrepareRecording();
+
+  /**
+   * Ubdate all divisional buttons light.
+   * @param buttonToLight
+   * @param manualIndexOnlyFor
+   */
+  void UpdateAllButtonsLight(
+    GOButtonControl *buttonToLight, int manualIndexOnlyFor) override;
 
 public:
   GOManual(GOOrganController *organController);

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -86,7 +86,7 @@ private:
   void PrepareRecording();
 
   /**
-   * Ubdate all divisional buttons light.
+   * Update all divisional buttons light.
    * @param buttonToLight
    * @param manualIndexOnlyFor
    */

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -32,7 +32,9 @@ GOOrganModel::GOOrganModel(GOConfig &config)
     m_OrganModelModified(false),
     m_FirstManual(0),
     m_ODFManualCount(0),
-    m_ODFRankCount(0) {}
+    m_ODFRankCount(0) {
+  RegisterCombinationButtonSet(this);
+}
 
 GOOrganModel::~GOOrganModel() {}
 
@@ -284,4 +286,10 @@ unsigned GOOrganModel::GetGeneralCount() { return m_generals.size(); }
 
 GOGeneralButtonControl *GOOrganModel::GetGeneral(unsigned index) {
   return m_generals[index];
+}
+
+void GOOrganModel::UpdateAllButtonsLight(
+  GOButtonControl *buttonToLight, int manualIndexOnlyFor) {
+  for (GOGeneralButtonControl *pGeneral : m_generals)
+    UpdateOneButtonLight(pGeneral, buttonToLight);
 }

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -292,5 +292,5 @@ void GOOrganModel::UpdateAllButtonsLight(
   GOButtonControl *buttonToLight, int manualIndexOnlyFor) {
   if (manualIndexOnlyFor < 0)
     for (GOGeneralButtonControl *pGeneral : m_generals)
-      UpdateOneButtonLight(pGeneral, buttonToLight);
+      updateOneButtonLight(pGeneral, buttonToLight);
 }

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -290,6 +290,7 @@ GOGeneralButtonControl *GOOrganModel::GetGeneral(unsigned index) {
 
 void GOOrganModel::UpdateAllButtonsLight(
   GOButtonControl *buttonToLight, int manualIndexOnlyFor) {
-  for (GOGeneralButtonControl *pGeneral : m_generals)
-    UpdateOneButtonLight(pGeneral, buttonToLight);
+  if (manualIndexOnlyFor < 0)
+    for (GOGeneralButtonControl *pGeneral : m_generals)
+      UpdateOneButtonLight(pGeneral, buttonToLight);
 }

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -67,7 +67,7 @@ protected:
   void Load(GOConfigReader &cfg, GOOrganController *organController);
 
   /**
-   * Ubdate all generals buttons light.
+   * Update all generals buttons light.
    * @param buttonToLight - the button that should be lighted on. All other
    *   divisionals are lighted off
    * @param manualIndexOnlyFor - if >= 0 change lighting of this manual only

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -10,6 +10,7 @@
 
 #include "ptrvector.h"
 
+#include "combinations/control/GOCombinationButtonSet.h"
 #include "midi/GOMidiSendProxy.h"
 #include "midi/dialog-creator/GOMidiDialogCreatorProxy.h"
 #include "modification/GOModificationProxy.h"
@@ -30,7 +31,8 @@ class GOSwitch;
 class GOTremulant;
 class GOWindchest;
 
-class GOOrganModel : public GOEventHandlerList,
+class GOOrganModel : private GOCombinationButtonSet,
+                     public GOEventHandlerList,
                      public GOMidiDialogCreatorProxy,
                      public GOMidiSendProxy {
 private:
@@ -63,6 +65,15 @@ protected:
   unsigned m_ODFRankCount;
 
   void Load(GOConfigReader &cfg, GOOrganController *organController);
+
+  /**
+   * Ubdate all generals buttons light.
+   * @param buttonToLight - the button that should be lighted on. All other
+   *   divisionals are lighted off
+   * @param manualIndexOnlyFor - if >= 0 change lighting of this manual only
+   */
+  void UpdateAllButtonsLight(
+    GOButtonControl *buttonToLight, int manualIndexOnlyFor) override;
 
 public:
   GOOrganModel(GOConfig &config);


### PR DESCRIPTION
Resolves: #1536

GO has lots of different combination systems: ODF/Generals, Banked Generals, Frame Generals, ODF/Divisional, Banked Divisionals.

Earlier each button of each system, when is pushed, was responsible for disabling buttons in all other systems and there were gaps in this knoledge caused bugs.

This PR introduces the GOCombinationButtonSet interface for controlling combination buttons. Each subsystem implementing this interface is responsible for controlling light only of it's own buttons. GOEventHandlerList collects all such objects and GOSetter broadcasts across them all.

Now GOSetter is responsible for Banked Generals and Frame Generals (Sequencer) buttons, GODivisionalSetter - for banked dividionals, GOOrganModel - for ODF Generals and GOManual - for ODF divisionals.

All other combination light controlling code has been removed. It was in
-  GODivisionalSetter::SwitchDivisionalTo
- GOSetter::ButtonStateChanged
- GOSetter::PushGeneral
- GOSetter::UpdatePosition
- GODivisionalButtonControl::Push()

This PR also renames GOSetter::ResetDisplay to GOSetter::ResetCmbButtons and reimplements throught broadcasting (GOSetter::UpdateAllSetsButtonsLight)