### PR TITLE
Extracted GODialog from GOTabbedDialog

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -65,6 +65,7 @@ control/GOElementCreator.cpp
 control/GOEventDistributor.cpp
 control/GOLabelControl.cpp
 control/GOPistonControl.cpp
+dialogs/common/GODialog.cpp
 dialogs/common/GODialogCloser.cpp
 dialogs/common/GODialogTab.cpp
 dialogs/common/GOTabbedDialog.cpp

--- a/src/grandorgue/dialogs/common/GODialog.cpp
+++ b/src/grandorgue/dialogs/common/GODialog.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GODialog.h"
+
+#include <wx/app.h>
+#include <wx/sizer.h>
+
+#include "help/GOHelpRequestor.h"
+
+#include "GOEvent.h"
+
+const wxString GODialog::WX_EMPTY = wxEmptyString;
+
+BEGIN_EVENT_TABLE(GODialog, wxPropertySheetDialog)
+EVT_BUTTON(wxID_HELP, GODialog::OnHelp)
+END_EVENT_TABLE()
+
+GODialog::GODialog(
+  wxWindow *win,
+  const wxString &name,  // not translated
+  const wxString &title, // translated
+  long addStyle)
+  : wxPropertySheetDialog(
+    win,
+    wxID_ANY,
+    title,
+    wxDefaultPosition,
+    wxDefaultSize,
+    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | addStyle),
+    GODialogCloser(this),
+    m_name(name) {
+  p_ButtonSizer = CreateButtonSizer(wxOK | wxCANCEL | wxHELP);
+  GetInnerSizer()->Add(p_ButtonSizer, 0, wxEXPAND | wxALL, 5);
+}
+
+void GODialog::OnHelp(wxCommandEvent &event) {
+  const wxString &helpSuffix = GetHelpSuffix();
+  const wxString helpSection
+    = m_name + (helpSuffix.IsEmpty() ? WX_EMPTY : wxT(".") + helpSuffix);
+
+  GOHelpRequestor::DisplayHelp(helpSection, IsModal());
+}

--- a/src/grandorgue/dialogs/common/GODialog.h
+++ b/src/grandorgue/dialogs/common/GODialog.h
@@ -17,7 +17,7 @@ class wxSizer;
 class GODialog : public wxPropertySheetDialog, public GODialogCloser {
 private:
   static const wxString WX_EMPTY;
-  
+
   const wxString m_name;
   wxSizer *p_ButtonSizer;
 
@@ -43,4 +43,3 @@ protected:
 };
 
 #endif /* GODIALOG_H */
-

--- a/src/grandorgue/dialogs/common/GODialog.h
+++ b/src/grandorgue/dialogs/common/GODialog.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GODIALOG_H
+#define GODIALOG_H
+
+#include <wx/propdlg.h>
+
+#include "GODialogCloser.h"
+
+class wxSizer;
+
+class GODialog : public wxPropertySheetDialog, public GODialogCloser {
+private:
+  static const wxString WX_EMPTY;
+  
+  const wxString m_name;
+  wxSizer *p_ButtonSizer;
+
+  void OnHelp(wxCommandEvent &event);
+
+protected:
+  GODialog(
+    wxWindow *win,
+    const wxString &name,  // not translated
+    const wxString &title, // translated
+    long addStyle = 0);
+
+  wxSizer *GetButtonSizer() const { return p_ButtonSizer; }
+
+  /**
+   * For complex dialogs return the current help subsection.
+   * The default implementation is for simple dialogs without subsections
+   * @return the current subsection name or an emptyy string
+   */
+  virtual const wxString &GetHelpSuffix() const { return WX_EMPTY; }
+
+  DECLARE_EVENT_TABLE()
+};
+
+#endif /* GODIALOG_H */
+

--- a/src/grandorgue/dialogs/common/GOTabbedDialog.cpp
+++ b/src/grandorgue/dialogs/common/GOTabbedDialog.cpp
@@ -9,38 +9,18 @@
 
 #include <algorithm>
 
-#include <wx/app.h>
 #include <wx/bookctrl.h>
 #include <wx/panel.h>
-#include <wx/sizer.h>
-
-#include "help/GOHelpRequestor.h"
 
 #include "GODialogTab.h"
