### PR TITLE
Extracted enums from GOMidiReceiverEventPatternList.h to separate header files

### DIFF
--- a/src/core/midi/GOMidiMatchType.h
+++ b/src/core/midi/GOMidiMatchType.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDIMATCHTYPE_H
+#define GOMIDIMATCHTYPE_H
+
+enum GOMidiMatchType {
+  MIDI_MATCH_NONE,
+  MIDI_MATCH_ON,
+  MIDI_MATCH_OFF,
+  MIDI_MATCH_CHANGE,
+  MIDI_MATCH_RESET,
+};
+
+#endif /* GOMIDIMATCHTYPE_H */

--- a/src/core/midi/GOMidiReceiverBase.h
+++ b/src/core/midi/GOMidiReceiverBase.h
@@ -8,6 +8,7 @@
 #ifndef GOMIDIRECEIVERBASE_H
 #define GOMIDIRECEIVERBASE_H
 
+#include "GOMidiMatchType.h"
 #include "GOMidiReceiverEventPatternList.h"
 #include "GOTime.h"
 

--- a/src/core/midi/GOMidiReceiverEventPatternList.h
+++ b/src/core/midi/GOMidiReceiverEventPatternList.h
@@ -10,23 +10,7 @@
 
 #include "GOMidiEventPatternList.h"
 #include "GOMidiReceiverEventPattern.h"
-
-typedef enum {
-  MIDI_RECV_DRAWSTOP,
-  MIDI_RECV_BUTTON,
-  MIDI_RECV_ENCLOSURE,
-  MIDI_RECV_MANUAL,
-  MIDI_RECV_SETTER,
-  MIDI_RECV_ORGAN,
-} GOMidiReceiverType;
-
-typedef enum {
-  MIDI_MATCH_NONE,
-  MIDI_MATCH_ON,
-  MIDI_MATCH_OFF,
-  MIDI_MATCH_CHANGE,
-  MIDI_MATCH_RESET,
-} GOMidiMatchType;
+#include "GOMidiReceiverType.h"
 
 using GOMidiReceiverEventPatternList
   = GOMidiEventPatternList<GOMidiReceiverType, GOMidiReceiverEventPattern>;

--- a/src/core/midi/GOMidiReceiverType.h
+++ b/src/core/midi/GOMidiReceiverType.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDIRECEIVERTYPE_H
+#define GOMIDIRECEIVERTYPE_H
+
+enum GOMidiReceiverType {
+  MIDI_RECV_DRAWSTOP,
+  MIDI_RECV_BUTTON,
+  MIDI_RECV_ENCLOSURE,
+  MIDI_RECV_MANUAL,
+  MIDI_RECV_SETTER,
+  MIDI_RECV_ORGAN,
+};
+
+#endif /* GOMIDIRECEIVERTYPE_H */


### PR DESCRIPTION
As @larspalo mentioned in https://github.com/GrandOrgue/grandorgue/pull/1654#discussion_r1332084229, I moved enum definitions from `GOMidiReceiverEventPatternList.h` to separate header files.

It is just refactoring. No GO behavior should be changed.
