### PR TITLE
Renamed some methods added the const qualifier and added some comments

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -374,7 +374,7 @@ wxString GOOrganController::Load(
   GOConfigFileReader odf_ini_file;
 
   if (!odf_ini_file.Read(odf_name.Open(m_FileStore).get())) {
-    errMsg.Printf(_("Unable to read '%s'"), odf_name.GetTitle().c_str());
+    errMsg.Printf(_("Unable to read '%s'"), odf_name.GetPath().c_str());
     return errMsg;
   }
 

--- a/src/grandorgue/loader/GOLoaderFilename.h
+++ b/src/grandorgue/loader/GOLoaderFilename.h
@@ -43,7 +43,7 @@ public:
   void AssignResource(const wxString &path) { Assign(ROOT_RESOURCE, path); }
   void AssignAbsolute(const wxString &path) { Assign(ROOT_ABSOLUTE, path); }
 
-  const wxString &GetTitle() const { return m_path; }
+  const wxString &GetPath() const { return m_path; }
   void Hash(GOHash &hash) const;
 
   /**

--- a/src/grandorgue/model/GOCacheObject.h
+++ b/src/grandorgue/model/GOCacheObject.h
@@ -58,9 +58,9 @@ public:
    */
   bool LoadFromCacheWithoutExc(GOMemoryPool &pool, GOCache &cache);
 
-  virtual bool SaveCache(GOCacheWriter &cache) = 0;
-  virtual void UpdateHash(GOHash &hash) = 0;
-  virtual const wxString &GetLoadTitle() = 0;
+  virtual bool SaveCache(GOCacheWriter &cache) const = 0;
+  virtual void UpdateHash(GOHash &hash) const = 0;
+  virtual const wxString &GetLoadTitle() const = 0;
 };
 
 #endif

--- a/src/grandorgue/model/GOReferencePipe.cpp
+++ b/src/grandorgue/model/GOReferencePipe.cpp
@@ -56,10 +56,6 @@ void GOReferencePipe::Initialize() {
   m_ReferenceID = m_Reference->RegisterReference(this);
 }
 
-void GOReferencePipe::UpdateHash(GOHash &hash) {}
-
-const wxString &GOReferencePipe::GetLoadTitle() { return m_Filename; }
-
 void GOReferencePipe::VelocityChanged(
   unsigned velocity, unsigned old_velocity) {
   m_Reference->SetVelocity(velocity, m_ReferenceID);

--- a/src/grandorgue/model/GOReferencePipe.h
+++ b/src/grandorgue/model/GOReferencePipe.h
@@ -23,9 +23,9 @@ private:
   void Initialize();
   void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) override {}
   bool LoadCache(GOMemoryPool &pool, GOCache &cache) override { return true; }
