### PR TITLE
Moved Initialisation of General and Divisional templates from GOOrganController to GOOrganModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Changed the default value of the CombinationsStoreNonDisplayedDrawstops ODF settings to false
 - Fixed capability of running on MacOs 11.3
 - Fixed "The device does not support requested channel count" error when using an USB audio card on MacOS https://github.com/GrandOrgue/grandorgue/issues/1550
 # 3.12.1 (2023-06-06)

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -7150,10 +7150,10 @@ state of divisional couplers.
           <term>CombinationsStoreNonDisplayedDrawstops</term>
           <listitem>
             <para>
-(boolean, default: true) determines, if the state of 
-invisible objects (on the main panel) is stored in divisionals,
-generals and the setter.
-     </para>
+	      (boolean, default: true) determines, if the state of read-only
+	      objects (that is calculated based on the state of another objects)
+	      is stored in divisionals, generals and the setter.
+	    </para>
           </listitem>
         </varlistentry>
         <varlistentry>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -7150,7 +7150,7 @@ state of divisional couplers.
           <term>CombinationsStoreNonDisplayedDrawstops</term>
           <listitem>
             <para>
-	      (boolean, default: true) determines, if the state of read-only
+	      (boolean, default: false) determines, if the state of read-only
 	      objects (that is calculated based on the state of another objects)
 	      is stored in divisionals, generals and the setter.
 	    </para>

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -117,7 +117,6 @@ GOOrganController::GOOrganController(
     m_SampleSetId1(0),
     m_SampleSetId2(0),
     m_bitmaps(this),
-    m_GeneralTemplate(*this),
     m_PitchLabel(this),
     m_TemperamentLabel(this),
     m_MainWindowData(this, wxT("MainWindow")) {
@@ -255,19 +254,9 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   GOOrganModel::Load(cfg, this);
 
-  for (unsigned i = 0; i < m_enclosures.size(); i++)
-    m_enclosures[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("E%d"), i)));
-
-  for (unsigned i = 0; i < m_switches.size(); i++)
-    m_switches[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("S%d"), i)));
-
-  for (unsigned i = 0; i < m_tremulants.size(); i++)
-    m_tremulants[i]->SetElementID(
-      GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
-
   m_VirtualCouplers.Init(*this, cfg);
+
+  GOOrganModel::LoadCmbButtons(cfg, this);
 
   m_DivisionalSetter = new GODivisionalSetter(this, m_setter->GetState());
   m_elementcreators.push_back(m_DivisionalSetter);
@@ -313,10 +302,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   for (unsigned i = 0; i < m_panels.size(); i++)
     m_panels[i]->Layout();
-
-  m_GeneralTemplate.InitGeneral();
-  for (unsigned i = m_FirstManual; i < m_manuals.size(); i++)
-    m_manuals[i]->GetDivisionalTemplate().InitDivisional(i);
 
   GetRootPipeConfigNode().SetName(GetChurchName());
   ReadCombinations(cfg);
@@ -1090,10 +1075,6 @@ wxString GOOrganController::GetTemperament() { return m_Temperament; }
 void GOOrganController::AllNotesOff() {
   for (unsigned k = GetFirstManualIndex(); k <= GetManualAndPedalCount(); k++)
     GetManual(k)->AllNotesOff();
-}
-
-GOCombinationDefinition &GOOrganController::GetGeneralTemplate() {
-  return m_GeneralTemplate;
 }
 
 GOLabelControl *GOOrganController::GetPitchLabel() { return &m_PitchLabel; }

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -14,7 +14,6 @@
 
 #include "ptrvector.h"
 
-#include "combinations/model/GOCombinationDefinition.h"
 #include "control/GOEventDistributor.h"
 #include "control/GOLabelControl.h"
 #include "gui/GOGUIMouseState.h"
@@ -30,6 +29,7 @@
 
 class GOGUIPanel;
 class GOGUIPanelCreator;
+class GOGUICouplerPanel;
 class GOArchive;
 class GOAudioRecorder;
 class GOButtonControl;
@@ -101,7 +101,6 @@ private:
 
   GOMemoryPool m_pool;
   GOBitmapCache m_bitmaps;
-  GOCombinationDefinition m_GeneralTemplate;
   GOLabelControl m_PitchLabel;
   GOLabelControl m_TemperamentLabel;
   GOMainWindowData m_MainWindowData;
@@ -185,7 +184,6 @@ public:
   void SetTemperament(wxString name);
   wxString GetTemperament();
 
-  GOCombinationDefinition &GetGeneralTemplate();
   GOLabelControl *GetPitchLabel();
   GOLabelControl *GetTemperamentLabel();
   GOMainWindowData *GetMainWindowData();

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -45,9 +45,8 @@ void GOCombinationDefinition::Add(
   int manual,
   unsigned index,
   bool store_unconditional) {
-  if (control->IsReadOnly())
-    return;
   Element def;
+
   def.type = type;
   def.manual = manual;
   def.index = index;

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -103,7 +103,8 @@ public:
     int manualNumber,
     unsigned first_midi,
     unsigned keys);
-  void Load(GOConfigReader &cfg, wxString group, int manualNumber);
+  void Load(GOConfigReader &cfg, const wxString &group, int manualNumber);
+  void LoadDivisionals(GOConfigReader &cfg);
   unsigned RegisterCoupler(GOCoupler *coupler);
   void SetKey(
     unsigned note, unsigned velocity, GOCoupler *prev, unsigned couplerID);

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -57,7 +57,7 @@ void GOOrganModel::Load(
   m_GeneralsStoreDivisionalCouplers = cfg.ReadBoolean(
     ODFSetting, WX_ORGAN, wxT("GeneralsStoreDivisionalCouplers"));
   m_CombinationsStoreNonDisplayedDrawstops = cfg.ReadBoolean(
-    ODFSetting, WX_ORGAN, wxT("CombinationsStoreNonDisplayedDrawstops"));
+    ODFSetting, WX_ORGAN, wxT("CombinationsStoreNonDisplayedDrawstops"), false);
 
   unsigned NumberOfWindchestGroups = cfg.ReadInteger(
     ODFSetting, WX_ORGAN, wxT("NumberOfWindchestGroups"), 1, 999);

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -24,6 +24,7 @@
 
 GOOrganModel::GOOrganModel(GOConfig &config)
   : m_config(config),
+    m_GeneralTemplate(*this),
     m_DivisionalsStoreIntermanualCouplers(false),
     m_DivisionalsStoreIntramanualCouplers(false),
     m_DivisionalsStoreTremulants(false),
@@ -43,35 +44,33 @@ unsigned GOOrganModel::GetRecorderElementID(const wxString &name) {
   return m_config.GetMidiMap().GetElementByString(name);
 }
 
+static const wxString WX_ORGAN = wxT("Organ");
+
 void GOOrganModel::Load(
   GOConfigReader &cfg, GOOrganController *organController) {
-  wxString group = wxT("Organ");
   m_DivisionalsStoreIntermanualCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("DivisionalsStoreIntermanualCouplers"));
+    ODFSetting, WX_ORGAN, wxT("DivisionalsStoreIntermanualCouplers"));
   m_DivisionalsStoreIntramanualCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("DivisionalsStoreIntramanualCouplers"));
