### PR TITLE
Fixed capability of running on MacOs 11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed capability of running on MacOs 11.3
 - Fixed "The device does not support requested channel count" error when using an USB audio card on MacOS https://github.com/GrandOrgue/grandorgue/issues/1550
 # 3.12.1 (2023-06-06)
 - Fixed not storing switch state in combinations in organs with panels of the new style https://github.com/GrandOrgue/grandorgue/issues/1498

--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -23,7 +23,7 @@ pushd build/osx
 rm -rf *
 export LANG=C
 
-OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl"
+OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl -DCMAKE_OSX_DEPLOYMENT_TARGET=11.1"
 GO_PRMS="-DCMAKE_BUILD_TYPE=Release $CMAKE_VERSION_PRMS"
 cmake -G "Unix Makefiles" $OS_PRMS $GO_PRMS . $SRC_DIR
 make -k $PARALLEL_PRMS VERBOSE=1 package


### PR DESCRIPTION
After removing support of MacOs 10.15, the new GrandOrgue versions required MacOs 11.7 or above. But there were no any technical reasons for it, so I mupdated requirements  to 11.1+