### PR TITLE
Fixed saving manual switches as global in yaml https://github.com/GrandOrgue/grandorgue/issues/1599

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed saving manual switches as global in yaml https://github.com/GrandOrgue/grandorgue/issues/1599
 - Fixed convolution enabling warrning in the Settings dialog https://github.com/GrandOrgue/grandorgue/issues/1617
 - Fixed "Release Length is not valid" error when applying changes for several Organ Settings objects at once https://github.com/GrandOrgue/grandorgue/issues/1601
 - Fixed saving all combinations as full

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -106,7 +106,8 @@ void GOCombination::SetStatesFromYaml(
       maxElementNumber = r_OrganModel.GetTremulantCount();
       break;
     case GOCombinationDefinition::COMBINATION_SWITCH:
-      maxElementNumber = r_OrganModel.GetSwitchCount();
+      maxElementNumber
+        = pManual ? pManual->GetSwitchCount() : r_OrganModel.GetSwitchCount();
       break;
     case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:
       maxElementNumber = r_OrganModel.GetDivisionalCouplerCount();
@@ -136,7 +137,9 @@ void GOCombination::SetStatesFromYaml(
           realElementName = r_OrganModel.GetTremulant(i)->GetName();
           break;
         case GOCombinationDefinition::COMBINATION_SWITCH:
-          realElementName = r_OrganModel.GetSwitch(i)->GetName();
+          realElementName
+            = (pManual ? pManual->GetSwitch(i) : r_OrganModel.GetSwitch(i))
+                ->GetName();
           break;
         case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:
           realElementName = r_OrganModel.GetDivisionalCoupler(i)->GetName();

--- a/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
+++ b/src/grandorgue/combinations/model/GOCombinationDefinition.cpp
@@ -84,8 +84,16 @@ void GOCombinationDefinition::InitGeneral() {
   for (unsigned i = 0; i < r_OrganModel.GetTremulantCount(); i++)
     AddGeneral(r_OrganModel.GetTremulant(i), COMBINATION_TREMULANT, -1, i + 1);
 
-  for (unsigned i = 0; i < r_OrganModel.GetSwitchCount(); i++)
-    AddGeneral(r_OrganModel.GetSwitch(i), COMBINATION_SWITCH, -1, i + 1);
+  for (unsigned i = 0; i < r_OrganModel.GetSwitchCount(); i++) {
+    GOSwitch *pSwitch = r_OrganModel.GetSwitch(i);
+    int manualN = pSwitch->GetAssociatedManualN();
+
+    AddGeneral(
+      pSwitch,
+      COMBINATION_SWITCH,
+      manualN,
+      (manualN >= 0 ? pSwitch->GetIndexInManual() : i) + 1);
+  }
 
   for (unsigned i = 0; i < r_OrganModel.GetDivisionalCouplerCount(); i++)
     AddGeneral(

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -202,8 +202,7 @@ void GODivisionalCombination::PutElementToYamlMap(
     break;
 
   case GOCombinationDefinition::COMBINATION_SWITCH:
-    yamlMap[SWITCHES][valueLabel]
-      = r_OrganModel.GetSwitch(objectIndex)->GetName();
+    yamlMap[SWITCHES][valueLabel] = manual.GetSwitch(objectIndex)->GetName();
     break;
 
   case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -38,6 +38,8 @@ void GOGeneralCombination::Load(GOConfigReader &cfg, const wxString &group) {
     LoadCombination(cfg, ODFSetting);
 }
 
+const wxString WX_SWITCH_MANUAL_03D = wxT("SwitchManual%03d");
+
 void GOGeneralCombination::LoadCombinationInt(
   GOConfigReader &cfg, GOSettingType srcType) {
   wxString buffer;
@@ -71,6 +73,7 @@ void GOGeneralCombination::LoadCombinationInt(
     0,
     r_OrganModel.GetDivisionalCouplerCount(),
     r_OrganModel.GeneralsStoreDivisionalCouplers());
+  unsigned maxManualN = r_OrganModel.GetManualAndPedalCount();
 
   for (unsigned i = 0; i < NumberOfStops; i++) {
     unsigned m = cfg.ReadInteger(
@@ -78,7 +81,7 @@ void GOGeneralCombination::LoadCombinationInt(
       m_group,
       wxString::Format(wxT("StopManual%03d"), i + 1),
       r_OrganModel.GetFirstManualIndex(),
-      r_OrganModel.GetManualAndPedalCount());
+      maxManualN);
 
     buffer.Printf(wxT("StopNumber%03d"), i + 1);
     SetLoadedState(
@@ -120,11 +123,34 @@ void GOGeneralCombination::LoadCombinationInt(
 
   cnt = r_OrganModel.GetSwitchCount();
   for (unsigned i = 0; i < NumberOfSwitches; i++) {
-    buffer.Printf(wxT("SwitchNumber%03d"), i + 1);
-    SetLoadedState(
+    int switchManualN = cfg.ReadInteger(
+      srcType,
+      m_group,
+      wxString::Format(WX_SWITCH_MANUAL_03D, i + 1),
       -1,
+      maxManualN,
+      false,
+      -1);
+
+    buffer.Printf(wxT("SwitchNumber%03d"), i + 1);
+
+    int switchNumber = cfg.ReadInteger(srcType, m_group, buffer, -cnt, cnt);
+
+    if (switchManualN < 0 && switchNumber != 0) {
+      // the switch has been saved as global. Try to convert it's number to a
+      // manual switch
+      GOSwitch *pSwitch = r_OrganModel.GetSwitch(abs(switchNumber) - 1);
+
+      switchManualN = pSwitch->GetAssociatedManualN();
+      if (switchManualN >= 0) // may be converted
+        switchNumber = (pSwitch->GetIndexInManual() + 1)
+          // copy the sign
+          * ((switchNumber > 0) - (switchNumber < 0));
+    }
+    SetLoadedState(
+      switchManualN,
       GOCombinationDefinition::COMBINATION_SWITCH,
-      cfg.ReadInteger(srcType, m_group, buffer, -cnt, cnt),
+      switchNumber,
       buffer);
   }
 
@@ -180,8 +206,14 @@ void GOGeneralCombination::SaveInt(GOConfigWriter &cfg) {
 
       case GOCombinationDefinition::COMBINATION_SWITCH:
         switch_count++;
-        buffer.Printf(wxT("SwitchNumber%03d"), switch_count);
-        cfg.WriteInteger(m_group, buffer, value);
+        cfg.WriteInteger(
+          m_group,
+          wxString::Format(WX_SWITCH_MANUAL_03D, switch_count),
+          e.manual);
+        cfg.WriteInteger(
+          m_group,
+          wxString::Format(wxT("SwitchNumber%03d"), switch_count),
+          value);
         break;
 
       case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:
@@ -243,8 +275,16 @@ void GOGeneralCombination::PutElementToYamlMap(
     break;
 
   case GOCombinationDefinition::COMBINATION_SWITCH:
-    yamlMap[SWITCHES][valueLabel]
-      = r_OrganModel.GetSwitch(objectIndex)->GetName();
+    if (e.manual >= 0) { // manual switch
+      GOManual &manual = *r_OrganModel.GetManual(e.manual);
+      YAML::Node manualNode = yamlMap[MANUALS][manualLabel];
+
+      manualNode[NAME] = manual.GetName();
+      manualNode[SWITCHES][valueLabel]
+        = manual.GetSwitch(objectIndex)->GetName();
+    } else // global switch
+      yamlMap[SWITCHES][valueLabel]
+        = r_OrganModel.GetSwitch(objectIndex)->GetName();
     break;
 
   case GOCombinationDefinition::COMBINATION_DIVISIONALCOUPLER:
@@ -276,6 +316,12 @@ void GOGeneralCombination::FromYamlMap(const YAML::Node &yamlMap) {
         manualEntry.second[COUPLERS],
         manualNum,
         GOCombinationDefinition::COMBINATION_COUPLER);
+
+      // manual switches
+      SetStatesFromYaml(
+        manualEntry.second[SWITCHES],
+        manualNum,
+        GOCombinationDefinition::COMBINATION_SWITCH);
     } else
       wxLogError(_("Invalid manual number %s"), manualNumStr);
   }
@@ -284,7 +330,7 @@ void GOGeneralCombination::FromYamlMap(const YAML::Node &yamlMap) {
   SetStatesFromYaml(
     yamlMap[TREMULANTS], -1, GOCombinationDefinition::COMBINATION_TREMULANT);
 
-  // switches
+  // global switches
   SetStatesFromYaml(
     yamlMap[SWITCHES], -1, GOCombinationDefinition::COMBINATION_SWITCH);
 


### PR DESCRIPTION
Resolves: #1599 

After this PR the switches referenced only from one manual start saving to .cmb and .yaml as manual switches instead of global ones.

When importing from .cmb and .yaml, both kinds of the switch references (global or manual) are supported.