### PR TITLE
Extracted saving panel size and position code into the separate class GOGUISizeKeeper

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -120,6 +120,7 @@ gui/GOGUIPanel.cpp
 gui/GOGUIPanelWidget.cpp
 gui/GOGUIRecorderPanel.cpp
 gui/GOGUISequencerPanel.cpp
+gui/GOGUISizeKeeper.cpp
 help/GOHelpController.cpp
 help/GOHelpRequestor.cpp
 loader/GOFileStore.cpp

--- a/src/grandorgue/GOPanelView.h
+++ b/src/grandorgue/GOPanelView.h
@@ -21,14 +21,13 @@ class GOPanelView : public wxScrolledWindow, public GOView {
 private:
   GOGUIPanelWidget *m_panelwidget;
   GOGUIPanel *m_panel;
-  wxTopLevelWindow
-    *m_TopWindow; // only if the parent is top level window, else NULL
+  wxTopLevelWindow *m_TopWindow;
   wxSize m_Scroll;
 
   void OnSize(wxSizeEvent &event);
 
 public:
-  GOPanelView(GODocumentBase *doc, GOGUIPanel *panel, wxWindow *parent);
+  GOPanelView(GODocumentBase *doc, GOGUIPanel *panel, wxTopLevelWindow *parent);
   ~GOPanelView();
 
   void AddEvent(GOGUIControl *control);

--- a/src/grandorgue/gui/GOGUIPanel.h
+++ b/src/grandorgue/gui/GOGUIPanel.h
@@ -15,7 +15,7 @@
 
 #include "primitives/GOBitmap.h"
 
-#include "GOSaveableObject.h"
+#include "GOGUISizeKeeper.h"
 
 class GOGUIControl;
 class GOGUIDisplayMetrics;
@@ -31,9 +31,10 @@ class GOOrganController;
 
 #define GOBitmapPrefix "../GO:"
 
-class GOGUIPanel : private GOSaveableObject {
+class GOGUIPanel : public GOGUISizeKeeper {
 private:
-  void ReadSizeInfoFromCfg(GOConfigReader &cfg, bool isOpenByDefault);
+  void BasicLoad(
+    GOConfigReader &cfg, const wxString &group, bool isOpenByDefault);
   void LoadButton(
     GOConfigReader &cfg,
     GOButtonControl *pButtonControl,
@@ -59,15 +60,12 @@ protected:
   GOGUIDisplayMetrics *m_metrics;
   GOGUILayoutEngine *m_layout;
   GOPanelView *m_view;
-  wxRect m_rect;
-  int m_DisplayNum;
-  bool m_IsMaximized;
   bool m_InitialOpenWindow;
 
   void LoadControl(GOGUIControl *control, GOConfigReader &cfg, wxString group);
   void LoadBackgroundControl(
     GOGUIControl *control, GOConfigReader &cfg, wxString group);
-  void Save(GOConfigWriter &cfg);
+  void Save(GOConfigWriter &cfg) override;
 
   GOGUIControl *CreateGUIElement(GOConfigReader &cfg, wxString group);
 
@@ -82,15 +80,18 @@ public:
     wxString name,
     wxString group,
     wxString group_name = wxT(""));
-  void Load(GOConfigReader &cfg, wxString group);
+  void Load(GOConfigReader &cfg, const wxString &group);
   void Layout();
 
   void SetView(GOPanelView *view);
 
   GOOrganController *GetOrganFile();
-  const wxString &GetGroup() { return m_group; }
   const wxString &GetName();
   const wxString &GetGroupName();
+
+  // gets the current size info of the window
+  virtual void CaptureSizeInfo(const wxTopLevelWindow &win) override;
+
   void AddEvent(GOGUIControl *control);
   void AddControl(GOGUIControl *control);
   GOGUIDisplayMetrics *GetDisplayMetrics();
@@ -109,12 +110,6 @@ public:
   unsigned GetHeight();
   bool InitialOpenWindow();
 
-  wxRect GetWindowRect();
-  void SetWindowRect(wxRect rect);
-  int GetDisplayNum() const { return m_DisplayNum; }
-  void SetDisplayNum(int displayNum) { m_DisplayNum = displayNum; }
-  bool IsMaximized() const { return m_IsMaximized; }
-  void SetMaximized(bool isMaximized) { m_IsMaximized = isMaximized; }
   void SetInitialOpenWindow(bool open);
 };
 

--- a/src/grandorgue/gui/GOGUISizeKeeper.cpp
+++ b/src/grandorgue/gui/GOGUISizeKeeper.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOGUISizeKeeper.h"
+
+#include <wx/display.h>
+#include <wx/toplevel.h>
+
+#include "config/GOConfigReader.h"
+#include "config/GOConfigWriter.h"
+
+constexpr static int windowLimit = 10000;
+
+const wxString WX_WINDOW_X = wxT("WindowX");
+const wxString WX_WINDOW_Y = wxT("WindowY");
+const wxString WX_WINDOW_WIDTH = wxT("WindowWidth");
+const wxString WX_WINDOW_HEIGHT = wxT("WindowHeight");
+const wxString WX_DISPLAY_NUMBER = wxT("DisplayNumber");
+const wxString WX_WINDOW_MAXIMIZED = wxT("WindowMaximized");
+
+// read the size info from config files
+void GOGUISizeKeeper::Load(GOConfigReader &cfg, const wxString &group) {
+  SetGroup(group);
+  int x = cfg.ReadInteger(
+    CMBSetting, m_group, WX_WINDOW_X, -windowLimit, windowLimit, false, 0);
+  int y = cfg.ReadInteger(
+    CMBSetting, m_group, WX_WINDOW_Y, -windowLimit, windowLimit, false, 0);
+  int w = cfg.ReadInteger(
+    CMBSetting, m_group, WX_WINDOW_WIDTH, 0, windowLimit, false, 0);
+  int h = cfg.ReadInteger(
+    CMBSetting, m_group, WX_WINDOW_HEIGHT, 0, windowLimit, false, 0);
+
+  m_rect = wxRect(x, y, w, h);
+  m_DisplayNum = cfg.ReadInteger(
+    CMBSetting, m_group, WX_DISPLAY_NUMBER, -1, windowLimit, false, -1);
+  m_IsMaximized
+    = cfg.ReadBoolean(CMBSetting, m_group, WX_WINDOW_MAXIMIZED, false, false);
+}
+
+// save the size info to the config file
+void GOGUISizeKeeper::Save(GOConfigWriter &cfg) {
+  cfg.WriteBoolean(m_group, WX_WINDOW_MAXIMIZED, m_IsMaximized);
+  if (m_DisplayNum >= 0)
+    cfg.WriteInteger(m_group, WX_DISPLAY_NUMBER, m_DisplayNum);
+
+  wxRect size = m_rect;
+
+  cfg.WriteInteger(
+    m_group,
+    WX_WINDOW_X,
+    std::min(windowLimit, std::max(-windowLimit, size.GetLeft())));
+  cfg.WriteInteger(
+    m_group,
+    WX_WINDOW_Y,
+    std::min(windowLimit, std::max(-windowLimit, size.GetTop())));
+  cfg.WriteInteger(
+    m_group, WX_WINDOW_WIDTH, std::min(windowLimit, size.GetWidth()));
+  cfg.WriteInteger(
+    m_group, WX_WINDOW_HEIGHT, std::min(windowLimit, size.GetHeight()));
+}
+
+// gets the current size info of the window
+void GOGUISizeKeeper::CaptureSizeInfo(const wxTopLevelWindow &win) {
+  m_rect = win.GetRect();
+  m_IsMaximized = win.IsMaximized();
+
+  // calculate the best display num
+  m_DisplayNum = wxDisplay::GetFromWindow(&win);
+  if (m_DisplayNum == wxNOT_FOUND)
+    // actually wxNOT_FOUND == -1, but we don't want to depend on it
+    m_DisplayNum = -1;
+  else if (!m_IsMaximized) {
+    // check that the window fits the display
+    // we do not check it for maximized window because their decoration may be
+    // outside the display
+    const wxDisplay display(m_DisplayNum);
+    const wxRect clientArea = display.GetClientArea();
+
+    if (!clientArea.Contains(m_rect))
+      // do not store the dispplay num if the window does not fit it
+      m_DisplayNum = -1;
+  }
+}
+
+// make the windows position and size as the stored size info
+void GOGUISizeKeeper::ApplySizeInfo(wxTopLevelWindow &win) {
+  // m_rect contains the position and size of the window as saved by the user
+  // previously, or otherwise its default values
+
+  // If both width and height are set, set position and size of the window
+  // E.g. in case of corrupted preferences, this might not be the case
+  if (!m_rect.IsEmpty())
+    win.SetSize(m_rect);
+
+  // However, even if this worked, we cannot be sure that the window is now
+  // fully within the client area of an existing display.
+  // For example, the user may have disconnected the display, or lowered its
+  // resolution. So, we need to get the client area of the desired display, or
+  // if it does not exist anymore, the client area of the default display
+  int nr = m_DisplayNum >= 0 && m_DisplayNum < (int)wxDisplay::GetCount()
+    ? m_DisplayNum
+    : wxDisplay::GetFromWindow(&win);
+
+  // Check if the window is visible. If not, center it at the first display
+  if (nr == wxNOT_FOUND) {
+    wxRect max = wxDisplay((unsigned)0).GetClientArea();
+    // If our current window is within this area, all is fine
+    wxRect current = win.GetRect();
+
+    if (!max.Contains(current)) {
+      // Otherwise, check and correct width and height,
+      // and place the frame at the center of the Client Area of the display
+      if (current.GetWidth() > max.GetWidth())
+        current.SetWidth(max.GetWidth());
+      if (current.GetHeight() > max.GetHeight())
+        current.SetHeight(max.GetHeight());
+      win.SetSize(current.CenterIn(max, wxBOTH));
+    }
+  }
+  win.Maximize(m_IsMaximized);
+}

--- a/src/grandorgue/gui/GOGUISizeKeeper.h
+++ b/src/grandorgue/gui/GOGUISizeKeeper.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOGUISIZEKEEPER_H
+#define GOGUISIZEKEEPER_H
+
+#include <wx/gdicmn.h>
+
+#include "GOSaveableObject.h"
+
+class wxTopLevelWindow;
+
+class GOConfigReader;
+class GOConfigWriter;
+
+/**
+ * Saving and restoring a window size info (position and size)
+ * and size in a config file.
+ * Note: not all window managers allows applications to control window positions
+ */
+class GOGUISizeKeeper : public GOSaveableObject {
+private:
+  wxRect m_rect = wxRect(wxDefaultPosition, wxDefaultSize);
+  int m_DisplayNum = -1;
+  bool m_IsMaximized = false;
+
+public:
+  const wxRect &GetWindowRect() const { return m_rect; }
+
+  void SetWindowRect(const wxRect &rect) { m_rect = rect; }
+
+  // set the group and read the size info from config files
+  virtual void Load(GOConfigReader &cfg, const wxString &group);
+
+  // save the size info to the config file
+  virtual void Save(GOConfigWriter &cfg) override;
+
+  // gets the current size info of the window
+  virtual void CaptureSizeInfo(const wxTopLevelWindow &win);
+
+  // make the windows position and size as the stored size info
+  void ApplySizeInfo(wxTopLevelWindow &win);
+};
+
+#endif /* GOGUISIZEKEEPER_H */


### PR DESCRIPTION
I've started working on #1035 (saving GOGUISizeKeeper dialog positions).

Before the all code of saving and sizing was in `GOPanelView` and `GOGUIPanel`. It worked only with GO panels and it couldn't be used for dialogs.

This PR extracted this code to the new class `GOGUISizeKeeper`, that will be used also for dialogs.

It is just refactoring. No GO behavior should be changed.

NB: if a panel was saved as maximized, it cann't be restored on gnome desktop on recent linux versions as like it didn't work before this PR. 