-#include "GOEvent.h"
-
-BEGIN_EVENT_TABLE(GOTabbedDialog, wxPropertySheetDialog)
-EVT_BUTTON(wxID_HELP, GOTabbedDialog::OnHelp)
-END_EVENT_TABLE()
 
 GOTabbedDialog::GOTabbedDialog(
   wxWindow *win,
   const wxString &name,  // not translated
   const wxString &title, // translated
-  long addStyle)
-  : wxPropertySheetDialog(
-    win,
-    wxID_ANY,
-    title,
-    wxDefaultPosition,
-    wxDefaultSize,
-    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | addStyle),
-    GODialogCloser(this),
-    m_name(name) {
+  long addStyle) : GODialog(win, name, title, addStyle) {
   p_book = GetBookCtrl();
   p_book->SetExtraStyle(p_book->GetExtraStyle() | wxWS_EX_VALIDATE_RECURSIVELY);
-  p_ButtonSizer = CreateButtonSizer(wxOK | wxCANCEL | wxHELP);
-  GetInnerSizer()->Add(p_ButtonSizer, 0, wxEXPAND | wxALL, 5);
 }
 
 void GOTabbedDialog::AddTab(
@@ -51,10 +31,6 @@ void GOTabbedDialog::AddTab(
 
 void GOTabbedDialog::AddTab(GODialogTab *tab) {
   AddTab(tab, tab->GetName(), tab->GetLabel());
-}
-
-void GOTabbedDialog::OnHelp(wxCommandEvent &event) {
-  GOHelpRequestor::DisplayHelp(m_name + "." + GetCurrTabName(), IsModal());
 }
 
 const wxString &GOTabbedDialog::GetCurrTabName() const {

--- a/src/grandorgue/dialogs/common/GOTabbedDialog.cpp
+++ b/src/grandorgue/dialogs/common/GOTabbedDialog.cpp
@@ -18,7 +18,8 @@ GOTabbedDialog::GOTabbedDialog(
   wxWindow *win,
   const wxString &name,  // not translated
   const wxString &title, // translated
-  long addStyle) : GODialog(win, name, title, addStyle) {
+  long addStyle)
+  : GODialog(win, name, title, addStyle) {
   p_book = GetBookCtrl();
   p_book->SetExtraStyle(p_book->GetExtraStyle() | wxWS_EX_VALIDATE_RECURSIVELY);
 }

--- a/src/grandorgue/dialogs/common/GOTabbedDialog.h
+++ b/src/grandorgue/dialogs/common/GOTabbedDialog.h
@@ -10,24 +10,17 @@
 
 #include <vector>
 
-#include <wx/propdlg.h>
-
-#include "GODialogCloser.h"
+#include "GODialog.h"
 
 class wxBookCtrlBase;
 class wxPanel;
-class wxSizer;
 
 class GODialogTab;
 
-class GOTabbedDialog : public wxPropertySheetDialog, public GODialogCloser {
+class GOTabbedDialog : public GODialog {
 private:
-  const wxString m_name;
   std::vector<wxString> m_TabNames;
   wxBookCtrlBase *p_book;
-  wxSizer *p_ButtonSizer;
-
-  void OnHelp(wxCommandEvent &event);
 
 protected:
   GOTabbedDialog(
@@ -36,15 +29,14 @@ protected:
     const wxString &title, // translated
     long addStyle = 0);
 
-  wxSizer *GetButtonSizer() const { return p_ButtonSizer; }
-
   void AddTab(wxPanel *tab, const wxString &tabName, const wxString &tabTitle);
   void AddTab(GODialogTab *tab);
 
 public:
   const wxString &GetCurrTabName() const;
-
   wxBookCtrlBase *GetBook() const { return p_book; }
+  
+  const wxString &GetHelpSuffix() const override { return GetCurrTabName(); }
 
   void NavigateToTab(const wxString &tabName);
 
@@ -52,7 +44,6 @@ public:
   virtual bool Validate() override;
   virtual bool TransferDataFromWindow() override;
 
-  DECLARE_EVENT_TABLE()
 };
 
 #endif /* GOTABBEDDIALOG_H */

--- a/src/grandorgue/dialogs/common/GOTabbedDialog.h
+++ b/src/grandorgue/dialogs/common/GOTabbedDialog.h
@@ -35,7 +35,7 @@ protected:
 public:
   const wxString &GetCurrTabName() const;
   wxBookCtrlBase *GetBook() const { return p_book; }
-  
+
   const wxString &GetHelpSuffix() const override { return GetCurrTabName(); }
 
   void NavigateToTab(const wxString &tabName);
@@ -43,7 +43,6 @@ public:
   virtual bool TransferDataToWindow() override;
   virtual bool Validate() override;
   virtual bool TransferDataFromWindow() override;
-
 };
 
 #endif /* GOTABBEDDIALOG_H */


### PR DESCRIPTION
This is a preparing PR for #1415 and #1416.

It extracted a common class `GODialog` from `GOTabbedDialog`. Later it will be used in the Organ Settings dialog.

It is just refactoring. No GO behavior should be changed.