### PR TITLE
Extracted GOVirtualCouplerController from GOGUICouplerPanel

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -211,6 +211,7 @@ GOProperties.cpp
 GOFrame.cpp
 GODocument.cpp
 GOPanelView.cpp
+GOVirtualCouplerController.cpp
 )
 
 if (USE_INTERNAL_ZITACONVOLVER)

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -133,6 +133,7 @@ GOOrganController::~GOOrganController() {
   m_manuals.clear();
   m_tremulants.clear();
   m_ranks.clear();
+  m_VirtualCouplers.Cleanup();
   GOOrganModel::Cleanup();
   GOOrganModel::SetModelModificationListener(nullptr);
   GOOrganModel::SetMidiDialogCreator(nullptr);
@@ -266,6 +267,8 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
     m_tremulants[i]->SetElementID(
       GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
 
+  m_VirtualCouplers.Init(*this, cfg);
+
   m_DivisionalSetter = new GODivisionalSetter(this, m_setter->GetState());
   m_elementcreators.push_back(m_DivisionalSetter);
   m_AudioRecorder = new GOAudioRecorder(this);
@@ -275,7 +278,7 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   m_elementcreators.push_back(m_MidiPlayer);
   m_elementcreators.push_back(m_MidiRecorder);
   m_elementcreators.push_back(new GOMetronome(this));
-  m_panelcreators.push_back(new GOGUICouplerPanel(this));
+  m_panelcreators.push_back(new GOGUICouplerPanel(this, m_VirtualCouplers));
   m_panelcreators.push_back(new GOGUIFloatingPanel(this));
   m_panelcreators.push_back(new GOGUIMetronomePanel(this));
   m_panelcreators.push_back(new GOGUICrescendoPanel(this));
@@ -1087,10 +1090,6 @@ wxString GOOrganController::GetTemperament() { return m_Temperament; }
 void GOOrganController::AllNotesOff() {
   for (unsigned k = GetFirstManualIndex(); k <= GetManualAndPedalCount(); k++)
     GetManual(k)->AllNotesOff();
-}
-
-int GOOrganController::GetRecorderElementID(wxString name) {
-  return m_config.GetMidiMap().GetElementByString(name);
 }
 
 GOCombinationDefinition &GOOrganController::GetGeneralTemplate() {

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -26,6 +26,7 @@
 #include "GOMainWindowData.h"
 #include "GOMemoryPool.h"
 #include "GOTimer.h"
+#include "GOVirtualCouplerController.h"
 
 class GOGUIPanel;
 class GOGUIPanelCreator;
@@ -85,6 +86,8 @@ private:
   wxString m_OrganComments;
   wxString m_RecordingDetails;
   wxString m_InfoFilename;
+
+  GOVirtualCouplerController m_VirtualCouplers;
 
   ptr_vector<GOGUIPanel> m_panels;
   ptr_vector<GOGUIPanelCreator> m_panelcreators;
@@ -182,7 +185,6 @@ public:
   void SetTemperament(wxString name);
   wxString GetTemperament();
 
-  int GetRecorderElementID(wxString name);
   GOCombinationDefinition &GetGeneralTemplate();
   GOLabelControl *GetPitchLabel();
   GOLabelControl *GetTemperamentLabel();

--- a/src/grandorgue/GOVirtualCouplerController.cpp
+++ b/src/grandorgue/GOVirtualCouplerController.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOVirtualCouplerController.h"
+
+#include <wx/intl.h>
+
+#include "model/GOCoupler.h"
+#include "model/GOManual.h"
+#include "model/GOOrganModel.h"
+
+void load_coupler(
+  GOOrganModel &organModel,
+  GOConfigReader &cfg,
+  GOVirtualCouplerController::ManualCouplerSet &manualCouplers,
+  unsigned srcManualN,
+  unsigned dstManualN,
+  bool unisonOff,
+  GOCoupler::GOCouplerType couplerType,
+  int keyshift,
+  const wxString &cfgGroupFmt,
+  const wxString &recorderNameFmt,
+  const wxString &couplerLabel) {
+  GOManual *pSrcManual = organModel.GetManual(srcManualN);
+  GOCoupler *pCoupler = new GOCoupler(organModel, srcManualN);
+
+  pCoupler->Init(
+    cfg,
+    wxString::Format(cfgGroupFmt, srcManualN, dstManualN),
+    couplerLabel,
+    unisonOff,
+    false,
+    keyshift,
+    dstManualN,
+    couplerType);
+  pCoupler->SetElementID(organModel.GetRecorderElementID(
+    wxString::Format(recorderNameFmt, srcManualN, dstManualN)));
+  pSrcManual->AddCoupler(pCoupler);
+  manualCouplers.push_back(pCoupler);
+}
+
+GOVirtualCouplerController::CouplerSetKey make_key(
+  unsigned srcManualN, unsigned dstManualN) {
+  return std::make_pair(srcManualN, dstManualN);
+}
+
+void GOVirtualCouplerController::Init(
+  GOOrganModel &organModel, GOConfigReader &cfg) {
+  for (unsigned srcManualN = organModel.GetFirstManualIndex();
+       srcManualN <= organModel.GetManualAndPedalCount();
+       srcManualN++) {
+    for (unsigned int dstManualN = organModel.GetFirstManualIndex();
+         dstManualN < organModel.GetODFManualCount();
+         dstManualN++) {
+      ManualCouplerSet &manualCouplers
+        = m_CouplerPtrs[make_key(srcManualN, dstManualN)];
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        false,
+        GOCoupler::COUPLER_NORMAL,
+        -12,
+        wxT("SetterManual%03dCoupler%03dT16"),
+        wxT("S%dM%dC16"),
+        _("16"));
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        srcManualN == dstManualN,
+        GOCoupler::COUPLER_NORMAL,
+        0,
+        wxT("SetterManual%03dCoupler%03dT8"),
+        wxT("S%dM%dC8"),
+        srcManualN != dstManualN ? _("8") : _("U.O."));
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        false,
+        GOCoupler::COUPLER_NORMAL,
+        12,
+        wxT("SetterManual%03dCoupler%03dT4"),
+        wxT("S%dM%dC4"),
+        _("4"));
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        false,
+        GOCoupler::COUPLER_BASS,
+        0,
+        wxT("SetterManual%03dCoupler%03dBAS"),
+        wxT("S%dM%dCB"),
+        _("BAS"));
+
+      load_coupler(
+        organModel,
+        cfg,
+        manualCouplers,
+        srcManualN,
+        dstManualN,
+        false,
+        GOCoupler::COUPLER_MELODY,
+        0,
+        wxT("SetterManual%03dCoupler%03dMEL"),
+        wxT("S%dM%dCM"),
+        _("MEL"));
+    }
+  }
+}
+
+GOCoupler *GOVirtualCouplerController::GetCoupler(
+  unsigned fromManual, unsigned toManual, CouplerType type) const {
+  const auto iter = m_CouplerPtrs.find(make_key(fromManual, toManual));
+
+  return iter != m_CouplerPtrs.end() ? iter->second[type] : nullptr;
+}

