### PR TITLE
Added the global function get_go_icon

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -96,6 +96,7 @@ document-base/GOView.cpp
 gui/primitives/GOBitmap.cpp
 gui/primitives/GODC.cpp
 gui/primitives/GOFont.cpp
+gui/primitives/go_gui_utils.cpp
 gui/GOGUIBankedGeneralsPanel.cpp
 gui/GOGUIButton.cpp
 gui/GOGUICrescendoPanel.cpp

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -11,7 +11,6 @@
 #include <wx/display.h>
 #include <wx/fileconf.h>
 #include <wx/filedlg.h>
-#include <wx/icon.h>
 #include <wx/image.h>
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
@@ -33,6 +32,7 @@
 #include "dialogs/settings/GOSettingsReason.h"
 #include "files/GOStdFileName.h"
 #include "gui/GOGUIPanel.h"
+#include "gui/primitives/go_gui_utils.h"
 #include "help/GOHelpRequestor.h"
 #include "midi/GOMidi.h"
 #include "midi/GOMidiEvent.h"
@@ -153,9 +153,7 @@ GOFrame::GOFrame(
     m_AfterSettingsEventType(wxEVT_NULL),
     m_AfterSettingsEventId(0),
     p_AfterSettingsEventOrgan(NULL) {
-  wxIcon icon;
-  icon.CopyFromBitmap(GetImage_GOIcon());
-  SetIcon(icon);
+  SetIcon(get_go_icon());
 
   wxArrayString choices;
 

--- a/src/grandorgue/GOPanelView.cpp
+++ b/src/grandorgue/GOPanelView.cpp
@@ -9,12 +9,11 @@
 
 #include <wx/display.h>
 #include <wx/frame.h>
-#include <wx/icon.h>
 #include <wx/image.h>
 
-#include "Images.h"
 #include "gui/GOGUIPanel.h"
 #include "gui/GOGUIPanelWidget.h"
+#include "gui/primitives/go_gui_utils.h"
 
 BEGIN_EVENT_TABLE(GOPanelView, wxScrolledWindow)
 EVT_SIZE(GOPanelView::OnSize)
@@ -35,9 +34,7 @@ GOPanelView *GOPanelView::createWithFrame(
   // We probably should change this to add black borders to it. Also, for these
   // platforms a full-screen mode would be beneficial (on MacOS is already
   // works).
-  wxIcon icon;
-  icon.CopyFromBitmap(GetImage_GOIcon());
-  frame->SetIcon(icon);
+  frame->SetIcon(get_go_icon());
   return new GOPanelView(doc, panel, frame);
 }
 

--- a/src/grandorgue/gui/GOGUIButton.cpp
+++ b/src/grandorgue/gui/GOGUIButton.cpp
@@ -12,12 +12,12 @@
 #include "config/GOConfigReader.h"
 #include "control/GOButtonControl.h"
 #include "primitives/GODC.h"
+#include "primitives/go_gui_utils.h"
 
 #include "GOGUIDisplayMetrics.h"
 #include "GOGUILayoutEngine.h"
 #include "GOGUIMouseState.h"
 #include "GOGUIPanel.h"
-#include "go_gui_utils.h"
 
 GOGUIButton::GOGUIButton(
   GOGUIPanel *panel, GOButtonControl *control, bool is_piston)

--- a/src/grandorgue/gui/GOGUIEnclosure.cpp
+++ b/src/grandorgue/gui/GOGUIEnclosure.cpp
@@ -12,12 +12,12 @@
 #include "config/GOConfigReader.h"
 #include "model/GOEnclosure.h"
 #include "primitives/GODC.h"
+#include "primitives/go_gui_utils.h"
 
 #include "GOGUIDisplayMetrics.h"
 #include "GOGUILayoutEngine.h"
 #include "GOGUIMouseState.h"
 #include "GOGUIPanel.h"
-#include "go_gui_utils.h"
 
 GOGUIEnclosure::GOGUIEnclosure(GOGUIPanel *panel, GOEnclosure *control)
   : GOGUIControl(panel, control),

--- a/src/grandorgue/gui/GOGUIHW1DisplayMetrics.cpp
+++ b/src/grandorgue/gui/GOGUIHW1DisplayMetrics.cpp
@@ -8,8 +8,7 @@
 #include "GOGUIHW1DisplayMetrics.h"
 
 #include "config/GOConfigReader.h"
-
-#include "go_gui_utils.h"
+#include "primitives/go_gui_utils.h"
 
 GOGUIHW1DisplayMetrics::GOGUIHW1DisplayMetrics(
   GOConfigReader &ini, wxString group)

--- a/src/grandorgue/gui/GOGUILabel.cpp
+++ b/src/grandorgue/gui/GOGUILabel.cpp
@@ -12,12 +12,12 @@
 #include "control/GOLabelControl.h"
 #include "primitives/GOBitmap.h"
 #include "primitives/GODC.h"
+#include "primitives/go_gui_utils.h"
 
 #include "GOGUIDisplayMetrics.h"
 #include "GOGUILayoutEngine.h"
 #include "GOGUIPanel.h"
 #include "GOOrganController.h"
-#include "go_gui_utils.h"
 
 GOGUILabel::GOGUILabel(GOGUIPanel *panel, GOLabelControl *label)
   : GOGUIControl(panel, label),

--- a/src/grandorgue/gui/GOGUISequencerPanel.cpp
+++ b/src/grandorgue/gui/GOGUISequencerPanel.cpp
@@ -10,6 +10,7 @@
 #include <wx/intl.h>
 
 #include "combinations/GOSetter.h"
+#include "primitives/go_gui_utils.h"
 
 #include "GOGUIButton.h"
 #include "GOGUIHW1Background.h"
@@ -17,8 +18,6 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
-
-#include "go_gui_utils.h"
 
 GOGUISequencerPanel::GOGUISequencerPanel(GOOrganController *organController)
   : m_OrganController(organController) {}

--- a/src/grandorgue/gui/primitives/go_gui_utils.cpp
+++ b/src/grandorgue/gui/primitives/go_gui_utils.cpp
@@ -7,6 +7,7 @@
 
 #include "go_gui_utils.h"
 
+#include <wx/bitmap.h>
 #include <wx/icon.h>
 #include <wx/image.h>
 
@@ -17,7 +18,9 @@ static wxIcon go_icon;
 
 static void assure_initialised() {
   if (!has_initialised) {
-    go_icon.CopyFromBitmap(GetImage_GOIcon());
+    wxBitmap iconBitmap(GetImage_GOIcon());
+
+    go_icon.CopyFromBitmap(iconBitmap);
     has_initialised = true;
   }
 }

--- a/src/grandorgue/gui/primitives/go_gui_utils.cpp
+++ b/src/grandorgue/gui/primitives/go_gui_utils.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "go_gui_utils.h"
+
+#include <wx/icon.h>
+
+#include "Images.h"
+
+static bool has_initialised = false;
+static wxIcon go_icon;
+
+static void assure_initialised() {
+  if (!has_initialised) {
+    go_icon.CopyFromBitmap(GetImage_GOIcon());
+    has_initialised = true;
+  }
+}
+
+const wxIcon &get_go_icon() {
+  assure_initialised();
+  return go_icon;
+}

--- a/src/grandorgue/gui/primitives/go_gui_utils.cpp
+++ b/src/grandorgue/gui/primitives/go_gui_utils.cpp
@@ -8,6 +8,7 @@
 #include "go_gui_utils.h"
 
 #include <wx/icon.h>
+#include <wx/image.h>
 
 #include "Images.h"
 

--- a/src/grandorgue/gui/primitives/go_gui_utils.h
+++ b/src/grandorgue/gui/primitives/go_gui_utils.h
@@ -12,8 +12,12 @@
 
 #include "GOLogicalColour.h"
 
+class wxIcon;
+
 inline wxColour logicalToWxColour(const GOLogicalColour &lc) {
   return wxColour(lc.m_red, lc.m_green, lc.m_blue);
 }
+
+extern const wxIcon &get_go_icon();
 
 #endif /* GO_GUI_UTILS_H */


### PR DESCRIPTION
This PR
1. Moves `src/grandorgue/gui/go_gui_utils.h` to the `src/grandorgue/gui/primitives` directory
2. Moved initialisation of the GO application icon from several places to the new function `get_go_icon`
