### PR TITLE
Adopted the build instruction and the build scripts to new ubuntu versions https://github.com/GrandOrgue/grandorgue/issues/1673

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -36,7 +36,7 @@ You can download the source code archive from GitHub
     - Or run the prepared scripts for certain linux distributions by a sudoer user:
         - on Fedora run ``<GO source tree>/build-scripts/for-linux/prepare-fedora.sh``
         - on OpenSuse run ``<GO source tree>/build-scripts/for-linux/prepare-opensuse.sh``
-        - on Debian 9+ or on Ubuntu 18+ run ``<GO source tree>/build-scripts/for-linux/prepare-debian-ubuntu.sh``
+        - on Debian 9+ or on Ubuntu 18+ run ``<GO source tree>/build-scripts/for-linux/prepare-debian-based.sh``
 3. Build
     - Manually
         1. Create an empty build directory, eg:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Adopted the build instruction and the build scripts to new ubuntu versions https://github.com/GrandOrgue/grandorgue/issues/1673
 - Improved concurrency handling
 - Added deregistering organs in the temporary directory that do not more exist https://github.com/GrandOrgue/grandorgue/issues/1660
 - Fixed error messages after multiple runs of GrandOrgue ftom Appimage with a demo organ https://github.com/GrandOrgue/grandorgue/issues/1660

--- a/build-scripts/for-appimage-x86_64/build-on-linux.sh
+++ b/build-scripts/for-appimage-x86_64/build-on-linux.sh
@@ -6,12 +6,13 @@
 
 set -e
 
-source $(dirname $0)/../set-ver-prms.sh "$1" "$2"
+DIR=$(readlink -f $(dirname $0))
+source $DIR/../set-ver-prms.sh "$1" "$2"
 
 if [[ -n "$3" ]]; then
-	SRC_DIR=$3
+	SRC_DIR=$(readlink -f $3)
 else
-	SRC_DIR=$(readlink -f $(dirname $0)/../..)
+	SRC_DIR=$(readlink -f $DIR/../..)
 fi
 
 PARALLEL_PRMS="-j$(nproc)"
@@ -22,7 +23,12 @@ pushd build/appimage-x86_64
 rm -rf *
 export LANG=C
 
-GO_PRMS="-DCMAKE_INSTALL_PREFIX=/usr -DRTAUDIO_USE_JACK=OFF -DRTMIDI_USE_JACK=OFF -DGO_USE_JACK=OFF -DCMAKE_BUILD_TYPE=Release $CMAKE_VERSION_PRMS"
+GO_PRMS="-DCMAKE_INSTALL_PREFIX=/usr \
+  -DRTAUDIO_USE_JACK=OFF \
+  -DRTMIDI_USE_JACK=OFF \
+  -DGO_USE_JACK=OFF \
+  -DCMAKE_BUILD_TYPE=Release \
+  $CMAKE_VERSION_PRMS"
 echo "cmake -G \"Unix Makefiles\" $GO_PRMS . $SRC_DIR"
 cmake -G "Unix Makefiles" $GO_PRMS . $SRC_DIR
 make -k $PARALLEL_PRMS

--- a/build-scripts/for-linux-aarch64/build-on-linux.sh
+++ b/build-scripts/for-linux-aarch64/build-on-linux.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-DIR=$(dirname $0)
+DIR=$(readlink -f $(dirname $0))
 source $DIR/../set-ver-prms.sh "$1" "$2"
 
 if [[ -n "$3" ]]; then

--- a/build-scripts/for-linux-armhf/build-on-linux.sh
+++ b/build-scripts/for-linux-armhf/build-on-linux.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-DIR=$(dirname $0)
+DIR=$(readlink -f $(dirname $0))
 source $DIR/../set-ver-prms.sh "$1" "$2"
 
 if [[ -n "$3" ]]; then

--- a/build-scripts/for-linux/build-on-linux.sh
+++ b/build-scripts/for-linux/build-on-linux.sh
@@ -3,12 +3,12 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
-# $4 - package suffix: empty or wx30
+# $4 - package suffix: empty or wx30 or wx32
 # $5 - target deb architecture. Default - current
 
 set -e
 
-DIR=$(dirname $0)
+DIR=$(readlink -f $(dirname $0))
 source $DIR/../set-ver-prms.sh "$1" "$2"
 
 if [[ -n "$3" ]]; then

--- a/build-scripts/for-linux/build-on-linux.sh
+++ b/build-scripts/for-linux/build-on-linux.sh
@@ -33,6 +33,12 @@ GO_PRMS="-DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_PACKAGE_SUFFIX=$PACKAGE_SUFFIX \
   $($DIR/cmake-prm-yaml-cpp.bash $TARGET_ARCH)"
 
+# a workaround of the new dpkg-shlibdeps that prevents cpack from making the DEB package
+if ! dpkg-shlibdeps --help 1>/dev/null; then
+  echo "set(IGNORE_MISSING_INFO_FLAG --ignore-missing-info)" >CPackSpkgShlibdeps.cmake
+  GO_PRMS="$GO_PRMS -DCPACK_PROPERTIES_FILE=$(readlink -f CPackSpkgShlibdeps.cmake)"
+fi
+
 echo "cmake -G \"Unix Makefiles\" $GO_PRMS . $SRC_DIR"
 cmake -G "Unix Makefiles" $GO_PRMS . $SRC_DIR
 make -k $PARALLEL_PRMS VERBOSE=1 package

--- a/build-scripts/for-linux/prepare-ubuntu-wx-repo.bash
+++ b/build-scripts/for-linux/prepare-ubuntu-wx-repo.bash
@@ -9,7 +9,7 @@ set -e
 WX_PACKAGE_NAME=$1
 
 sudo apt-get update
-if ! apt-cache show $WX_PACKAGE_NAME; then
+if ! apt-cache show $WX_PACKAGE_NAME 2>/dev/null; then
   # the wx package is not found
   if [[ "$WX_PACKAGE_NAME" == "libwxgtk3.2-dev" ]]; then
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common


### PR DESCRIPTION
Resolves: #1673

This PR:
1. build-scripts/for-linux/prepare-debian-based.sh: when no wx parameter has been passed earlier wx3.0 was used, now  using the available libwxgtk-dev in the current distribution.
2. prepare-scripts: hid the error messages on determining the existing wx package
3. build-on-linux.sh: fixed running from a relative path
4. BUILD.md - fixed the preparing script name for linux

It impacts only the build processus. No GO behavior should be changed
