### PR TITLE
Fixed installing dependencies for libwxgtk3-dev

### DIFF
--- a/build-scripts/for-linux/prepare-debian-based.sh
+++ b/build-scripts/for-linux/prepare-debian-based.sh
@@ -42,6 +42,10 @@ else
   GCC_SUFFIX=-$(dpkg-architecture -A $TARGET_ARCH -q DEB_TARGET_MULTIARCH)
 fi
 
+# it is necessary for future installing wx
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  libcups2:$TARGET_ARCH
+
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   cmake \
   docbook-xsl \


### PR DESCRIPTION
Some changes in the ubuntu packages broke capability of installing wxWidgets for non-amd64 environment: see [the failed builds](https://github.com/GrandOrgue/grandorgue/actions/runs/6163103280)

This PR adds a workaround of installing dependencies.

No GO behavior should be changed.