### PR TITLE
Fixed absence of the Help button on the Organ Setting dialog https://github.com/GrandOrgue/grandorgue/issues/1416

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed absence of the Help button on the Organ Setting dialog https://github.com/GrandOrgue/grandorgue/issues/1416
 - Fixed displaying buttons if the manual is not visible https://github.com/GrandOrgue/grandorgue/issues/1566
 - Changed the default value of the CombinationsStoreNonDisplayedDrawstops ODF settings to false
 - Fixed capability of running on MacOs 11.3

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -68,6 +68,7 @@ control/GOLabelControl.cpp
 control/GOPistonControl.cpp
 dialogs/common/GODialogCloser.cpp
 dialogs/common/GODialogTab.cpp
+dialogs/common/GOSimpleDialog.cpp
 dialogs/common/GOTabbedDialog.cpp
 dialogs/midi-event/GOMidiEventDialog.cpp
 dialogs/midi-event/GOMidiEventKeyTab.cpp

--- a/src/grandorgue/dialogs/GOOrganDialog.h
+++ b/src/grandorgue/dialogs/GOOrganDialog.h
@@ -9,8 +9,8 @@
 #define GOORGANDIALOG_H
 
 #include <vector>
-#include <wx/dialog.h>
 
+#include "common/GOSimpleDialog.h"
 #include "document-base/GOView.h"
 
 class GOPipeConfigNode;
@@ -28,7 +28,7 @@ class wxTreeCtrl;
 class wxTreeEvent;
 class wxTreeItemId;
 
-class GOOrganDialog : public wxDialog, public GOView {
+class GOOrganDialog : public GOSimpleDialog, public GOView {
 private:
   GOOrganController *m_OrganController;
   wxTreeCtrl *m_Tree;
@@ -70,11 +70,7 @@ private:
   wxButton *m_Collapse;
   OrganTreeItemData *m_Last;
   unsigned m_LoadChangeCnt;
-  wxDialog *m_ModalDialog;
-  bool m_Destroying;
-  bool m_DestroyPending;
 
-  bool CloseModal();
   void FillTree();
   void Load();
   bool Changed();
@@ -86,6 +82,12 @@ private:
   void FillTree(wxTreeItemId parent, GOPipeConfigNode &config);
   void CloseTree(wxTreeItemId parent);
   void ResetSelectedToDefault(bool isForChildren);
+  /**
+   * Checks if all changes have been applied. If some unapplied changes are
+   * present, then display an error message.
+   * Returns if there are unapplied changes
+   */
+  bool CheckForUnapplied();
 
   void OnTreeChanging(wxTreeEvent &e);
   void OnTreeChanged(wxTreeEvent &e);
@@ -114,8 +116,6 @@ private:
   void OnEventReset(wxCommandEvent &e);
   void OnEventDefault(wxCommandEvent &e);
   void OnEventDefaultAll(wxCommandEvent &e);
-  void OnOK(wxCommandEvent &event);
-  void OnCancel(wxCommandEvent &event);
   void OnAudioGroupAssitant(wxCommandEvent &e);
   void OnCollapse(wxCommandEvent &e);
 
@@ -150,12 +150,12 @@ protected:
     ID_EVENT_COMPRESS
   };
 
+  bool Validate() override { return !CheckForUnapplied(); }
+
 public:
   GOOrganDialog(
     GODocumentBase *doc, wxWindow *parent, GOOrganController *organController);
-  ~GOOrganDialog();
-
-  bool Destroy();
+  virtual ~GOOrganDialog() {}
 
   DECLARE_EVENT_TABLE()
 };

--- a/src/grandorgue/dialogs/common/GOSimpleDialog.cpp
+++ b/src/grandorgue/dialogs/common/GOSimpleDialog.cpp
@@ -13,7 +13,7 @@
 void GOSimpleDialog::LayoutWithInnerSizer(wxSizer *pInnerSizer) {
   wxBoxSizer *const pTopSizer = new wxBoxSizer(wxVERTICAL);
 
-  pTopSizer->Add(pInnerSizer, 1, wxGROW | wxEXPAND | wxALL, 2);
+  pTopSizer->Add(pInnerSizer, 1, wxGROW | wxEXPAND | wxALL, 5);
   pTopSizer->Add(new wxStaticLine(this), 0, wxEXPAND | wxALL, 5);
   pTopSizer->Add(GetButtonSizer(), 0, wxEXPAND | wxALL, 5);
   SetSizerAndFit(pTopSizer);

--- a/src/grandorgue/dialogs/common/GOSimpleDialog.cpp
+++ b/src/grandorgue/dialogs/common/GOSimpleDialog.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSimpleDialog.h"
+
+#include <wx/sizer.h>
+#include <wx/statline.h>
+
+void GOSimpleDialog::LayoutWithInnerSizer(wxSizer *pInnerSizer) {
+  wxBoxSizer *const pTopSizer = new wxBoxSizer(wxVERTICAL);
+
+  pTopSizer->Add(pInnerSizer, 1, wxGROW | wxEXPAND | wxALL, 2);
+  pTopSizer->Add(new wxStaticLine(this), 0, wxEXPAND | wxALL, 5);
+  pTopSizer->Add(GetButtonSizer(), 0, wxEXPAND | wxALL, 5);
+  SetSizerAndFit(pTopSizer);
+}

--- a/src/grandorgue/dialogs/common/GOSimpleDialog.h
+++ b/src/grandorgue/dialogs/common/GOSimpleDialog.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSIMPLEDIALOG_H
+#define GOSIMPLEDIALOG_H
+
+#include <wx/dialog.h>
+
+#include "GODialog.h"
+
+class wxSizer;
+
+class GOSimpleDialog : public GODialog<wxDialog> {
+private:
+protected:
+  GOSimpleDialog(
+    wxWindow *win,
+    const wxString &name,  // not translated
+    const wxString &title, // translated
+    long addStyle = 0)
+    : GODialog(win, name, title, addStyle) {}
+
+  void LayoutWithInnerSizer(wxSizer *pInnerSizer);
+};
+
+#endif /* GOSIMPLEDIALOG_H */


### PR DESCRIPTION
Resolves: #1416

This PR adds the `Help` capability to the Organ Settings Dialog.

For this GOOrganDialog is made as a subclass of `GODialog`. An intermediate subclass `GOSimpleDialog` (in opposit to `GOTabbedDialog`) has been added.

Using a common base `GODialog` allowed to remove a lot of code from `GOOrganDialog` itself.
