### PR TITLE
Moved Initialisation of General and Divisional templates from GOOrganController to GOOrganModel

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -211,6 +211,7 @@ GOProperties.cpp
 GOFrame.cpp
 GODocument.cpp
 GOPanelView.cpp
+GOVirtualCouplerController.cpp
 )
 
 if (USE_INTERNAL_ZITACONVOLVER)

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -133,6 +133,7 @@ GOOrganController::~GOOrganController() {
   m_manuals.clear();
   m_tremulants.clear();
   m_ranks.clear();
+  m_VirtualCouplers.Cleanup();
   GOOrganModel::Cleanup();
   GOOrganModel::SetModelModificationListener(nullptr);
   GOOrganModel::SetMidiDialogCreator(nullptr);
@@ -266,6 +267,8 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
     m_tremulants[i]->SetElementID(
       GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
 
+  m_VirtualCouplers.Init(*this, cfg);
+
   m_DivisionalSetter = new GODivisionalSetter(this, m_setter->GetState());
   m_elementcreators.push_back(m_DivisionalSetter);
   m_AudioRecorder = new GOAudioRecorder(this);
@@ -275,7 +278,7 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   m_elementcreators.push_back(m_MidiPlayer);
   m_elementcreators.push_back(m_MidiRecorder);
   m_elementcreators.push_back(new GOMetronome(this));
-  m_panelcreators.push_back(new GOGUICouplerPanel(this));
+  m_panelcreators.push_back(new GOGUICouplerPanel(this, m_VirtualCouplers));
   m_panelcreators.push_back(new GOGUIFloatingPanel(this));
   m_panelcreators.push_back(new GOGUIMetronomePanel(this));
   m_panelcreators.push_back(new GOGUICrescendoPanel(this));
@@ -1087,10 +1090,6 @@ wxString GOOrganController::GetTemperament() { return m_Temperament; }
 void GOOrganController::AllNotesOff() {
   for (unsigned k = GetFirstManualIndex(); k <= GetManualAndPedalCount(); k++)
     GetManual(k)->AllNotesOff();
-}
-
-int GOOrganController::GetRecorderElementID(wxString name) {
-  return m_config.GetMidiMap().GetElementByString(name);
 }
 
 GOCombinationDefinition &GOOrganController::GetGeneralTemplate() {

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -117,7 +117,6 @@ GOOrganController::GOOrganController(
     m_SampleSetId1(0),
     m_SampleSetId2(0),
     m_bitmaps(this),
-    m_GeneralTemplate(*this),
     m_PitchLabel(this),
     m_TemperamentLabel(this),
     m_MainWindowData(this, wxT("MainWindow")) {
@@ -255,19 +254,9 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   GOOrganModel::Load(cfg, this);
 
-  for (unsigned i = 0; i < m_enclosures.size(); i++)
-    m_enclosures[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("E%d"), i)));
-
-  for (unsigned i = 0; i < m_switches.size(); i++)
-    m_switches[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("S%d"), i)));
-
-  for (unsigned i = 0; i < m_tremulants.size(); i++)
-    m_tremulants[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
-
   m_VirtualCouplers.Init(*this, cfg);
+
+  GOOrganModel::LoadCmbButtons(cfg, this);
 
   m_DivisionalSetter = new GODivisionalSetter(this, m_setter->GetState());
   m_elementcreators.push_back(m_DivisionalSetter);
@@ -313,10 +302,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   for (unsigned i = 0; i < m_panels.size(); i++)
     m_panels[i]->Layout();
-
-  m_GeneralTemplate.InitGeneral();
-  for (unsigned i = m_FirstManual; i < m_manuals.size(); i++)
-    m_manuals[i]->GetDivisionalTemplate().InitDivisional(i);
 
   GetRootPipeConfigNode().SetName(GetChurchName());
   ReadCombinations(cfg);
@@ -1090,10 +1075,6 @@ wxString GOOrganController::GetTemperament() { return m_Temperament; }
 void GOOrganController::AllNotesOff() {
   for (unsigned k = GetFirstManualIndex(); k <= GetManualAndPedalCount(); k++)
     GetManual(k)->AllNotesOff();
-}
-
-GOCombinationDefinition &GOOrganController::GetGeneralTemplate() {
-  return m_GeneralTemplate;
 }
 
 GOLabelControl *GOOrganController::GetPitchLabel() { return &m_PitchLabel; }

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -26,6 +26,7 @@
 #include "GOMainWindowData.h"
 #include "GOMemoryPool.h"
 #include "GOTimer.h"
+#include "GOVirtualCouplerController.h"
 
 class GOGUIPanel;
 class GOGUIPanelCreator;
@@ -85,6 +86,8 @@ private:
   wxString m_OrganComments;
   wxString m_RecordingDetails;
   wxString m_InfoFilename;
+
+  GOVirtualCouplerController m_VirtualCouplers;
 
   ptr_vector<GOGUIPanel> m_panels;
   ptr_vector<GOGUIPanelCreator> m_panelcreators;
@@ -182,7 +185,6 @@ public:
   void SetTemperament(wxString name);
   wxString GetTemperament();
 
-  int GetRecorderElementID(wxString name);
   GOCombinationDefinition &GetGeneralTemplate();
   GOLabelControl *GetPitchLabel();
   GOLabelControl *GetTemperamentLabel();

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -14,7 +14,6 @@
 
 #include "ptrvector.h"
 
-#include "combinations/model/GOCombinationDefinition.h"
 #include "control/GOEventDistributor.h"
 #include "control/GOLabelControl.h"
 #include "gui/GOGUIMouseState.h"
@@ -30,6 +29,7 @@
 
 class GOGUIPanel;
 class GOGUIPanelCreator;
+class GOGUICouplerPanel;
 class GOArchive;
 class GOAudioRecorder;
 class GOButtonControl;
@@ -101,7 +101,6 @@ private:
 
   GOMemoryPool m_pool;
   GOBitmapCache m_bitmaps;
-  GOCombinationDefinition m_GeneralTemplate;
   GOLabelControl m_PitchLabel;
   GOLabelControl m_TemperamentLabel;
   GOMainWindowData m_MainWindowData;
@@ -185,7 +184,6 @@ public:
   void SetTemperament(wxString name);
   wxString GetTemperament();
 
-  GOCombinationDefinition &GetGeneralTemplate();
   GOLabelControl *GetPitchLabel();
   GOLabelControl *GetTemperamentLabel();
   GOMainWindowData *GetMainWindowData();

--- a/src/grandorgue/GOVirtualCouplerController.cpp
+++ b/src/grandorgue/GOVirtualCouplerController.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOVirtualCouplerController.h"
+
+#include <wx/intl.h>
+
+#include "model/GOCoupler.h"
+#include "model/GOManual.h"
+#include "model/GOOrganModel.h"
+
+void load_coupler(
+  GOOrganModel &organModel,
+  GOConfigReader &cfg,
+  GOVirtualCouplerController::ManualCouplerSet &manualCouplers,
+  unsigned srcManualN,
+  unsigned dstManualN,
+  bool unisonOff,
+  GOCoupler::GOCouplerType couplerType,
+  int keyshift,
+  const wxString &cfgGroupFmt,
+  const wxString &recorderNameFmt,
+  const wxString &couplerLabel) {
+  GOManual *pSrcManual = organModel.GetManual(srcManualN);
+  GOCoupler *pCoupler = new GOCoupler(organModel, srcManualN);
+
+  pCoupler->Init(
+    cfg,
+    wxString::Format(cfgGroupFmt, srcManualN, dstManualN),
+    couplerLabel,
+    unisonOff,
+    false,
+    keyshift,
+    dstManualN,
+    couplerType);
+  pCoupler->SetElementID(organModel.GetRecorderElementID(
+    wxString::Format(recorderNameFmt, srcManualN, dstManualN)));
+  pSrcManual->AddCoupler(pCoupler);
+  manualCouplers.push_back(pCoupler);
+}
+
+GOVirtualCouplerController::CouplerSetKey make_key(
+  unsigned srcManualN, unsigned dstManualN) {
+  return std::make_pair(srcManualN, dstManualN);
+}
+
+void GOVirtualCouplerController::Init(
+  GOOrganModel &organModel, GOConfigReader &cfg) {
+  for (unsigned srcManualN = organModel.GetFirstManualIndex();
+       srcManualN <= organModel.GetManualAndPedalCount();
+       srcManualN++) {
+    for (unsigned int dstManualN = organModel.GetFirstManualIndex();
+         dstManualN < organModel.GetODFManualCount();
+         dstManualN++) {
+      ManualCouplerSet &manualCouplers
+        = m_CouplerPtrs[make_key(srcManualN, dstManualN)];
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        false,
+        GOCoupler::COUPLER_NORMAL,
+        -12,
+        wxT("SetterManual%03dCoupler%03dT16"),
+        wxT("S%dM%dC16"),
+        _("16"));
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        srcManualN == dstManualN,
+        GOCoupler::COUPLER_NORMAL,
+        0,
+        wxT("SetterManual%03dCoupler%03dT8"),
+        wxT("S%dM%dC8"),
+        srcManualN != dstManualN ? _("8") : _("U.O."));
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        false,
+        GOCoupler::COUPLER_NORMAL,
+        12,
+        wxT("SetterManual%03dCoupler%03dT4"),
+        wxT("S%dM%dC4"),
+        _("4"));
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        false,
+        GOCoupler::COUPLER_BASS,
+        0,
+        wxT("SetterManual%03dCoupler%03dBAS"),
+        wxT("S%dM%dCB"),
+        _("BAS"));
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        false,
+        GOCoupler::COUPLER_MELODY,
+        0,
+        wxT("SetterManual%03dCoupler%03dMEL"),
+        wxT("S%dM%dCM"),
+        _("MEL"));
+    }
+  }
+}
+
+GOCoupler *GOVirtualCouplerController::GetCoupler(
+  unsigned fromManual, unsigned toManual, CouplerType type) const {
+  const auto iter = m_CouplerPtrs.find(make_key(fromManual, toManual));
+
+  return iter != m_CouplerPtrs.end() ? iter->second[type] : nullptr;
+}

