### PR TITLE
Fix GCC 12 compiler warnings

### DIFF
--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -242,7 +242,7 @@ inline void GOAudioSection::MonoUncompressedLinear(
 template <class T>
 inline void GOAudioSection::StereoUncompressedLinear(
   audio_section_stream *stream, float *output, unsigned int n_blocks) {
-  typedef T stereoSample[0][2];
+  typedef T stereoSample[][2];
 
   // "borrow" the output buffer to compute release alignment info
   stereoSample &input = (stereoSample &)*(T *)(stream->ptr);
@@ -305,7 +305,7 @@ inline void GOAudioSection::MonoUncompressedPolyphase(
 template <class T>
 inline void GOAudioSection::StereoUncompressedPolyphase(
   audio_section_stream *stream, float *output, unsigned int n_blocks) {
-  typedef T stereoSample[0][2];
+  typedef T stereoSample[][2];
 
   // copy the sample buffer
   stereoSample &input = (stereoSample &)*(T *)(stream->ptr);


### PR DESCRIPTION
This PR fixes several compiler warnings generated by GCC 12 similar too:
```
src/grandorgue/sound/GOSoundAudioSection.cpp:261:14: warning: array subscript <unknown> is outside array bounds of ‘stereoSample’ {aka ‘GOInt24 [0][2]’} [-Warray-bounds]
  261 |       + input[pos + 1][0]
      |         ~~~~~^
```