### PR TITLE
Fixed crash on switching divisionals when a bidirectional devisional coupler was engaged https://github.com/GrandOrgue/grandorgue/issues/1725

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on switching divisionals when a bidirectional devisional coupler was engaged https://github.com/GrandOrgue/grandorgue/issues/1725
 # 3.13.2 (2023-11-19)
 - Fixed loading an organ when some configuration entry is out of range https://github.com/GrandOrgue/grandorgue/issues/1696
 - Fixed crash when trying to load a sample set with a truncated wave file https://github.com/GrandOrgue/grandorgue/discussions/370

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -1013,46 +1013,71 @@ void GOSetter::PushGeneral(
 }
 
 void GOSetter::PushDivisional(
-  GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) {
-  GOCombination::ExtraElementsSet elementSet;
-  const GOCombination::ExtraElementsSet *pExtraSet
-    = GetCrescendoAddSet(elementSet);
+  std::unordered_set<GODivisionalCombination *> &usedCmbs,
+  GODivisionalCombination &cmb,
+  GOButtonControl *pButtonToLight) {
+  // protection against infinite recursion
+  if (usedCmbs.insert(&cmb).second) {
+    GOCombination::ExtraElementsSet elementSet;
+    const GOCombination::ExtraElementsSet *pExtraSet
+      = GetCrescendoAddSet(elementSet);
 
-  NotifyCmbPushed(cmb.Push(m_state, pExtraSet));
-  /* only use divisional couples, if not in setter mode */
-  if (!m_state.m_IsActive) {
-    unsigned cmbManualNumber = cmb.GetManualNumber();
-    unsigned divisionalNumber = cmb.GetDivisionalNumber();
+    NotifyCmbPushed(cmb.Push(m_state, pExtraSet));
+    /* only use divisional couples, if not in setter mode */
+    if (!m_state.m_IsActive) {
+      unsigned cmbManualNumber = cmb.GetManualNumber();
+      unsigned divisionalNumber = cmb.GetDivisionalNumber();
 
-    for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
-         k++) {
-      GODivisionalCoupler *coupler = m_OrganController->GetDivisionalCoupler(k);
-      if (!coupler->IsEngaged())
-        continue;
-
-      for (unsigned i = 0; i < coupler->GetNumberOfManuals(); i++) {
-        if (coupler->GetManual(i) != cmbManualNumber)
+      for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
+           k++) {
+        GODivisionalCoupler *coupler
+          = m_OrganController->GetDivisionalCoupler(k);
+        if (!coupler->IsEngaged())
           continue;
 
-        for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++)
-          m_OrganController->GetManual(coupler->GetManual(j))
-            ->GetDivisional(divisionalNumber)
-            ->Push();
+        for (unsigned i = 0; i < coupler->GetNumberOfManuals(); i++) {
+          if (coupler->GetManual(i) != cmbManualNumber)
+            continue;
 
-        if (coupler->IsBidirectional())
-          for (unsigned j = 0; j < coupler->GetNumberOfManuals(); j++) {
-            if (coupler->GetManual(j) == cmbManualNumber)
-              break;
-            m_OrganController->GetManual(coupler->GetManual(j))
-              ->GetDivisional(divisionalNumber)
-              ->Push();
+          for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++) {
+            GODivisionalButtonControl *coupledDivisional
+              = m_OrganController->GetManual(coupler->GetManual(j))
+                  ->GetDivisional(divisionalNumber);
+
+            PushDivisional(
+              usedCmbs, coupledDivisional->GetCombination(), coupledDivisional);
           }
-        break;
+
+          if (coupler->IsBidirectional())
+            for (unsigned j = 0; j < coupler->GetNumberOfManuals(); j++) {
+              unsigned coupledManualIndex = coupler->GetManual(j);
+
+              if (coupledManualIndex == cmbManualNumber)
+                break;
+
+              GODivisionalButtonControl *coupledDivisional
+                = m_OrganController->GetManual(coupledManualIndex)
+                    ->GetDivisional(divisionalNumber);
+
+              PushDivisional(
+                usedCmbs,
+                coupledDivisional->GetCombination(),
+                coupledDivisional);
+            }
+          break;
+        }
       }
     }
+    if (!pExtraSet)
+      UpdateAllSetsButtonsLight(pButtonToLight, cmb.GetManualNumber());
   }
-  if (!pExtraSet)
-    UpdateAllSetsButtonsLight(pButtonToLight, cmb.GetManualNumber());
+}
+
+void GOSetter::PushDivisional(
+  GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) {
+  std::unordered_set<GODivisionalCombination *> usedCmbs;
+
+  PushDivisional(usedCmbs, cmb, pButtonToLight);
 }
 
 void GOSetter::Next() { SetPosition(m_pos + 1); }

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -8,6 +8,8 @@
 #ifndef GOSETTER_H
 #define GOSETTER_H
 
+#include <unordered_set>
+
 #include <wx/arrstr.h>
 
 #include "ptrvector.h"
@@ -195,6 +197,10 @@ public:
    */
   void PushGeneral(
     GOGeneralCombination &cmb, GOButtonControl *pButtonToLight) override;
+  void PushDivisional(
+    std::unordered_set<GODivisionalCombination *> &usedCmbs,
+    GODivisionalCombination &cmb,
+    GOButtonControl *pButtonToLight);
   void PushDivisional(
     GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) override;
 


### PR DESCRIPTION
Resolves: #1725

This PR addes protection against recussive calling `GOSetter::PushDivisional()`. It also replaces calling chain `GOSetter::PushDivisional()` -> `GODivisionalButtonControl::Push()` -> `GOOrganModel::PushDivisional()` -> `GOSetter::PushDivisional()` with a simpler one `GOSetter::PushDivisional()` -> `GOSetter::PushDivisional()`