### PR TITLE
Fixed hang on Panic button press on MacOs https://github.com/GrandOrgue/grandorgue/issues/1726

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed hang on Panic button press on MacOs https://github.com/GrandOrgue/grandorgue/issues/1726
 - Fixed crash on switching divisionals when a bidirectional devisional coupler was engaged https://github.com/GrandOrgue/grandorgue/issues/1725
 # 3.13.2 (2023-11-19)
 - Fixed loading an organ when some configuration entry is out of range https://github.com/GrandOrgue/grandorgue/issues/1696

--- a/src/grandorgue/sound/GOSound.cpp
+++ b/src/grandorgue/sound/GOSound.cpp
@@ -374,7 +374,7 @@ bool GOSound::AudioCallback(
       m_WaitCount.exchange(0);
 
       for (unsigned i = 0; i < m_AudioOutputs.size(); i++) {
-          GOMutexLocker lock(m_AudioOutputs[i].mutex, i == dev_index);
+        GOMutexLocker lock(m_AudioOutputs[i].mutex, i == dev_index);
         m_AudioOutputs[i].wait = false;
         m_AudioOutputs[i].condition.Signal();
       }

--- a/src/grandorgue/sound/GOSound.h
+++ b/src/grandorgue/sound/GOSound.h
@@ -64,6 +64,7 @@ class GOSound {
 
 private:
   bool m_open;
+  std::atomic_bool m_IsRunning;
 
   GOMutex m_lock;
   GOMutex m_thread_lock;
@@ -73,6 +74,9 @@ private:
   std::vector<GOSoundOutput> m_AudioOutputs;
   std::atomic_uint m_WaitCount;
   std::atomic_uint m_CalcCount;
+  GOMutex m_CallbackMutex;
+  std::atomic_int m_NCallbacksEntered;
+  GOCondition m_CallbackCondition;
 
   unsigned m_SamplesPerBuffer;
 

--- a/src/grandorgue/sound/GOSound.h
+++ b/src/grandorgue/sound/GOSound.h
@@ -66,6 +66,14 @@ private:
   bool m_open;
   std::atomic_bool m_IsRunning;
 
+  // counter of audio callbacks that have been entered but have not yet been
+  // exited
+  std::atomic_uint m_NCallbacksEntered;
+
+  // For waiting for and notifying when m_NCallbacksEntered bacomes 0
+  GOMutex m_CallbackMutex;
+  GOCondition m_CallbackCondition;
+
   GOMutex m_lock;
   GOMutex m_thread_lock;
 
@@ -74,9 +82,6 @@ private:
   std::vector<GOSoundOutput> m_AudioOutputs;
   std::atomic_uint m_WaitCount;
   std::atomic_uint m_CalcCount;
-  GOMutex m_CallbackMutex;
-  std::atomic_int m_NCallbacksEntered;
-  GOCondition m_CallbackCondition;
 
   unsigned m_SamplesPerBuffer;
 

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -353,16 +353,27 @@ void GOSoundEngine::SetupReverb(GOConfig &settings) {
       m_AudioOutputs[i]->SetupReverb(settings);
 }
 
+unsigned GOSoundEngine::GetBufferSizeFor(
+  unsigned outputIndex, unsigned nFrames) {
+  return sizeof(float) * nFrames
+    * m_AudioOutputs[outputIndex + 1]->GetChannels();
+}
+
+void GOSoundEngine::GetEmptyAudioOutput(
+  unsigned outputIndex, unsigned nFrames, float *pOutputBuffer) {
+  memset(pOutputBuffer, 0, GetBufferSizeFor(outputIndex, nFrames));
+}
+
 void GOSoundEngine::GetAudioOutput(
   float *output_buffer, unsigned n_frames, unsigned audio_output, bool last) {
-  size_t const nBytes = sizeof(float) * n_frames
-    * m_AudioOutputs[audio_output + 1]->GetChannels();
-
   if (m_HasBeenSetup.load()) {
     m_AudioOutputs[audio_output + 1]->Finish(last);
-    memcpy(output_buffer, m_AudioOutputs[audio_output + 1]->m_Buffer, nBytes);
+    memcpy(
+      output_buffer,
+      m_AudioOutputs[audio_output + 1]->m_Buffer,
+      GetBufferSizeFor(audio_output, n_frames));
   } else
-    memset(output_buffer, 0, nBytes);
+    GetEmptyAudioOutput(audio_output, n_frames, output_buffer);
 }
 
 void GOSoundEngine::NextPeriod() {

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -76,6 +76,7 @@ private:
   void CreateReleaseSampler(GOSoundSampler *sampler);
   void SwitchAttackSampler(GOSoundSampler *sampler);
   float GetRandomFactor();
+  unsigned GetBufferSizeFor(unsigned outputIndex, unsigned n_frames);
 
 public:
   GOSoundEngine();
@@ -113,6 +114,8 @@ public:
   void UpdateVelocity(
     const GOSoundProvider *pipe, GOSoundSampler *handle, unsigned velocity);
 
+  void GetEmptyAudioOutput(
+    unsigned outputIndex, unsigned nFrames, float *pOutputBuffer);
   void GetAudioOutput(
     float *output_buffer, unsigned n_frames, unsigned audio_output, bool last);
   void NextPeriod();

--- a/src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.h
+++ b/src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.h
@@ -26,7 +26,15 @@ private:
   GOSoundSamplerList m_Release;
   GOMutex m_Mutex;
   GOCondition m_Condition;
-  unsigned m_ActiveCount;
+
+  // the number of threads are processing the samples
+  std::atomic_uint m_ActiveCount;
+
+  // processing state
+  //   0 - no threads are processing the samples
+  //   1 - some threads are processing the samples and none has finished
+  //   2 - some thread has finished processing samples but not all
+  //   3 - all threads have finished processing samples
   std::atomic_uint m_Done;
   std::atomic_bool m_Stop;
 

--- a/src/grandorgue/sound/scheduler/GOSoundReleaseWorkItem.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundReleaseWorkItem.cpp
@@ -24,8 +24,8 @@ void GOSoundReleaseWorkItem::Clear() { m_List.Clear(); }
 
 void GOSoundReleaseWorkItem::Reset() {
   m_Stop.store(false);
-  m_Cnt = 0;
-  m_WaitCnt = 0;
+  m_Cnt.store(0);
+  m_WaitCnt.store(0);
 }
 
 void GOSoundReleaseWorkItem::Add(GOSoundSampler *sampler) {
@@ -41,12 +41,12 @@ void GOSoundReleaseWorkItem::Run(GOSoundThread *pThread) {
       if (m_Stop.load() && m_Cnt > 10)
         break;
     }
-    unsigned wait = m_WaitCnt;
+    unsigned wait = m_WaitCnt.load();
     if (wait < m_AudioGroups.size()) {
-      m_AudioGroups[wait]->Finish(false);
+      m_AudioGroups[wait]->Finish(false, pThread);
       m_WaitCnt.compare_exchange_strong(wait, wait + 1);
     }
-  } while (!m_Stop.load() && m_WaitCnt < m_AudioGroups.size());
+  } while (!m_Stop.load() && m_WaitCnt.load() < m_AudioGroups.size());
 }
 
 void GOSoundReleaseWorkItem::Exec() {


### PR DESCRIPTION
Resolves: #1726

The reason of hang was 
1. Because GOSound::CloseSound started destroying sound objects
2. An audio callback waited infinitelly for the sound objects to finish
3. CoreAudio waited infinitelly for the audio callback to exit

This PR 
1. introduces the `GOSound::m_IsRunning` flag that allows the audio callback to do anything
2. `GOSound::CloseSound()` resets `GOSound::m_IsRunning` and waits for all callbacks to finish. 
3. `GOSound::m_NCallbacksEntered` is used for counting of enered audio callbacks and indicating that all ones have been finished
4. GOSoundGroupWorkItem: fixed bug that it became not finished (m_done = 2 instead of 3) after the threads were stopped