### PR TITLE
Renamed GODrawStop::StoreInDivisional to IsToStoreInDivisional, GODrawStop::StoreGeneral to IsToStoreInGeneral https://github.com/GrandOrgue/grandorgue/issues/1498

### DIFF
--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -31,12 +31,12 @@ GOCombinationDefinition::~GOCombinationDefinition() {}
 
 void GOCombinationDefinition::AddGeneral(
   GODrawstop *control, ElementType type, int manual, unsigned index) {
-  Add(control, type, manual, index, control->GetStoreGeneral());
+  Add(control, type, manual, index, control->IsToStoreInGeneral());
 }
 
 void GOCombinationDefinition::AddDivisional(
   GODrawstop *control, ElementType type, int manual, unsigned index) {
-  Add(control, type, manual, index, control->GetStoreDivisional());
+  Add(control, type, manual, index, control->IsToStoreInDivisional());
 }
 
 void GOCombinationDefinition::Add(

--- a/src/grandorgue/model/GOCoupler.cpp
+++ b/src/grandorgue/model/GOCoupler.cpp
@@ -245,12 +245,12 @@ void GOCoupler::Load(GOConfigReader &cfg, wxString group) {
       = r_OrganModel.GetManual(m_DestinationManual)->RegisterCoupler(this);
 }
 
-void GOCoupler::SetupCombinationState() {
-  m_StoreDivisional
+void GOCoupler::SetupIsToStoreInCmb() {
+  m_IsToStoreInDivisional
     = ((r_OrganModel.DivisionalsStoreIntramanualCouplers() && !IsIntermanual())
        || (r_OrganModel.DivisionalsStoreIntermanualCouplers() && IsIntermanual()))
     && (r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed());
-  m_StoreGeneral
+  m_IsToStoreInGeneral
     = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
 }
 

--- a/src/grandorgue/model/GOCoupler.h
+++ b/src/grandorgue/model/GOCoupler.h
@@ -50,7 +50,7 @@ private:
   void SetOut(int note, unsigned velocity);
   unsigned GetInternalState(int note);
   void ChangeState(bool on);
-  void SetupCombinationState();
+  void SetupIsToStoreInCmb();
 
   void PreparePlayback();
 

--- a/src/grandorgue/model/GODivisionalCoupler.cpp
+++ b/src/grandorgue/model/GODivisionalCoupler.cpp
@@ -42,9 +42,9 @@ void GODivisionalCoupler::Load(GOConfigReader &cfg, wxString group) {
   GODrawstop::Load(cfg, group);
 }
 
-void GODivisionalCoupler::SetupCombinationState() {
-  m_StoreDivisional = false;
-  m_StoreGeneral = r_OrganModel.GeneralsStoreDivisionalCouplers();
+void GODivisionalCoupler::SetupIsToStoreInCmb() {
+  m_IsToStoreInDivisional = false;
+  m_IsToStoreInGeneral = r_OrganModel.GeneralsStoreDivisionalCouplers();
 }
 
 void GODivisionalCoupler::ChangeState(bool on) {}

--- a/src/grandorgue/model/GODivisionalCoupler.h
+++ b/src/grandorgue/model/GODivisionalCoupler.h
@@ -18,7 +18,7 @@ private:
   std::vector<unsigned> m_manuals;
 
   void ChangeState(bool on);
-  void SetupCombinationState();
+  void SetupIsToStoreInCmb();
 
 public:
   GODivisionalCoupler(GOOrganModel &organModel);

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -33,8 +33,8 @@ GODrawstop::GODrawstop(GOOrganModel &organModel)
     m_CombinationState(false),
     m_ControlledDrawstops(),
     m_ControllingDrawstops(),
-    m_StoreDivisional(false),
-    m_StoreGeneral(false) {}
+    m_IsToStoreInDivisional(false),
+    m_IsToStoreInGeneral(false) {}
 
 void GODrawstop::RegisterControlled(GODrawstop *sw) {
   m_ControlledDrawstops.push_back(sw);
@@ -44,8 +44,8 @@ void GODrawstop::Init(GOConfigReader &cfg, wxString group, wxString name) {
   m_Type = FUNCTION_INPUT;
   m_Engaged = cfg.ReadBoolean(CMBSetting, group, wxT("DefaultToEngaged"));
   m_GCState = 0;
-  m_StoreDivisional = true;
-  m_StoreGeneral = true;
+  m_IsToStoreInDivisional = true;
+  m_IsToStoreInGeneral = true;
   GOButtonControl::Init(cfg, group, name);
 }
 
@@ -106,11 +106,15 @@ void GODrawstop::Load(GOConfigReader &cfg, wxString group) {
   }
 
   GOButtonControl::Load(cfg, group);
-  SetupCombinationState();
-  m_StoreDivisional = cfg.ReadBoolean(
-    ODFSetting, group, wxT("StoreInDivisional"), false, m_StoreDivisional);
-  m_StoreGeneral = cfg.ReadBoolean(
-    ODFSetting, group, wxT("StoreInGeneral"), false, m_StoreGeneral);
+  SetupIsToStoreInCmb();
+  m_IsToStoreInDivisional = cfg.ReadBoolean(
+    ODFSetting,
+    group,
+    wxT("StoreInDivisional"),
+    false,
+    m_IsToStoreInDivisional);
+  m_IsToStoreInGeneral = cfg.ReadBoolean(
+    ODFSetting, group, wxT("StoreInGeneral"), false, m_IsToStoreInGeneral);
 }
 
 void GODrawstop::Save(GOConfigWriter &cfg) {
@@ -152,8 +156,6 @@ void GODrawstop::SetCombination(bool on) {
   m_CombinationState = on;
   Set(on);
 }
-
-bool GODrawstop::IsActive() const { return m_ActiveState; }
 
 void GODrawstop::StartPlayback() {
   GOButtonControl::StartPlayback();
@@ -202,9 +204,3 @@ void GODrawstop::Update() {
     break;
   }
 }
-
-bool GODrawstop::GetCombinationState() const { return IsEngaged(); }
-
-bool GODrawstop::GetStoreDivisional() const { return m_StoreDivisional; }
-
-bool GODrawstop::GetStoreGeneral() const { return m_StoreGeneral; }

--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -35,12 +35,21 @@ private:
   std::vector<GODrawstop *> m_ControllingDrawstops;
 
 protected:
-  bool m_StoreDivisional;
-  bool m_StoreGeneral;
+  /*
+   * m_IsToStoreInDivisional and m_IsToStoreInGeneral control whether the
+   * drawstop state should be saved in combinations by default.
+   * When Full is enabled the state is saved regardless these variables.
+   * The initial intention was to save the state of drawstops controlled by the
+   * user and not to save the state that is calculated from the state of other
+   * elements
+   */
+  bool m_IsToStoreInDivisional;
+  bool m_IsToStoreInGeneral;
+
+  virtual void SetupIsToStoreInCmb() = 0;
 
   void SetState(bool on);
   virtual void ChangeState(bool on) = 0;
-  virtual void SetupCombinationState() = 0;
 
   void Save(GOConfigWriter &cfg);
 
@@ -48,6 +57,12 @@ protected:
 
 public:
   GODrawstop(GOOrganModel &organModel);
+
+  bool IsToStoreInDivisional() const { return m_IsToStoreInDivisional; }
+  bool IsToStoreInGeneral() const { return m_IsToStoreInGeneral; }
+  bool IsActive() const { return m_ActiveState; }
+  bool GetCombinationState() const override { return IsEngaged(); }
+
   void Init(GOConfigReader &cfg, wxString group, wxString name);
   void Load(GOConfigReader &cfg, wxString group);
   void RegisterControlled(GODrawstop *sw);
@@ -55,11 +70,6 @@ public:
   virtual void Update();
   void Reset();
   void SetCombination(bool on);
-
-  bool IsActive() const;
-  bool GetCombinationState() const;
-  bool GetStoreDivisional() const;
-  bool GetStoreGeneral() const;
 };
 
 #endif

--- a/src/grandorgue/model/GOStop.cpp
+++ b/src/grandorgue/model/GOStop.cpp
@@ -95,18 +95,18 @@ void GOStop::Load(GOConfigReader &cfg, wxString group) {
 
   m_KeyVelocity.resize(m_NumberOfAccessiblePipes);
   std::fill(m_KeyVelocity.begin(), m_KeyVelocity.end(), 0);
-  m_StoreDivisional
+  m_IsToStoreInDivisional
     = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
-  m_StoreGeneral
+  m_IsToStoreInGeneral
     = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
 
   GODrawstop::Load(cfg, group);
 }
 
-void GOStop::SetupCombinationState() {
-  m_StoreDivisional
+void GOStop::SetupIsToStoreInCmb() {
+  m_IsToStoreInDivisional
     = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
-  m_StoreGeneral
+  m_IsToStoreInGeneral
     = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
 }
 

--- a/src/grandorgue/model/GOStop.h
+++ b/src/grandorgue/model/GOStop.h
@@ -33,7 +33,7 @@ private:
 
   void SetRankKey(unsigned key, unsigned velocity);
   void ChangeState(bool on);
-  void SetupCombinationState();
+  void SetupIsToStoreInCmb();
 
   void AbortPlayback();
   void PreparePlayback();

--- a/src/grandorgue/model/GOSwitch.cpp
+++ b/src/grandorgue/model/GOSwitch.cpp
@@ -17,10 +17,10 @@ GOSwitch::~GOSwitch() {}
 
 void GOSwitch::ChangeState(bool on) {}
 
-void GOSwitch::SetupCombinationState() {
-  m_StoreDivisional
+void GOSwitch::SetupIsToStoreInCmb() {
+  m_IsToStoreInDivisional
     = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
-  m_StoreGeneral
+  m_IsToStoreInGeneral
     = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
 }
 

--- a/src/grandorgue/model/GOSwitch.h
+++ b/src/grandorgue/model/GOSwitch.h
@@ -13,7 +13,7 @@
 class GOSwitch : public GODrawstop {
 protected:
   void ChangeState(bool);
-  void SetupCombinationState();
+  void SetupIsToStoreInCmb();
 
 public:
   GOSwitch(GOOrganModel &organModel);

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -82,10 +82,10 @@ void GOTremulant::Load(
   r_OrganModel.RegisterCacheObject(this);
 }
 
-void GOTremulant::SetupCombinationState() {
-  m_StoreDivisional = r_OrganModel.DivisionalsStoreTremulants()
+void GOTremulant::SetupIsToStoreInCmb() {
+  m_IsToStoreInDivisional = r_OrganModel.DivisionalsStoreTremulants()
     && (r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed());
-  m_StoreGeneral
+  m_IsToStoreInGeneral
     = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
 }
 

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -38,7 +38,7 @@ private:
 
   void InitSoundProvider(GOMemoryPool &pool);
   void ChangeState(bool on);
-  void SetupCombinationState();
+  void SetupIsToStoreInCmb();
 
   void Initialize();
   void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool);


### PR DESCRIPTION
This is the first PR on #1498

- Renamed m_StoreGeneral and m_StoreDivisional of GODrawstop as well as some corresponding methods
- Added a comment text in GODrawstop
- Brought some simple GODrawstop methods online

This is a pure renaming. No GO behavior should be changed.
