### PR TITLE
Fixed setting a reverb file name by default to the current directory https://github.com/GrandOrgue/grandorgue/issues/1741

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed setting a reverb file name by default to the current directory https://github.com/GrandOrgue/grandorgue/issues/1741
 - Fixed crash on enabling convolution reverb https://github.com/GrandOrgue/grandorgue/issues/1741
 - Fixed hang on Panic button press on MacOs https://github.com/GrandOrgue/grandorgue/issues/1726
 - Fixed crash on switching divisionals when a bidirectional devisional coupler was engaged https://github.com/GrandOrgue/grandorgue/issues/1725

--- a/src/core/settings/GOSettingFile.cpp
+++ b/src/core/settings/GOSettingFile.cpp
@@ -16,8 +16,12 @@ GOSettingFile::GOSettingFile(
 wxString GOSettingFile::validate(wxString value) {
   if (value == wxEmptyString || !wxFileExists(value))
     value = getDefaultValue();
-  wxFileName file(value);
-  file.MakeAbsolute();
-  value = file.GetFullPath();
+  if (!value.IsEmpty()) {
+    // convert value to an absolute path
+    wxFileName file(value);
+
+    file.MakeAbsolute();
+    value = file.GetFullPath();
+  }
   return value;
 }


### PR DESCRIPTION
Resolves: #1741

This is the last PR related to #1741.

It fixes the bad default value of the ReverbFile.
 