--- a/src/grandorgue/GOVirtualCouplerController.h
+++ b/src/grandorgue/GOVirtualCouplerController.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOVIRTUALCOUPLERCONTROLLER_H
+#define GOVIRTUALCOUPLERCONTROLLER_H
+
+#include <map>
+#include <utility>
+#include <vector>
+
+class GOConfigReader;
+class GOCoupler;
+class GOOrganModel;
+
+class GOVirtualCouplerController {
+  /**
+   * Represents virtual couplers that do not exist vin ODF and are added
+   * virtually by GrandOrgue. They are exposed on the GOGUICouplerPanel
+   */
+
+public:
+  enum CouplerType {
+    COUPLER_16,
+    COUPLER_8,
+    COUPLER_4,
+    COUPLER_BAS,
+    COUPLER_MEL
+  };
+
+  // FromManual, toManual
+  using CouplerSetKey = std::pair<unsigned, unsigned>;
+
+  // indexed by CouplerType
+  using ManualCouplerSet = std::vector<GOCoupler *>;
+
+private:
+  std::map<CouplerSetKey, ManualCouplerSet> m_CouplerPtrs;
+
+public:
+  // Create virtual couplers for each manual pairs with all CouplerType and add
+  // them to the organ model
+  void Init(GOOrganModel &organModel, GOConfigReader &cfg);
+
+  // Clears the couplers
+  void Cleanup() { m_CouplerPtrs.clear(); }
+
+  // Returns the coupler pointer
+  GOCoupler *GetCoupler(
+    unsigned fromManual, unsigned toManual, CouplerType type) const;
+};
+
+#endif /* GOVIRTUALCOUPLERCONTROLLER_H */

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -45,9 +45,8 @@ void GOCombinationDefinition::Add(
   int manual,
   unsigned index,
   bool store_unconditional) {
-  if (control->IsReadOnly())
-    return;
   Element def;
+
   def.type = type;
   def.manual = manual;
   def.index = index;

--- a/src/grandorgue/gui/GOGUICouplerPanel.cpp
+++ b/src/grandorgue/gui/GOGUICouplerPanel.cpp
@@ -19,11 +19,7 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
-
-GOGUICouplerPanel::GOGUICouplerPanel(GOOrganController *organController)
-  : m_OrganController(organController) {}
-
-GOGUICouplerPanel::~GOGUICouplerPanel() {}
+#include "GOVirtualCouplerController.h"
 
 void GOGUICouplerPanel::CreatePanels(GOConfigReader &cfg) {
   for (unsigned i = m_OrganController->GetFirstManualIndex();
@@ -70,110 +66,60 @@ GOGUIPanel *GOGUICouplerPanel::CreateCouplerPanel(
       dest_manual->GetName());
     panel->AddControl(PosDisplay);
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT16"), manual_nr, i),
-      _("16"),
-      false,
-      false,
-      -12,
-      i,
-      GOCoupler::COUPLER_NORMAL);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dC16"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT16"), manual_nr, i),
-      2,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_16))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dT16"), manual_nr, i),
+        2,
+        100 + i);
+      panel->AddControl(button);
+    }
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT8"), manual_nr, i),
-      manual_nr != i ? _("8") : _("U.O."),
-      manual_nr == i,
-      false,
-      0,
-      i,
-      GOCoupler::COUPLER_NORMAL);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dC8"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT8"), manual_nr, i),
-      3,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_8))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dT8"), manual_nr, i),
+        3,
+        100 + i);
+      panel->AddControl(button);
+    }
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT4"), manual_nr, i),
-      _("4"),
-      false,
-      false,
-      12,
-      i,
-      GOCoupler::COUPLER_NORMAL);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dC4"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT4"), manual_nr, i),
-      4,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_4))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dT4"), manual_nr, i),
+        4,
+        100 + i);
+      panel->AddControl(button);
+    }
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dBAS"), manual_nr, i),
-      _("BAS"),
-      false,
-      false,
-      0,
-      i,
-      GOCoupler::COUPLER_BASS);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dCB"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dBAS"), manual_nr, i),
-      5,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_BAS))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dBAS"), manual_nr, i),
+        5,
+        100 + i);
+      panel->AddControl(button);
+    }
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dMEL"), manual_nr, i),
-      _("MEL"),
-      false,
-      false,
-      0,
-      i,
-      GOCoupler::COUPLER_MELODY);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dCM"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dMEL"), manual_nr, i),
-      6,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_MEL))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dMEL"), manual_nr, i),
+        6,
+        100 + i);
+      panel->AddControl(button);
+    }
   }
 
   return panel;

