### PR TITLE
Fixed error messages after multiple runs of GrandOrgue ftom Appimage with a demo organ https://github.com/GrandOrgue/grandorgue/issues/1660

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed error messages after multiple runs of GrandOrgue ftom Appimage with a demo organ https://github.com/GrandOrgue/grandorgue/issues/1660
 # 3.13.0 (2023-10-11)
 - Implemented option to send MIDI Note Off as 0x8X or 0x9X with velocity 0 https://github.com/GrandOrgue/grandorgue/issues/1640
 - Added capability of control buttons with Control Change MIDI events with different keys but same values using "Bx Ctrl Change Fixed On Value Toggle" and "Bx Ctrl Change Fixed Off Value Toggle" https://github.com/GrandOrgue/grandorgue/issues/1392

--- a/src/core/archive/GOArchiveCreator.cpp
+++ b/src/core/archive/GOArchiveCreator.cpp
@@ -66,7 +66,9 @@ bool GOArchiveCreator::AddPackage(const wxString &path) {
       return true;
     }
   m_packageIDs.push_back(a);
-  GOArchive *archive = m_Manager.LoadArchive(a->GetID());
+
+  GOArchive *archive = m_Manager.LoadArchive(a->GetID(), path);
+
   if (!archive) {
     wxLogError(_("Failed to load organ package %s"), path.c_str());
     return false;

--- a/src/core/archive/GOArchiveManager.h
+++ b/src/core/archive/GOArchiveManager.h
@@ -26,7 +26,7 @@ public:
   GOArchiveManager(GOOrganList &OrganList, const wxString &cacheDir);
   ~GOArchiveManager();
 
-  GOArchive *LoadArchive(const wxString &id);
+  GOArchive *LoadArchive(const wxString &id, const wxString &archivePath);
   wxString InstallPackage(const wxString &path);
   bool RegisterPackage(const wxString &path);
   void RegisterPackageDirectory(const wxString &path);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -347,7 +347,11 @@ wxString GOOrganController::Load(
     wxString errMsg;
 
     if (!m_FileStore.LoadArchives(
-          m_config, m_config.OrganCachePath(), organ.GetArchiveID(), errMsg))
+          m_config,
+          m_config.OrganCachePath(),
+          organ.GetArchiveID(),
+          organ.GetArchivePath(),
+          errMsg))
       return errMsg;
     m_ArchivePath = organ.GetArchivePath();
     m_odf = organ.GetODFPath();

--- a/src/grandorgue/loader/GOFileStore.cpp
+++ b/src/grandorgue/loader/GOFileStore.cpp
@@ -28,12 +28,13 @@ void GOFileStore::SetDirectory(const wxString &directory) {
 bool GOFileStore::LoadArchive(
   GOOrganList &organList,
   const wxString &cacheDir,
-  const wxString id,
+  const wxString &id,
+  const wxString &archivePath,
   const wxString &parentId,
   wxString &errMsg) {
   bool isOk = true;
   GOArchiveManager manager(organList, cacheDir);
-  GOArchive *archive = manager.LoadArchive(id);
+  GOArchive *archive = manager.LoadArchive(id, archivePath);
 
   if (archive)
     m_archives.push_back(archive);
@@ -61,15 +62,18 @@ bool GOFileStore::LoadArchive(
 bool GOFileStore::LoadArchives(
   GOOrganList &organList,
   const wxString &cacheDir,
-  const wxString mainId,
+  const wxString &mainArchiveId,
+  const wxString &mainArchivePath,
   wxString &errMsg) {
   SetDirectory(wxEmptyString); // clean up all
 
-  bool isOk = LoadArchive(organList, cacheDir, mainId, wxEmptyString, errMsg);
+  bool isOk = LoadArchive(
+    organList, cacheDir, mainArchiveId, mainArchivePath, wxEmptyString, errMsg);
 
   if (isOk)
     for (auto depId : m_archives[0]->GetDependencies()) {
-      isOk = LoadArchive(organList, cacheDir, depId, mainId, errMsg);
+      isOk = LoadArchive(
+        organList, cacheDir, depId, wxEmptyString, mainArchiveId, errMsg);
       if (!isOk)
         break;
     }

--- a/src/grandorgue/loader/GOFileStore.h
+++ b/src/grandorgue/loader/GOFileStore.h
@@ -31,7 +31,8 @@ private:
   bool LoadArchive(
     GOOrganList &organList,
     const wxString &cacheDir,
-    const wxString id,
+    const wxString &id,
+    const wxString &archivePath,
     const wxString &parentId,
     wxString &errMsg);
 
@@ -50,7 +51,9 @@ public:
    * Load archive directories for the given archive id and all it's dependencies
    * @param organList - a list of registered organs
    * @param cacheDir - a directory to read/write index files
-   * @param mainId - an identifier of the main archive to load
+   * @param mainArchiveId - an identifier of the main archive to load
+   * @param mainArchivePath - an path to the main archive to load. If empty
+   *   then search among organList
    * @param errMsg - an error message that is returned if the operation fails
    * @return - true if success and false if any error occured (the error message
    *   is returned in errMsg)
@@ -58,7 +61,8 @@ public:
   bool LoadArchives(
     GOOrganList &organList,
     const wxString &cacheDir,
-    const wxString mainId,
+    const wxString &mainArchiveId,
+    const wxString &mainArchivePath,
     wxString &errMsg);
 
   /**


### PR DESCRIPTION
This is the first PR related to #1660

Because running GrandOrgue from applimage causing unpacking it to a temporary directory, the demo Organ may be registered multiple time with different paths. Old paths are not more valid, because the old directories have already been deleted.

Earlier opening an organ from a package were only by ArchiveId and the path was not taken in account. It caused trying to open the archive from all paths had been registered and logging error messages on each invalid path.

This PR adds passing the archive path to GOArchiveManager::LoadArchive that makes unnecessary looking over invalid paths. So this PR *eliminates logging extra error messages*.

Multiple demo organs registered are still an issue and will be fixed with another PR.