### PR TITLE
GOProgressDialog: set icon

### DIFF
--- a/src/grandorgue/dialogs/GOProgressDialog.cpp
+++ b/src/grandorgue/dialogs/GOProgressDialog.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "GOProgressDialog.h"
+#include "gui/primitives/go_gui_utils.h"
 
 #include <wx/progdlg.h>
 #include <wx/stopwatch.h>
@@ -45,6 +46,7 @@ void GOProgressDialog::Setup(
     NULL,
     wxPD_CAN_ABORT | wxPD_APP_MODAL | wxPD_ELAPSED_TIME | wxPD_ESTIMATED_TIME
       | wxPD_REMAINING_TIME);
+  m_dlg->SetIcon(get_go_icon());
   m_last = 0;
   m_const = 0;
   m_value = 0;


### PR DESCRIPTION
This is a follow-up PR for #1587 (that's why I didn't mention it in the CHANGELOG). Since the constructor of `wxProgressDialog` has a different signature compared to `wxDialog`, it is not possible to inherit from `GODialog`.

Before:
![image](https://github.com/GrandOrgue/grandorgue/assets/15248220/17f47f9c-66f3-40c4-9a53-191efd07b7be)

After:
![image](https://github.com/GrandOrgue/grandorgue/assets/15248220/72c26b64-c1fc-46c2-a03b-526cada5264f)
