### PR TITLE
Fixed crash when trying to load a sample set with a truncated wave file https://github.com/GrandOrgue/grandorgue/discussions/370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash when trying to load a sample set with a truncated wave file https://github.com/GrandOrgue/grandorgue/discussions/370
 - Fixed crash on closing an organ https://github.com/GrandOrgue/grandorgue/issues/1678
 # 3.13.1 (2023-11-05)
 - Fixed the maximal value of the "SYSEX Hauptwerk 32 Byte LCD" midi send events https://github.com/GrandOrgue/grandorgue/issues/1686

--- a/src/core/GOWave.cpp
+++ b/src/core/GOWave.cpp
@@ -138,15 +138,20 @@ static void check_for_bounds(
   unsigned long chunkOffset) {
   unsigned long size = pHeader->dwSize;
 
-  if (offset + size > length)
+  if (offset + size > length) {
+    char buf[5];
+
+    strncpy(buf, (const char *)&pHeader->fccChunk, 4);
+    buf[4] = '\x00';
     throw wxString::Format(
-      _("Malformed wave file '%s'. The chunk %x at %lu with the size 8 + %lu "
-        "ends after the end of file %lu"),
+      _("Malformed wave file '%s'. The chunk '%4s' at %lu with the size 8 + %lu"
+        " ends after the end of file %lu"),
       fileName,
-      (unsigned)pHeader->fccChunk,
+      buf,
       chunkOffset,
       size,
       length);
+  }
 }
 
 void GOWave::Open(const GOBuffer<uint8_t> &content, const wxString fileName) {
@@ -272,14 +277,6 @@ void GOWave::Open(const GOBuffer<uint8_t> &content, const wxString fileName) {
         m_Loops.erase(m_Loops.begin() + i);
       }
     }
-  } catch (wxString msg) {
-    wxLogError(_("unhandled exception: %s\n"), msg);
-
-    /* Free any memory that was allocated by chunk loading procedures */
-    Close();
-
-    /* Rethrow the exception */
-    throw;
   } catch (...) {
     /* Free any memory that was allocated by chunk loading procedures */
     Close();

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -573,8 +573,11 @@ wxString GOOrganController::Load(
               obj->GetLoadTitle(),
               obj->GetLoadError());
         }
-        errMsg.Printf(
-          _("There are errors while loading the organ. See Log Messages."));
+        GOMessageBox(
+          _("There are errors while loading the organ. See Log Messages."),
+          _("Load error"),
+          wxOK | wxICON_ERROR,
+          NULL);
       } else {
         if (objectDistributor.IsComplete())
           m_Cacheable = true;

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -270,19 +270,12 @@ void GOSoundingPipe::LoadData(
       m_LoopCrossfadeLength,
       m_ReleaseCrossfadeLength);
     Validate();
-  } catch (wxString str) {
-    m_SoundProvider.ClearData();
-    throw wxString::Format(
-      _("Error while loading samples for rank %s pipe %s: %s"),
-      m_Rank->GetName().c_str(),
-      GetLoadTitle().c_str(),
-      str.c_str());
   } catch (std::bad_alloc &ba) {
     m_SoundProvider.ClearData();
     throw GOOutOfMemory();
-  } catch (GOOutOfMemory e) {
+  } catch (...) {
     m_SoundProvider.ClearData();
-    throw GOOutOfMemory();
+    throw;
   }
 }
 


### PR DESCRIPTION
This PR solves some difficulties described in #370:

- adds checking that .wav chunks do not extend beyond the end of the file
- removed extra exception handling in ``GOWave::Open``
- earlier if an exception occured during loading a pipe, the loading of organ was aborted. Now it continues loading with error messages in the Log window