### PR TITLE
Added associating of a switch with a manual https://github.com/GrandOrgue/grandorgue/issues/1599

### DIFF
--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -64,7 +64,9 @@ private:
   int m_MIDIInputNumber;
 
   std::vector<unsigned> m_tremulant_ids;
-  std::vector<unsigned> m_switch_ids;
+
+  // Global Switch Id is the number of switch in ODF started with 1
+  std::vector<unsigned> m_GlobalSwitchIds;
 
   wxString m_name;
 
@@ -154,7 +156,7 @@ public:
    *   if the tremulant is not found
    */
   int FindTremulantByName(const wxString &name) const;
-  unsigned GetSwitchCount() const { return m_switch_ids.size(); }
+  unsigned GetSwitchCount() const { return m_GlobalSwitchIds.size(); }
   GOSwitch *GetSwitch(unsigned index);
   /**
    * Find a switch belonging to this manual by it's name

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -87,6 +87,8 @@ void GOOrganModel::Load(GOConfigReader &cfg) {
       cfg, wxString::Format(wxT("Enclosure%03u"), i + 1), i);
   }
 
+  // Switches must be loaded before manuals because manuals reference to
+  // switches
   unsigned NumberOfSwitches
     = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfSwitches"), 0, 999, 0);
   m_switches.resize(0);
@@ -114,6 +116,8 @@ void GOOrganModel::Load(GOConfigReader &cfg) {
     m_ranks[i]->Load(cfg, wxString::Format(wxT("Rank%03d"), i + 1), -1);
   }
 
+  // Switches must be loaded before manuals because manuals reference to
+  // switches
   for (unsigned int i = m_FirstManual; i < m_ODFManualCount; i++)
     m_manuals[i]->Load(cfg, wxString::Format(wxT("Manual%03d"), i), i);
 

--- a/src/grandorgue/model/GOSwitch.cpp
+++ b/src/grandorgue/model/GOSwitch.cpp
@@ -9,12 +9,9 @@
 
 #include <wx/intl.h>
 
-#include "GOOrganModel.h"
-
-GOSwitch::GOSwitch(GOOrganModel &organModel) : GODrawstop(organModel) {}
-
-GOSwitch::~GOSwitch() {}
-
-void GOSwitch::ChangeState(bool on) {}
+void GOSwitch::AssociateWithManual(int manualN, unsigned indexInManual) {
+  m_AssociatedManualN = m_AssociatedManualN < -1 ? manualN : -1;
+  m_IndexInManual = m_AssociatedManualN >= 0 ? indexInManual : 0;
+}
 
 wxString GOSwitch::GetMidiType() { return _("Drawstop"); }

--- a/src/grandorgue/model/GOSwitch.h
+++ b/src/grandorgue/model/GOSwitch.h
@@ -11,14 +11,28 @@
 #include "GODrawStop.h"
 
 class GOSwitch : public GODrawstop {
+  // the number of manual for mainual switches
+  // -2 global switches not referenced from manuals
+  // -1 global switches referenced from more than one manual
+
+  int m_AssociatedManualN = -2;
+  unsigned m_IndexInManual = 0;
+
 protected:
-  void ChangeState(bool);
+  void ChangeState(bool) override {}
 
 public:
-  GOSwitch(GOOrganModel &organModel);
-  ~GOSwitch();
+  GOSwitch(GOOrganModel &organModel) : GODrawstop(organModel) {}
 
-  wxString GetMidiType();
+  // Return -1 for all kinds of global switches
+  int GetAssociatedManualN() const { return std::max(m_AssociatedManualN, -1); }
+  unsigned GetIndexInManual() const { return m_IndexInManual; }
+
+  // Set m_AssociatedManualN.
+  // Check that the switch is referenced not more than once
+  void AssociateWithManual(int manualN, unsigned indexInManual);
+
+  wxString GetMidiType() override;
 };
 
 #endif


### PR DESCRIPTION
This is a second PR related to #1599.

As was discussed there, not all switches remain global. If a switch is referenced exactly from one manual, then it becomes owned by this manual.

This PR introduces two GOSwitch properties: `AssociatedManualN` and `IndexInManual` and the method `GOSwitch::AssociateWithManual`. It is called when the GOManual is read from ODF.

This PR also renames `GOManual::m_switch_ids` to `m_GlobalSwitchIds`.

The new properties are not used yet, so no GO behavior should be changed.