### PR TITLE
Fixed loading an organ when some configuration entry is out of range https://github.com/GrandOrgue/grandorgue/issues/1696

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed loading an organ when some configuration entry is out of range https://github.com/GrandOrgue/grandorgue/issues/1696
 - Fixed crash when trying to load a sample set with a truncated wave file https://github.com/GrandOrgue/grandorgue/discussions/370
 - Fixed crash on closing an organ https://github.com/GrandOrgue/grandorgue/issues/1678
 # 3.13.1 (2023-11-05)

--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -375,6 +375,12 @@ int GOConfigReader::ReadInteger(
   }
 
   if (retval < nmin || retval > nmax) {
+    if (type == ODFSetting)
+      throw wxString::Format(
+        _("Out of range value at section '%s' entry '%s': %ld"),
+        group,
+        key,
+        retval);
     wxLogError(
       _("Out of range value at section '%s' entry '%s': %ld. Assumed %d"),
       group,
@@ -456,6 +462,12 @@ double GOConfigReader::ReadFloat(
   }
 
   if (retval < nmin || retval > nmax) {
+    if (type == ODFSetting)
+      throw wxString::Format(
+        _("Out of range value at section '%s' entry '%s': %f"),
+        group,
+        key,
+        retval);
     wxLogError(
       _("Out of range value at section '%s' entry '%s': %f. Assumed %f."),
       group,

--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -374,16 +374,16 @@ int GOConfigReader::ReadInteger(
       value.c_str());
   }
 
-  if (nmin <= retval && retval <= nmax)
-    return retval;
-
-  wxString error;
-  error.Printf(
-    _("Out of range value at section '%s' entry '%s': %ld"),
-    group,
-    key,
-    retval);
-  throw error;
+  if (retval < nmin || retval > nmax) {
+    wxLogError(
+      _("Out of range value at section '%s' entry '%s': %ld. Assumed %d"),
+      group,
+      key,
+      retval,
+      defaultValue);
+    retval = defaultValue;
+  }
+  return retval;
 }
 
 int GOConfigReader::ReadLong(
@@ -455,16 +455,16 @@ double GOConfigReader::ReadFloat(
     throw error;
   }
 
-  if (nmin <= retval && retval <= nmax)
-    return retval;
-
-  wxString error;
-  error.Printf(
-    _("Out of range value at section '%s' entry '%s': %f"),
-    group.c_str(),
-    key.c_str(),
-    retval);
-  throw error;
+  if (retval < nmin || retval > nmax) {
+    wxLogError(
+      _("Out of range value at section '%s' entry '%s': %f. Assumed %f."),
+      group,
+      key,
+      retval,
+      defaultValue);
+    retval = defaultValue;
+  }
+  return retval;
 }
 
 unsigned GOConfigReader::ReadSize(


### PR DESCRIPTION
Resolves: #1696

This PR changes handling of ``Out of range`` configuration errors dramatically.

Earlier loading the organ was finishing. Now the default value is used for this configurantion entry and loading the organ continues. An error message appears in the Log window.

I'm not sure that the new behavior does not cause unattended side effects.