--- a/src/grandorgue/gui/GOGUICouplerPanel.h
+++ b/src/grandorgue/gui/GOGUICouplerPanel.h
@@ -12,16 +12,20 @@
 
 class GOGUIPanel;
 class GOOrganController;
+class GOVirtualCouplerController;
 
 class GOGUICouplerPanel : public GOGUIPanelCreator {
 private:
   GOOrganController *m_OrganController;
+  const GOVirtualCouplerController &r_VirtualCouplers;
 
   GOGUIPanel *CreateCouplerPanel(GOConfigReader &cfg, unsigned manual_nr);
 
 public:
-  GOGUICouplerPanel(GOOrganController *organController);
-  ~GOGUICouplerPanel();
+  GOGUICouplerPanel(
+    GOOrganController *organController,
+    const GOVirtualCouplerController &virtualCouplers)
+    : m_OrganController(organController), r_VirtualCouplers(virtualCouplers) {}
 
   void CreatePanels(GOConfigReader &cfg);
 };

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -103,7 +103,8 @@ public:
     int manualNumber,
     unsigned first_midi,
     unsigned keys);
-  void Load(GOConfigReader &cfg, wxString group, int manualNumber);
+  void Load(GOConfigReader &cfg, const wxString &group, int manualNumber);
+  void LoadDivisionals(GOConfigReader &cfg);
   unsigned RegisterCoupler(GOCoupler *coupler);
   void SetKey(
     unsigned note, unsigned velocity, GOCoupler *prev, unsigned couplerID);

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -8,6 +8,7 @@
 #include "GOOrganModel.h"
 
 #include "combinations/control/GOGeneralButtonControl.h"
