### PR TITLE
Fixed crash on enabling convolution reverb https://github.com/GrandOrgue/grandorgue/issues/1741

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on enabling convolution reverb https://github.com/GrandOrgue/grandorgue/issues/1741
 - Fixed hang on Panic button press on MacOs https://github.com/GrandOrgue/grandorgue/issues/1726
 - Fixed crash on switching divisionals when a bidirectional devisional coupler was engaged https://github.com/GrandOrgue/grandorgue/issues/1725
 # 3.13.2 (2023-11-19)

--- a/src/core/files/GOStandardFile.cpp
+++ b/src/core/files/GOStandardFile.cpp
@@ -22,10 +22,14 @@ const wxString GOStandardFile::GetPath() { return m_Path; }
 size_t GOStandardFile::GetSize() { return m_Size; }
 
 bool GOStandardFile::Open() {
-  if (!m_File.Open(m_Path, wxFile::read))
-    return false;
-  m_Size = m_File.Length();
-  return true;
+  bool isOk = false;
+
+  // Avoid opening a directory
+  if (wxFileExists(m_Path) && m_File.Open(m_Path, wxFile::read)) {
+    m_Size = m_File.Length();
+    isOk = true;
+  }
+  return isOk;
 }
 void GOStandardFile::Close() { m_File.Close(); }
 


### PR DESCRIPTION
It is the first PR related to #1741 

The reason of the crash was that:
1. the impulse response file name field contained a directory name instead of a file name.  
2. In this case `m_File.Length()` of the directory returned a negative value that was converted to a huge unsigned value. 
3. An attempt to allocate memory of this size caused an Out Of Memory exception

This PR fixes crash when the field contains a directory name instead of the file name.

Fixing appearance of the directory name in this field by default will be a subject of a next PR.