### PR TITLE
Fixed change tracking and enabling/disabling the Discard and Apply buttons in the Organ Settings dialog https://github.com/GrandOrgue/grandorgue/issues/1674

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed change tracking and enableing/disabling the Discard and Apply buttons in the Organ Settings dialog https://github.com/GrandOrgue/grandorgue/issues/1674
+- Renamed the Reset button to Discard in the Organ Settings dialog https://github.com/GrandOrgue/grandorgue/issues/1674
 - Adopted the build instruction and the build scripts to new ubuntu versions https://github.com/GrandOrgue/grandorgue/issues/1673
 - Improved concurrency handling
 - Added deregistering organs in the temporary directory that do not more exist https://github.com/GrandOrgue/grandorgue/issues/1660

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -5591,7 +5591,7 @@ Within  windchests, the ranks are ordered as found in the definition file.
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>Reset</term>
+          <term>Discard</term>
           <listitem>
             <simpara>This button is grayed out until a value is modified. It restores all previously applied values.</simpara>
           </listitem>

--- a/src/grandorgue/dialogs/GOOrganSettingsDialog.h
+++ b/src/grandorgue/dialogs/GOOrganSettingsDialog.h
@@ -63,7 +63,7 @@ private:
   wxStaticText *m_MemoryDisplay;
   wxStaticText *m_BitDisplay;
   wxButton *m_Apply;
-  wxButton *m_Reset;
+  wxButton *m_Discard;
   wxButton *m_Default;
   wxButton *m_DefaultAll;
   wxButton *m_AudioGroupAssistant;
@@ -112,41 +112,12 @@ private:
   void OnAttackLoadChanged(wxCommandEvent &e);
   void OnReleaseLoadChanged(wxCommandEvent &e);
   void OnEventApply(wxCommandEvent &e);
-  void OnEventReset(wxCommandEvent &e);
+  void OnEventDiscard(wxCommandEvent &e);
   void OnEventDefault(wxCommandEvent &e);
   void OnEventDefaultAll(wxCommandEvent &e);
   void OnAudioGroupAssitant(wxCommandEvent &e);
 
 protected:
-  enum {
-    ID_EVENT_TREE = 200,
-    ID_EVENT_APPLY,
-    ID_EVENT_RESET,
-    ID_EVENT_AUDIO_GROUP_ASSISTANT,
-    ID_EVENT_DEFAULT,
-    ID_EVENT_DEFAULT_ALL,
-    ID_EVENT_AMPLITUDE,
-    ID_EVENT_AMPLITUDE_SPIN,
-    ID_EVENT_GAIN,
-    ID_EVENT_GAIN_SPIN,
-    ID_EVENT_MANUAL_TUNING,
-    ID_EVENT_MANUAL_TUNING_SPIN,
-    ID_EVENT_AUTO_TUNING_CORRECTION,
-    ID_EVENT_AUTO_TUNING_CORRECTION_SPIN,
-    ID_EVENT_DELAY,
-    ID_EVENT_DELAY_SPIN,
-    ID_EVENT_RELEASE_LENGTH,
-    ID_EVENT_RELEASE_LENGTH_SPIN,
-    ID_EVENT_AUDIO_GROUP,
-    ID_EVENT_IGNORE_PITCH,
-    ID_EVENT_LOOP_LOAD,
-    ID_EVENT_ATTACK_LOAD,
-    ID_EVENT_RELEASE_LOAD,
-    ID_EVENT_BITS_PER_SAMPLE,
-    ID_EVENT_CHANNELS,
-    ID_EVENT_COMPRESS
-  };
-
   bool TransferDataToWindow() override;
   bool Validate() override { return !CheckForUnapplied(); }
 


### PR DESCRIPTION
This is the first PR related to #1674 

In the Organ Settings dialog:

- Renamed Reset to Discard
- Fixed bug where Reset and Apply were always enabled