### PR TITLE
Fixed GO crashing due to race condition when closing an organ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on closing an organ https://github.com/GrandOrgue/grandorgue/issues/1678
 # 3.13.1 (2023-11-05)
 - Fixed the maximal value of the "SYSEX Hauptwerk 32 Byte LCD" midi send events https://github.com/GrandOrgue/grandorgue/issues/1686
 - Fixed discard in the Organ Settings dialog when multiple objects are selected https://github.com/GrandOrgue/grandorgue/issues/1674

--- a/src/grandorgue/sound/GOSound.cpp
+++ b/src/grandorgue/sound/GOSound.cpp
@@ -240,8 +240,10 @@ void GOSound::AssignOrganFile(GOOrganController *organController) {
     multi.Add(m_AudioOutputs[i].mutex);
 
   if (m_OrganController) {
+    StopThreads();
     m_OrganController->Abort();
     m_SoundEngine.ClearSetup();
+    StartThreads();
   }
 
   m_OrganController = organController;

--- a/src/grandorgue/sound/GOSound.cpp
+++ b/src/grandorgue/sound/GOSound.cpp
@@ -54,11 +54,6 @@ void GOSound::StartThreads() {
     m_Threads[i]->Run();
 }
 
-void GOSound::WaitForThreadsToReleaseWorkItems() {
-  for (unsigned i = 0; i < m_Threads.size(); i++)
-    m_Threads[i]->WaitForReleaseOfWorkItems();
-}
-
 void GOSound::StopThreads() {
   for (unsigned i = 0; i < m_Threads.size(); i++)
     m_Threads[i]->Delete();
@@ -247,7 +242,8 @@ void GOSound::AssignOrganFile(GOOrganController *organController) {
   if (m_OrganController) {
     // ensure pointers to work items are not held by threads
     m_SoundEngine.GetScheduler().PauseGivingWork();
-    WaitForThreadsToReleaseWorkItems();
+    for (GOSoundThread *thread : m_Threads)
+      thread->WaitForIdle();
 
     m_OrganController->Abort();
     // now work items are safe to be deleted

--- a/src/grandorgue/sound/GOSound.cpp
+++ b/src/grandorgue/sound/GOSound.cpp
@@ -245,14 +245,16 @@ void GOSound::AssignOrganFile(GOOrganController *organController) {
     multi.Add(m_AudioOutputs[i].mutex);
 
   if (m_OrganController) {
-    // clear any scheduled work items
-    m_SoundEngine.GetScheduler().Clear();
     // ensure pointers to work items are not held by threads
+    m_SoundEngine.GetScheduler().PauseGivingWork();
     WaitForThreadsToReleaseWorkItems();
 
     m_OrganController->Abort();
     // now work items are safe to be deleted
     m_SoundEngine.ClearSetup();
+
+    // resume processing of work items
+    m_SoundEngine.GetScheduler().ResumeGivingWork();
   }
 
   m_OrganController = organController;

--- a/src/grandorgue/sound/GOSound.h
+++ b/src/grandorgue/sound/GOSound.h
@@ -94,7 +94,6 @@ private:
 
   void StopThreads();
   void StartThreads();
-  void WaitForThreadsToReleaseWorkItems();
 
   void ResetMeters();
 

--- a/src/grandorgue/sound/GOSound.h
+++ b/src/grandorgue/sound/GOSound.h
@@ -94,6 +94,7 @@ private:
 
   void StopThreads();
   void StartThreads();
+  void WaitForThreadsToReleaseWorkItems();
 
   void ResetMeters();
 

--- a/src/grandorgue/sound/scheduler/GOSoundScheduler.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundScheduler.cpp
@@ -131,7 +131,7 @@ void GOSoundScheduler::Exec() {
 
 GOSoundWorkItem *GOSoundScheduler::GetNextGroup() {
   do {
-    if (m_IsNotGivingWork) {
+    if (m_IsNotGivingWork.load()) {
       return nullptr;
     }
     unsigned next = m_NextItem.fetch_add(1);

--- a/src/grandorgue/sound/scheduler/GOSoundScheduler.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundScheduler.cpp
@@ -11,7 +11,11 @@
 #include "threading/GOMutexLocker.h"
 
 GOSoundScheduler::GOSoundScheduler()
-  : m_Work(), m_WorkItems(), m_ItemCount(0), m_RepeatCount(0) {}
+  : m_Work(),
+    m_WorkItems(),
+    m_IsNotGivingWork(false),
+    m_ItemCount(0),
+    m_RepeatCount(0) {}
 
 GOSoundScheduler::~GOSoundScheduler() {
   GOMutexLocker lock(m_Mutex);
@@ -127,6 +131,9 @@ void GOSoundScheduler::Exec() {
 
 GOSoundWorkItem *GOSoundScheduler::GetNextGroup() {
   do {
+    if (m_IsNotGivingWork) {
+      return nullptr;
+    }
     unsigned next = m_NextItem.fetch_add(1);
     if (next >= m_ItemCount)
       return nullptr;

--- a/src/grandorgue/sound/scheduler/GOSoundScheduler.h
+++ b/src/grandorgue/sound/scheduler/GOSoundScheduler.h
@@ -48,8 +48,8 @@ public:
   void Add(GOSoundWorkItem *item);
   void Remove(GOSoundWorkItem *item);
 
-  void PauseGivingWork() { m_IsNotGivingWork = true; }
-  void ResumeGivingWork() { m_IsNotGivingWork = false; }
+  void PauseGivingWork() { m_IsNotGivingWork.store(true); }
+  void ResumeGivingWork() { m_IsNotGivingWork.store(false); }
 
   GOSoundWorkItem *GetNextGroup();
 };

--- a/src/grandorgue/sound/scheduler/GOSoundScheduler.h
+++ b/src/grandorgue/sound/scheduler/GOSoundScheduler.h
@@ -18,6 +18,8 @@ class GOSoundScheduler {
 private:
   std::vector<GOSoundWorkItem *> m_Work;
   std::vector<GOSoundWorkItem **> m_WorkItems;
+  // if GetNextGroup() always returns nullptr
+  std::atomic_bool m_IsNotGivingWork;
   std::atomic_uint m_NextItem;
   std::atomic_uint m_ItemCount;
   unsigned m_RepeatCount;
@@ -45,6 +47,9 @@ public:
   void Exec();
   void Add(GOSoundWorkItem *item);
   void Remove(GOSoundWorkItem *item);
+
+  void PauseGivingWork() { m_IsNotGivingWork = true; }
+  void ResumeGivingWork() { m_IsNotGivingWork = false; }
 
   GOSoundWorkItem *GetNextGroup();
 };

--- a/src/grandorgue/sound/scheduler/GOSoundThread.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundThread.cpp
@@ -52,9 +52,8 @@ void GOSoundThread::Entry() {
   return;
 }
 
-void GOSoundThread::WaitForReleaseOfWorkItems() {
-  GOMutexLocker lock(
-    m_Mutex, false, "GOSoundThread::WaitForReleaseOfWorkItems");
+void GOSoundThread::WaitForIdle() {
+  GOMutexLocker lock(m_Mutex, false, "GOSoundThread::WaitForIdle");
   while (!m_IsIdle) {
     m_IdleStateReachedCondition.Wait();
   }

--- a/src/grandorgue/sound/scheduler/GOSoundThread.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundThread.cpp
@@ -40,10 +40,10 @@ void GOSoundThread::Entry() {
       break;
 
     GOMutexLocker lock(m_Mutex, false, "GOSoundThread::Entry", this);
-    m_IsIdle = true;
-    m_IdleStateReachedCondition.Broadcast();
     if (!lock.IsLocked() || ShouldStop())
       break;
+    m_IsIdle = true;
+    m_IdleStateReachedCondition.Broadcast();
     if (!m_Condition.WaitOrStop("GOSoundThread::Entry"))
       break;
     m_IsIdle = false;

--- a/src/grandorgue/sound/scheduler/GOSoundThread.h
+++ b/src/grandorgue/sound/scheduler/GOSoundThread.h
@@ -20,12 +20,25 @@ private:
 
   GOMutex m_Mutex;
   GOCondition m_Condition;
+  GOCondition m_IdleStateReachedCondition;
+  bool m_IsIdle; // guarded by m_Mutex
 
   void Entry();
 
 public:
   GOSoundThread(GOSoundScheduler *scheduler);
 
+  /*
+   * === Prerequisites ===
+   * During the execution the following must be true:
+   * 1. m_Scheduler->GetNextGroup() always returns nullptr
+   * 2. thread is running and is not marked to be stopped
+   *
+   * === Result ===
+   * Method returns when the thread forgets all pointers to work items
+   * (so that work items can be deleted safely)
+   */
+  void WaitForReleaseOfWorkItems();
   void Run();
   void Delete();
   void Wakeup();

--- a/src/grandorgue/sound/scheduler/GOSoundThread.h
+++ b/src/grandorgue/sound/scheduler/GOSoundThread.h
@@ -21,6 +21,7 @@ private:
   GOMutex m_Mutex;
   GOCondition m_Condition;
   GOCondition m_IdleStateReachedCondition;
+  // whether the thread sleeps and waits for waking up with m_Condition
   bool m_IsIdle; // guarded by m_Mutex
 
   void Entry();

--- a/src/grandorgue/sound/scheduler/GOSoundThread.h
+++ b/src/grandorgue/sound/scheduler/GOSoundThread.h
@@ -36,10 +36,10 @@ public:
    * 2. thread is running and is not marked to be stopped
    *
    * === Result ===
-   * Method returns when the thread forgets all pointers to work items
+   * Method returns when the thread is idle (i.e. does not run any work items)
    * (so that work items can be deleted safely)
    */
-  void WaitForReleaseOfWorkItems();
+  void WaitForIdle();
   void Run();
   void Delete();
   void Wakeup();


### PR DESCRIPTION
Fixes #1678.
GOSoundThreads could run work items that were deleted concurrently. 
This PR ensures that GOSoundThreads don't hold any work items when GOSound::AssignOrganFile() is deleting them.