+#include "config/GOConfig.h"
 #include "config/GOConfigReader.h"
 #include "control/GOPistonControl.h"
 #include "modification/GOModificationListener.h"
@@ -37,6 +38,10 @@ GOOrganModel::GOOrganModel(GOConfig &config)
 }
 
 GOOrganModel::~GOOrganModel() {}
+
+unsigned GOOrganModel::GetRecorderElementID(const wxString &name) {
+  return m_config.GetMidiMap().GetElementByString(name);
+}
 
 void GOOrganModel::Load(
   GOConfigReader &cfg, GOOrganController *organController) {

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -24,6 +24,7 @@
 
 GOOrganModel::GOOrganModel(GOConfig &config)
   : m_config(config),
+    m_GeneralTemplate(*this),
     m_DivisionalsStoreIntermanualCouplers(false),
     m_DivisionalsStoreIntramanualCouplers(false),
     m_DivisionalsStoreTremulants(false),
@@ -43,35 +44,33 @@ unsigned GOOrganModel::GetRecorderElementID(const wxString &name) {
   return m_config.GetMidiMap().GetElementByString(name);
 }
 
+static const wxString WX_ORGAN = wxT("Organ");
+
 void GOOrganModel::Load(
   GOConfigReader &cfg, GOOrganController *organController) {
-  wxString group = wxT("Organ");
   m_DivisionalsStoreIntermanualCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("DivisionalsStoreIntermanualCouplers"));
+    ODFSetting, WX_ORGAN, wxT("DivisionalsStoreIntermanualCouplers"));
   m_DivisionalsStoreIntramanualCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("DivisionalsStoreIntramanualCouplers"));
