### PR TITLE
Extracted abstraction of GOCombinationController from GOSetter

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -46,8 +46,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 set(grandorgue_src
 combinations/control/GOCombinationButtonSet.cpp
-combinations/control/GOGeneralButtonControl.cpp
+combinations/control/GOCombinationControllerProxy.cpp
 combinations/control/GODivisionalButtonControl.cpp
+combinations/control/GOGeneralButtonControl.cpp
 combinations/model/GOCombination.cpp
 combinations/model/GOCombinationDefinition.cpp
 combinations/model/GODivisionalCombination.cpp

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -133,8 +133,11 @@ GOOrganController::~GOOrganController() {
   m_manuals.clear();
   m_tremulants.clear();
   m_ranks.clear();
+  GOOrganModel::Cleanup();
   GOOrganModel::SetModelModificationListener(nullptr);
   GOOrganModel::SetMidiDialogCreator(nullptr);
+  GOOrganModel::SetCombinationController(nullptr);
+  m_elementcreators.clear();
 }
 
 void GOOrganController::SetOrganModified(bool modified) {
@@ -246,6 +249,7 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   // It must be created before GOOrganModel::Load because lots of objects
   // reference to it
   m_setter = new GOSetter(this);
+  GOOrganModel::SetCombinationController(m_setter);
   m_elementcreators.push_back(m_setter);
 
   GOOrganModel::Load(cfg, this);

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -193,8 +193,8 @@ public:
    * @param pButton the button to light on
    * return if anything is changed
    */
-  void PushGeneral(GOGeneralCombination &cmb, GOButtonControl *pButtonToLight)
-    override;
+  void PushGeneral(
+    GOGeneralCombination &cmb, GOButtonControl *pButtonToLight) override;
   void PushDivisional(
     GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) override;
 

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -13,6 +13,7 @@
 #include "ptrvector.h"
 
 #include "control/GOCombinationButtonSet.h"
+#include "control/GOCombinationController.h"
 #include "control/GOControlChangedHandler.h"
 #include "control/GOElementCreator.h"
 #include "control/GOLabelControl.h"
@@ -30,6 +31,7 @@ class GODivisionalCombination;
 
 class GOSetter : private GOSoundStateHandler,
                  private GOCombinationButtonSet,
+                 public GOCombinationController,
                  private GOControlChangedHandler,
                  public GOElementCreator,
                  public GOSaveableObject,
@@ -191,9 +193,10 @@ public:
    * @param pButton the button to light on
    * return if anything is changed
    */
-  void PushGeneral(GOGeneralCombination &cmb, GOButtonControl *pButtonToLight);
+  void PushGeneral(GOGeneralCombination &cmb, GOButtonControl *pButtonToLight)
+    override;
   void PushDivisional(
-    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight);
+    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) override;
 
   /*
    * If current crescendo is in override mode then returns nullptr

--- a/src/grandorgue/combinations/control/GOCombinationController.h
+++ b/src/grandorgue/combinations/control/GOCombinationController.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOCOMBINATIONCONTROLLER_H
+#define GOCOMBINATIONCONTROLLER_H
+
+class GODivisionalCombination;
+class GOGeneralCombination;
+class GOButtonControl;
+
+class GOCombinationController {
+public:
+  /*
+   * Activate cmb
+   * If the crescendo in add mode then not to disable stops that are present in
+   * extraSet
+   * If isFromCrescendo and it is in add mode then then does not depress other
+   * buttons
+   * @param cmb the cmb to activate or to set
+   * @param pButton the button to light on
+   * return if anything is changed
+   */
+  virtual void PushGeneral(
+    GOGeneralCombination &cmb, GOButtonControl *pButtonToLight) = 0;
+  virtual void PushDivisional(
+    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) = 0;
+
+};
+
+#endif /* GOCOMBINATIONCONTROLLER_H */
+

