### PR TITLE
Fixed not storing switch state in combinations in organs with panels of the new style https://github.com/GrandOrgue/grandorgue/issues/1498

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed not storing switch state in combinations in organs with panels of the new style https://github.com/GrandOrgue/grandorgue/issues/1498
 - Fixed displaying light of various combination buttons https://github.com/GrandOrgue/grandorgue/issues/1536 
 - Fixed saving empty and scoped combinations to yaml https://github.com/GrandOrgue/grandorgue/issues/1531
 - Fixed bug of GC not working on manual with only a single stop https://github.com/GrandOrgue/grandorgue/issues/1556

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -50,10 +50,13 @@ void GODrawstop::Init(GOConfigReader &cfg, wxString group, wxString name) {
 }
 
 void GODrawstop::SetupIsToStoreInCmb() {
+  const bool isControlledByUser = !IsReadOnly();
+
   m_IsToStoreInDivisional
-    = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
-  m_IsToStoreInGeneral
-    = r_OrganModel.CombinationsStoreNonDisplayedDrawstops() || IsDisplayed();
+    = r_OrganModel.CombinationsStoreNonDisplayedDrawstops()
+    || isControlledByUser;
+  m_IsToStoreInGeneral = r_OrganModel.CombinationsStoreNonDisplayedDrawstops()
+    || isControlledByUser;
 }
 
 void GODrawstop::Load(GOConfigReader &cfg, wxString group) {


### PR DESCRIPTION
Resolves #1498 

This is the last PR on #1498. It changes the criteria of storing switch state in combinations from visibility to being not read only.