--- a/src/grandorgue/GOVirtualCouplerController.h
+++ b/src/grandorgue/GOVirtualCouplerController.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOVIRTUALCOUPLERCONTROLLER_H
+#define GOVIRTUALCOUPLERCONTROLLER_H
+
+#include <map>
+#include <utility>
+#include <vector>
+
+class GOConfigReader;
+class GOCoupler;
+class GOOrganModel;
+
+class GOVirtualCouplerController {
+  /**
+   * Represents virtual couplers that do not exist vin ODF and are added
+   * virtually by GrandOrgue. They are exposed on the GOGUICouplerPanel
+   */
+
+public:
+  enum CouplerType {
+    COUPLER_16,
+    COUPLER_8,
+    COUPLER_4,
+    COUPLER_BAS,
+    COUPLER_MEL
+  };
+
+  // FromManual, toManual
+  using CouplerSetKey = std::pair<unsigned, unsigned>;
+
+  // indexed by CouplerType
+  using ManualCouplerSet = std::vector<GOCoupler *>;
+
+private:
+  std::map<CouplerSetKey, ManualCouplerSet> m_CouplerPtrs;
+
+public:
+  // Create virtual couplers for each manual pairs with all CouplerType and add
+  // them to the organ model
+  void Init(GOOrganModel &organModel, GOConfigReader &cfg);
+
+  // Clears the couplers
+  void Cleanup() { m_CouplerPtrs.clear(); }
+
+  // Returns the coupler pointer
+  GOCoupler *GetCoupler(
+    unsigned fromManual, unsigned toManual, CouplerType type) const;
+};
+
+#endif /* GOVIRTUALCOUPLERCONTROLLER_H */

