### PR TITLE
Renamed midi_message_type to GOMidiEvent::MidiType

### DIFF
--- a/src/core/midi/GOMidiEvent.cpp
+++ b/src/core/midi/GOMidiEvent.cpp
@@ -13,7 +13,7 @@
 #include "GORodgers.h"
 
 GOMidiEvent::GOMidiEvent()
-  : m_miditype(MIDI_NONE),
+  : m_MidiType(MIDI_NONE),
     m_channel(-1),
     m_key(-1),
     m_value(-1),
@@ -22,7 +22,7 @@ GOMidiEvent::GOMidiEvent()
     m_data() {}
 
 GOMidiEvent::GOMidiEvent(const GOMidiEvent &e)
-  : m_miditype(e.m_miditype),
+  : m_MidiType(e.m_MidiType),
     m_channel(e.m_channel),
     m_key(e.m_key),
     m_value(e.m_value),

--- a/src/core/midi/GOMidiEvent.h
+++ b/src/core/midi/GOMidiEvent.h
@@ -9,33 +9,11 @@
 #define GOMIDIEVENT_H
 
 #include <cstdint>
-
 #include <vector>
 
 #include "GOTime.h"
 
 class GOMidiMap;
-
-typedef enum {
-  MIDI_NONE,
-  MIDI_RESET,
-  MIDI_NOTE,
-  MIDI_AFTERTOUCH,
-  MIDI_CTRL_CHANGE,
-  MIDI_PGM_CHANGE,
-  MIDI_RPN,
-  MIDI_NRPN,
-  MIDI_SYSEX_JOHANNUS_9,
-  MIDI_SYSEX_JOHANNUS_11,
-  MIDI_SYSEX_VISCOUNT,
-  MIDI_SYSEX_AHLBORN_GALANTI,
-  MIDI_SYSEX_GO_CLEAR,
-  MIDI_SYSEX_GO_SETUP,
-  MIDI_SYSEX_GO_SAMPLESET,
-  MIDI_SYSEX_HW_STRING,
-  MIDI_SYSEX_HW_LCD,
-  MIDI_SYSEX_RODGERS_STOP_CHANGE,
-} midi_message_type;
 
 #define MIDI_CTRL_BANK_SELECT_MSB 0
 #define MIDI_CTRL_BANK_SELECT_LSB 32