--- a/src/grandorgue/combinations/control/GOCombinationController.h
+++ b/src/grandorgue/combinations/control/GOCombinationController.h
@@ -25,11 +25,11 @@ public:
    * return if anything is changed
    */
   virtual void PushGeneral(
-    GOGeneralCombination &cmb, GOButtonControl *pButtonToLight) = 0;
+    GOGeneralCombination &cmb, GOButtonControl *pButtonToLight)
+    = 0;
   virtual void PushDivisional(
-    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) = 0;
-
+    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight)
+    = 0;
 };
 
 #endif /* GOCOMBINATIONCONTROLLER_H */
-

--- a/src/grandorgue/combinations/control/GOCombinationControllerProxy.cpp
+++ b/src/grandorgue/combinations/control/GOCombinationControllerProxy.cpp
@@ -17,5 +17,4 @@ void GOCombinationControllerProxy::PushDivisional(
   GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) {
   if (p_controller)
     p_controller->PushDivisional(cmb, pButtonToLight);
-  
 }

--- a/src/grandorgue/combinations/control/GOCombinationControllerProxy.cpp
+++ b/src/grandorgue/combinations/control/GOCombinationControllerProxy.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOCombinationControllerProxy.h"
+
+void GOCombinationControllerProxy::PushGeneral(
+  GOGeneralCombination &cmb, GOButtonControl *pButtonToLight) {
+  if (p_controller)
+    p_controller->PushGeneral(cmb, pButtonToLight);
+}
+
+void GOCombinationControllerProxy::PushDivisional(
+  GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) {
+  if (p_controller)
+    p_controller->PushDivisional(cmb, pButtonToLight);
+  
+}

--- a/src/grandorgue/combinations/control/GOCombinationControllerProxy.h
+++ b/src/grandorgue/combinations/control/GOCombinationControllerProxy.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOCOMBINATIONCONTROLLERPROXY_H
+#define GOCOMBINATIONCONTROLLERPROXY_H
+
+#include "GOCombinationController.h"
+
+class GOCombinationControllerProxy : public GOCombinationController {
+private:
+  GOCombinationController *p_controller = nullptr;
+  
+public:
+  void SetCombinationController(GOCombinationController *pController) {
+      p_controller = pController;
+  }
+
+  void PushGeneral(
+    GOGeneralCombination &cmb, GOButtonControl *pButtonToLight) override;
+  void PushDivisional(
+    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) override;
+};
+
+#endif /* GOCOMBINATIONCONTROLLERPROXY_H */
+

--- a/src/grandorgue/combinations/control/GOCombinationControllerProxy.h
+++ b/src/grandorgue/combinations/control/GOCombinationControllerProxy.h
@@ -13,10 +13,10 @@
 class GOCombinationControllerProxy : public GOCombinationController {
 private:
   GOCombinationController *p_controller = nullptr;
-  
+
 public:
   void SetCombinationController(GOCombinationController *pController) {
-      p_controller = pController;
+    p_controller = pController;
   }
 
   void PushGeneral(
@@ -26,4 +26,3 @@ public:
 };
 
 #endif /* GOCOMBINATIONCONTROLLERPROXY_H */
-

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -11,6 +11,7 @@
 #include "ptrvector.h"
 
 #include "combinations/control/GOCombinationButtonSet.h"
+#include "combinations/control/GOCombinationControllerProxy.h"
 #include "midi/GOMidiSendProxy.h"
 #include "midi/dialog-creator/GOMidiDialogCreatorProxy.h"
 #include "modification/GOModificationProxy.h"
@@ -32,6 +33,7 @@ class GOTremulant;
 class GOWindchest;
 
 class GOOrganModel : private GOCombinationButtonSet,
+                     public GOCombinationControllerProxy,
                      public GOEventHandlerList,
                      public GOMidiDialogCreatorProxy,
                      public GOMidiSendProxy {


### PR DESCRIPTION
In order to remove dependencies on GOOrganController and GOSetter from combinations/control I extracted a separate interface `GOCombinationController` from GOSetter.

It is just a refactoring. No GO behavior should be changed.