### PR TITLE
Passing GOManual instead of manualNumber into GOCombinationDefinition::InitDivisional

### DIFF
--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -95,31 +95,23 @@ void GOCombinationDefinition::InitGeneral() {
       i + 1);
 }
 
-void GOCombinationDefinition::InitDivisional(unsigned manual_number) {
-  GOManual *associatedManual = r_OrganModel.GetManual(manual_number);
+void GOCombinationDefinition::InitDivisional(GOManual &manual) {
+  unsigned manualN = manual.GetManulNumber();
+
   m_elements.resize(0);
 
-  for (unsigned i = 0; i < associatedManual->GetStopCount(); i++)
-    AddDivisional(
-      associatedManual->GetStop(i), COMBINATION_STOP, manual_number, i + 1);
+  for (unsigned i = 0; i < manual.GetStopCount(); i++)
+    AddDivisional(manual.GetStop(i), COMBINATION_STOP, manualN, i + 1);
 
-  for (unsigned i = 0; i < associatedManual->GetCouplerCount(); i++)
-    AddDivisional(
-      associatedManual->GetCoupler(i),
-      COMBINATION_COUPLER,
-      manual_number,
-      i + 1);
+  for (unsigned i = 0; i < manual.GetCouplerCount(); i++)
+    AddDivisional(manual.GetCoupler(i), COMBINATION_COUPLER, manualN, i + 1);
 
-  for (unsigned i = 0; i < associatedManual->GetTremulantCount(); i++)
+  for (unsigned i = 0; i < manual.GetTremulantCount(); i++)
     AddDivisional(
-      associatedManual->GetTremulant(i),
-      COMBINATION_TREMULANT,
-      manual_number,
-      i + 1);
+      manual.GetTremulant(i), COMBINATION_TREMULANT, manualN, i + 1);
 
-  for (unsigned i = 0; i < associatedManual->GetSwitchCount(); i++)
-    AddDivisional(
-      associatedManual->GetSwitch(i), COMBINATION_SWITCH, manual_number, i + 1);
+  for (unsigned i = 0; i < manual.GetSwitchCount(); i++)
+    AddDivisional(manual.GetSwitch(i), COMBINATION_SWITCH, manualN, i + 1);
 }
 
 int GOCombinationDefinition::FindElement(

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.h
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.h
@@ -62,7 +62,7 @@ public:
   GOOrganModel &GetOrganModel() { return r_OrganModel; }
 
   void InitGeneral();
-  void InitDivisional(unsigned manual_number);
+  void InitDivisional(GOManual &manual);
 
   const std::vector<Element> &GetElements() const { return m_elements; };
   int FindElement(ElementType type, int manual, unsigned index) const;

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -233,7 +233,7 @@ void GOManual::LoadDivisionals(GOConfigReader &cfg) {
     ODFSetting, m_group, wxT("NumberOfDivisionals"), 0, 999, false);
   wxString buffer;
 
-  m_DivisionalTemplate.InitDivisional(m_manual_number);
+  m_DivisionalTemplate.InitDivisional(*this);
   m_divisionals.resize(0);
   for (unsigned i = 0; i < nDivisionals; i++) {
     m_divisionals.push_back(

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -97,6 +97,9 @@ private:
 
 public:
   GOManual(GOOrganModel &organModel);
+
+  unsigned GetManulNumber() const { return m_manual_number; }
+
   void Init(
     GOConfigReader &cfg,
     wxString group,


### PR DESCRIPTION
This is the first PR related to #1599.

Because the combination systems requires more information from GOManual, not just it's number, I passed the reference to the manual to GOCombinationDefinition::InitDivisional.

It is just refactoring. No GO behavior should be changed.
