### PR TITLE
Fixed "Release Length is not valid" error when applying changes for several Organ Settings objects at once https://github.com/GrandOrgue/grandorgue/issues/1601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed "Release Length is not valid" error when applying changes for several Organ Settings objects at once https://github.com/GrandOrgue/grandorgue/issues/1601
 - Fixed saving all combinations as full
 # 3.12.2 (2023-07-23)
 - Fixed size of the Organ Settings Dialog https://github.com/GrandOrgue/grandorgue/issues/1415

--- a/src/grandorgue/dialogs/GOOrganDialog.cpp
+++ b/src/grandorgue/dialogs/GOOrganDialog.cpp
@@ -888,7 +888,12 @@ void GOOrganDialog::OnEventApply(wxCommandEvent &e) {
     return;
   }
 
-  if (!str_to_release_length(m_ReleaseLength->GetValue(), releaseLength)) {
+  const wxString releaseLengthStr = m_ReleaseLength->GetValue();
+  const bool isReleaseLengthPresent = !releaseLengthStr.IsEmpty();
+
+  if (
+    isReleaseLengthPresent
+    && !str_to_release_length(releaseLengthStr, releaseLength)) {
     GOMessageBox(
       _("Release Length is invalid"), _("Error"), wxOK | wxICON_ERROR, this);
     return;
@@ -911,7 +916,7 @@ void GOOrganDialog::OnEventApply(wxCommandEvent &e) {
       e->config->SetAutoTuningCorrection(autoTuningCorrection);
     if (m_Delay->IsModified())
       e->config->SetDelay(delay);
-    if (m_ReleaseLength->IsModified()) {
+    if (isReleaseLengthPresent && m_ReleaseLength->IsModified()) {
       long parentReleaseLength = parent ? parent->GetEffectiveReleaseTail() : 0;
       bool isLessThanParent = releaseLength > 0
         && (!parentReleaseLength || releaseLength < parentReleaseLength);


### PR DESCRIPTION
Resolves: #1601