### PR TITLE
Increased the maximum allowed number of tremulants to 999.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Increased the maximum number of Tremulants from 10 to 999
 - Fixed setting a reverb file name by default to the current directory https://github.com/GrandOrgue/grandorgue/issues/1741
 - Fixed crash on enabling convolution reverb https://github.com/GrandOrgue/grandorgue/issues/1741
 - Fixed hang on Panic button press on MacOs https://github.com/GrandOrgue/grandorgue/issues/1726

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -7105,7 +7105,7 @@ The manual information for each manual is available in sections called
           <term>NumberOfTremulants</term>
           <listitem>
             <para>
-(integer 0 - 10, required) number of tremulants. The details of each tremulant are contained in a section called <emphasis>Tremulant999</emphasis>
+(integer 0 - 999, required) number of tremulants. The details of each tremulant are contained in a section called <emphasis>Tremulant999</emphasis>
      </para>
           </listitem>
         </varlistentry>

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -98,7 +98,7 @@ void GOOrganModel::Load(GOConfigReader &cfg) {
   }
 
   unsigned NumberOfTremulants
-    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfTremulants"), 0, 10);
+    = cfg.ReadInteger(ODFSetting, WX_ORGAN, wxT("NumberOfTremulants"), 0, 999);
   for (unsigned i = 0; i < NumberOfTremulants; i++) {
     m_tremulants.push_back(new GOTremulant(*this));
     m_tremulants[i]->Load(


### PR DESCRIPTION
As suggested in https://github.com/GrandOrgue/grandorgue/discussions/1756 I increased the number of allowed tremulants.