### PR TITLE
Increased maximum value of Pipe999LoopCrossfadeLength and Pipe999ReleaseCrossfadeLength. Now they are 3000 https://github.com/GrandOrgue/grandorgue/issues/1612

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Increased maximum value of Pipe999LoopCrossfadeLength and Pipe999ReleaseCrossfadeLength. Now they are 3000 https://github.com/GrandOrgue/grandorgue/issues/1612
 # 3.12.3 (2023-08-14)
 - Fixed saving manual switches as global in yaml https://github.com/GrandOrgue/grandorgue/issues/1599
 - Fixed convolution enabling warrning in the Settings dialog https://github.com/GrandOrgue/grandorgue/issues/1617

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -10312,7 +10312,7 @@ specified in samples.
           <term>Pipe999LoopCrossfadeLength</term>
           <listitem>
             <para>
-(integer 0 - 120, default: 0) Crossfade length in ms between loop start and loop
+(integer 0 - 3000, default: 0) Crossfade length in ms between loop start and loop
 end. A cross fade requires enough samples before the start of the loop.
             </para>
           </listitem>
@@ -10321,7 +10321,7 @@ end. A cross fade requires enough samples before the start of the loop.
           <term>Pipe999ReleaseCrossfadeLength</term>
           <listitem>
             <para>
-(integer 0 - 200, default: 0) Crossfade length in ms between loop and the
+(integer 0 - 3000, default: 0) Crossfade length in ms between loop and the
 release (or other attacks). 0 means automatic selection.
             </para>
           </listitem>

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -198,13 +198,13 @@ void GOSoundingPipe::Load(
     false,
     -1.0);
   m_LoopCrossfadeLength = cfg.ReadInteger(
-    ODFSetting, group, prefix + wxT("LoopCrossfadeLength"), 0, 120, false, 0);
+    ODFSetting, group, prefix + wxT("LoopCrossfadeLength"), 0, 3000, false, 0);
   m_ReleaseCrossfadeLength = cfg.ReadInteger(
     ODFSetting,
     group,
     prefix + wxT("ReleaseCrossfadeLength"),
     0,
-    200,
+    3000,
     false,
     0);
   m_RetunePipe = cfg.ReadBoolean(


### PR DESCRIPTION
Resolves #1612

Waits:
- [x] #1634