### PR TITLE
Fixed saving all combinations as full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed saving all combinations as full
 # 3.12.2 (2023-07-23)
 - Fixed size of the Organ Settings Dialog https://github.com/GrandOrgue/grandorgue/issues/1415
 - Fixed an incorrect dialog window icon

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -290,7 +290,7 @@ const wxString WX_HAS_SCOPE = wxT("HasScope");
 void GOCombination::LoadCombination(
   GOConfigReader &cfg, GOSettingType srcType) {
   Clear();
-  m_IsFull = cfg.ReadBoolean(srcType, m_group, WX_IS_FULL, false, true);
+  m_IsFull = cfg.ReadBoolean(srcType, m_group, WX_IS_FULL, false, false);
   LoadCombinationInt(cfg, srcType);
   m_HasScope = cfg.ReadBoolean(srcType, m_group, WX_HAS_SCOPE, false, false);
 }


### PR DESCRIPTION
Before this PR all combinations were errorneously saved to .yaml as `Full`