+    ODFSetting, WX_ORGAN, wxT("DivisionalsStoreIntramanualCouplers"));
   m_DivisionalsStoreTremulants
-    = cfg.ReadBoolean(ODFSetting, group, wxT("DivisionalsStoreTremulants"));
+    = cfg.ReadBoolean(ODFSetting, WX_ORGAN, wxT("DivisionalsStoreTremulants"));
   m_GeneralsStoreDivisionalCouplers = cfg.ReadBoolean(
-    ODFSetting, group, wxT("GeneralsStoreDivisionalCouplers"));
+    ODFSetting, WX_ORGAN, wxT("GeneralsStoreDivisionalCouplers"));
   m_CombinationsStoreNonDisplayedDrawstops = cfg.ReadBoolean(
-    ODFSetting,
-    group,
-    wxT("CombinationsStoreNonDisplayedDrawstops"),
-    false,
-    true);
+    ODFSetting, WX_ORGAN, wxT("CombinationsStoreNonDisplayedDrawstops"));
 
   unsigned NumberOfWindchestGroups = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfWindchestGroups"), 1, 999);
+    ODFSetting, WX_ORGAN, wxT("NumberOfWindchestGroups"), 1, 999);
 
-  m_RootPipeConfigNode.Load(cfg, group, wxEmptyString);
+  m_RootPipeConfigNode.Load(cfg, WX_ORGAN, wxEmptyString);
   m_windchests.resize(0);
   for (unsigned i = 0; i < NumberOfWindchestGroups; i++)
     m_windchests.push_back(new GOWindchest(*organController));
 
   m_ODFManualCount
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfManuals"), 1, 16) + 1;
-  m_FirstManual = cfg.ReadBoolean(ODFSetting, group, wxT("HasPedals")) ? 0 : 1;
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfManuals"), 1, 16) + 1;
+  m_FirstManual
+    = cfg.ReadBoolean(ODFSetting, WX_ORGAN, wxT("HasPedals")) ? 0 : 1;
 
   m_manuals.resize(0);
   m_manuals.resize(m_FirstManual); // Add empty slot for pedal, if necessary
