### PR TITLE
Added capability of control buttons with Control Change MIDI events with different keys but same values using "Bx Ctrl Change Fixed On Value Toggle" and "Bx Ctrl Change Fixed Off Value Toggle" https://github.com/GrandOrgue/grandorgue/issues/1392

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added capability of control buttons with Control Change MIDI events with different keys but same values using "Bx Ctrl Change Fixed On Value Toggle" and "Bx Ctrl Change Fixed Off Value Toggle" https://github.com/GrandOrgue/grandorgue/issues/1392
 - Added saving dialog positions and sizes https://github.com/GrandOrgue/grandorgue/issues/1035
 - Increased maximum value of Pipe999LoopCrossfadeLength and Pipe999ReleaseCrossfadeLength. Now they are 3000 https://github.com/GrandOrgue/grandorgue/issues/1612
 # 3.12.3 (2023-08-14)

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -710,12 +710,12 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED_ON
       && m_events[i].key == e.GetKey()
       && e.GetValue() == m_events[i].high_value)
-      return debounce(e, MIDI_MATCH_CHANGE, i);
+      return debounce(e, MIDI_MATCH_ON, i);
     if (
       eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED_OFF
       && m_events[i].key == e.GetKey() && e.GetValue() == m_events[i].low_value)
-      return debounce(e, MIDI_MATCH_CHANGE, i);
+      return debounce(e, MIDI_MATCH_OFF, i);
     if (
       eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
       && m_events[i].type == MIDI_M_CTRL_CHANGE_FIXED_ON_OFF


### PR DESCRIPTION
Resolves: #1392

This PR
1. Fixed matching midi events with `Bx Ctrl Change Fixed On Value Toggle` and `Bx Ctrl Change Fixed Off Value Toggle` event patterns. Earlier they trigger drowstops between ON and OFF. Now the first event only switches the drawstop ON and the second one switches to OFF. The events are ignored if the drawstop is already in the ON (OFF) state.
2. If ON and OFF ctrl change events have different keys and the same values, now `Detect for complex MIDI setup` creates two event patterns with `Bx Ctrl Change Fixed On Value Toggle` and `Bx Ctrl Change Fixed Off Value Toggle`