-  bool SaveCache(GOCacheWriter &cache) override { return true; }
-  void UpdateHash(GOHash &hash);
-  const wxString &GetLoadTitle();
+  bool SaveCache(GOCacheWriter &cache) const override { return true; }
+  void UpdateHash(GOHash &hash) const override {}
+  const wxString &GetLoadTitle() const override { return m_Filename; }
 
   void VelocityChanged(unsigned velocity, unsigned old_velocity) override;
 

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -256,7 +256,7 @@ void GOSoundingPipe::Load(
 void GOSoundingPipe::LoadData(
   const GOFileStore &fileStore, GOMemoryPool &pool) {
   try {
-    m_SoundProvider.LoadFromFile(
+    m_SoundProvider.LoadFromSampleFiles(
       fileStore,
       pool,
       m_AttackInfo,
@@ -294,11 +294,11 @@ bool GOSoundingPipe::LoadCache(GOMemoryPool &pool, GOCache &cache) {
   }
 }
 
-bool GOSoundingPipe::SaveCache(GOCacheWriter &cache) {
+bool GOSoundingPipe::SaveCache(GOCacheWriter &cache) const {
   return m_SoundProvider.SaveCache(cache);
 }
 
-void GOSoundingPipe::UpdateHash(GOHash &hash) {
+void GOSoundingPipe::UpdateHash(GOHash &hash) const {
   hash.Update(m_Filename);
   hash.Update(m_PipeConfigNode.GetEffectiveBitsPerSample());
   hash.Update(m_PipeConfigNode.GetEffectiveCompress());

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -256,7 +256,7 @@ void GOSoundingPipe::Load(
 void GOSoundingPipe::LoadData(
   const GOFileStore &fileStore, GOMemoryPool &pool) {
   try {
-    m_SoundProvider.LoadFromSampleFiles(
+    m_SoundProvider.LoadFromMultipleFiles(
       fileStore,
       pool,
       m_AttackInfo,

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -69,12 +69,12 @@ private:
   void Validate();
 
   // Callbacks for GOCacheObject
-  const wxString &GetLoadTitle() override { return m_Filename; }
+  const wxString &GetLoadTitle() const override { return m_Filename; }
   void Initialize() override {}
   void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) override;
   bool LoadCache(GOMemoryPool &pool, GOCache &cache) override;
-  bool SaveCache(GOCacheWriter &cache) override;
-  void UpdateHash(GOHash &hash) override;
+  bool SaveCache(GOCacheWriter &cache) const override;
+  void UpdateHash(GOHash &hash) const override;
 
   // Callbacks from GOPipeConfigNode
   void UpdateAmplitude() override;

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -52,12 +52,6 @@ bool GOTremulant::LoadCache(GOMemoryPool &pool, GOCache &cache) {
   return true;
 }
 
-bool GOTremulant::SaveCache(GOCacheWriter &cache) { return true; }
-
-void GOTremulant::UpdateHash(GOHash &ctx) {}
-
-const wxString &GOTremulant::GetLoadTitle() { return m_Name; }
-
 void GOTremulant::Load(
   GOConfigReader &cfg, wxString group, int sampler_group_id) {
   m_TremulantType = (GOTremulantType)cfg.ReadEnum(

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -43,9 +43,9 @@ private:
   void Initialize();
   void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool);
   bool LoadCache(GOMemoryPool &pool, GOCache &cache);
-  bool SaveCache(GOCacheWriter &cache);
-  void UpdateHash(GOHash &hash);
-  const wxString &GetLoadTitle();
+  bool SaveCache(GOCacheWriter &cache) const override { return true; }
+  void UpdateHash(GOHash &hash) const override {}
+  const wxString &GetLoadTitle() const override { return m_Name; };
 
   void AbortPlayback();
   void StartPlayback();

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -212,8 +212,6 @@ void GOPipeConfig::Save(GOConfigWriter &cfg) {
 
 GOPipeUpdateCallback *GOPipeConfig::GetCallback() { return m_Callback; }
 
-const wxString &GOPipeConfig::GetAudioGroup() { return m_AudioGroup; }
-
 void GOPipeConfig::SetAudioGroup(const wxString &str) {
   m_AudioGroup = str;
   m_Callback->UpdateAudioGroup();
@@ -260,51 +258,35 @@ void GOPipeConfig::SetAutoTuningCorrection(float cent) {
   m_OrganModel->SetOrganModelModified();
 }
 
-unsigned GOPipeConfig::GetDelay() { return m_Delay; }
-
-unsigned GOPipeConfig::GetDefaultDelay() { return m_DefaultDelay; }
-
 void GOPipeConfig::SetDelay(unsigned delay) {
   m_Delay = delay;
   m_OrganModel->SetOrganModelModified();
 }
-
-int GOPipeConfig::GetBitsPerSample() { return m_BitsPerSample; }
 
 void GOPipeConfig::SetBitsPerSample(int value) {
   m_BitsPerSample = value;
   m_OrganModel->SetOrganModelModified();
 }
 
-int GOPipeConfig::GetCompress() { return m_Compress; }
-
 void GOPipeConfig::SetCompress(int value) {
   m_Compress = value;
   m_OrganModel->SetOrganModelModified();
 }
-
-int GOPipeConfig::GetChannels() { return m_Channels; }
 
 void GOPipeConfig::SetChannels(int value) {
   m_Channels = value;
   m_OrganModel->SetOrganModelModified();
 }
 
-int GOPipeConfig::GetLoopLoad() { return m_LoopLoad; }
-
 void GOPipeConfig::SetLoopLoad(int value) {
   m_LoopLoad = value;
   m_OrganModel->SetOrganModelModified();
 }
 
-int GOPipeConfig::GetAttackLoad() { return m_AttackLoad; }
-
 void GOPipeConfig::SetAttackLoad(int value) {
   m_AttackLoad = value;
   m_OrganModel->SetOrganModelModified();
 }
-
-int GOPipeConfig::GetReleaseLoad() { return m_ReleaseLoad; }
 
 void GOPipeConfig::SetReleaseLoad(int value) {
   m_ReleaseLoad = value;

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -70,29 +70,30 @@ public:
   float GetAutoTuningCorrection() const { return m_AutoTuningCorrection; }
   void SetAutoTuningCorrection(float cent);
 
-  unsigned GetDelay();
-  unsigned GetDefaultDelay();
+  unsigned GetDefaultDelay() const { return m_DefaultDelay; }
+
+  unsigned GetDelay() const { return m_Delay; }
   void SetDelay(unsigned delay);
 
-  const wxString &GetAudioGroup();
+  const wxString &GetAudioGroup() const { return m_AudioGroup; }
   void SetAudioGroup(const wxString &str);
 
-  int GetBitsPerSample();
+  int GetBitsPerSample() const { return m_BitsPerSample; }
   void SetBitsPerSample(int value);
 
-  int GetCompress();
+  int GetCompress() const { return m_Compress; }
   void SetCompress(int value);
 
-  int GetChannels();
+  int GetChannels() const { return m_Channels; }
   void SetChannels(int value);
 
-  int GetLoopLoad();
+  int GetLoopLoad() const { return m_LoopLoad; }
   void SetLoopLoad(int value);
 
-  int GetAttackLoad();
+  int GetAttackLoad() const { return m_AttackLoad; }
   void SetAttackLoad(int value);
 
-  int GetReleaseLoad();
+  int GetReleaseLoad() const { return m_ReleaseLoad; }
   void SetReleaseLoad(int value);
 
   int IsIgnorePitch() const { return m_IgnorePitch; }

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -112,14 +112,14 @@ float GOPipeConfigNode::GetEffectiveAutoTuningCorection() const {
   return cents;
 }
 
-unsigned GOPipeConfigNode::GetEffectiveDelay() {
+unsigned GOPipeConfigNode::GetEffectiveDelay() const {
   if (m_parent)
     return m_PipeConfig.GetDelay() + m_parent->GetEffectiveDelay();
   else
     return m_PipeConfig.GetDelay();
 }
 
-wxString GOPipeConfigNode::GetEffectiveAudioGroup() {
+wxString GOPipeConfigNode::GetEffectiveAudioGroup() const {
   if (m_PipeConfig.GetAudioGroup() != wxEmptyString)
     return m_PipeConfig.GetAudioGroup();
   if (m_parent)
@@ -128,7 +128,7 @@ wxString GOPipeConfigNode::GetEffectiveAudioGroup() {
     return wxEmptyString;
 }
 
-unsigned GOPipeConfigNode::GetEffectiveBitsPerSample() {
+unsigned GOPipeConfigNode::GetEffectiveBitsPerSample() const {
   if (m_PipeConfig.GetBitsPerSample() != -1)
     return m_PipeConfig.GetBitsPerSample();
   if (m_parent)
@@ -137,7 +137,7 @@ unsigned GOPipeConfigNode::GetEffectiveBitsPerSample() {
     return m_config.BitsPerSample();
 }
 
-bool GOPipeConfigNode::GetEffectiveCompress() {
+bool GOPipeConfigNode::GetEffectiveCompress() const {
   if (m_PipeConfig.GetCompress() != -1)
     return m_PipeConfig.GetCompress() ? true : false;
   if (m_parent)
@@ -146,7 +146,7 @@ bool GOPipeConfigNode::GetEffectiveCompress() {
     return m_config.LosslessCompression();
 }
 
-unsigned GOPipeConfigNode::GetEffectiveLoopLoad() {
+unsigned GOPipeConfigNode::GetEffectiveLoopLoad() const {
   if (m_PipeConfig.GetLoopLoad() != -1)
     return m_PipeConfig.GetLoopLoad();
   if (m_parent)
@@ -155,7 +155,7 @@ unsigned GOPipeConfigNode::GetEffectiveLoopLoad() {
     return m_config.LoopLoad();
 }
 
-unsigned GOPipeConfigNode::GetEffectiveAttackLoad() {
+unsigned GOPipeConfigNode::GetEffectiveAttackLoad() const {
   if (m_PipeConfig.GetAttackLoad() != -1)
     return m_PipeConfig.GetAttackLoad();
   if (m_parent)
@@ -164,7 +164,7 @@ unsigned GOPipeConfigNode::GetEffectiveAttackLoad() {
     return m_config.AttackLoad();
 }
 
-unsigned GOPipeConfigNode::GetEffectiveReleaseLoad() {
+unsigned GOPipeConfigNode::GetEffectiveReleaseLoad() const {
   if (m_PipeConfig.GetReleaseLoad() != -1)
     return m_PipeConfig.GetReleaseLoad();
   if (m_parent)
@@ -173,7 +173,7 @@ unsigned GOPipeConfigNode::GetEffectiveReleaseLoad() {
     return m_config.ReleaseLoad();
 }
 
-unsigned GOPipeConfigNode::GetEffectiveChannels() {
+unsigned GOPipeConfigNode::GetEffectiveChannels() const {
   if (m_PipeConfig.GetChannels() != -1)
     return m_PipeConfig.GetChannels();
   if (m_parent)
@@ -182,7 +182,7 @@ unsigned GOPipeConfigNode::GetEffectiveChannels() {
     return m_config.LoadChannels();
 }
 
-GOSampleStatistic GOPipeConfigNode::GetStatistic() {
+GOSampleStatistic GOPipeConfigNode::GetStatistic() const {
   if (m_StatisticCallback)
     return m_StatisticCallback->GetStatistic();
   return GOSampleStatistic();

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -55,22 +55,22 @@ public:
   float GetEffectiveManualTuning() const;
   float GetEffectiveAutoTuningCorection() const;
 
-  unsigned GetEffectiveDelay();
-  wxString GetEffectiveAudioGroup();
+  unsigned GetEffectiveDelay() const;
+  wxString GetEffectiveAudioGroup() const;
 
-  unsigned GetEffectiveBitsPerSample();
-  bool GetEffectiveCompress();
-  unsigned GetEffectiveLoopLoad();
-  unsigned GetEffectiveAttackLoad();
-  unsigned GetEffectiveReleaseLoad();
-  unsigned GetEffectiveChannels();
+  unsigned GetEffectiveBitsPerSample() const;
+  bool GetEffectiveCompress() const;
+  unsigned GetEffectiveLoopLoad() const;
+  unsigned GetEffectiveAttackLoad() const;
+  unsigned GetEffectiveReleaseLoad() const;
+  unsigned GetEffectiveChannels() const;
   bool GetEffectiveIgnorePitch() const;
   unsigned GetEffectiveReleaseTail() const;
 
   virtual void AddChild(GOPipeConfigNode *node);
   virtual unsigned GetChildCount();
   virtual GOPipeConfigNode *GetChild(unsigned index);
-  virtual GOSampleStatistic GetStatistic();
+  virtual GOSampleStatistic GetStatistic() const;
 };
 
 #endif

--- a/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp
@@ -55,7 +55,7 @@ void GOPipeConfigTreeNode::UpdateReleaseTail() {
     m_Callback->UpdateReleaseTail();
 }
 
-GOSampleStatistic GOPipeConfigTreeNode::GetStatistic() {
+GOSampleStatistic GOPipeConfigTreeNode::GetStatistic() const {
   GOSampleStatistic stat = GOPipeConfigNode::GetStatistic();
   for (unsigned i = 0; i < m_Childs.size(); i++)
     stat.Cumulate(m_Childs[i]->GetStatistic());

--- a/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.h
@@ -32,7 +32,7 @@ public:
   void AddChild(GOPipeConfigNode *node);
   unsigned GetChildCount();
   GOPipeConfigNode *GetChild(unsigned index);
-  GOSampleStatistic GetStatistic();
+  GOSampleStatistic GetStatistic() const;
 };
 
 #endif

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -732,6 +732,9 @@ void GOAudioSection::Setup(
         loop_length * m_BytesPerSample,
         (end_length - copy_len) * m_BytesPerSample);
       if (fade_len > 0)
+        // TODO: Remove the parameter names from the comment and reduce the
+        // number of parameters of DoCrossfade that the call would be easy
+        // readable without additional comments
         DoCrossfade(
           end_seg.end_data,                  // dest
           MAX_READAHEAD,                     // dest_offset

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -668,11 +668,13 @@ void GOAudioSection::Setup(
     /* Setup the loops and find the amount of data we need to store in the
      * main block. */
     unsigned min_reqd_samples = 0;
+
     for (unsigned i = 0; i < loop_points->size(); i++) {
       audio_start_data_segment start_seg;
       audio_end_data_segment end_seg;
       const GOWaveLoop &loop = (*loop_points)[i];
       unsigned fade_len = crossfade_length;
+
       if (loop.m_EndPosition + 1 > min_reqd_samples)
         min_reqd_samples = loop.m_EndPosition + 1;
 
@@ -683,24 +685,19 @@ void GOAudioSection::Setup(
         = 1 + end_seg.end_offset - start_seg.start_offset;
       unsigned end_length;
 
+      if (fade_len > end_seg.end_offset - start_seg.start_offset)
+        throw(wxString) _("Loop too short for crossfade");
+
+      if (start_seg.start_offset < fade_len)
+        throw(wxString) _("Not enough samples for a crossfade");
+
+      // calculate the fade segment size and offsets
       if (end_seg.end_offset - start_seg.start_offset > SHORT_LOOP_LENGTH) {
-        if (fade_len > end_seg.end_offset - start_seg.start_offset)
-          throw(wxString) _("Loop too short for crossfade");
-
-        if (start_seg.start_offset < fade_len)
-          throw(wxString) _("Not enough samples for a crossfade");
-
         end_seg.transition_offset
           = end_seg.end_offset - MAX_READAHEAD - fade_len + 1;
         end_seg.read_end = end_seg.end_offset - fade_len;
         end_length = 2 * MAX_READAHEAD + fade_len;
       } else {
-        if (fade_len > end_seg.end_offset - start_seg.start_offset)
-          throw(wxString) _("Loop too short for crossfade");
-
-        if (start_seg.start_offset < fade_len)
-          throw(wxString) _("Not enough samples for a crossfade");
-
         end_seg.transition_offset = start_seg.start_offset;
         end_seg.read_end = end_seg.end_offset;
         end_length = SHORT_LOOP_LENGTH + MAX_READAHEAD;
@@ -711,16 +708,18 @@ void GOAudioSection::Setup(
             + (SHORT_LOOP_LENGTH / loop_length) * SHORT_LOOP_LENGTH + fade_len;
       }
       end_seg.end_size = end_length * m_BytesPerSample;
-      end_seg.end_data = (unsigned char *)m_Pool.Alloc(end_seg.end_size, true);
-      end_seg.end_ptr
-        = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;
 
+      // Allocate the fade segment
+      end_seg.end_data = (unsigned char *)m_Pool.Alloc(end_seg.end_size, true);
       if (!end_seg.end_data)
         throw GOOutOfMemory();
+      end_seg.end_ptr
+        = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;
 
       const unsigned copy_len
         = 1 + end_seg.end_offset - end_seg.transition_offset;
 
+      // Fill the fade seg with transition data, then with the loop start data
       memcpy(
         end_seg.end_data,
         ((const unsigned char *)pcm_data)
@@ -734,15 +733,15 @@ void GOAudioSection::Setup(
         (end_length - copy_len) * m_BytesPerSample);
       if (fade_len > 0)
         DoCrossfade(
-          end_seg.end_data,
-          MAX_READAHEAD,
-          (const unsigned char *)pcm_data,
-          start_seg.start_offset - fade_len,
-          pcm_data_channels,
-          m_BitsPerSample,
-          fade_len,
-          loop_length,
-          end_length);
+          end_seg.end_data,                  // dest
+          MAX_READAHEAD,                     // dest_offset
+          (const unsigned char *)pcm_data,   // src
+          start_seg.start_offset - fade_len, // src_offset
+          pcm_data_channels,                 // channels
+          m_BitsPerSample,                   // bits_per_sample
+          fade_len,                          // fade_length
+          loop_length,                       // loop_length
+          end_length);                       // length
 
       end_seg.end_loop_length = loop_length;
       end_seg.end_pos = end_length + end_seg.transition_offset;

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -90,7 +90,7 @@ void GOSoundProvider::UseSampleGroup(unsigned sample_group) {
   m_SampleGroup = sample_group;
 }
 
-bool GOSoundProvider::SaveCache(GOCacheWriter &cache) {
+bool GOSoundProvider::SaveCache(GOCacheWriter &cache) const {
   if (!cache.Write(&m_MidiKeyNumber, sizeof(m_MidiKeyNumber)))
     return false;
   if (!cache.Write(&m_MidiPitchFract, sizeof(m_MidiPitchFract)))

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -55,7 +55,7 @@ public:
   void ClearData();
 
   virtual bool LoadCache(GOMemoryPool &pool, GOCache &cache);
-  virtual bool SaveCache(GOCacheWriter &cache);
+  virtual bool SaveCache(GOCacheWriter &cache) const;
 
   void UseSampleGroup(unsigned sample_group);
   void SetVelocityParameter(float min_volume, float max_volume);

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -181,7 +181,7 @@ void GOSoundProviderWave::LoadPitch(GOOpenedFile *file) {
   m_MidiPitchFract = wave.GetPitchFract();
 }
 
-void GOSoundProviderWave::LoadFromWavFile(
+void GOSoundProviderWave::LoadFromOneFile(
   GOMemoryPool &pool,
   GOOpenedFile *file,
   const std::vector<GOWaveLoop> *loops,
@@ -278,7 +278,7 @@ unsigned GOSoundProviderWave::GetFaderLength(unsigned MidiKeyNumber) {
   return fade_length;
 }
 
-void GOSoundProviderWave::LoadFromSampleFiles(
+void GOSoundProviderWave::LoadFromMultipleFiles(
   const GOFileStore &fileStore,
   GOMemoryPool &pool,
   std::vector<attack_load_info> attacks,
@@ -376,7 +376,7 @@ void GOSoundProviderWave::LoadFromSampleFiles(
 
   try {
     for (unsigned i = 0; i < attacks.size(); i++) {
-      LoadFromWavFile(
+      LoadFromOneFile(
         pool,
         attacks[i].filename.Open(fileStore).get(),
         &attacks[i].loops,
@@ -400,7 +400,7 @@ void GOSoundProviderWave::LoadFromSampleFiles(
     }
 
     for (unsigned i = 0; i < releases.size(); i++) {
-      LoadFromWavFile(
+      LoadFromOneFile(
         pool,
         releases[i].filename.Open(fileStore).get(),
         nullptr,

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -181,7 +181,7 @@ void GOSoundProviderWave::LoadPitch(GOOpenedFile *file) {
   m_MidiPitchFract = wave.GetPitchFract();
 }
 
-void GOSoundProviderWave::ProcessFile(
+void GOSoundProviderWave::LoadFromWavFile(
   GOMemoryPool &pool,
   GOOpenedFile *file,
   const std::vector<GOWaveLoop> *loops,
@@ -278,7 +278,7 @@ unsigned GOSoundProviderWave::GetFaderLength(unsigned MidiKeyNumber) {
   return fade_length;
 }
 
-void GOSoundProviderWave::LoadFromFile(
+void GOSoundProviderWave::LoadFromSampleFiles(
   const GOFileStore &fileStore,
   GOMemoryPool &pool,
   std::vector<attack_load_info> attacks,
@@ -376,7 +376,7 @@ void GOSoundProviderWave::LoadFromFile(
 
   try {
     for (unsigned i = 0; i < attacks.size(); i++) {
-      ProcessFile(
+      LoadFromWavFile(
         pool,
         attacks[i].filename.Open(fileStore).get(),
         &attacks[i].loops,
@@ -400,7 +400,7 @@ void GOSoundProviderWave::LoadFromFile(
     }
 
     for (unsigned i = 0; i < releases.size(); i++) {
-      ProcessFile(
+      LoadFromWavFile(
         pool,
         releases[i].filename.Open(fileStore).get(),
         nullptr,

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -89,7 +89,10 @@ class GOSoundProviderWave : public GOSoundProvider {
     unsigned channels,
     bool compress);
 
-  void ProcessFile(
+  /* Load attack or/and release samples from one wav file or from an archive
+   *
+   */
+  void LoadFromWavFile(
     GOMemoryPool &pool,
     GOOpenedFile *file,
     const std::vector<GOWaveLoop> *loops,
@@ -114,7 +117,11 @@ class GOSoundProviderWave : public GOSoundProvider {
   unsigned GetFaderLength(unsigned MidiKeyNumber);
 
 public:
-  void LoadFromFile(
+  /**
+   * Load all attack and release samples from corresponding .wav files or from
+   *an archive
+   **/
+  void LoadFromSampleFiles(
     const GOFileStore &fileStore,
     GOMemoryPool &pool,
     std::vector<attack_load_info> attacks,

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -89,10 +89,10 @@ class GOSoundProviderWave : public GOSoundProvider {
     unsigned channels,
     bool compress);
 
-  /* Load attack or/and release samples from one wav file or from an archive
-   *
+  /*
+   * Load attack or/and release samples from one wav file or from an archive
    */
-  void LoadFromWavFile(
+  void LoadFromOneFile(
     GOMemoryPool &pool,
     GOOpenedFile *file,
     const std::vector<GOWaveLoop> *loops,
@@ -117,11 +117,11 @@ class GOSoundProviderWave : public GOSoundProvider {
   unsigned GetFaderLength(unsigned MidiKeyNumber);
 
 public:
-  /**
+  /*
    * Load all attack and release samples from corresponding .wav files or from
-   *an archive
-   **/
-  void LoadFromSampleFiles(
+   * an archive
+   */
+  void LoadFromMultipleFiles(
     const GOFileStore &fileStore,
     GOMemoryPool &pool,
     std::vector<attack_load_info> attacks,

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -90,7 +90,7 @@ class GOSoundProviderWave : public GOSoundProvider {
     bool compress);
 
   /*
-   * Load attack or/and release samples from one wav file or from an archive
+   * Load attack and/or release samples from one wav file or from an archive
    */
   void LoadFromOneFile(
     GOMemoryPool &pool,

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -102,7 +102,7 @@ void GOPerfTestApp::RunTest(
         ainfo.release_end = -1;
         ainfo.loops.clear();
         attack.push_back(ainfo);
-        w->LoadFromFile(
+        w->LoadFromSampleFiles(
           organController->GetFileStore(),
           organController->GetMemoryPool(),
           attack,

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -102,7 +102,7 @@ void GOPerfTestApp::RunTest(
         ainfo.release_end = -1;
         ainfo.loops.clear();
         attack.push_back(ainfo);
-        w->LoadFromSampleFiles(
+        w->LoadFromMultipleFiles(
           organController->GetFileStore(),
           organController->GetMemoryPool(),
           attack,


### PR DESCRIPTION
This is the first PR related to #1724

This PR makes the code a little bit clear
1. Addes the `const` qualifier to lots of GetXXX() methods
2. Added the `override` qualifier to lots of methods
3. Renamed some methods
4. Added some comments
5. Moved some short implementations from .cpp to .h
6. GOAudioSection::Setup(): extracted the same code from the both branches of if/else

No GO behavior should be changed.