### PR TITLE
Moved Initialisation of General and Divisional templates from GOOrganController to GOOrganModel

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -117,7 +117,6 @@ GOOrganController::GOOrganController(
     m_SampleSetId1(0),
     m_SampleSetId2(0),
     m_bitmaps(this),
-    m_GeneralTemplate(*this),
     m_PitchLabel(this),
     m_TemperamentLabel(this),
     m_MainWindowData(this, wxT("MainWindow")) {
@@ -255,19 +254,9 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   GOOrganModel::Load(cfg, this);
 
-  for (unsigned i = 0; i < m_enclosures.size(); i++)
-    m_enclosures[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("E%d"), i)));
-
-  for (unsigned i = 0; i < m_switches.size(); i++)
-    m_switches[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("S%d"), i)));
-
-  for (unsigned i = 0; i < m_tremulants.size(); i++)
-    m_tremulants[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
-
   m_VirtualCouplers.Init(*this, cfg);
+
+  GOOrganModel::LoadCmbButtons(cfg, this);
 
   m_DivisionalSetter = new GODivisionalSetter(this, m_setter->GetState());
   m_elementcreators.push_back(m_DivisionalSetter);
@@ -313,10 +302,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   for (unsigned i = 0; i < m_panels.size(); i++)
     m_panels[i]->Layout();
-
-  m_GeneralTemplate.InitGeneral();
-  for (unsigned i = m_FirstManual; i < m_manuals.size(); i++)
-    m_manuals[i]->GetDivisionalTemplate().InitDivisional(i);
 
   GetRootPipeConfigNode().SetName(GetChurchName());
   ReadCombinations(cfg);
@@ -1090,10 +1075,6 @@ wxString GOOrganController::GetTemperament() { return m_Temperament; }
 void GOOrganController::AllNotesOff() {
   for (unsigned k = GetFirstManualIndex(); k <= GetManualAndPedalCount(); k++)
     GetManual(k)->AllNotesOff();
-}
-
-GOCombinationDefinition &GOOrganController::GetGeneralTemplate() {
-  return m_GeneralTemplate;
 }
 
 GOLabelControl *GOOrganController::GetPitchLabel() { return &m_PitchLabel; }

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -14,7 +14,6 @@
 
 #include "ptrvector.h"
 
-#include "combinations/model/GOCombinationDefinition.h"
 #include "control/GOEventDistributor.h"
 #include "control/GOLabelControl.h"
 #include "gui/GOGUIMouseState.h"
@@ -30,6 +29,7 @@
 
 class GOGUIPanel;
 class GOGUIPanelCreator;
+class GOGUICouplerPanel;
 class GOArchive;
 class GOAudioRecorder;
 class GOButtonControl;
@@ -101,7 +101,6 @@ private:
 
   GOMemoryPool m_pool;
   GOBitmapCache m_bitmaps;
-  GOCombinationDefinition m_GeneralTemplate;
   GOLabelControl m_PitchLabel;
   GOLabelControl m_TemperamentLabel;
   GOMainWindowData m_MainWindowData;
@@ -185,7 +184,6 @@ public:
   void SetTemperament(wxString name);
   wxString GetTemperament();
 
-  GOCombinationDefinition &GetGeneralTemplate();
   GOLabelControl *GetPitchLabel();
   GOLabelControl *GetTemperamentLabel();
   GOMainWindowData *GetMainWindowData();

--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -213,18 +213,15 @@ void GODivisionalSetter::LoadCombination(GOConfigReader &cfg) {
   for (unsigned manualN = 0; manualN < m_NManuals; manualN++) {
     unsigned odfManualIndex = m_FirstManualIndex + manualN;
     DivisionalMap &divMap = m_DivisionalMaps[manualN];
-    GOManual *pManual = m_OrganController->GetManual(odfManualIndex);
-    GOCombinationDefinition &cmbTemplate = pManual->GetDivisionalTemplate();
 
     for (unsigned nDivisionals = N_DIVISIONALS * DIVISIONAL_BANKS,
                   divisionalIndex = 0;
          divisionalIndex < nDivisionals;
          divisionalIndex++) {
       // try to load the combination
-      GODivisionalCombination *pCmb = GODivisionalCombination::LoadFrom(
+      GODivisionalCombination *pCmb = GODivisionalCombination::loadFrom(
         *m_OrganController,
         cfg,
-        cmbTemplate,
         GetDivisionalButtonName(odfManualIndex, divisionalIndex),
         WX_EMPTY_STRING, // legacyGroupName is not used yet
         odfManualIndex,
@@ -310,7 +307,6 @@ void GODivisionalSetter::FromYaml(const YAML::Node &yamlNode) {
     unsigned odfManualIndex = m_FirstManualIndex + manualN;
     const wxString manualLabel = manual_yaml_key(odfManualIndex);
     GOManual *const pManual = m_OrganController->GetManual(odfManualIndex);
-    GOCombinationDefinition &cmbTemplate = pManual->GetDivisionalTemplate();
     DivisionalMap &divMap = m_DivisionalMaps[manualN];
 
     // simple divisionals
@@ -332,11 +328,10 @@ void GODivisionalSetter::FromYaml(const YAML::Node &yamlNode) {
       if (cmbNode.IsMap()) {
         unsigned i
           = banked_divisional_yaml_key_to_index(cmbEntry.first.as<wxString>());
-        GODivisionalCombination *pCmb
-          = new GODivisionalCombination(*m_OrganController, cmbTemplate, false);
+        GODivisionalCombination *pCmb = new GODivisionalCombination(
+          *m_OrganController, odfManualIndex, false);
 
-        pCmb->Init(
-          GetDivisionalButtonName(odfManualIndex, i), odfManualIndex, i);
+        pCmb->Init(GetDivisionalButtonName(odfManualIndex, i), i);
         cmbNode >> *pCmb;
         divMap[i] = pCmb;
       }
@@ -358,14 +353,10 @@ void GODivisionalSetter::SwitchDivisionalTo(
     if (!isExist && r_SetterState.m_IsActive) {
       // create a new combination
       const unsigned manualIndex = m_FirstManualIndex + manualN;
-      GOCombinationDefinition &divTemplate
-        = m_OrganController->GetManual(manualIndex)->GetDivisionalTemplate();
 
-      pCmb = new GODivisionalCombination(*m_OrganController, divTemplate, true);
+      pCmb = new GODivisionalCombination(*m_OrganController, manualIndex, true);
       pCmb->Init(
-        GetDivisionalButtonName(manualIndex, divisionalIdx),
-        manualIndex,
-        divisionalIdx);
+        GetDivisionalButtonName(manualIndex, divisionalIdx), divisionalIdx);
       divMap[divisionalIdx] = pCmb;
     }
 

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -352,16 +352,15 @@ void GOSetter::Load(GOConfigReader &cfg) {
 
   m_framegeneral.resize(0);
   for (unsigned i = 0; i < FRAME_GENERALS; i++) {
-    m_framegeneral.push_back(new GOGeneralCombination(
-      *m_OrganController, m_OrganController->GetGeneralTemplate(), true));
+    m_framegeneral.push_back(
+      new GOGeneralCombination(*m_OrganController, true));
     buffer.Printf(wxT("FrameGeneral%03d"), i + 1);
     m_framegeneral[i]->Load(cfg, buffer);
   }
 
   m_general.resize(0);
   for (unsigned i = 0; i < GENERALS * GENERAL_BANKS; i++) {
-    m_general.push_back(new GOGeneralCombination(
-      *m_OrganController, m_OrganController->GetGeneralTemplate(), true));
+    m_general.push_back(new GOGeneralCombination(*m_OrganController, true));
     buffer.Printf(wxT("SetterGeneral%03d"), i + 1);
     m_general[i]->Load(cfg, buffer);
   }
@@ -377,8 +376,7 @@ void GOSetter::Load(GOConfigReader &cfg) {
       CMBSetting, buffer, WX_OVERRIDE_MODE, false, defaultAddMode);
   }
   for (unsigned i = 0; i < N_CRESCENDOS * CRESCENDO_STEPS; i++) {
-    m_crescendo.push_back(new GOGeneralCombination(
-      *m_OrganController, m_OrganController->GetGeneralTemplate(), true));
+    m_crescendo.push_back(new GOGeneralCombination(*m_OrganController, true));
     m_CrescendoExtraSets.emplace_back();
     buffer.Printf(
       wxT("SetterCrescendo%d_%03d"),

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -15,31 +15,25 @@
 #include "GOOrganController.h"
 
 GODivisionalButtonControl::GODivisionalButtonControl(
-  GOOrganController *organController,
-  GOCombinationDefinition &divisionalTemplate,
-  bool isSetter)
+  GOOrganController *organController, unsigned manualNumber, bool isSetter)
   : GOPushbuttonControl(*organController),
     r_setter(*organController->GetSetter()),
-    m_combination(*organController, divisionalTemplate, isSetter) {}
+    m_combination(*organController, manualNumber, isSetter) {}
 
 wxString GODivisionalButtonControl::GetMidiType() { return _("Divisional"); };
 
 void GODivisionalButtonControl::Init(
   GOConfigReader &cfg,
   const wxString &group,
-  int manualNumber,
   int divisionalNumber,
   const wxString &name) {
   GOPushbuttonControl::Init(cfg, group, name);
-  m_combination.Init(group, manualNumber, divisionalNumber);
+  m_combination.Init(group, divisionalNumber);
 }
 void GODivisionalButtonControl::Load(
-  GOConfigReader &cfg,
-  const wxString &group,
-  int manualNumber,
-  int divisionalNumber) {
+  GOConfigReader &cfg, const wxString &group, int divisionalNumber) {
   GOPushbuttonControl::Load(cfg, group);
-  m_combination.Load(cfg, group, manualNumber, divisionalNumber);
+  m_combination.Load(cfg, group, divisionalNumber);
 }
 
 void GODivisionalButtonControl::LoadCombination(GOConfigReader &cfg) {

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -10,9 +10,7 @@
 #include "wx/intl.h"
 
 #include "combinations/GOSetter.h"
-#include "model/GOManual.h"
-
-#include "GOOrganController.h"
+#include "model/GOOrganModel.h"
 
 GODivisionalButtonControl::GODivisionalButtonControl(
   GOOrganModel &organModel, unsigned manualNumber, bool isSetter)
@@ -46,5 +44,5 @@ void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
 }
 
 void GODivisionalButtonControl::Push() {
-  organModel.PushDivisional(m_combination, this);
+  r_OrganModel.PushDivisional(m_combination, this);
 }

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -15,10 +15,10 @@
 #include "GOOrganController.h"
 
 GODivisionalButtonControl::GODivisionalButtonControl(
-  GOOrganController *organController, unsigned manualNumber, bool isSetter)
-  : GOPushbuttonControl(*organController),
-    r_setter(*organController->GetSetter()),
-    m_combination(*organController, manualNumber, isSetter) {}
+  GOOrganModel &organModel, unsigned manualNumber, bool isSetter)
+  : GOPushbuttonControl(organModel),
+    r_OrganModel(organModel),
+    m_combination(organModel, manualNumber, isSetter) {}
 
 wxString GODivisionalButtonControl::GetMidiType() { return _("Divisional"); };
 
@@ -46,5 +46,5 @@ void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
 }
 
 void GODivisionalButtonControl::Push() {
-  r_setter.PushDivisional(m_combination, this);
+  organModel.PushDivisional(m_combination, this);
 }

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.h
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.h
@@ -8,6 +8,8 @@
 #ifndef GODIVISIONALBUTTONCONTROL_H
 #define GODIVISIONALBUTTONCONTROL_H
 
+#include <wx/string.h>
+
 #include "combinations/model/GODivisionalCombination.h"
 #include "control/GOPushbuttonControl.h"
 

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.h
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.h
@@ -12,16 +12,16 @@
 #include "control/GOPushbuttonControl.h"
 
 class GOConfigReader;
-class GOSetter;
+class GOOrganModel;
 
 class GODivisionalButtonControl : public GOPushbuttonControl {
 private:
-  GOSetter &r_setter;
+  GOOrganModel &r_OrganModel;
   GODivisionalCombination m_combination;
 
 public:
   GODivisionalButtonControl(
-    GOOrganController *organController, unsigned manualNumber, bool isSetter);
+    GOOrganModel &organModel, unsigned manualNumber, bool isSetter);
 
   GODivisionalCombination &GetCombination() { return m_combination; }
   wxString GetMidiType() override;

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.h
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.h
@@ -21,9 +21,7 @@ private:
 
 public:
   GODivisionalButtonControl(
-    GOOrganController *organController,
-    GOCombinationDefinition &divisionalTemplate,
-    bool isSetter);
+    GOOrganController *organController, unsigned manualNumber, bool isSetter);
 
   GODivisionalCombination &GetCombination() { return m_combination; }
   wxString GetMidiType() override;
@@ -31,15 +29,10 @@ public:
   void Init(
     GOConfigReader &cfg,
     const wxString &group,
-    int manualNumber,
     int divisionalNumber,
     const wxString &name);
 
-  void Load(
-    GOConfigReader &cfg,
-    const wxString &group,
-    int manualNumber,
-    int divisionalNumber);
+  void Load(GOConfigReader &cfg, const wxString &group, int divisionalNumber);
 
   void LoadCombination(GOConfigReader &cfg);
   void Save(GOConfigWriter &cfg);

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -9,17 +9,14 @@
 
 #include <wx/intl.h>
 
-#include "combinations/GOSetter.h"
-
-#include "GOOrganController.h"
+#include "combinations/model/GOCombinationDefinition.h"
+#include "model/GOOrganModel.h"
 
 GOGeneralButtonControl::GOGeneralButtonControl(
-  GOCombinationDefinition &general_template,
-  GOOrganController *organController,
-  bool is_setter)
-  : GOPushbuttonControl(*organController),
-    r_setter(*organController->GetSetter()),
-    m_combination(*organController, general_template, is_setter) {}
+  GOOrganModel &organModel, bool is_setter)
+  : GOPushbuttonControl(organModel),
+    r_OrganModel(organModel),
+    m_combination(r_OrganModel, is_setter) {}
 
 void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
   m_combination.Load(cfg, group);
@@ -27,7 +24,7 @@ void GOGeneralButtonControl::Load(GOConfigReader &cfg, wxString group) {
 }
 
 void GOGeneralButtonControl::Push() {
-  r_setter.PushGeneral(m_combination, this);
+  r_OrganModel.PushGeneral(m_combination, this);
 }
 
 GOGeneralCombination &GOGeneralButtonControl::GetCombination() {

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.h
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.h
@@ -12,18 +12,15 @@
 #include "control/GOPushbuttonControl.h"
 
 class GOConfigReader;
-class GOSetter;
+class GOOrganModel;
 
 class GOGeneralButtonControl : public GOPushbuttonControl {
 private:
-  GOSetter &r_setter;
+  GOOrganModel &r_OrganModel;
   GOGeneralCombination m_combination;
 
 public:
-  GOGeneralButtonControl(
-    GOCombinationDefinition &general_template,
-    GOOrganController *organController,
-    bool is_setter);
+  GOGeneralButtonControl(GOOrganModel &organModel, bool is_setter);
   void Load(GOConfigReader &cfg, wxString group);
   void Push() override;
   GOGeneralCombination &GetCombination();

--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -25,8 +25,10 @@ class GOCombination : public GOSaveableObject, public GOSaveableToYaml {
 public:
   using ExtraElementsSet = std::unordered_set<unsigned>;
 
-private:
+protected:
   GOOrganModel &r_OrganModel;
+
+private:
   const GOCombinationDefinition &m_Template;
 
   /**

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -45,9 +45,8 @@ void GOCombinationDefinition::Add(
   int manual,
   unsigned index,
   bool store_unconditional) {
-  if (control->IsReadOnly())
-    return;
   Element def;
+
   def.type = type;
   def.manual = manual;
   def.index = index;

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -21,26 +21,24 @@
 #include "yaml/go-wx-yaml.h"
 
 GODivisionalCombination::GODivisionalCombination(
-  GOOrganModel &organModel,
-  const GOCombinationDefinition &cmbDef,
-  bool isSetter)
-  : GOCombination(organModel, cmbDef),
+  GOOrganModel &organModel, unsigned manualNumber, bool isSetter)
+  : GOCombination(
+    organModel, organModel.GetManual(manualNumber)->GetDivisionalTemplate()),
     r_OrganModel(organModel),
-    m_odfManualNumber(1),
+    m_odfManualNumber(manualNumber),
     m_DivisionalNumber(0),
     m_IsSetter(isSetter) {}
 
 void GODivisionalCombination::Init(
-  const wxString &group, int manualNumber, int divisionalNumber) {
+  const wxString &group, int divisionalNumber) {
   m_group = group;
-  m_odfManualNumber = manualNumber;
   m_DivisionalNumber = divisionalNumber;
   m_Protected = false;
 }
 
 void GODivisionalCombination::Load(
-  GOConfigReader &cfg, wxString group, int manualNumber, int divisionalNumber) {
-  Init(group, manualNumber, divisionalNumber);
+  GOConfigReader &cfg, const wxString &group, int divisionalNumber) {
+  Init(group, divisionalNumber);
   m_Protected
     = cfg.ReadBoolean(ODFSetting, group, wxT("Protected"), false, false);
 
@@ -239,10 +237,9 @@ void GODivisionalCombination::FromYamlMap(const YAML::Node &yamlMap) {
     GOCombinationDefinition::COMBINATION_SWITCH);
 }
 
-GODivisionalCombination *GODivisionalCombination::LoadFrom(
+GODivisionalCombination *GODivisionalCombination::loadFrom(
   GOOrganModel &organModel,
   GOConfigReader &cfg,
-  const GOCombinationDefinition &cmbDef,
   const wxString &group,
   const wxString &readGroup,
   int manualNumber,
@@ -252,12 +249,8 @@ GODivisionalCombination *GODivisionalCombination::LoadFrom(
   bool isCmbOnReadGroup = !readGroup.IsEmpty() && isCmbOnFile(cfg, readGroup);
 
   if (isCmbOnGroup || isCmbOnReadGroup) {
-    pCmb = new GODivisionalCombination(organModel, cmbDef, false);
-    pCmb->Load(
-      cfg,
-      isCmbOnReadGroup ? readGroup : group,
-      manualNumber,
-      divisionalNumber);
+    pCmb = new GODivisionalCombination(organModel, manualNumber, false);
+    pCmb->Load(cfg, isCmbOnReadGroup ? readGroup : group, divisionalNumber);
     pCmb->LoadCombination(cfg);
     if (isCmbOnReadGroup) {  // The combination was loaded from the legacy group
       pCmb->m_group = group; // It will be saved to the normal group

--- a/src/grandorgue/combinations/model/GODivisionalCombination.h
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.h
@@ -43,26 +43,19 @@ protected:
 
 public:
   GODivisionalCombination(
-    GOOrganModel &organModel,
-    const GOCombinationDefinition &cmbDef,
-    bool isSetter);
+    GOOrganModel &organModel, unsigned manualNumber, bool isSetter);
 
   unsigned GetManualNumber() const { return m_odfManualNumber; }
   int GetDivisionalNumber() const { return m_DivisionalNumber; }
 
-  void Init(const wxString &group, int manualNumber, int divisionalNumber);
-  void Load(
-    GOConfigReader &cfg,
-    wxString group,
-    int manualNumber,
-    int divisionalNumber);
+  void Init(const wxString &group, int divisionalNumber);
+  void Load(GOConfigReader &cfg, const wxString &group, int divisionalNumber);
 
   // checks if the combination exists in the config file
   // returns the loaded combination if it exists else returns nullptr
-  static GODivisionalCombination *LoadFrom(
+  static GODivisionalCombination *loadFrom(
     GOOrganModel &organModel,
     GOConfigReader &cfg,
-    const GOCombinationDefinition &cmbDef,
     const wxString &group,
     // for compatibility with the old preset: load the combination with the old
     // group name

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -26,7 +26,7 @@ GOGeneralCombination::GOGeneralCombination(
   : GOCombination(organModel, organModel.GetGeneralTemplate()),
     m_IsSetter(isSetter) {}
 
-void GOGeneralCombination::Load(GOConfigReader &cfg, wxString group) {
+void GOGeneralCombination::Load(GOConfigReader &cfg, const wxString &group) {
   r_OrganModel.RegisterSaveableObject(this);
   m_group = group;
 

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -22,11 +22,8 @@
 #include "yaml/go-wx-yaml.h"
 
 GOGeneralCombination::GOGeneralCombination(
-  GOOrganModel &organModel,
-  const GOCombinationDefinition &cmbDef,
-  bool isSetter)
-  : GOCombination(organModel, cmbDef),
-    r_OrganModel(organModel),
+  GOOrganModel &organModel, bool isSetter)
+  : GOCombination(organModel, organModel.GetGeneralTemplate()),
     m_IsSetter(isSetter) {}
 
 void GOGeneralCombination::Load(GOConfigReader &cfg, wxString group) {

--- a/src/grandorgue/combinations/model/GOGeneralCombination.h
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.h
@@ -38,7 +38,7 @@ private:
 
 public:
   GOGeneralCombination(GOOrganModel &organModel, bool isSetter);
-  void Load(GOConfigReader &cfg, wxString group);
+  void Load(GOConfigReader &cfg, const wxString &group);
 };
 
 #endif /* GOGENERALCOMBINATION_H */

--- a/src/grandorgue/combinations/model/GOGeneralCombination.h
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.h
@@ -19,7 +19,6 @@ class GOSetter;
 
 class GOGeneralCombination : public GOCombination {
 private:
-  GOOrganModel &r_OrganModel;
   bool m_IsSetter;
 
   void LoadCombinationInt(GOConfigReader &cfg, GOSettingType srcType) override;
@@ -38,10 +37,7 @@ private:
   void FromYamlMap(const YAML::Node &yamlMap) override;
 
 public:
-  GOGeneralCombination(
-    GOOrganModel &organModel,
-    const GOCombinationDefinition &cmbDef,
-    bool isSetter);
+  GOGeneralCombination(GOOrganModel &organModel, bool isSetter);
   void Load(GOConfigReader &cfg, wxString group);
 };
 

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -236,8 +236,8 @@ void GOManual::LoadDivisionals(GOConfigReader &cfg) {
   m_DivisionalTemplate.InitDivisional(m_manual_number);
   m_divisionals.resize(0);
   for (unsigned i = 0; i < nDivisionals; i++) {
-    m_divisionals.push_back(
-      new GODivisionalButtonControl(m_OrganController, m_manual_number, false));
+    m_divisionals.push_back(new GODivisionalButtonControl(
+      *m_OrganController, m_manual_number, false));
 
     buffer.Printf(wxT("Divisional%03d"), i + 1);
     buffer.Printf(

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -236,15 +236,15 @@ void GOManual::LoadDivisionals(GOConfigReader &cfg) {
   m_DivisionalTemplate.InitDivisional(m_manual_number);
   m_divisionals.resize(0);
   for (unsigned i = 0; i < nDivisionals; i++) {
-    m_divisionals.push_back(new GODivisionalButtonControl(
-      m_OrganController, m_DivisionalTemplate, false));
+    m_divisionals.push_back(
+      new GODivisionalButtonControl(m_OrganController, m_manual_number, false));
 
     buffer.Printf(wxT("Divisional%03d"), i + 1);
     buffer.Printf(
       wxT("Divisional%03d"),
       cfg.ReadInteger(ODFSetting, m_group, buffer, 1, 999));
     cfg.MarkGroupInUse(buffer);
-    m_divisionals[i]->Load(cfg, buffer, m_manual_number, i);
+    m_divisionals[i]->Load(cfg, buffer, i);
   }
 }
 

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -103,7 +103,8 @@ public:
     int manualNumber,
     unsigned first_midi,
     unsigned keys);
-  void Load(GOConfigReader &cfg, wxString group, int manualNumber);
+  void Load(GOConfigReader &cfg, const wxString &group, int manualNumber);
+  void LoadDivisionals(GOConfigReader &cfg);
   unsigned RegisterCoupler(GOCoupler *coupler);
   void SetKey(
     unsigned note, unsigned velocity, GOCoupler *prev, unsigned couplerID);

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -178,8 +178,7 @@ void GOOrganModel::LoadCmbButtons(
   m_GeneralTemplate.InitGeneral();
   m_generals.resize(0);
   for (unsigned i = 0; i < NumberOfGenerals; i++) {
-    m_generals.push_back(
-      new GOGeneralButtonControl(m_GeneralTemplate, organController, false));
+    m_generals.push_back(new GOGeneralButtonControl(*this, false));
     m_generals[i]->Load(cfg, wxString::Format(wxT("General%03d"), i + 1));
   }
 

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -24,6 +24,7 @@
 
 GOOrganModel::GOOrganModel(GOConfig &config)
   : m_config(config),
+    m_GeneralTemplate(*this),
     m_DivisionalsStoreIntermanualCouplers(false),
     m_DivisionalsStoreIntramanualCouplers(false),
     m_DivisionalsStoreTremulants(false),
@@ -43,35 +44,33 @@ unsigned GOOrganModel::GetRecorderElementID(const wxString &name) {
   return m_config.GetMidiMap().GetElementByString(name);
 }
 
+static const wxString WX_ORGAN = wxT("Organ");
+
 void GOOrganModel::Load(
   GOConfigReader &cfg, GOOrganController *organController) {
-  wxString group = wxT("Organ");
   m_DivisionalsStoreIntermanualCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("DivisionalsStoreIntermanualCouplers"));
+    ODFSetting, WX_ORGAN, wxT("DivisionalsStoreIntermanualCouplers"));
   m_DivisionalsStoreIntramanualCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("DivisionalsStoreIntramanualCouplers"));
+    ODFSetting, WX_ORGAN, wxT("DivisionalsStoreIntramanualCouplers"));
   m_DivisionalsStoreTremulants
-    = cfg.ReadBoolean(ODFSetting, group, wxT("DivisionalsStoreTremulants"));
+    = cfg.ReadBoolean(ODFSetting, WX_ORGAN, wxT("DivisionalsStoreTremulants"));
   m_GeneralsStoreDivisionalCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("GeneralsStoreDivisionalCouplers"));
+    ODFSetting, WX_ORGAN, wxT("GeneralsStoreDivisionalCouplers"));
   m_CombinationsStoreNonDisplayedDrawstops = cfg.ReadBoolean(
-    ODFSetting,
-    group,
-    wxT("CombinationsStoreNonDisplayedDrawstops"),
-    false,
-    true);
+    ODFSetting, WX_ORGAN, wxT("CombinationsStoreNonDisplayedDrawstops"));
 
   unsigned NumberOfWindchestGroups = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfWindchestGroups"), 1, 999);
+    ODFSetting, WX_ORGAN, wxT("NumberOfWindchestGroups"), 1, 999);
 
-  m_RootPipeConfigNode.Load(cfg, group, wxEmptyString);
+  m_RootPipeConfigNode.Load(cfg, WX_ORGAN, wxEmptyString);
   m_windchests.resize(0);
   for (unsigned i = 0; i < NumberOfWindchestGroups; i++)
     m_windchests.push_back(new GOWindchest(*organController));
 
   m_ODFManualCount
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfManuals"), 1, 16) + 1;
-  m_FirstManual = cfg.ReadBoolean(ODFSetting, group, wxT("HasPedals")) ? 0 : 1;
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfManuals"), 1, 16) + 1;
+  m_FirstManual
+    = cfg.ReadBoolean(ODFSetting, WX_ORGAN, wxT("HasPedals")) ? 0 : 1;
 
   m_manuals.resize(0);
   m_manuals.resize(m_FirstManual); // Add empty slot for pedal, if necessary
@@ -82,7 +81,7 @@ void GOOrganModel::Load(
     m_manuals.push_back(new GOManual(organController));
 
   unsigned NumberOfEnclosures
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfEnclosures"), 0, 999);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfEnclosures"), 0, 999);
   m_enclosures.resize(0);
   for (unsigned i = 0; i < NumberOfEnclosures; i++) {
     m_enclosures.push_back(new GOEnclosure(*organController));
@@ -91,7 +90,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfSwitches
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfSwitches"), 0, 999, 0);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfSwitches"), 0, 999, 0);
   m_switches.resize(0);
   for (unsigned i = 0; i < NumberOfSwitches; i++) {
     m_switches.push_back(new GOSwitch(*organController));
@@ -99,7 +98,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfTremulants
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfTremulants"), 0, 10);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfTremulants"), 0, 10);
   for (unsigned i = 0; i < NumberOfTremulants; i++) {
     m_tremulants.push_back(new GOTremulant(*organController));
     m_tremulants[i]->Load(
@@ -110,8 +109,8 @@ void GOOrganModel::Load(
     m_windchests[i]->Load(
       cfg, wxString::Format(wxT("WindchestGroup%03d"), i + 1), i);
 
-  m_ODFRankCount
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfRanks"), 0, 999, false);
+  m_ODFRankCount = cfg.ReadInteger(
+    ODFSetting, WX_ORGAN, wxT("NumberOfRanks"), 0, 999, false);
   for (unsigned i = 0; i < m_ODFRankCount; i++) {
     m_ranks.push_back(new GORank(*organController));
     m_ranks[i]->Load(cfg, wxString::Format(wxT("Rank%03d"), i + 1), -1);
@@ -140,7 +139,7 @@ void GOOrganModel::Load(
       max_key - min_key);
 
   unsigned NumberOfReversiblePistons = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfReversiblePistons"), 0, 32);
+    ODFSetting, WX_ORGAN, wxT("NumberOfReversiblePistons"), 0, 32);
   m_pistons.resize(0);
   for (unsigned i = 0; i < NumberOfReversiblePistons; i++) {
     m_pistons.push_back(new GOPistonControl(*this));
@@ -149,7 +148,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfDivisionalCouplers = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfDivisionalCouplers"), 0, 8);
+    ODFSetting, WX_ORGAN, wxT("NumberOfDivisionalCouplers"), 0, 8);
   m_DivisionalCoupler.resize(0);
   for (unsigned i = 0; i < NumberOfDivisionalCouplers; i++) {
     m_DivisionalCoupler.push_back(new GODivisionalCoupler(*organController));
@@ -157,15 +156,36 @@ void GOOrganModel::Load(
       cfg, wxString::Format(wxT("DivisionalCoupler%03d"), i + 1));
   }
 
-  organController->GetGeneralTemplate().InitGeneral();
+  for (unsigned i = 0; i < m_enclosures.size(); i++)
+    m_enclosures[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("E%d"), i)));
+
+  for (unsigned i = 0; i < m_switches.size(); i++)
+    m_switches[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("S%d"), i)));
+
+  for (unsigned i = 0; i < m_tremulants.size(); i++)
+    m_tremulants[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
+}
+
+void GOOrganModel::LoadCmbButtons(
+  GOConfigReader &cfg, GOOrganController *organController) {
+  // Generals
   unsigned NumberOfGenerals
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfGenerals"), 0, 99);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfGenerals"), 0, 99);
+
+  m_GeneralTemplate.InitGeneral();
   m_generals.resize(0);
   for (unsigned i = 0; i < NumberOfGenerals; i++) {
-    m_generals.push_back(new GOGeneralButtonControl(
-      organController->GetGeneralTemplate(), organController, false));
+    m_generals.push_back(
+      new GOGeneralButtonControl(m_GeneralTemplate, organController, false));
     m_generals[i]->Load(cfg, wxString::Format(wxT("General%03d"), i + 1));
   }