--- a/src/grandorgue/gui/GOGUICouplerPanel.cpp
+++ b/src/grandorgue/gui/GOGUICouplerPanel.cpp
@@ -19,11 +19,7 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
-
-GOGUICouplerPanel::GOGUICouplerPanel(GOOrganController *organController)
-  : m_OrganController(organController) {}
-
-GOGUICouplerPanel::~GOGUICouplerPanel() {}
+#include "GOVirtualCouplerController.h"
 
 void GOGUICouplerPanel::CreatePanels(GOConfigReader &cfg) {
   for (unsigned i = m_OrganController->GetFirstManualIndex();
@@ -70,110 +66,60 @@ GOGUIPanel *GOGUICouplerPanel::CreateCouplerPanel(
       dest_manual->GetName());
     panel->AddControl(PosDisplay);
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT16"), manual_nr, i),
-      _("16"),
-      false,
-      false,
-      -12,
-      i,
-      GOCoupler::COUPLER_NORMAL);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dC16"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT16"), manual_nr, i),
-      2,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_16))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dT16"), manual_nr, i),
+        2,
+        100 + i);
+      panel->AddControl(button);
+    }
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT8"), manual_nr, i),
-      manual_nr != i ? _("8") : _("U.O."),
-      manual_nr == i,
-      false,
-      0,
-      i,
-      GOCoupler::COUPLER_NORMAL);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dC8"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT8"), manual_nr, i),
-      3,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_8))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dT8"), manual_nr, i),
+        3,
+        100 + i);
+      panel->AddControl(button);
+    }
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT4"), manual_nr, i),
-      _("4"),
-      false,
-      false,
-      12,
-      i,
-      GOCoupler::COUPLER_NORMAL);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dC4"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dT4"), manual_nr, i),
-      4,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_4))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dT4"), manual_nr, i),
+        4,
+        100 + i);
+      panel->AddControl(button);
+    }
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dBAS"), manual_nr, i),
-      _("BAS"),
-      false,
-      false,
-      0,
-      i,
-      GOCoupler::COUPLER_BASS);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dCB"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dBAS"), manual_nr, i),
-      5,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_BAS))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dBAS"), manual_nr, i),
+        5,
+        100 + i);
+      panel->AddControl(button);
+    }
 
-    coupler = new GOCoupler(*m_OrganController, manual_nr);
-    coupler->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dMEL"), manual_nr, i),
-      _("MEL"),
-      false,
-      false,
-      0,
-      i,
-      GOCoupler::COUPLER_MELODY);
-    coupler->SetElementID(m_OrganController->GetRecorderElementID(
-      wxString::Format(wxT("S%dM%dCM"), manual_nr, i)));
-    manual->AddCoupler(coupler);
-    button = new GOGUIButton(panel, coupler, false);
-    button->Init(
-      cfg,
-      wxString::Format(wxT("SetterManual%03dCoupler%03dMEL"), manual_nr, i),
-      6,
-      100 + i);
-    panel->AddControl(button);
+    if ((coupler = r_VirtualCouplers.GetCoupler(
+           manual_nr, i, GOVirtualCouplerController::COUPLER_MEL))) {
+      button = new GOGUIButton(panel, coupler, false);
+      button->Init(
+        cfg,
+        wxString::Format(wxT("SetterManual%03dCoupler%03dMEL"), manual_nr, i),
+        6,
+        100 + i);
+      panel->AddControl(button);
+    }
   }
 
   return panel;

--- a/src/grandorgue/gui/GOGUICouplerPanel.h
+++ b/src/grandorgue/gui/GOGUICouplerPanel.h
@@ -12,16 +12,20 @@
 
 class GOGUIPanel;
 class GOOrganController;
+class GOVirtualCouplerController;
 
 class GOGUICouplerPanel : public GOGUIPanelCreator {
 private:
   GOOrganController *m_OrganController;
+  const GOVirtualCouplerController &r_VirtualCouplers;
 
   GOGUIPanel *CreateCouplerPanel(GOConfigReader &cfg, unsigned manual_nr);
 
 public:
-  GOGUICouplerPanel(GOOrganController *organController);
-  ~GOGUICouplerPanel();
+  GOGUICouplerPanel(
+    GOOrganController *organController,
+    const GOVirtualCouplerController &virtualCouplers)
+    : m_OrganController(organController), r_VirtualCouplers(virtualCouplers) {}
 
   void CreatePanels(GOConfigReader &cfg);
 };

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -8,6 +8,7 @@
 #include "GOOrganModel.h"
 
 #include "combinations/control/GOGeneralButtonControl.h"
+#include "config/GOConfig.h"
 #include "config/GOConfigReader.h"
 #include "control/GOPistonControl.h"
 #include "modification/GOModificationListener.h"
@@ -37,6 +38,10 @@ GOOrganModel::GOOrganModel(GOConfig &config)
 }
 
 GOOrganModel::~GOOrganModel() {}
+
+unsigned GOOrganModel::GetRecorderElementID(const wxString &name) {
+  return m_config.GetMidiMap().GetElementByString(name);
+}
 
 void GOOrganModel::Load(
   GOConfigReader &cfg, GOOrganController *organController) {

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -84,6 +84,8 @@ public:
   const GOConfig &GetConfig() const { return m_config; }
   GOConfig &GetConfig() { return m_config; }
 
+  unsigned GetRecorderElementID(const wxString &name);
+
   /* combinations properties */
   bool DivisionalsStoreIntermanualCouplers() const {
     return m_DivisionalsStoreIntermanualCouplers;


### PR DESCRIPTION
My attempts to fix #1576 were failed because the virtual couplers were created too late in GOGUICouplerPanel::CreatePanels. Moving it's call up caused segfault.

For fixing it I splitted GOGUICouplerPanel::CreatePanels in this PR to the GUI and the controller parts. The controller part (GOVirtualCouplerController) creates GOCoupler instances as well as the GUI part creates visible objects on top of it.

This is only refactoring. No GO behavior should be changed.

