### PR TITLE
Fixed a wrong .wav filename in the log message window https://github.com/GrandOrgue/grandorgue/issues/1724

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed a wrong .wav filename in the log message window https://github.com/GrandOrgue/grandorgue/issues/1724
 - Increased the maximum number of Tremulants from 10 to 999
 - Fixed setting a reverb file name by default to the current directory https://github.com/GrandOrgue/grandorgue/issues/1741
 - Fixed crash on enabling convolution reverb https://github.com/GrandOrgue/grandorgue/issues/1741

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -565,7 +565,7 @@ wxString GOOrganController::Load(
       if (wereExceptions) {
         for (auto obj : GetCacheObjects()) {
           if (!obj->IsReady())
-            wxLogError(_("Unable to load data: %s"), obj->GetLoadError());
+            wxLogError(obj->GetLoadError());
         }
         GOMessageBox(
           _("There are errors while loading the organ. See Log Messages."),

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -517,10 +517,7 @@ wxString GOOrganController::Load(
       if (cache_ok) {
         while ((obj = objectDistributor.FetchNext())) {
           if (!obj->LoadFromCacheWithoutExc(m_pool, reader)) {
-            wxLogWarning(
-              _("Cache load failure: Failed to read %s from cache: %s"),
-              obj->GetLoadTitle(),
-              obj->GetLoadError());
+            wxLogWarning(_("Cache load failure: %s"), obj->GetLoadError());
             break;
           }
           if (!dlg->Update(objectDistributor.GetPos(), obj->GetLoadTitle()))
@@ -568,10 +565,7 @@ wxString GOOrganController::Load(
       if (wereExceptions) {
         for (auto obj : GetCacheObjects()) {
           if (!obj->IsReady())
-            wxLogError(
-              _("Unable to load %s: %s"),
-              obj->GetNameForError(),
-              obj->GetLoadError());
+            wxLogError(_("Unable to load data: %s"), obj->GetLoadError());
         }
         GOMessageBox(
           _("There are errors while loading the organ. See Log Messages."),

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -570,7 +570,7 @@ wxString GOOrganController::Load(
           if (!obj->IsReady())
             wxLogError(
               _("Unable to load %s: %s"),
-              obj->GetLoadTitle(),
+              obj->GetNameForError(),
               obj->GetLoadError());
         }
         GOMessageBox(

--- a/src/grandorgue/model/GOCacheObject.cpp
+++ b/src/grandorgue/model/GOCacheObject.cpp
@@ -11,9 +11,30 @@
 
 #include "GOAlloc.h"
 
+void GOCacheObject::SetGroupAndPrefix(
+  const wxString &group, const wxString &keyPrefix) {
+  m_group = group;
+  m_KeyPrefix = keyPrefix;
+}
+
 void GOCacheObject::InitBeforeLoad() {
   m_IsReady = false;
   m_LoadError.Clear();
+}
+
+const wxString GOCacheObject::GenerateMessage(const wxString &srcMsg) {
+  wxString res;
+
+  if (!m_group.IsEmpty()) {
+    res << m_group;
+    if (!m_KeyPrefix.IsEmpty()) {
+      res << "/";
+      res << m_KeyPrefix;
+    }
+    res << ": ";
+  }
+  res << srcMsg;
+  return res;
 }
 
 bool GOCacheObject::InitWithoutExc() {
@@ -24,11 +45,11 @@ bool GOCacheObject::InitWithoutExc() {
   } catch (GOOutOfMemory e) {
     throw e;
   } catch (wxString error) {
-    m_LoadError = error;
+    m_LoadError = GenerateMessage(error);
   } catch (const std::exception &e) {
-    m_LoadError = e.what();
+    m_LoadError = GenerateMessage(e.what());
   } catch (...) { // We must not allow unhandled exceptions here
-    m_LoadError = _("Unknown exception");
+    m_LoadError = GenerateMessage(_("Unknown exception"));
   }
   return m_IsReady;
 }
@@ -42,11 +63,11 @@ bool GOCacheObject::LoadFromFileWithoutExc(
   } catch (GOOutOfMemory e) {
     throw e;
   } catch (wxString error) {
-    m_LoadError = error;
+    m_LoadError = GenerateMessage(error);
   } catch (const std::exception &e) {
-    m_LoadError = e.what();
+    m_LoadError = GenerateMessage(e.what());
   } catch (...) { // We must not allow unhandled exceptions here
-    m_LoadError = _("Unknown exception");
+    m_LoadError = GenerateMessage(_("Unknown exception"));
   }
   return m_IsReady;
 }
@@ -59,11 +80,11 @@ bool GOCacheObject::LoadFromCacheWithoutExc(
   } catch (GOOutOfMemory e) {
     throw e;
   } catch (wxString error) {
-    m_LoadError = error;
+    m_LoadError = GenerateMessage(error);
   } catch (const std::exception &e) {
-    m_LoadError = e.what();
+    m_LoadError = GenerateMessage(e.what());
   } catch (...) { // We must not allow unhandled exceptions here
-    m_LoadError = _("Unknown exception");
+    m_LoadError = GenerateMessage(_("Unknown exception"));
   }
   return m_IsReady;
 }

--- a/src/grandorgue/model/GOCacheObject.h
+++ b/src/grandorgue/model/GOCacheObject.h
@@ -19,11 +19,19 @@ class GOMemoryPool;
 class GOCacheObject {
 private:
   bool m_IsReady = false;
+
+  // the group name in the ODF
+  wxString m_group;
+
+  // the ODF key prefix of all settings belong to this object
+  wxString m_KeyPrefix;
+
   wxString m_LoadError;
 
   void InitBeforeLoad();
 
 protected:
+  void SetGroupAndPrefix(const wxString &group, const wxString &keyPrefix);
   virtual void Initialize() = 0;
   virtual void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) = 0;
   virtual bool LoadCache(GOMemoryPool &pool, GOCache &cache) = 0;
@@ -61,7 +69,9 @@ public:
   virtual bool SaveCache(GOCacheWriter &cache) const = 0;
   virtual void UpdateHash(GOHash &hash) const = 0;
   virtual const wxString &GetLoadTitle() const = 0;
-  virtual const wxString &GetNameForError() const { return GetLoadTitle(); }
+
+  // Returns the message string prefixed with group and keyPrefix
+  const wxString GenerateMessage(const wxString &srcMsg);
 };
 
 #endif

--- a/src/grandorgue/model/GOCacheObject.h
+++ b/src/grandorgue/model/GOCacheObject.h
@@ -61,6 +61,7 @@ public:
   virtual bool SaveCache(GOCacheWriter &cache) const = 0;
   virtual void UpdateHash(GOHash &hash) const = 0;
   virtual const wxString &GetLoadTitle() const = 0;
+  virtual const wxString &GetNameForError() const { return GetLoadTitle(); }
 };
 
 #endif

--- a/src/grandorgue/model/GOReferencePipe.cpp
+++ b/src/grandorgue/model/GOReferencePipe.cpp
@@ -27,6 +27,7 @@ GOReferencePipe::GOReferencePipe(
 
 void GOReferencePipe::Load(
   GOConfigReader &cfg, wxString group, wxString prefix) {
+  SetGroupAndPrefix(group, prefix);
   m_model->RegisterCacheObject(this);
   m_Filename = cfg.ReadStringTrim(ODFSetting, group, prefix);
   if (!m_Filename.StartsWith(wxT("REF:")))

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -136,6 +136,7 @@ void GOSoundingPipe::LoadAttack(
 
 void GOSoundingPipe::Init(
   GOConfigReader &cfg, wxString group, wxString prefix, wxString filename) {
+  SetGroupAndPrefix(group, prefix);
   p_OrganModel->RegisterCacheObject(this);
   m_Filename = filename;
   m_PipeConfigNode.Init(cfg, group, prefix);
@@ -166,6 +167,7 @@ void GOSoundingPipe::Init(
 
 void GOSoundingPipe::Load(
   GOConfigReader &cfg, wxString group, wxString prefix) {
+  SetGroupAndPrefix(group, prefix);
   p_OrganModel->RegisterCacheObject(this);
   m_Filename = cfg.ReadStringTrim(ODFSetting, group, prefix);
   m_PipeConfigNode.Load(cfg, group, prefix);

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -54,6 +54,7 @@ bool GOTremulant::LoadCache(GOMemoryPool &pool, GOCache &cache) {
 
 void GOTremulant::Load(
   GOConfigReader &cfg, wxString group, int sampler_group_id) {
+  SetGroupAndPrefix(group, wxEmptyString);
   m_TremulantType = (GOTremulantType)cfg.ReadEnum(
     ODFSetting,
     group,

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -202,7 +202,7 @@ void GOSoundProviderWave::LoadFromOneFile(
   bool use_pitch,
   unsigned loop_crossfade_length,
   unsigned max_released_time) {
-  // if an exception occurs during Open(), it alteady contains the file name
+  // if an exception occurs during Open(), it already contains the file name
   std::unique_ptr<GOOpenedFile> openedFilePtr = loaderFilename.Open(fileStore);
 
   // catch a possible exception and rethrow it prefixed with the filename

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -202,7 +202,7 @@ void GOSoundProviderWave::LoadFromOneFile(
   bool use_pitch,
   unsigned loop_crossfade_length,
   unsigned max_released_time) {
-  // if an exception occures during Open(), it alteady contains the file name
+  // if an exception occurs during Open(), it alteady contains the file name
   std::unique_ptr<GOOpenedFile> openedFilePtr = loaderFilename.Open(fileStore);
 
   // catch a possible exception and rethrow it prefixed with the filename

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -93,8 +93,9 @@ class GOSoundProviderWave : public GOSoundProvider {
    * Load attack and/or release samples from one wav file or from an archive
    */
   void LoadFromOneFile(
+    const GOFileStore &fileStore,
     GOMemoryPool &pool,
-    GOOpenedFile *file,
+    const GOLoaderFilename &loaderFilename,
     const std::vector<GOWaveLoop> *loops,
     bool is_attack,
     bool is_release,


### PR DESCRIPTION
This is the second PR related to #1724 

It
1. Passes the actual filename to `GOSoundProviderWave::LoadFromOneFile`
2. Moved substituting the filename from `GOOrganController::LoadOrgan` to `GOSoundProviderWave::LoadFromOneFile`
3. Added prefixing error messages with Stop999/Pipe999 in `GOCacheObject`