### PR TITLE
Fixed "The devive does not support requested channel count" error when using an USB audio card on MacOS https://github.com/GrandOrgue/grandorgue/issues/1550

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Fixed "The devive does not support requested channel count" error when using an USB audio card on MacOS https://github.com/GrandOrgue/grandorgue/issues/1550
+- Fixed "The device does not support requested channel count" error when using an USB audio card on MacOS https://github.com/GrandOrgue/grandorgue/issues/1550
 # 3.12.1 (2023-06-06)
 - Fixed not storing switch state in combinations in organs with panels of the new style https://github.com/GrandOrgue/grandorgue/issues/1498
 - Fixed displaying light of various combination buttons https://github.com/GrandOrgue/grandorgue/issues/1536 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed "The devive does not support requested channel count" error when using an USB audio card on MacOS https://github.com/GrandOrgue/grandorgue/issues/1550
 # 3.12.1 (2023-06-06)
 - Fixed not storing switch state in combinations in organs with panels of the new style https://github.com/GrandOrgue/grandorgue/issues/1498
 - Fixed displaying light of various combination buttons https://github.com/GrandOrgue/grandorgue/issues/1536 

--- a/src/grandorgue/sound/ports/GOSoundPortaudioPort.h
+++ b/src/grandorgue/sound/ports/GOSoundPortaudioPort.h
@@ -14,6 +14,7 @@
 
 class GOSoundPortaudioPort : public GOSoundPort {
 private:
+  unsigned m_PaDevIndex;
   PaStream *m_stream;
 
   static int Callback(
@@ -24,14 +25,15 @@ private:
     PaStreamCallbackFlags statusFlags,
     void *userData);
 
-  static wxString getName(unsigned index);
+  static wxString getName(const PaDeviceInfo *pInfo);
   static wxString getLastError(PaError error);
 
 public:
   static const wxString PORT_NAME;
   static const wxString PORT_NAME_OLD;
 
-  GOSoundPortaudioPort(GOSound *sound, wxString name);
+  GOSoundPortaudioPort(
+    GOSound *sound, unsigned paDevIndex, const wxString &name);
   virtual ~GOSoundPortaudioPort();
 
   void Open();
@@ -42,7 +44,7 @@ public:
     return GOSoundPortFactory::c_NoApis;
   }
   static GOSoundPort *create(
-    const GOPortsConfig &portsConfig, GOSound *sound, wxString name);
+    const GOPortsConfig &portsConfig, GOSound *sound, const wxString &name);
   static void addDevices(
     const GOPortsConfig &portsConfig, std::vector<GOSoundDevInfo> &list);
   static void terminate();

--- a/src/grandorgue/sound/ports/GOSoundRtPort.h
+++ b/src/grandorgue/sound/ports/GOSoundRtPort.h
@@ -15,6 +15,7 @@
 class GOSoundRtPort : public GOSoundPort {
 private:
   RtAudio *m_rtApi;
+  unsigned m_RtDevIndex;
   unsigned m_nBuffers;
 
   static int Callback(
@@ -25,14 +26,16 @@ private:
     RtAudioStreamStatus status,
     void *userData);
 
-  static wxString getName(RtAudio *rtApi, unsigned index);
+  static wxString getName(RtAudio *rtApi, const RtAudio::DeviceInfo &devInfo);
+
+  GOSoundRtPort(
+    GOSound *sound, RtAudio *rtApi, unsigned rtDevIndex, const wxString &name);
 
 public:
   static const wxString PORT_NAME;
   static const wxString PORT_NAME_OLD;
 
   // rtApi to be deleted in the destructor
-  GOSoundRtPort(GOSound *sound, RtAudio *rtApi, wxString name);
   ~GOSoundRtPort();
 
   void Open();


### PR DESCRIPTION
Resolves: #1550

The problem was caused by duplicating device name in MacOS for USB audio devices

This PR
- Adds checking for the output channel count when matching devices by name
- Eliminates double searching a device by name: earlier both create and Open were searching the devices, now create searches the device and remember it's number that is used by Open

Both `GOSoundPortaudioPort` and `GOSoundRtPort` are taken in this PR.
