### PR TITLE
Added deregistering organs in the temporary directory that do not more exist https://github.com/GrandOrgue/grandorgue/issues/1660

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added deregistering organs in the temporary directory that do not more exist https://github.com/GrandOrgue/grandorgue/issues/1660
 - Fixed error messages after multiple runs of GrandOrgue ftom Appimage with a demo organ https://github.com/GrandOrgue/grandorgue/issues/1660
 # 3.13.0 (2023-10-11)
 - Implemented option to send MIDI Note Off as 0x8X or 0x9X with velocity 0 https://github.com/GrandOrgue/grandorgue/issues/1640

--- a/src/core/GOOrgan.cpp
+++ b/src/core/GOOrgan.cpp
@@ -85,8 +85,6 @@ const wxString &GOOrgan::GetRecordingDetail() const {
   return m_RecordingDetail;
 }
 
-const wxString &GOOrgan::GetArchiveID() const { return m_ArchiveID; }
-
 GOMidiReceiverBase &GOOrgan::GetMIDIReceiver() { return m_midi; }
 
 const wxString GOOrgan::GetUITitle() const {
@@ -121,13 +119,19 @@ bool GOOrgan::Match(const GOMidiEvent &e) {
 }
 
 bool GOOrgan::IsUsable(const GOOrganList &organs) const {
-  if (m_ArchiveID != wxEmptyString) {
-    const GOArchiveFile *archive = organs.GetArchiveByID(m_ArchiveID, true);
+  bool res;
+
+  if (!m_ArchiveID.IsEmpty()) {
+    const GOArchiveFile *archive = m_ArchivePath.IsEmpty()
+      ? organs.GetArchiveByID(m_ArchiveID, true)
+      : organs.GetArchiveByPath(m_ArchivePath);
+
     if (!archive)
-      return false;
-    return archive->IsComplete(organs);
+      res = false;
+    res = archive->IsComplete(organs);
   } else
-    return wxFileExists(m_ODF);
+    res = wxFileExists(m_ODF);
+  return res;
 }
 
 const wxString GOOrgan::GetOrganHash() const {

--- a/src/core/GOOrgan.h
+++ b/src/core/GOOrgan.h
@@ -50,10 +50,13 @@ public:
   const wxString &GetChurchName() const;
   const wxString &GetOrganBuilder() const;
   const wxString &GetRecordingDetail() const;
-  const wxString &GetArchiveID() const;
+  const wxString &GetArchiveID() const { return m_ArchiveID; }
   const wxString &GetArchivePath() const { return m_ArchivePath; }
   void SetArchivePath(const wxString &archivePath) {
     m_ArchivePath = archivePath;
+  }
+  const wxString &GetPath() const {
+    return m_ArchiveID.IsEmpty() ? m_ODF : m_ArchivePath;
   }
   const wxString GetOrganHash() const;
   long GetLastUse() const;

--- a/src/core/GOOrganList.h
+++ b/src/core/GOOrganList.h
@@ -32,8 +32,9 @@ public:
   ~GOOrganList();
 
   void AddOrgan(const GOOrgan &organ);
-  const ptr_vector<GOOrgan> &GetOrganList() const;
-  ptr_vector<GOOrgan> &GetOrganList();
+  void RemoveInvalidTmpOrgans();
+  const ptr_vector<GOOrgan> &GetOrganList() const { return m_OrganList; }
+  ptr_vector<GOOrgan> &GetOrganList() { return m_OrganList; }
   std::vector<const GOOrgan *> GetLRUOrganList();
 
   void AddArchive(const GOArchiveFile &archive);

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -522,6 +522,11 @@ void GOFrame::Init(wxString filename) {
     event.SetClientData(pReasons);
     GetEventHandler()->AddPendingEvent(event);
   }
+
+  // Remove demo organs that have been registered from temporary (appimage)
+  // directories and they are not more valid
+  m_config.RemoveInvalidTmpOrgans();
+
   GOArchiveManager manager(m_config, m_config.OrganCachePath());
   manager.RegisterPackageDirectory(m_config.GetPackageDirectory());
   manager.RegisterPackageDirectory(m_config.OrganPackagePath());


### PR DESCRIPTION
This is the second and the last PR related to #1660

Now when GrandOrgue starts, it automatically removes registration of all organs that were under the temporary directory and are not more exist. It solves the problem of multiplication of the Demo organ when GO is rinning from Appimage.