+    ODFSetting, WX_ORGAN, wxT("DivisionalsStoreIntramanualCouplers"));
   m_DivisionalsStoreTremulants
-    = cfg.ReadBoolean(ODFSetting, group, wxT("DivisionalsStoreTremulants"));
+    = cfg.ReadBoolean(ODFSetting, WX_ORGAN, wxT("DivisionalsStoreTremulants"));
   m_GeneralsStoreDivisionalCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("GeneralsStoreDivisionalCouplers"));
+    ODFSetting, WX_ORGAN, wxT("GeneralsStoreDivisionalCouplers"));
   m_CombinationsStoreNonDisplayedDrawstops = cfg.ReadBoolean(
-    ODFSetting,
-    group,
-    wxT("CombinationsStoreNonDisplayedDrawstops"),
-    false,
-    true);
+    ODFSetting, WX_ORGAN, wxT("CombinationsStoreNonDisplayedDrawstops"));
 
   unsigned NumberOfWindchestGroups = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfWindchestGroups"), 1, 999);
+    ODFSetting, WX_ORGAN, wxT("NumberOfWindchestGroups"), 1, 999);
 
-  m_RootPipeConfigNode.Load(cfg, group, wxEmptyString);
+  m_RootPipeConfigNode.Load(cfg, WX_ORGAN, wxEmptyString);
   m_windchests.resize(0);
   for (unsigned i = 0; i < NumberOfWindchestGroups; i++)
     m_windchests.push_back(new GOWindchest(*organController));
 
   m_ODFManualCount
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfManuals"), 1, 16) + 1;
-  m_FirstManual = cfg.ReadBoolean(ODFSetting, group, wxT("HasPedals")) ? 0 : 1;
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfManuals"), 1, 16) + 1;
+  m_FirstManual
+    = cfg.ReadBoolean(ODFSetting, WX_ORGAN, wxT("HasPedals")) ? 0 : 1;
 
   m_manuals.resize(0);
   m_manuals.resize(m_FirstManual); // Add empty slot for pedal, if necessary
@@ -82,7 +81,7 @@ void GOOrganModel::Load(
     m_manuals.push_back(new GOManual(organController));
 
   unsigned NumberOfEnclosures
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfEnclosures"), 0, 999);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfEnclosures"), 0, 999);
   m_enclosures.resize(0);
   for (unsigned i = 0; i < NumberOfEnclosures; i++) {
     m_enclosures.push_back(new GOEnclosure(*organController));
@@ -91,7 +90,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfSwitches
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfSwitches"), 0, 999, 0);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfSwitches"), 0, 999, 0);
   m_switches.resize(0);
   for (unsigned i = 0; i < NumberOfSwitches; i++) {
     m_switches.push_back(new GOSwitch(*organController));
@@ -99,7 +98,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfTremulants
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfTremulants"), 0, 10);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfTremulants"), 0, 10);
   for (unsigned i = 0; i < NumberOfTremulants; i++) {
     m_tremulants.push_back(new GOTremulant(*organController));
     m_tremulants[i]->Load(
@@ -110,8 +109,8 @@ void GOOrganModel::Load(
     m_windchests[i]->Load(
       cfg, wxString::Format(wxT("WindchestGroup%03d"), i + 1), i);
 
-  m_ODFRankCount
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfRanks"), 0, 999, false);
+  m_ODFRankCount = cfg.ReadInteger(
+    ODFSetting, WX_ORGAN, wxT("NumberOfRanks"), 0, 999, false);
   for (unsigned i = 0; i < m_ODFRankCount; i++) {
     m_ranks.push_back(new GORank(*organController));
     m_ranks[i]->Load(cfg, wxString::Format(wxT("Rank%03d"), i + 1), -1);
@@ -140,7 +139,7 @@ void GOOrganModel::Load(
       max_key - min_key);
 
   unsigned NumberOfReversiblePistons = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfReversiblePistons"), 0, 32);
+    ODFSetting, WX_ORGAN, wxT("NumberOfReversiblePistons"), 0, 32);
   m_pistons.resize(0);
   for (unsigned i = 0; i < NumberOfReversiblePistons; i++) {
     m_pistons.push_back(new GOPistonControl(*this));
@@ -149,7 +148,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfDivisionalCouplers = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfDivisionalCouplers"), 0, 8);
+    ODFSetting, WX_ORGAN, wxT("NumberOfDivisionalCouplers"), 0, 8);
   m_DivisionalCoupler.resize(0);
   for (unsigned i = 0; i < NumberOfDivisionalCouplers; i++) {
     m_DivisionalCoupler.push_back(new GODivisionalCoupler(*organController));
@@ -157,15 +156,36 @@ void GOOrganModel::Load(
       cfg, wxString::Format(wxT("DivisionalCoupler%03d"), i + 1));
   }
 
-  organController->GetGeneralTemplate().InitGeneral();
+  for (unsigned i = 0; i < m_enclosures.size(); i++)
+    m_enclosures[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("E%d"), i)));
+
+  for (unsigned i = 0; i < m_switches.size(); i++)
+    m_switches[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("S%d"), i)));
+
+  for (unsigned i = 0; i < m_tremulants.size(); i++)
+    m_tremulants[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
+}
+
+void GOOrganModel::LoadCmbButtons(
+  GOConfigReader &cfg, GOOrganController *organController) {
+  // Generals
   unsigned NumberOfGenerals
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfGenerals"), 0, 99);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfGenerals"), 0, 99);
+
+  m_GeneralTemplate.InitGeneral();
   m_generals.resize(0);
   for (unsigned i = 0; i < NumberOfGenerals; i++) {
-    m_generals.push_back(new GOGeneralButtonControl(
-      organController->GetGeneralTemplate(), organController, false));
+    m_generals.push_back(
+      new GOGeneralButtonControl(m_GeneralTemplate, organController, false));
     m_generals[i]->Load(cfg, wxString::Format(wxT("General%03d"), i + 1));
   }