+
+  // Divisionals
+  for (unsigned i = m_FirstManual; i < m_manuals.size(); i++)
+    m_manuals[i]->LoadDivisionals(cfg);
 }
 
 void GOOrganModel::SetOrganModelModified(bool modified) {

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -12,6 +12,7 @@
 
 #include "combinations/control/GOCombinationButtonSet.h"
 #include "combinations/control/GOCombinationControllerProxy.h"
+#include "combinations/model/GOCombinationDefinition.h"
 #include "midi/GOMidiSendProxy.h"
 #include "midi/dialog-creator/GOMidiDialogCreatorProxy.h"
 #include "modification/GOModificationProxy.h"
@@ -38,9 +39,10 @@ class GOOrganModel : private GOCombinationButtonSet,
                      public GOMidiDialogCreatorProxy,
                      public GOMidiSendProxy {
 private:
-  GOModificationProxy m_ModificationProxy;
-
   GOConfig &m_config;
+
+  GOModificationProxy m_ModificationProxy;
+  GOCombinationDefinition m_GeneralTemplate;
 
   bool m_DivisionalsStoreIntermanualCouplers;
   bool m_DivisionalsStoreIntramanualCouplers;
@@ -69,6 +71,13 @@ protected:
   void Load(GOConfigReader &cfg, GOOrganController *organController);
 
   /**
+   * Called after Load() and InitCmbTemplates();
+   * Init general and divisional templates
+   * Load generals and divisionals from ODF/cmb
+   */
+  void LoadCmbButtons(GOConfigReader &cfg, GOOrganController *organController);
+
+  /**
    * Update all generals buttons light.
    * @param buttonToLight - the button that should be lighted on. All other
    *   divisionals are lighted off
@@ -85,6 +94,10 @@ public:
   GOConfig &GetConfig() { return m_config; }
 
   unsigned GetRecorderElementID(const wxString &name);
+
+  const GOCombinationDefinition &GetGeneralTemplate() const {
+    return m_GeneralTemplate;
+  }
 
   /* combinations properties */
   bool DivisionalsStoreIntermanualCouplers() const {


### PR DESCRIPTION
This is a new PR instead of #1576

In order to eliminating usage of GOOrganController I moved storing and initialisation of GOGeneralCombination GODivisionalCombination from GOOrganController to GOOrganModel.

It is just refactoring. No GO controller should be changed.

After merging #1580 the capability of saving virtual coupler states are saved correctly with this PR.