### PR TITLE
Correct window icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed incorrect window icon and migrated GOMidiListDialog from wxDialog to GOSimpleDialog https://github.com/GrandOrgue/grandorgue/pull/1587
 - Fixed absence of the Help button on the Organ Setting dialog https://github.com/GrandOrgue/grandorgue/issues/1416
 - Fixed displaying buttons if the manual is not visible https://github.com/GrandOrgue/grandorgue/issues/1566
 - Changed the default value of the CombinationsStoreNonDisplayedDrawstops ODF settings to false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Fixed incorrect window icon and migrated GOMidiListDialog from wxDialog to GOSimpleDialog https://github.com/GrandOrgue/grandorgue/pull/1587
+- Fixed an incorrect dialog window icon
 - Fixed absence of the Help button on the Organ Setting dialog https://github.com/GrandOrgue/grandorgue/issues/1416
 - Fixed displaying buttons if the manual is not visible https://github.com/GrandOrgue/grandorgue/issues/1566
 - Changed the default value of the CombinationsStoreNonDisplayedDrawstops ODF settings to false

--- a/src/grandorgue/dialogs/GOMidiListDialog.cpp
+++ b/src/grandorgue/dialogs/GOMidiListDialog.cpp
@@ -15,12 +15,11 @@
 
 #include "GOEvent.h"
 
-BEGIN_EVENT_TABLE(GOMidiListDialog, wxDialog)
+BEGIN_EVENT_TABLE(GOMidiListDialog, GOSimpleDialog)
 EVT_LIST_ITEM_SELECTED(ID_LIST, GOMidiListDialog::OnObjectClick)
 EVT_LIST_ITEM_ACTIVATED(ID_LIST, GOMidiListDialog::OnObjectDoubleClick)
 EVT_BUTTON(ID_STATUS, GOMidiListDialog::OnStatus)
 EVT_BUTTON(ID_EDIT, GOMidiListDialog::OnEdit)
-EVT_BUTTON(wxID_OK, GOMidiListDialog::OnOK)
 EVT_COMMAND_RANGE(
   ID_BUTTON, ID_BUTTON_LAST, wxEVT_BUTTON, GOMidiListDialog::OnButton)
 END_EVENT_TABLE()
@@ -29,13 +28,12 @@ GOMidiListDialog::GOMidiListDialog(
   GODocumentBase *doc,
   wxWindow *parent,
   const std::vector<GOMidiConfigurator *> &midi_elements)