@@ -82,7 +81,7 @@ void GOOrganModel::Load(
     m_manuals.push_back(new GOManual(organController));
 
   unsigned NumberOfEnclosures
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfEnclosures"), 0, 999);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfEnclosures"), 0, 999);
   m_enclosures.resize(0);
   for (unsigned i = 0; i < NumberOfEnclosures; i++) {
     m_enclosures.push_back(new GOEnclosure(*organController));
@@ -91,7 +90,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfSwitches
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfSwitches"), 0, 999, 0);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfSwitches"), 0, 999, 0);
   m_switches.resize(0);
   for (unsigned i = 0; i < NumberOfSwitches; i++) {
     m_switches.push_back(new GOSwitch(*organController));
@@ -99,7 +98,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfTremulants
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfTremulants"), 0, 10);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfTremulants"), 0, 10);
   for (unsigned i = 0; i < NumberOfTremulants; i++) {
     m_tremulants.push_back(new GOTremulant(*organController));
     m_tremulants[i]->Load(
@@ -110,8 +109,8 @@ void GOOrganModel::Load(
     m_windchests[i]->Load(
       cfg, wxString::Format(wxT("WindchestGroup%03d"), i + 1), i);
 
-  m_ODFRankCount
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfRanks"), 0, 999, false);
+  m_ODFRankCount = cfg.ReadInteger(
+    ODFSetting, WX_ORGAN, wxT("NumberOfRanks"), 0, 999, false);
   for (unsigned i = 0; i < m_ODFRankCount; i++) {
     m_ranks.push_back(new GORank(*organController));
     m_ranks[i]->Load(cfg, wxString::Format(wxT("Rank%03d"), i + 1), -1);
@@ -140,7 +139,7 @@ void GOOrganModel::Load(
       max_key - min_key);
 
   unsigned NumberOfReversiblePistons = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfReversiblePistons"), 0, 32);
+    ODFSetting, WX_ORGAN, wxT("NumberOfReversiblePistons"), 0, 32);
   m_pistons.resize(0);
   for (unsigned i = 0; i < NumberOfReversiblePistons; i++) {
     m_pistons.push_back(new GOPistonControl(*this));
@@ -149,7 +148,7 @@ void GOOrganModel::Load(
   }
 
   unsigned NumberOfDivisionalCouplers = cfg.ReadInteger(
-    ODFSetting, group, wxT("NumberOfDivisionalCouplers"), 0, 8);
+    ODFSetting, WX_ORGAN, wxT("NumberOfDivisionalCouplers"), 0, 8);
   m_DivisionalCoupler.resize(0);
   for (unsigned i = 0; i < NumberOfDivisionalCouplers; i++) {
     m_DivisionalCoupler.push_back(new GODivisionalCoupler(*organController));
@@ -157,15 +156,36 @@ void GOOrganModel::Load(
       cfg, wxString::Format(wxT("DivisionalCoupler%03d"), i + 1));
   }
 
-  organController->GetGeneralTemplate().InitGeneral();
+  for (unsigned i = 0; i < m_enclosures.size(); i++)
+    m_enclosures[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("E%d"), i)));
+
+  for (unsigned i = 0; i < m_switches.size(); i++)
+    m_switches[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("S%d"), i)));
+
+  for (unsigned i = 0; i < m_tremulants.size(); i++)
+    m_tremulants[i]->SetElementID(
+      GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
+}
+
+void GOOrganModel::LoadCmbButtons(
+  GOConfigReader &cfg, GOOrganController *organController) {
+  // Generals
   unsigned NumberOfGenerals
-    = cfg.ReadInteger(ODFSetting, group, wxT("NumberOfGenerals"), 0, 99);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfGenerals"), 0, 99);
+
+  m_GeneralTemplate.InitGeneral();
   m_generals.resize(0);
   for (unsigned i = 0; i < NumberOfGenerals; i++) {
-    m_generals.push_back(new GOGeneralButtonControl(
-      organController->GetGeneralTemplate(), organController, false));
+    m_generals.push_back(
+      new GOGeneralButtonControl(m_GeneralTemplate, organController, false));
     m_generals[i]->Load(cfg, wxString::Format(wxT("General%03d"), i + 1));
   }
+
+  // Divisionals
+  for (unsigned i = m_FirstManual; i < m_manuals.size(); i++)
+    m_manuals[i]->LoadDivisionals(cfg);
 }
 
 void GOOrganModel::SetOrganModelModified(bool modified) {

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -12,6 +12,7 @@
 
 #include "combinations/control/GOCombinationButtonSet.h"
 #include "combinations/control/GOCombinationControllerProxy.h"
+#include "combinations/model/GOCombinationDefinition.h"
 #include "midi/GOMidiSendProxy.h"
 #include "midi/dialog-creator/GOMidiDialogCreatorProxy.h"
 #include "modification/GOModificationProxy.h"
@@ -38,9 +39,10 @@ class GOOrganModel : private GOCombinationButtonSet,
                      public GOMidiDialogCreatorProxy,
                      public GOMidiSendProxy {
 private:
-  GOModificationProxy m_ModificationProxy;
-
   GOConfig &m_config;
+
+  GOModificationProxy m_ModificationProxy;
+  GOCombinationDefinition m_GeneralTemplate;
 
   bool m_DivisionalsStoreIntermanualCouplers;
   bool m_DivisionalsStoreIntramanualCouplers;
@@ -69,6 +71,13 @@ protected:
   void Load(GOConfigReader &cfg, GOOrganController *organController);
 
   /**
+   * Called after Load() and InitCmbTemplates();
+   * Init general and divisional templates
+   * Load generals and divisionals from ODF/cmb
+   */
+  void LoadCmbButtons(GOConfigReader &cfg, GOOrganController *organController);
+
+  /**
    * Update all generals buttons light.
    * @param buttonToLight - the button that should be lighted on. All other
    *   divisionals are lighted off
@@ -85,6 +94,10 @@ public:
   GOConfig &GetConfig() { return m_config; }
 
   unsigned GetRecorderElementID(const wxString &name);
+
+  const GOCombinationDefinition &GetGeneralTemplate() const {
+    return m_GeneralTemplate;
+  }
 
   /* combinations properties */
   bool DivisionalsStoreIntermanualCouplers() const {


### PR DESCRIPTION
This is a new PR instead of https://github.com/GrandOrgue/grandorgue/pull/1576

In order to eliminating usage of GOOrganController I moved storing and initialisation of GOGeneralCombination GODivisionalCombination from GOOrganController to GOOrganModel.

It is just refactoring. No GO controller should be changed.

After merging https://github.com/GrandOrgue/grandorgue/pull/1580 the capability of saving virtual coupler states are saved correctly with this PR.