@@ -48,8 +26,30 @@ typedef enum {
 #define MIDI_CTRL_NOTES_OFF 123
 
 class GOMidiEvent {
+public:
+  enum MidiType {
+    MIDI_NONE,
+    MIDI_RESET,
+    MIDI_NOTE,
+    MIDI_AFTERTOUCH,
+    MIDI_CTRL_CHANGE,
+    MIDI_PGM_CHANGE,
+    MIDI_RPN,
+    MIDI_NRPN,
+    MIDI_SYSEX_JOHANNUS_9,
+    MIDI_SYSEX_JOHANNUS_11,
+    MIDI_SYSEX_VISCOUNT,
+    MIDI_SYSEX_AHLBORN_GALANTI,
+    MIDI_SYSEX_GO_CLEAR,
+    MIDI_SYSEX_GO_SETUP,
+    MIDI_SYSEX_GO_SAMPLESET,
+    MIDI_SYSEX_HW_STRING,
+    MIDI_SYSEX_HW_LCD,
+    MIDI_SYSEX_RODGERS_STOP_CHANGE,
+  };
+
 private:
-  midi_message_type m_miditype;
+  MidiType m_MidiType;
   int m_channel, m_key, m_value;
   unsigned m_device;
   GOTime m_time;
@@ -60,8 +60,8 @@ public:
   GOMidiEvent();
   GOMidiEvent(const GOMidiEvent &e);
 
-  midi_message_type GetMidiType() const { return m_miditype; }
-  void SetMidiType(midi_message_type t) { m_miditype = t; }
+  MidiType GetMidiType() const { return m_MidiType; }
+  void SetMidiType(MidiType t) { m_MidiType = t; }
 
   void SetDevice(unsigned dev) { m_device = dev; }
 

--- a/src/core/midi/GOMidiFileReader.cpp
+++ b/src/core/midi/GOMidiFileReader.cpp
@@ -312,7 +312,7 @@ bool GOMidiFileReader::ReadEvent(GOMidiEvent &e) {
 
     e.FromMidi(msg, m_Map);
     e.SetTime(m_LastTime);
-    if (e.GetMidiType() != MIDI_NONE)
+    if (e.GetMidiType() != GOMidiEvent::MIDI_NONE)
       return true;
   } while (true);
 }

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -454,12 +454,13 @@ GOMidiMatchType GOMidiReceiverBase::Match(const GOMidiEvent &e, int &value) {
 
 GOMidiMatchType GOMidiReceiverBase::Match(
   const GOMidiEvent &e, const unsigned midi_map[128], int &key, int &value) {
-  value = 0;
+  const GOMidiEvent::MidiType eMidiType = e.GetMidiType();
 
+  value = 0;
   if (
-    e.GetMidiType() == MIDI_SYSEX_GO_CLEAR
-    || e.GetMidiType() == MIDI_SYSEX_GO_SAMPLESET) {
-    if (e.GetMidiType() == MIDI_SYSEX_GO_CLEAR && e.GetChannel() == 0)
+    eMidiType == GOMidiEvent::MIDI_SYSEX_GO_CLEAR
+    || eMidiType == GOMidiEvent::MIDI_SYSEX_GO_SAMPLESET) {
+    if (eMidiType == GOMidiEvent::MIDI_SYSEX_GO_CLEAR && e.GetChannel() == 0)
       deleteInternal(e.GetDevice());
     else {
       unsigned pos = createInternal(e.GetDevice());
@@ -467,7 +468,7 @@ GOMidiMatchType GOMidiReceiverBase::Match(
     }
     return MIDI_MATCH_NONE;
   }
-  if (e.GetMidiType() == MIDI_SYSEX_GO_SETUP) {
+  if (eMidiType == GOMidiEvent::MIDI_SYSEX_GO_SETUP) {
     if (m_ElementID == -1)
       return MIDI_MATCH_NONE;
     if (m_ElementID != e.GetKey())
@@ -483,7 +484,7 @@ GOMidiMatchType GOMidiReceiverBase::Match(
     if (m_Internal[i].device == e.GetDevice()) {
       if (m_type == MIDI_RECV_MANUAL) {
         if (
-          e.GetMidiType() == MIDI_NOTE
+          eMidiType == GOMidiEvent::MIDI_NOTE
           && e.GetChannel() == m_Internal[i].channel) {
           key = e.GetKey() + GetTranspose();
           value = e.GetValue();
@@ -498,13 +499,13 @@ GOMidiMatchType GOMidiReceiverBase::Match(
         }
 
         if (
-          e.GetMidiType() == MIDI_CTRL_CHANGE
+          eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
           && e.GetKey() == MIDI_CTRL_NOTES_OFF
           && e.GetChannel() == m_Internal[i].channel)
           return MIDI_MATCH_RESET;
       } else {
         if (
-          e.GetMidiType() == MIDI_NRPN
+          eMidiType == GOMidiEvent::MIDI_NRPN
           && e.GetChannel() == m_Internal[i].channel
           && e.GetKey() == m_Internal[i].key) {
           value = e.GetValue();
@@ -533,7 +534,9 @@ GOMidiMatchType GOMidiReceiverBase::Match(
         && m_events[i].type != MIDI_M_NOTE_SHORT_OCTAVE
         && m_events[i].type != MIDI_M_NOTE_NORMAL)
         continue;
-      if (e.GetMidiType() == MIDI_NOTE || e.GetMidiType() == MIDI_AFTERTOUCH) {
+      if (
+        eMidiType == GOMidiEvent::MIDI_NOTE
+        || eMidiType == GOMidiEvent::MIDI_AFTERTOUCH) {
         if (
           e.GetKey() < m_events[i].low_key || e.GetKey() > m_events[i].high_key)
           continue;
@@ -556,7 +559,7 @@ GOMidiMatchType GOMidiReceiverBase::Match(
           key = midi_map[key];
         if (m_events[i].type == MIDI_M_NOTE_NO_VELOCITY) {
           value = e.GetValue() ? 127 : 0;
-          if (e.GetMidiType() == MIDI_AFTERTOUCH)
+          if (eMidiType == GOMidiEvent::MIDI_AFTERTOUCH)
             continue;
         } else
           value = m_events[i].ConvertSrcValueToInt(e.GetValue());
@@ -574,12 +577,12 @@ GOMidiMatchType GOMidiReceiverBase::Match(
         continue;
       }
       if (
-        e.GetMidiType() == MIDI_CTRL_CHANGE
+        eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
         && e.GetKey() == MIDI_CTRL_NOTES_OFF)
         return MIDI_MATCH_RESET;
 
       if (
-        e.GetMidiType() == MIDI_CTRL_CHANGE
+        eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
         && e.GetKey() == MIDI_CTRL_SOUNDS_OFF)
         return MIDI_MATCH_RESET;
 
@@ -588,26 +591,26 @@ GOMidiMatchType GOMidiReceiverBase::Match(
     if (m_type == MIDI_RECV_ENCLOSURE) {
       if (
         m_events[i].type == MIDI_M_CTRL_CHANGE
-        && e.GetMidiType() == MIDI_CTRL_CHANGE
+        && eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
         && m_events[i].key == e.GetKey()) {
         value = m_events[i].ConvertSrcValueToInt(e.GetValue());
         return MIDI_MATCH_CHANGE;
       }
       if (
-        m_events[i].type == MIDI_M_RPN && e.GetMidiType() == MIDI_RPN
+        m_events[i].type == MIDI_M_RPN && eMidiType == GOMidiEvent::MIDI_RPN
         && m_events[i].key == e.GetKey()) {
         value = m_events[i].ConvertSrcValueToInt(e.GetValue());
         return MIDI_MATCH_CHANGE;
       }
       if (
-        m_events[i].type == MIDI_M_NRPN && e.GetMidiType() == MIDI_NRPN
+        m_events[i].type == MIDI_M_NRPN && eMidiType == GOMidiEvent::MIDI_NRPN
         && m_events[i].key == e.GetKey()) {
         value = m_events[i].ConvertSrcValueToInt(e.GetValue());
         return MIDI_MATCH_CHANGE;
       }
       if (
         m_events[i].type == MIDI_M_PGM_RANGE
-        && e.GetMidiType() == MIDI_PGM_CHANGE)
+        && eMidiType == GOMidiEvent::MIDI_PGM_CHANGE)
         if (
           (m_events[i].low_value <= e.GetKey()
            && e.GetKey() <= m_events[i].high_value)
@@ -618,7 +621,7 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       continue;
     }
     if (
-      e.GetMidiType() == MIDI_NOTE && m_events[i].type == MIDI_M_NOTE
+      eMidiType == GOMidiEvent::MIDI_NOTE && m_events[i].type == MIDI_M_NOTE
       && m_events[i].key == e.GetKey()) {
       if (m_events[i].low_value <= m_events[i].high_value) {
         if (e.GetValue() <= m_events[i].low_value)
@@ -634,26 +637,27 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       continue;
     }
     if (
-      e.GetMidiType() == MIDI_NOTE && m_events[i].type == MIDI_M_NOTE_ON
+      eMidiType == GOMidiEvent::MIDI_NOTE && m_events[i].type == MIDI_M_NOTE_ON
       && m_events[i].key == e.GetKey()
       && e.GetValue() >= m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_NOTE && m_events[i].type == MIDI_M_NOTE_OFF
+      eMidiType == GOMidiEvent::MIDI_NOTE && m_events[i].type == MIDI_M_NOTE_OFF
       && m_events[i].key == e.GetKey() && e.GetValue() <= m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_NOTE && m_events[i].type == MIDI_M_NOTE_ON_OFF
-      && m_events[i].key == e.GetKey()
+      eMidiType == GOMidiEvent::MIDI_NOTE
+      && m_events[i].type == MIDI_M_NOTE_ON_OFF && m_events[i].key == e.GetKey()
       && e.GetValue() >= m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_NOTE && m_events[i].type == MIDI_M_NOTE_ON_OFF
-      && m_events[i].key == e.GetKey() && e.GetValue() <= m_events[i].low_value)
+      eMidiType == GOMidiEvent::MIDI_NOTE
+      && m_events[i].type == MIDI_M_NOTE_ON_OFF && m_events[i].key == e.GetKey()
+      && e.GetValue() <= m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
 
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE
       && m_events[i].key == e.GetKey()) {
       if (m_events[i].low_value <= m_events[i].high_value) {
@@ -670,29 +674,29 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       continue;
     }
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_ON
       && m_events[i].key == e.GetKey()
       && e.GetValue() >= m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_OFF
       && m_events[i].key == e.GetKey() && e.GetValue() <= m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_ON_OFF
       && m_events[i].key == e.GetKey()
       && e.GetValue() >= m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_ON_OFF
       && m_events[i].key == e.GetKey() && e.GetValue() <= m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED
       && m_events[i].key == e.GetKey()) {
       if (e.GetValue() == m_events[i].low_value)
@@ -702,30 +706,30 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       continue;
     }
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED_ON
       && m_events[i].key == e.GetKey()
       && e.GetValue() == m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED_OFF
       && m_events[i].key == e.GetKey() && e.GetValue() == m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED_ON_OFF
       && m_events[i].key == e.GetKey()
       && e.GetValue() == m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED_ON_OFF
       && m_events[i].key == e.GetKey() && e.GetValue() == m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_CTRL_CHANGE && m_events[i].type == MIDI_M_CTRL_BIT
-      && m_events[i].key == e.GetKey()) {
+      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
+      && m_events[i].type == MIDI_M_CTRL_BIT && m_events[i].key == e.GetKey()) {
       unsigned mask = 1 << m_events[i].low_value;
       if (e.GetValue() & mask)
         return debounce(e, MIDI_MATCH_ON, i);
@@ -734,7 +738,7 @@ GOMidiMatchType GOMidiReceiverBase::Match(
     }
 
     if (
-      e.GetMidiType() == MIDI_RPN && m_events[i].type == MIDI_M_RPN
+      eMidiType == GOMidiEvent::MIDI_RPN && m_events[i].type == MIDI_M_RPN
       && m_events[i].key == e.GetKey()) {
       if (m_events[i].low_value <= m_events[i].high_value) {
         if (e.GetValue() <= m_events[i].low_value)
@@ -750,26 +754,27 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       continue;
     }
     if (
-      e.GetMidiType() == MIDI_RPN && m_events[i].type == MIDI_M_RPN_ON
+      eMidiType == GOMidiEvent::MIDI_RPN && m_events[i].type == MIDI_M_RPN_ON
       && m_events[i].key == e.GetKey()
       && e.GetValue() >= m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_RPN && m_events[i].type == MIDI_M_RPN_OFF
+      eMidiType == GOMidiEvent::MIDI_RPN && m_events[i].type == MIDI_M_RPN_OFF
       && m_events[i].key == e.GetKey() && e.GetValue() <= m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_RPN && m_events[i].type == MIDI_M_RPN_ON_OFF
-      && m_events[i].key == e.GetKey()
+      eMidiType == GOMidiEvent::MIDI_RPN
+      && m_events[i].type == MIDI_M_RPN_ON_OFF && m_events[i].key == e.GetKey()
       && e.GetValue() >= m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_RPN && m_events[i].type == MIDI_M_RPN_ON_OFF
-      && m_events[i].key == e.GetKey() && e.GetValue() <= m_events[i].low_value)
+      eMidiType == GOMidiEvent::MIDI_RPN
+      && m_events[i].type == MIDI_M_RPN_ON_OFF && m_events[i].key == e.GetKey()
+      && e.GetValue() <= m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
 
     if (
-      e.GetMidiType() == MIDI_NRPN && m_events[i].type == MIDI_M_NRPN
+      eMidiType == GOMidiEvent::MIDI_NRPN && m_events[i].type == MIDI_M_NRPN
       && m_events[i].key == e.GetKey()) {
       if (m_events[i].low_value <= m_events[i].high_value) {
         if (e.GetValue() <= m_events[i].low_value)
@@ -785,88 +790,93 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       continue;
     }
     if (
-      e.GetMidiType() == MIDI_NRPN && m_events[i].type == MIDI_M_NRPN_ON
+      eMidiType == GOMidiEvent::MIDI_NRPN && m_events[i].type == MIDI_M_NRPN_ON
       && m_events[i].key == e.GetKey()
       && e.GetValue() >= m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_NRPN && m_events[i].type == MIDI_M_NRPN_OFF
+      eMidiType == GOMidiEvent::MIDI_NRPN && m_events[i].type == MIDI_M_NRPN_OFF
       && m_events[i].key == e.GetKey() && e.GetValue() <= m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_NRPN && m_events[i].type == MIDI_M_NRPN_ON_OFF
-      && m_events[i].key == e.GetKey()
+      eMidiType == GOMidiEvent::MIDI_NRPN
+      && m_events[i].type == MIDI_M_NRPN_ON_OFF && m_events[i].key == e.GetKey()
       && e.GetValue() >= m_events[i].high_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_NRPN && m_events[i].type == MIDI_M_NRPN_ON_OFF
-      && m_events[i].key == e.GetKey() && e.GetValue() <= m_events[i].low_value)
+      eMidiType == GOMidiEvent::MIDI_NRPN
+      && m_events[i].type == MIDI_M_NRPN_ON_OFF && m_events[i].key == e.GetKey()
+      && e.GetValue() <= m_events[i].low_value)
       return debounce(e, MIDI_MATCH_CHANGE, i);
 
     if (
-      e.GetMidiType() == MIDI_PGM_CHANGE
+      eMidiType == GOMidiEvent::MIDI_PGM_CHANGE
       && m_events[i].type == MIDI_M_PGM_CHANGE
       && m_events[i].key == e.GetKey()) {
       return debounce(e, MIDI_MATCH_CHANGE, i);
     }
     if (
-      e.GetMidiType() == MIDI_PGM_CHANGE && m_events[i].type == MIDI_M_PGM_RANGE
+      eMidiType == GOMidiEvent::MIDI_PGM_CHANGE
+      && m_events[i].type == MIDI_M_PGM_RANGE
       && m_events[i].low_value == e.GetKey())
       return MIDI_MATCH_OFF;
     if (
-      e.GetMidiType() == MIDI_PGM_CHANGE && m_events[i].type == MIDI_M_PGM_RANGE
+      eMidiType == GOMidiEvent::MIDI_PGM_CHANGE
+      && m_events[i].type == MIDI_M_PGM_RANGE
       && m_events[i].high_value == e.GetKey())
       return MIDI_MATCH_ON;
     if (
-      e.GetMidiType() == MIDI_SYSEX_JOHANNUS_9
+      eMidiType == GOMidiEvent::MIDI_SYSEX_JOHANNUS_9
       && m_events[i].type == MIDI_M_SYSEX_JOHANNUS_9
       && m_events[i].key == e.GetKey()) {
       return debounce(e, MIDI_MATCH_CHANGE, i);
     }
     if (
-      e.GetMidiType() == MIDI_SYSEX_JOHANNUS_11
+      eMidiType == GOMidiEvent::MIDI_SYSEX_JOHANNUS_11
       && m_events[i].type == MIDI_M_SYSEX_JOHANNUS_11
       && m_events[i].key == e.GetKey() && m_events[i].low_value <= e.GetValue()
       && m_events[i].high_value >= e.GetValue()) {
       return debounce(e, MIDI_MATCH_CHANGE, i);
     }
     if (
-      e.GetMidiType() == MIDI_RPN && m_events[i].type == MIDI_M_RPN_RANGE
+      eMidiType == GOMidiEvent::MIDI_RPN && m_events[i].type == MIDI_M_RPN_RANGE
       && m_events[i].low_value == e.GetKey() && m_events[i].key == e.GetValue())
       return MIDI_MATCH_OFF;
     if (
-      e.GetMidiType() == MIDI_RPN && m_events[i].type == MIDI_M_RPN_RANGE
+      eMidiType == GOMidiEvent::MIDI_RPN && m_events[i].type == MIDI_M_RPN_RANGE
       && m_events[i].high_value == e.GetKey()
       && m_events[i].key == e.GetValue())
       return MIDI_MATCH_ON;
     if (
-      e.GetMidiType() == MIDI_NRPN && m_events[i].type == MIDI_M_NRPN_RANGE
+      eMidiType == GOMidiEvent::MIDI_NRPN
+      && m_events[i].type == MIDI_M_NRPN_RANGE
       && m_events[i].low_value == e.GetKey() && m_events[i].key == e.GetValue())
       return MIDI_MATCH_OFF;
     if (
-      e.GetMidiType() == MIDI_NRPN && m_events[i].type == MIDI_M_NRPN_RANGE
+      eMidiType == GOMidiEvent::MIDI_NRPN
+      && m_events[i].type == MIDI_M_NRPN_RANGE
       && m_events[i].high_value == e.GetKey()
       && m_events[i].key == e.GetValue())
       return MIDI_MATCH_ON;
 
     if (
-      e.GetMidiType() == MIDI_SYSEX_VISCOUNT
+      eMidiType == GOMidiEvent::MIDI_SYSEX_VISCOUNT
       && m_events[i].type == MIDI_M_SYSEX_VISCOUNT
       && m_events[i].low_value == e.GetValue())
       return MIDI_MATCH_OFF;
     if (
-      e.GetMidiType() == MIDI_SYSEX_VISCOUNT
+      eMidiType == GOMidiEvent::MIDI_SYSEX_VISCOUNT
       && m_events[i].type == MIDI_M_SYSEX_VISCOUNT
       && m_events[i].high_value == e.GetValue())
       return MIDI_MATCH_ON;
     if (
-      e.GetMidiType() == MIDI_SYSEX_VISCOUNT
+      eMidiType == GOMidiEvent::MIDI_SYSEX_VISCOUNT
       && m_events[i].type == MIDI_M_SYSEX_VISCOUNT_TOGGLE
       && m_events[i].low_value == e.GetValue()) {
       return debounce(e, MIDI_MATCH_CHANGE, i);
     }
     if (
-      e.GetMidiType() == MIDI_SYSEX_RODGERS_STOP_CHANGE
+      eMidiType == GOMidiEvent::MIDI_SYSEX_RODGERS_STOP_CHANGE
       && m_events[i].type == MIDI_M_SYSEX_RODGERS_STOP_CHANGE
       && m_events[i].key == e.GetChannel()) {
       switch (GORodgersGetBit(m_events[i].low_value, e.GetKey(), e.GetData())) {
@@ -880,22 +890,22 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       }
     }
     if (
-      e.GetMidiType() == MIDI_SYSEX_AHLBORN_GALANTI
+      eMidiType == GOMidiEvent::MIDI_SYSEX_AHLBORN_GALANTI
       && m_events[i].type == MIDI_M_SYSEX_AHLBORN_GALANTI
       && m_events[i].low_value == e.GetValue())
       return MIDI_MATCH_OFF;
     if (
-      e.GetMidiType() == MIDI_SYSEX_AHLBORN_GALANTI
+      eMidiType == GOMidiEvent::MIDI_SYSEX_AHLBORN_GALANTI
       && m_events[i].type == MIDI_M_SYSEX_AHLBORN_GALANTI
       && m_events[i].high_value == e.GetValue())
       return MIDI_MATCH_ON;
     if (
-      e.GetMidiType() == MIDI_SYSEX_AHLBORN_GALANTI
+      eMidiType == GOMidiEvent::MIDI_SYSEX_AHLBORN_GALANTI
       && m_events[i].type == MIDI_M_SYSEX_AHLBORN_GALANTI_TOGGLE
       && m_events[i].low_value == e.GetValue())
       return debounce(e, MIDI_MATCH_CHANGE, i);
     if (
-      e.GetMidiType() == MIDI_SYSEX_AHLBORN_GALANTI
+      eMidiType == GOMidiEvent::MIDI_SYSEX_AHLBORN_GALANTI
       && m_events[i].type == MIDI_M_SYSEX_AHLBORN_GALANTI_TOGGLE
       && m_events[i].high_value == e.GetValue())
       return debounce(e, MIDI_MATCH_CHANGE, i);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -1018,16 +1018,16 @@ void GOOrganController::Update() {
 }
 
 void GOOrganController::ProcessMidi(const GOMidiEvent &event) {
-  if (event.GetMidiType() == MIDI_RESET) {
+  if (event.GetMidiType() == GOMidiEvent::MIDI_RESET) {
     Reset();
     return;
   }
   while (m_MidiSamplesetMatch.size() < event.GetDevice())
     m_MidiSamplesetMatch.push_back(true);
 
-  if (event.GetMidiType() == MIDI_SYSEX_GO_CLEAR)
+  if (event.GetMidiType() == GOMidiEvent::MIDI_SYSEX_GO_CLEAR)
     m_MidiSamplesetMatch[event.GetDevice()] = true;
-  else if (event.GetMidiType() == MIDI_SYSEX_GO_SAMPLESET) {
+  else if (event.GetMidiType() == GOMidiEvent::MIDI_SYSEX_GO_SAMPLESET) {
     if (
       event.GetKey() == m_SampleSetId1 && event.GetValue() == m_SampleSetId2) {
       m_MidiSamplesetMatch[event.GetDevice()] = true;
@@ -1035,7 +1035,7 @@ void GOOrganController::ProcessMidi(const GOMidiEvent &event) {
       m_MidiSamplesetMatch[event.GetDevice()] = false;
       return;
     }
-  } else if (event.GetMidiType() == MIDI_SYSEX_GO_SETUP) {
+  } else if (event.GetMidiType() == GOMidiEvent::MIDI_SYSEX_GO_SETUP) {
     if (!m_MidiSamplesetMatch[event.GetDevice()])
       return;
   }

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp
@@ -581,16 +581,16 @@ void GOMidiEventRecvTab::OnTimer(wxTimerEvent &event) {
 
 void GOMidiEventRecvTab::OnMidiEvent(const GOMidiEvent &event) {
   switch (event.GetMidiType()) {
-  case MIDI_NOTE:
-  case MIDI_CTRL_CHANGE:
-  case MIDI_PGM_CHANGE:
-  case MIDI_RPN:
-  case MIDI_NRPN:
-  case MIDI_SYSEX_JOHANNUS_9:
-  case MIDI_SYSEX_JOHANNUS_11:
-  case MIDI_SYSEX_VISCOUNT:
-  case MIDI_SYSEX_RODGERS_STOP_CHANGE:
-  case MIDI_SYSEX_AHLBORN_GALANTI:
+  case GOMidiEvent::MIDI_NOTE:
+  case GOMidiEvent::MIDI_CTRL_CHANGE:
+  case GOMidiEvent::MIDI_PGM_CHANGE:
+  case GOMidiEvent::MIDI_RPN:
+  case GOMidiEvent::MIDI_NRPN:
+  case GOMidiEvent::MIDI_SYSEX_JOHANNUS_9:
+  case GOMidiEvent::MIDI_SYSEX_JOHANNUS_11:
+  case GOMidiEvent::MIDI_SYSEX_VISCOUNT:
+  case GOMidiEvent::MIDI_SYSEX_RODGERS_STOP_CHANGE:
+  case GOMidiEvent::MIDI_SYSEX_AHLBORN_GALANTI:
     break;
 
   default:
@@ -666,14 +666,14 @@ bool GOMidiEventRecvTab::SimilarEvent(
   if (e1.GetChannel() != e2.GetChannel())
     return false;
 
-  if (e1.GetMidiType() == MIDI_PGM_CHANGE)
+  if (e1.GetMidiType() == GOMidiEvent::MIDI_PGM_CHANGE)
     return true;
-  if (e1.GetMidiType() == MIDI_SYSEX_VISCOUNT)
+  if (e1.GetMidiType() == GOMidiEvent::MIDI_SYSEX_VISCOUNT)
     return true;
-  if (e1.GetMidiType() == MIDI_SYSEX_AHLBORN_GALANTI)
+  if (e1.GetMidiType() == GOMidiEvent::MIDI_SYSEX_AHLBORN_GALANTI)
     return true;
   if (e1.GetKey() == e2.GetKey()) {
-    if (e1.GetMidiType() != MIDI_NOTE)
+    if (e1.GetMidiType() != GOMidiEvent::MIDI_NOTE)
       return true;
   }
   return false;
@@ -690,7 +690,7 @@ void GOMidiEventRecvTab::DetectEvent() {
       for (unsigned j = 0; j < m_OffList.size(); j++) {
         if (j + 1 < m_OffList.size()) {
           if (SimilarEvent(m_OffList[j], m_OffList[j + 1])) {
-            if (m_OffList[j].GetMidiType() != MIDI_NOTE)
+            if (m_OffList[j].GetMidiType() != GOMidiEvent::MIDI_NOTE)
               continue;
           }
         }
@@ -702,7 +702,7 @@ void GOMidiEventRecvTab::DetectEvent() {
         if (on.GetMidiType() != off.GetMidiType())
           continue;
         if (m_midi.GetType() == MIDI_RECV_MANUAL) {
-          if (on.GetMidiType() != MIDI_NOTE)
+          if (on.GetMidiType() != GOMidiEvent::MIDI_NOTE)
             continue;
           GOMidiReceiverEventPattern &e = m_midi.GetEvent(m_current);
           e.type = MIDI_M_NOTE;
@@ -724,12 +724,12 @@ void GOMidiEventRecvTab::DetectEvent() {
         bool is_range = false;
         if (
           on.GetValue() == off.GetValue() && on.GetKey() != off.GetKey()
-          && (on.GetMidiType() == MIDI_RPN || on.GetMidiType() == MIDI_NRPN)) {
+          && (on.GetMidiType() == GOMidiEvent::MIDI_RPN || on.GetMidiType() == GOMidiEvent::MIDI_NRPN)) {
           if (m_midi.GetType() == MIDI_RECV_ENCLOSURE)
             is_range = false;
           else
             is_range = true;
-        } else if (on.GetMidiType() == MIDI_PGM_CHANGE) {
+        } else if (on.GetMidiType() == GOMidiEvent::MIDI_PGM_CHANGE) {
           is_range = true;
         }
         if (on.GetKey() != off.GetKey() && !is_range)
@@ -740,16 +740,16 @@ void GOMidiEventRecvTab::DetectEvent() {
           unsigned high = on.GetValue();
           int key = on.GetKey();
           switch (on.GetMidiType()) {
-          case MIDI_CTRL_CHANGE:
+          case GOMidiEvent::MIDI_CTRL_CHANGE:
             e.type = MIDI_M_CTRL_CHANGE;
             break;
-          case MIDI_RPN:
+          case GOMidiEvent::MIDI_RPN:
             e.type = MIDI_M_RPN;
             break;
-          case MIDI_NRPN:
+          case GOMidiEvent::MIDI_NRPN:
             e.type = MIDI_M_NRPN;
             break;
-          case MIDI_PGM_CHANGE:
+          case GOMidiEvent::MIDI_PGM_CHANGE:
             e.type = MIDI_M_PGM_RANGE;
             low = off.GetKey();
             high = on.GetKey();
@@ -774,14 +774,14 @@ void GOMidiEventRecvTab::DetectEvent() {
         unsigned high = 1;
         int key = on.GetKey();
         switch (on.GetMidiType()) {
-        case MIDI_NOTE:
+        case GOMidiEvent::MIDI_NOTE:
           e.type = MIDI_M_NOTE;
           if (on.GetValue() > 0 && off.GetValue() > 0)
             e.type = MIDI_M_NOTE_ON;
           if (on.GetValue() == 0 && off.GetValue() == 0)
             e.type = MIDI_M_NOTE_OFF;
           break;
-        case MIDI_CTRL_CHANGE:
+        case GOMidiEvent::MIDI_CTRL_CHANGE:
           e.type = MIDI_M_CTRL_CHANGE;
           if (on.GetValue() == off.GetValue())
             e.type = on.GetValue() > 0 ? MIDI_M_CTRL_CHANGE_ON
@@ -801,7 +801,7 @@ void GOMidiEventRecvTab::DetectEvent() {
             }
           }
           break;
-        case MIDI_PGM_CHANGE:
+        case GOMidiEvent::MIDI_PGM_CHANGE:
           if (on.GetKey() == off.GetKey())
             e.type = MIDI_M_PGM_CHANGE;
           else {
@@ -811,7 +811,7 @@ void GOMidiEventRecvTab::DetectEvent() {
             key = -1;
           }
           break;
-        case MIDI_RPN:
+        case GOMidiEvent::MIDI_RPN:
           if (is_range) {
             e.type = MIDI_M_RPN_RANGE;
             key = on.GetValue();
@@ -823,7 +823,7 @@ void GOMidiEventRecvTab::DetectEvent() {
           if (on.GetValue() == off.GetValue())
             e.type = on.GetValue() > 0 ? MIDI_M_RPN_ON : MIDI_M_RPN_OFF;
           break;
-        case MIDI_NRPN:
+        case GOMidiEvent::MIDI_NRPN:
           if (is_range) {
             e.type = MIDI_M_NRPN_RANGE;
             key = on.GetValue();
@@ -835,14 +835,14 @@ void GOMidiEventRecvTab::DetectEvent() {
           if (on.GetValue() == off.GetValue())
             e.type = on.GetValue() > 0 ? MIDI_M_NRPN_ON : MIDI_M_NRPN_OFF;
           break;
-        case MIDI_SYSEX_JOHANNUS_9:
+        case GOMidiEvent::MIDI_SYSEX_JOHANNUS_9:
           e.type = MIDI_M_SYSEX_JOHANNUS_9;
           break;
-        case MIDI_SYSEX_JOHANNUS_11:
+        case GOMidiEvent::MIDI_SYSEX_JOHANNUS_11:
           e.type = MIDI_M_SYSEX_JOHANNUS_11;
           high = 0x7f;
           break;
-        case MIDI_SYSEX_VISCOUNT:
+        case GOMidiEvent::MIDI_SYSEX_VISCOUNT:
           if (on.GetValue() == off.GetValue()) {
             low = off.GetValue();
             e.type = MIDI_M_SYSEX_VISCOUNT_TOGGLE;
@@ -852,7 +852,7 @@ void GOMidiEventRecvTab::DetectEvent() {
             e.type = MIDI_M_SYSEX_VISCOUNT;
           }
           break;
-        case MIDI_SYSEX_RODGERS_STOP_CHANGE:
+        case GOMidiEvent::MIDI_SYSEX_RODGERS_STOP_CHANGE:
           for (unsigned i = 0; i
                < m_original->LowerValueLimit(MIDI_M_SYSEX_RODGERS_STOP_CHANGE);
                i++) {
@@ -867,7 +867,7 @@ void GOMidiEventRecvTab::DetectEvent() {
             }
           }
           break;
-        case MIDI_SYSEX_AHLBORN_GALANTI:
+        case GOMidiEvent::MIDI_SYSEX_AHLBORN_GALANTI:
           low = off.GetValue();
           high = on.GetValue();
           e.type = MIDI_M_SYSEX_AHLBORN_GALANTI;
@@ -899,33 +899,33 @@ void GOMidiEventRecvTab::DetectEvent() {
     ? 127
     : 1;
   switch (event.GetMidiType()) {
-  case MIDI_NOTE:
+  case GOMidiEvent::MIDI_NOTE:
     e.type = MIDI_M_NOTE;
     break;
-  case MIDI_CTRL_CHANGE:
+  case GOMidiEvent::MIDI_CTRL_CHANGE:
     e.type = MIDI_M_CTRL_CHANGE;
     break;
-  case MIDI_PGM_CHANGE:
+  case GOMidiEvent::MIDI_PGM_CHANGE:
     e.type = MIDI_M_PGM_CHANGE;
     break;
-  case MIDI_RPN:
+  case GOMidiEvent::MIDI_RPN:
     e.type = MIDI_M_RPN;
     break;
-  case MIDI_NRPN:
+  case GOMidiEvent::MIDI_NRPN:
     e.type = MIDI_M_NRPN;
     break;
-  case MIDI_SYSEX_JOHANNUS_9:
+  case GOMidiEvent::MIDI_SYSEX_JOHANNUS_9:
     e.type = MIDI_M_SYSEX_JOHANNUS_9;
     break;
-  case MIDI_SYSEX_JOHANNUS_11:
+  case GOMidiEvent::MIDI_SYSEX_JOHANNUS_11:
     e.type = MIDI_M_SYSEX_JOHANNUS_11;
     high_value = 127;
     break;
-  case MIDI_SYSEX_VISCOUNT:
+  case GOMidiEvent::MIDI_SYSEX_VISCOUNT:
     e.type = MIDI_M_SYSEX_VISCOUNT_TOGGLE;
     low_value = event.GetValue();
     break;
-  case MIDI_SYSEX_AHLBORN_GALANTI:
+  case GOMidiEvent::MIDI_SYSEX_AHLBORN_GALANTI:
     e.type = MIDI_M_SYSEX_AHLBORN_GALANTI;
     if (((event.GetValue() >> 7) & 0x0f) < 8) {
       high_value = event.GetValue();

--- a/src/grandorgue/midi/GOMidiInputMerger.cpp
+++ b/src/grandorgue/midi/GOMidiInputMerger.cpp
@@ -25,52 +25,61 @@ void GOMidiMerger::Clear() {
 
 bool GOMidiMerger::Process(GOMidiEvent &e) {
   if (
-    e.GetMidiType() == MIDI_CTRL_CHANGE
+    e.GetMidiType() == GOMidiEvent::MIDI_CTRL_CHANGE
     && e.GetKey() == MIDI_CTRL_BANK_SELECT_MSB) {
     m_BankMsb[e.GetChannel() - 1] = e.GetValue();
     return false;
   }
   if (
-    e.GetMidiType() == MIDI_CTRL_CHANGE
+    e.GetMidiType() == GOMidiEvent::MIDI_CTRL_CHANGE
     && e.GetKey() == MIDI_CTRL_BANK_SELECT_LSB) {
     m_BankLsb[e.GetChannel() - 1] = e.GetValue();
     return false;
   }
-  if (e.GetMidiType() == MIDI_CTRL_CHANGE && e.GetKey() == MIDI_CTRL_RPN_LSB) {
+  if (
+    e.GetMidiType() == GOMidiEvent::MIDI_CTRL_CHANGE
+    && e.GetKey() == MIDI_CTRL_RPN_LSB) {
     m_RpnLsb[e.GetChannel() - 1] = e.GetValue();
     m_Rpn = true;
     return false;
   }
-  if (e.GetMidiType() == MIDI_CTRL_CHANGE && e.GetKey() == MIDI_CTRL_RPN_MSB) {
+  if (
+    e.GetMidiType() == GOMidiEvent::MIDI_CTRL_CHANGE
+    && e.GetKey() == MIDI_CTRL_RPN_MSB) {
     m_RpnMsb[e.GetChannel() - 1] = e.GetValue();
     m_Rpn = true;
     return false;
   }
-  if (e.GetMidiType() == MIDI_CTRL_CHANGE && e.GetKey() == MIDI_CTRL_NRPN_LSB) {
+  if (
+    e.GetMidiType() == GOMidiEvent::MIDI_CTRL_CHANGE
+    && e.GetKey() == MIDI_CTRL_NRPN_LSB) {
     m_NrpnLsb[e.GetChannel() - 1] = e.GetValue();
     m_Rpn = false;
     return false;
   }
-  if (e.GetMidiType() == MIDI_CTRL_CHANGE && e.GetKey() == MIDI_CTRL_NRPN_MSB) {
+  if (
+    e.GetMidiType() == GOMidiEvent::MIDI_CTRL_CHANGE
+    && e.GetKey() == MIDI_CTRL_NRPN_MSB) {
     m_NrpnMsb[e.GetChannel() - 1] = e.GetValue();
     m_Rpn = false;
     return false;
   }
-  if (e.GetMidiType() == MIDI_PGM_CHANGE)
+  if (e.GetMidiType() == GOMidiEvent::MIDI_PGM_CHANGE)
     e.SetKey(
       ((e.GetKey() - 1) | (m_BankLsb[e.GetChannel() - 1] << 7)
        | (m_BankMsb[e.GetChannel() - 1] << 14))
       + 1);
 
   if (
-    e.GetMidiType() == MIDI_CTRL_CHANGE && e.GetKey() == MIDI_CTRL_DATA_ENTRY) {
+    e.GetMidiType() == GOMidiEvent::MIDI_CTRL_CHANGE
+    && e.GetKey() == MIDI_CTRL_DATA_ENTRY) {
     if (m_Rpn) {
-      e.SetMidiType(MIDI_RPN);
+      e.SetMidiType(GOMidiEvent::MIDI_RPN);
       e.SetKey(
         (m_RpnLsb[e.GetChannel() - 1] << 0)
         | (m_RpnMsb[e.GetChannel() - 1] << 7));
     } else {
-      e.SetMidiType(MIDI_NRPN);
+      e.SetMidiType(GOMidiEvent::MIDI_NRPN);
       e.SetKey(
         (m_NrpnLsb[e.GetChannel() - 1] << 0)
         | (m_NrpnMsb[e.GetChannel() - 1] << 7));

--- a/src/grandorgue/midi/GOMidiOutputMerger.cpp
+++ b/src/grandorgue/midi/GOMidiOutputMerger.cpp
@@ -18,8 +18,8 @@ void GOMidiOutputMerger::Clear() {
 
 bool GOMidiOutputMerger::Process(GOMidiEvent &e) {
   if (
-    e.GetMidiType() == MIDI_SYSEX_HW_STRING
-    || e.GetMidiType() == MIDI_SYSEX_HW_LCD) {
+    e.GetMidiType() == GOMidiEvent::MIDI_SYSEX_HW_STRING
+    || e.GetMidiType() == GOMidiEvent::MIDI_SYSEX_HW_LCD) {
     unsigned item = 0;
     while (item < m_HWState.size()) {
       if (
@@ -32,7 +32,7 @@ bool GOMidiOutputMerger::Process(GOMidiEvent &e) {
       GOMidiOutputMergerHWState s;
       s.type = e.GetMidiType();
       s.key = e.GetKey();
-      if (e.GetMidiType() == MIDI_SYSEX_HW_STRING)
+      if (e.GetMidiType() == GOMidiEvent::MIDI_SYSEX_HW_STRING)
         s.content = wxString(wxT(' '), 16);
       else
         s.content = wxString(wxT(' '), 32);
@@ -45,7 +45,7 @@ bool GOMidiOutputMerger::Process(GOMidiEvent &e) {
       s.content[i] = e.GetString()[j];
     e.SetString(s.content);
   }
-  if (e.GetMidiType() == MIDI_SYSEX_RODGERS_STOP_CHANGE) {
+  if (e.GetMidiType() == GOMidiEvent::MIDI_SYSEX_RODGERS_STOP_CHANGE) {
     if ((unsigned)e.GetChannel() >= m_RodgersState.size())
       m_RodgersState.resize(e.GetChannel() + 1);
     std::vector<uint8_t> &data = m_RodgersState[e.GetChannel()];

--- a/src/grandorgue/midi/GOMidiOutputMerger.h
+++ b/src/grandorgue/midi/GOMidiOutputMerger.h
@@ -10,19 +10,18 @@
 
 #include <wx/string.h>
 
+#include <cstdint>
 #include <vector>
 
 #include "midi/GOMidiEvent.h"
 
-class GOMidiOutputEvent;
-
 class GOMidiOutputMerger {
 private:
-  typedef struct {
-    midi_message_type type;
+  struct GOMidiOutputMergerHWState {
+    GOMidiEvent::MidiType type;
     int key;
     wxString content;
-  } GOMidiOutputMergerHWState;
+  };
   std::vector<GOMidiOutputMergerHWState> m_HWState;
   std::vector<std::vector<uint8_t>> m_RodgersState;
 

--- a/src/grandorgue/midi/GOMidiPlayer.cpp
+++ b/src/grandorgue/midi/GOMidiPlayer.cpp
@@ -158,7 +158,7 @@ void GOMidiPlayer::StopPlaying() {
   if (m_IsPlaying) {
     for (unsigned i = 1; i < 16; i++) {
       GOMidiEvent e;
-      e.SetMidiType(MIDI_CTRL_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_CTRL_CHANGE);
       e.SetChannel(i);
       e.SetKey(MIDI_CTRL_NOTES_OFF);
       e.SetValue(0);

--- a/src/grandorgue/midi/GOMidiPlayerContent.cpp
+++ b/src/grandorgue/midi/GOMidiPlayerContent.cpp
@@ -49,13 +49,13 @@ void GOMidiPlayerContent::SetupManual(
   GOMidiEvent e;
   e.SetTime(0);
 
-  e.SetMidiType(MIDI_SYSEX_GO_SETUP);
+  e.SetMidiType(GOMidiEvent::MIDI_SYSEX_GO_SETUP);
   e.SetKey(map.GetElementByString(ID));
   e.SetChannel(channel);
   e.SetValue(0);
   m_Events.push_back(e);
 
-  e.SetMidiType(MIDI_CTRL_CHANGE);
+  e.SetMidiType(GOMidiEvent::MIDI_CTRL_CHANGE);
   e.SetChannel(channel);
   e.SetKey(MIDI_CTRL_NOTES_OFF);
   e.SetValue(0);
@@ -70,10 +70,12 @@ bool GOMidiPlayerContent::Load(
 
   GOMidiMerger merger;
   merger.Clear();
-  if (events.size() && events[0].GetMidiType() != MIDI_SYSEX_GO_CLEAR) {
+  if (
+    events.size()
+    && events[0].GetMidiType() != GOMidiEvent::MIDI_SYSEX_GO_CLEAR) {
     GOMidiEvent e;
     e.SetTime(0);
-    e.SetMidiType(MIDI_SYSEX_GO_CLEAR);
+    e.SetMidiType(GOMidiEvent::MIDI_SYSEX_GO_CLEAR);
     e.SetChannel(0);
     m_Events.push_back(e);
 

--- a/src/grandorgue/midi/GOMidiRecorder.cpp
+++ b/src/grandorgue/midi/GOMidiRecorder.cpp
@@ -114,7 +114,7 @@ void GOMidiRecorder::Clear() {
   m_NextNRPN = 0;
 
   GOMidiEvent e;
-  e.SetMidiType(MIDI_SYSEX_GO_CLEAR);
+  e.SetMidiType(GOMidiEvent::MIDI_SYSEX_GO_CLEAR);
   e.SetTime(wxGetLocalTimeMillis());
   SendEvent(e);
 }
@@ -131,7 +131,7 @@ void GOMidiRecorder::PreconfigureMapping(
     if (m_Preconfig[i].elementID == ref) {
       GOMidiEvent e1;
       e1.SetTime(wxGetLocalTimeMillis());
-      e1.SetMidiType(MIDI_SYSEX_GO_SETUP);
+      e1.SetMidiType(GOMidiEvent::MIDI_SYSEX_GO_SETUP);
       e1.SetKey(id);
       e1.SetChannel(m_Preconfig[i].channel);
       e1.SetValue(m_Preconfig[i].key);
@@ -165,7 +165,7 @@ void GOMidiRecorder::PreconfigureMapping(
 
   GOMidiEvent e1;
   e1.SetTime(wxGetLocalTimeMillis());
-  e1.SetMidiType(MIDI_SYSEX_GO_SETUP);
+  e1.SetMidiType(GOMidiEvent::MIDI_SYSEX_GO_SETUP);
   e1.SetKey(id);
   e1.SetChannel(m.channel);
   e1.SetValue(m.key);
@@ -179,7 +179,7 @@ void GOMidiRecorder::PreconfigureMapping(
 void GOMidiRecorder::SetSamplesetId(unsigned id1, unsigned id2) {
   GOMidiEvent e1;
   e1.SetTime(wxGetLocalTimeMillis());
-  e1.SetMidiType(MIDI_SYSEX_GO_SAMPLESET);
+  e1.SetMidiType(GOMidiEvent::MIDI_SYSEX_GO_SAMPLESET);
   e1.SetKey(id1);
   e1.SetValue(id2);
   SendEvent(e1);
@@ -209,7 +209,7 @@ bool GOMidiRecorder::SetupMapping(unsigned element, bool isNRPN) {
     }
     GOMidiEvent e1;
     e1.SetTime(wxGetLocalTimeMillis());
-    e1.SetMidiType(MIDI_SYSEX_GO_SETUP);
+    e1.SetMidiType(GOMidiEvent::MIDI_SYSEX_GO_SETUP);
     e1.SetKey(m_Mappings[element].elementID);
     e1.SetChannel(m_Mappings[element].channel);
     e1.SetValue(m_Mappings[element].key);
@@ -221,12 +221,12 @@ bool GOMidiRecorder::SetupMapping(unsigned element, bool isNRPN) {
 void GOMidiRecorder::SendMidiRecorderMessage(GOMidiEvent &e) {
   if (!m_OutputDevice && !IsRecording())
     return;
-  if (!SetupMapping(e.GetDevice(), e.GetMidiType() == MIDI_NRPN))
+  if (!SetupMapping(e.GetDevice(), e.GetMidiType() == GOMidiEvent::MIDI_NRPN))
     return;
 
   e.SetTime(wxGetLocalTimeMillis());
   e.SetChannel(m_Mappings[e.GetDevice()].channel);
-  if (e.GetMidiType() == MIDI_NRPN)
+  if (e.GetMidiType() == GOMidiEvent::MIDI_NRPN)
     e.SetKey(m_Mappings[e.GetDevice()].key);
 
   SendEvent(e);

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -304,7 +304,7 @@ unsigned GOMidiSender::LengthLimit(GOMidiSenderMessageType type) {
 void GOMidiSender::SetDisplay(bool state) {
   if (m_ElementID != -1) {
     GOMidiEvent e;
-    e.SetMidiType(MIDI_NRPN);
+    e.SetMidiType(GOMidiEvent::MIDI_NRPN);
     e.SetDevice(m_ElementID);
     e.SetValue(state ? 0x7F : 0x00);
     r_proxy.SendMidiRecorderMessage(e);
@@ -314,7 +314,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_NOTE) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NOTE);
+      e.SetMidiType(GOMidiEvent::MIDI_NOTE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(state ? m_events[i].high_value : m_events[i].low_value);
@@ -323,7 +323,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_CTRL) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_CTRL_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_CTRL_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(state ? m_events[i].high_value : m_events[i].low_value);
@@ -332,7 +332,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_RPN) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_RPN);
+      e.SetMidiType(GOMidiEvent::MIDI_RPN);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(state ? m_events[i].high_value : m_events[i].low_value);
@@ -341,7 +341,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_NRPN) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NRPN);
+      e.SetMidiType(GOMidiEvent::MIDI_NRPN);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(state ? m_events[i].high_value : m_events[i].low_value);
@@ -350,7 +350,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_PGM_RANGE) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_PGM_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_PGM_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(state ? m_events[i].high_value : m_events[i].low_value);
       r_proxy.SendMidiMessage(e);
@@ -358,7 +358,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_RPN_RANGE) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_RPN);
+      e.SetMidiType(GOMidiEvent::MIDI_RPN);
       e.SetChannel(m_events[i].channel);
       e.SetValue(m_events[i].key);
       e.SetKey(state ? m_events[i].high_value : m_events[i].low_value);
@@ -367,7 +367,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_NRPN_RANGE) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NRPN);
+      e.SetMidiType(GOMidiEvent::MIDI_NRPN);
       e.SetChannel(m_events[i].channel);
       e.SetValue(m_events[i].key);
       e.SetKey(state ? m_events[i].high_value : m_events[i].low_value);
@@ -376,7 +376,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_PGM_ON && state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_PGM_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_PGM_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       r_proxy.SendMidiMessage(e);
@@ -384,7 +384,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_PGM_OFF && !state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_PGM_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_PGM_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       r_proxy.SendMidiMessage(e);
@@ -392,7 +392,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_NOTE_ON && state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NOTE);
+      e.SetMidiType(GOMidiEvent::MIDI_NOTE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].high_value);
@@ -401,7 +401,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_NOTE_OFF && !state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NOTE);
+      e.SetMidiType(GOMidiEvent::MIDI_NOTE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].low_value);
@@ -410,7 +410,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_CTRL_ON && state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_CTRL_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_CTRL_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].high_value);
@@ -419,7 +419,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_CTRL_OFF && !state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_CTRL_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_CTRL_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].low_value);
@@ -428,7 +428,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_RPN_ON && state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_RPN);
+      e.SetMidiType(GOMidiEvent::MIDI_RPN);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].high_value);
@@ -437,7 +437,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_RPN_OFF && !state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_RPN);
+      e.SetMidiType(GOMidiEvent::MIDI_RPN);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].low_value);
@@ -446,7 +446,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_NRPN_ON && state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NRPN);
+      e.SetMidiType(GOMidiEvent::MIDI_NRPN);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].high_value);
@@ -455,7 +455,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_NRPN_OFF && !state) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NRPN);
+      e.SetMidiType(GOMidiEvent::MIDI_NRPN);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].low_value);
@@ -464,7 +464,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_HW_LCD) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_HW_LCD);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_HW_LCD);
       e.SetChannel(m_events[i].low_value);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
@@ -474,7 +474,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_HW_STRING) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_HW_STRING);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_HW_STRING);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(state ? _("ON") : _("OFF"), m_events[i].length);
@@ -483,7 +483,7 @@ void GOMidiSender::SetDisplay(bool state) {
     if (m_events[i].type == MIDI_S_RODGERS_STOP_CHANGE) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_RODGERS_STOP_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_RODGERS_STOP_CHANGE);
       e.SetChannel(m_events[i].key);
       e.SetKey(m_events[i].low_value);
       e.SetValue(state);
@@ -495,7 +495,7 @@ void GOMidiSender::SetDisplay(bool state) {
 void GOMidiSender::ResetKey() {
   if (m_ElementID != -1) {
     GOMidiEvent e;
-    e.SetMidiType(MIDI_CTRL_CHANGE);
+    e.SetMidiType(GOMidiEvent::MIDI_CTRL_CHANGE);
     e.SetDevice(m_ElementID);
     e.SetKey(MIDI_CTRL_NOTES_OFF);
     e.SetValue(0);
@@ -508,7 +508,7 @@ void GOMidiSender::ResetKey() {
       || m_events[i].type == MIDI_S_NOTE_NO_VELOCITY) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_CTRL_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_CTRL_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(MIDI_CTRL_NOTES_OFF);
       e.SetValue(0);
@@ -520,7 +520,7 @@ void GOMidiSender::ResetKey() {
 void GOMidiSender::SetKey(unsigned key, unsigned velocity) {
   if (m_ElementID != -1) {
     GOMidiEvent e;
-    e.SetMidiType(MIDI_NOTE);
+    e.SetMidiType(GOMidiEvent::MIDI_NOTE);
     e.SetDevice(m_ElementID);
     e.SetKey(key & 0x7F);
     e.SetValue(velocity & 0x7F);
@@ -531,7 +531,7 @@ void GOMidiSender::SetKey(unsigned key, unsigned velocity) {
     if (m_events[i].type == MIDI_S_NOTE) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NOTE);
+      e.SetMidiType(GOMidiEvent::MIDI_NOTE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(key);
       e.SetValue(m_events[i].ConvertIntValueToDst(velocity));
@@ -540,7 +540,7 @@ void GOMidiSender::SetKey(unsigned key, unsigned velocity) {
     if (m_events[i].type == MIDI_S_NOTE_NO_VELOCITY) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NOTE);
+      e.SetMidiType(GOMidiEvent::MIDI_NOTE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(key);
       e.SetValue(velocity ? m_events[i].high_value : m_events[i].low_value);
@@ -552,7 +552,7 @@ void GOMidiSender::SetKey(unsigned key, unsigned velocity) {
 void GOMidiSender::SetValue(unsigned value) {
   if (m_ElementID != -1) {
     GOMidiEvent e;
-    e.SetMidiType(MIDI_NRPN);
+    e.SetMidiType(GOMidiEvent::MIDI_NRPN);
     e.SetDevice(m_ElementID);
     e.SetValue(value & 0x7F);
     r_proxy.SendMidiRecorderMessage(e);
@@ -562,7 +562,7 @@ void GOMidiSender::SetValue(unsigned value) {
     if (m_events[i].type == MIDI_S_CTRL) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_CTRL_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_CTRL_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].ConvertIntValueToDst(value));
@@ -571,7 +571,7 @@ void GOMidiSender::SetValue(unsigned value) {
     if (m_events[i].type == MIDI_S_RPN) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_RPN);
+      e.SetMidiType(GOMidiEvent::MIDI_RPN);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].ConvertIntValueToDst(value));
@@ -580,7 +580,7 @@ void GOMidiSender::SetValue(unsigned value) {
     if (m_events[i].type == MIDI_S_NRPN) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_NRPN);
+      e.SetMidiType(GOMidiEvent::MIDI_NRPN);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].ConvertIntValueToDst(value));
@@ -589,7 +589,7 @@ void GOMidiSender::SetValue(unsigned value) {
     if (m_events[i].type == MIDI_S_PGM_RANGE) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_PGM_CHANGE);
+      e.SetMidiType(GOMidiEvent::MIDI_PGM_CHANGE);
       e.SetChannel(m_events[i].channel);
       e.SetKey(m_events[i].ConvertIntValueToDst(value));
       r_proxy.SendMidiMessage(e);
@@ -597,7 +597,7 @@ void GOMidiSender::SetValue(unsigned value) {
     if (m_events[i].type == MIDI_S_HW_LCD) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_HW_LCD);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_HW_LCD);
       e.SetChannel(m_events[i].low_value);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
@@ -608,7 +608,7 @@ void GOMidiSender::SetValue(unsigned value) {
     if (m_events[i].type == MIDI_S_HW_STRING) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_HW_STRING);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_HW_STRING);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(
@@ -623,7 +623,7 @@ void GOMidiSender::SetLabel(const wxString &text) {
     if (m_events[i].type == MIDI_S_HW_LCD) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_HW_LCD);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_HW_LCD);
       e.SetChannel(m_events[i].low_value);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
@@ -633,7 +633,7 @@ void GOMidiSender::SetLabel(const wxString &text) {
     if (m_events[i].type == MIDI_S_HW_STRING) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_HW_STRING);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_HW_STRING);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(text, m_events[i].length);
@@ -647,7 +647,7 @@ void GOMidiSender::SetName(const wxString &text) {
     if (m_events[i].type == MIDI_S_HW_NAME_LCD) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_HW_LCD);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_HW_LCD);
       e.SetChannel(m_events[i].low_value);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
@@ -657,7 +657,7 @@ void GOMidiSender::SetName(const wxString &text) {
     if (m_events[i].type == MIDI_S_HW_NAME_STRING) {
       GOMidiEvent e;
       e.SetDevice(m_events[i].deviceId);
-      e.SetMidiType(MIDI_SYSEX_HW_STRING);
+      e.SetMidiType(GOMidiEvent::MIDI_SYSEX_HW_STRING);
       e.SetKey(m_events[i].key);
       e.SetValue(m_events[i].start);
       e.SetString(text, m_events[i].length);

--- a/src/grandorgue/midi/ports/GOMidiInPort.cpp
+++ b/src/grandorgue/midi/ports/GOMidiInPort.cpp
@@ -31,7 +31,7 @@ void GOMidiInPort::Receive(const std::vector<unsigned char> msg) {
 
   GOMidiEvent e;
   e.FromMidi(msg, m_midi->GetMidiMap());
-  if (e.GetMidiType() == MIDI_NONE)
+  if (e.GetMidiType() == GOMidiEvent::MIDI_NONE)
     return;
   e.SetDevice(GetID());
   e.SetTime(wxGetLocalTimeMillis());


### PR DESCRIPTION
Starting working on #1392,
- I moved the type midi_message_type into the class GOMidiEvent and renamed it to MidiType
- I renamed GOMidiEvent::m_miditype to m_MidiType
- I replaced multiple occurencies of e.GetMidiType() in GOMidiReceiverBase::Match with using a variable eMidiType

It is just refactoring. No GO behavior should be changed.