### PR TITLE
Fixed the maximal value of the "SYSEX Hauptwerk 32 Byte LCD" midi send events https://github.com/GrandOrgue/grandorgue/issues/1686

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed the maximal value of the "SYSEX Hauptwerk 32 Byte LCD" midi send events https://github.com/GrandOrgue/grandorgue/issues/1686
 - Fixed discard in the Organ Settings dialog when multiple objects are selected https://github.com/GrandOrgue/grandorgue/issues/1674
 - Moved all Organ Settings dialog buttons to the single button row https://github.com/GrandOrgue/grandorgue/issues/1674
 - Decreased number of decimal digits in the Organ Settings dialog https://github.com/GrandOrgue/grandorgue/issues/1627

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -124,15 +124,18 @@ void GOMidiSender::Load(GOConfigReader &cfg, wxString group, GOMidiMap &map) {
         0x1f,
         false,
         0);
-    if (HasLength(eventType))
+    if (HasLength(eventType)) {
+      unsigned maxLength = LengthLimit(eventType);
+
       m_events[i].length = cfg.ReadInteger(
         CMBSetting,
         group,
         wxString::Format(wxT("MIDISendLength%03d"), i + 1),
         0,
-        0x1f,
+        maxLength,
         false,
-        LengthLimit(eventType));
+        maxLength);
+    }
   }
 }
 


### PR DESCRIPTION
Resolves: #1686

This PR uses the actual maximum length for SYSEX Hauptwerk  LCD midi events.