-  : wxDialog(
+  : GOSimpleDialog(
     parent,
-    wxID_ANY,
+    wxT("MIDI Objects"),
     _("MIDI Objects"),
-    wxDefaultPosition,
-    wxDefaultSize,
-    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+    0,
+    wxOK | wxHELP),
     GOView(doc, this) {
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   topSizer->AddSpacer(5);
@@ -66,8 +64,6 @@ GOMidiListDialog::GOMidiListDialog(
   m_Status = new wxButton(this, ID_STATUS, _("&Status"));
   m_Status->Disable();
   buttons->Add(m_Status);
-  wxButton *close = new wxButton(this, wxID_OK, _("&Close"));
-  buttons->Add(close);
   topSizer->Add(buttons, 0, wxALIGN_RIGHT | wxALL, 1);
 
   for (unsigned i = 0; i < midi_elements.size(); i++) {
@@ -82,8 +78,8 @@ GOMidiListDialog::GOMidiListDialog(
   m_Objects->SetColumnWidth(1, wxLIST_AUTOSIZE);
 
   topSizer->AddSpacer(5);
-  this->SetSizer(topSizer);
   topSizer->Fit(this);
+  LayoutWithInnerSizer(topSizer);
 }
 
 GOMidiListDialog::~GOMidiListDialog() {}
@@ -103,8 +99,6 @@ void GOMidiListDialog::OnStatus(wxCommandEvent &event) {
     obj->GetMidiType() + _(" ") + obj->GetMidiName(),
     wxOK);
 }
-
-void GOMidiListDialog::OnOK(wxCommandEvent &event) { Destroy(); }
 
 void GOMidiListDialog::OnObjectClick(wxListEvent &event) {
   m_Edit->Enable();

--- a/src/grandorgue/dialogs/GOMidiListDialog.cpp
+++ b/src/grandorgue/dialogs/GOMidiListDialog.cpp
@@ -29,11 +29,7 @@ GOMidiListDialog::GOMidiListDialog(
   wxWindow *parent,
   const std::vector<GOMidiConfigurator *> &midi_elements)
   : GOSimpleDialog(
-    parent,
-    wxT("MIDI Objects"),
-    _("MIDI Objects"),
-    0,
-    wxOK | wxHELP),
+    parent, wxT("MIDI Objects"), _("MIDI Objects"), 0, wxOK | wxHELP),
     GOView(doc, this) {
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   topSizer->AddSpacer(5);

--- a/src/grandorgue/dialogs/GOMidiListDialog.cpp
+++ b/src/grandorgue/dialogs/GOMidiListDialog.cpp
@@ -78,7 +78,6 @@ GOMidiListDialog::GOMidiListDialog(
   m_Objects->SetColumnWidth(1, wxLIST_AUTOSIZE);
 
   topSizer->AddSpacer(5);
-  topSizer->Fit(this);
   LayoutWithInnerSizer(topSizer);
 }
 

--- a/src/grandorgue/dialogs/GOMidiListDialog.h
+++ b/src/grandorgue/dialogs/GOMidiListDialog.h
@@ -10,8 +10,7 @@
 
 #include <vector>
 
-#include <wx/dialog.h>
-
+#include "common/GOSimpleDialog.h"
 #include "document-base/GOView.h"
 
 class wxButton;
@@ -20,7 +19,7 @@ class wxListView;
 
 class GOMidiConfigurator;
 
-class GOMidiListDialog : public wxDialog, public GOView {
+class GOMidiListDialog : public GOSimpleDialog, public GOView {
 private:
   wxListView *m_Objects;
   wxButton *m_Edit;
@@ -38,7 +37,6 @@ private:
   void OnObjectClick(wxListEvent &event);
   void OnObjectDoubleClick(wxListEvent &event);
   void OnEdit(wxCommandEvent &event);
-  void OnOK(wxCommandEvent &event);
   void OnStatus(wxCommandEvent &event);
   void OnButton(wxCommandEvent &event);
 

--- a/src/grandorgue/dialogs/common/GODialog.h
+++ b/src/grandorgue/dialogs/common/GODialog.h
@@ -10,10 +10,10 @@
 
 #include <wx/sizer.h>
 
+#include "gui/primitives/go_gui_utils.h"
 #include "help/GOHelpRequestor.h"
 
 #include "GODialogCloser.h"
-#include "gui/primitives/go_gui_utils.h"
 
 class wxSizer;
 

--- a/src/grandorgue/dialogs/common/GODialog.h
+++ b/src/grandorgue/dialogs/common/GODialog.h
@@ -38,7 +38,8 @@ protected:
     wxWindow *win,
     const wxString &name,  // not translated
     const wxString &title, // translated
-    long addStyle = 0)
+    long addStyle = 0,
+    long buttonFlags = wxOK | wxCANCEL | wxHELP)
     : DialogClass(
       win,
       wxID_ANY,
@@ -48,8 +49,8 @@ protected:
       wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | addStyle),
       GODialogCloser(this),
       m_name(name) {
-    SetIcon(get_go_icon());
-    p_ButtonSizer = wxDialog::CreateButtonSizer(wxOK | wxCANCEL | wxHELP);
+    wxDialog::SetIcon(get_go_icon());
+    p_ButtonSizer = wxDialog::CreateButtonSizer(buttonFlags);
   }
 
   wxSizer *GetButtonSizer() const { return p_ButtonSizer; }

--- a/src/grandorgue/dialogs/common/GODialog.h
+++ b/src/grandorgue/dialogs/common/GODialog.h
@@ -13,6 +13,7 @@
 #include "help/GOHelpRequestor.h"
 
 #include "GODialogCloser.h"
+#include "gui/primitives/go_gui_utils.h"
 
 class wxSizer;
 
@@ -47,6 +48,7 @@ protected:
       wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | addStyle),
       GODialogCloser(this),
       m_name(name) {
+    SetIcon(get_go_icon());
     p_ButtonSizer = wxDialog::CreateButtonSizer(wxOK | wxCANCEL | wxHELP);
   }
 

--- a/src/grandorgue/dialogs/common/GOSimpleDialog.h
+++ b/src/grandorgue/dialogs/common/GOSimpleDialog.h
@@ -21,8 +21,9 @@ protected:
     wxWindow *win,
     const wxString &name,  // not translated
     const wxString &title, // translated
-    long addStyle = 0)
-    : GODialog(win, name, title, addStyle) {}
+    long addStyle = 0,
+    long buttonFlags = wxOK | wxCANCEL | wxHELP)
+    : GODialog(win, name, title, addStyle, buttonFlags) {}
 
   void LayoutWithInnerSizer(wxSizer *pInnerSizer);
 };


### PR DESCRIPTION
Some windows, e.g. the MIDI Objects, Settings or Organ settings window, used a default icon instead of the GO icon, which is fixed by this PR.

Before:
![image](https://github.com/GrandOrgue/grandorgue/assets/15248220/263d9ed0-8048-46a9-a863-656f18db425c)

After:
![image](https://github.com/GrandOrgue/grandorgue/assets/15248220/b78f0b5d-038a-42b6-a74b-1921832654e5)