+
+  // Divisionals
+  for (unsigned i = m_FirstManual; i < m_manuals.size(); i++)
+    m_manuals[i]->LoadDivisionals(cfg);
 }
 
 void GOOrganModel::SetOrganModelModified(bool modified) {

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -12,6 +12,7 @@
 
 #include "combinations/control/GOCombinationButtonSet.h"
 #include "combinations/control/GOCombinationControllerProxy.h"
+#include "combinations/model/GOCombinationDefinition.h"
 #include "midi/GOMidiSendProxy.h"
 #include "midi/dialog-creator/GOMidiDialogCreatorProxy.h"
 #include "modification/GOModificationProxy.h"
@@ -38,9 +39,10 @@ class GOOrganModel : private GOCombinationButtonSet,
                      public GOMidiDialogCreatorProxy,
                      public GOMidiSendProxy {
 private:
-  GOModificationProxy m_ModificationProxy;
-
   GOConfig &m_config;
+
+  GOModificationProxy m_ModificationProxy;
+  GOCombinationDefinition m_GeneralTemplate;
 
   bool m_DivisionalsStoreIntermanualCouplers;
   bool m_DivisionalsStoreIntramanualCouplers;
@@ -69,6 +71,13 @@ protected:
   void Load(GOConfigReader &cfg, GOOrganController *organController);
 
   /**
+   * Called after Load() and InitCmbTemplates();
+   * Init general and divisional templates
+   * Load generals and divisionals from ODF/cmb
+   */
+  void LoadCmbButtons(GOConfigReader &cfg, GOOrganController *organController);
+
+  /**
    * Update all generals buttons light.
    * @param buttonToLight - the button that should be lighted on. All other
    *   divisionals are lighted off
@@ -85,6 +94,10 @@ public:
   GOConfig &GetConfig() { return m_config; }
 
   unsigned GetRecorderElementID(const wxString &name);
+
+  const GOCombinationDefinition &GetGeneralTemplate() const {
+    return m_GeneralTemplate;
+  }
 
   /* combinations properties */
   bool DivisionalsStoreIntermanualCouplers() const {

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -84,6 +84,8 @@ public:
   const GOConfig &GetConfig() const { return m_config; }
   GOConfig &GetConfig() { return m_config; }
 
+  unsigned GetRecorderElementID(const wxString &name);
+
   /* combinations properties */
   bool DivisionalsStoreIntermanualCouplers() const {
     return m_DivisionalsStoreIntermanualCouplers;


### PR DESCRIPTION
In order to eliminating usage of GOOrganController I moved storing and initialisation of GOGeneralCombination GODivisionalCombination from GOOrganController to GOOrganModel.

It is jost refactoring. No GO controller should be changed.