### PR TITLE
Fixed not loading a pipe if some loop was not suitable for crossfade https://github.com/GrandOrgue/grandorgue/issues/1724

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed not loading a pipe if some loop was not suitable for crossfade https://github.com/GrandOrgue/grandorgue/issues/1724
 - Fixed a wrong .wav filename in the log message window https://github.com/GrandOrgue/grandorgue/issues/1724
 - Increased the maximum number of Tremulants from 10 to 999
 - Fixed setting a reverb file name by default to the current directory https://github.com/GrandOrgue/grandorgue/issues/1741

--- a/src/grandorgue/loader/GOLoaderFilename.h
+++ b/src/grandorgue/loader/GOLoaderFilename.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/loader/GOLoaderFilename.h
+++ b/src/grandorgue/loader/GOLoaderFilename.h
@@ -53,6 +53,15 @@ public:
    * @return a pointer to the GOFile
    */
   std::unique_ptr<GOOpenedFile> Open(const GOFileStore &fileStore) const;
+
+  wxString GenerateMessage(const wxString &srcMsg) const {
+    return wxString::Format("%s: %s", m_path, srcMsg);
+  }
+
+  static wxString generateMessage(
+    const GOLoaderFilename *pFileName, const wxString &srcMsg) {
+    return pFileName ? pFileName->GenerateMessage(srcMsg) : srcMsg;
+  }
 };
 
 #endif

--- a/src/grandorgue/model/GOCacheObject.cpp
+++ b/src/grandorgue/model/GOCacheObject.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/model/GOCacheObject.cpp
+++ b/src/grandorgue/model/GOCacheObject.cpp
@@ -22,7 +22,7 @@ void GOCacheObject::InitBeforeLoad() {
   m_LoadError.Clear();
 }
 
-const wxString GOCacheObject::GenerateMessage(const wxString &srcMsg) {
+const wxString GOCacheObject::GenerateMessage(const wxString &srcMsg) const {
   wxString res;
 
   if (!m_group.IsEmpty()) {

--- a/src/grandorgue/model/GOCacheObject.h
+++ b/src/grandorgue/model/GOCacheObject.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/model/GOCacheObject.h
+++ b/src/grandorgue/model/GOCacheObject.h
@@ -10,6 +10,8 @@
 
 #include <wx/string.h>
 
+#include "loader/GOLoaderFilename.h"
+
 class GOCache;
 class GOCacheWriter;
 class GOFileStore;
@@ -71,7 +73,20 @@ public:
   virtual const wxString &GetLoadTitle() const = 0;
 
   // Returns the message string prefixed with group and keyPrefix
-  const wxString GenerateMessage(const wxString &srcMsg);
+  const wxString GenerateMessage(const wxString &srcMsg) const;
+
+  static const wxString generateMessage(
+    const GOCacheObject *pObjectFor, const wxString &srcMsg) {
+    return pObjectFor ? pObjectFor->GenerateMessage(srcMsg) : srcMsg;
+  }
+
+  static const wxString generateMessage(
+    const GOCacheObject *pObjectFor,
+    const GOLoaderFilename *pFilename,
+    const wxString &srcMsg) {
+    return generateMessage(
+      pObjectFor, GOLoaderFilename::generateMessage(pFilename, srcMsg));
+  }
 };
 
 #endif

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -58,6 +58,7 @@ GOSoundingPipe::GOSoundingPipe(
     m_SampleMidiPitchFraction(0.0),
     m_RetunePipe(retune),
     m_IsTemperamentOriginalBased(true),
+    m_SoundProvider(this),
     m_PipeConfigNode(
       &rank->GetPipeConfig(), pOrganModel, this, &m_SoundProvider) {}
 

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -8,9 +8,13 @@
 #include "GOSoundAudioSection.h"
 
 #include <wx/intl.h>
+#include <wx/log.h>
 
 #include "loader/cache/GOCache.h"
 #include "loader/cache/GOCacheWriter.h"
+
+#include "loader/GOLoaderFilename.h"
+#include "model/GOCacheObject.h"
 
 #include "GOAlloc.h"
 #include "GOMemoryPool.h"
@@ -637,6 +641,8 @@ void GOAudioSection::DoCrossfade(
 }
 
 void GOAudioSection::Setup(
+  const GOCacheObject *pObjectFor,
+  const GOLoaderFilename *pLoaderFilename,
   const void *pcm_data,
   const GOWave::SAMPLE_FORMAT pcm_data_format,
   const unsigned pcm_data_channels,
@@ -684,75 +690,85 @@ void GOAudioSection::Setup(
       end_seg.next_start_segment_index = i + 1;
       const unsigned loop_length
         = 1 + end_seg.end_offset - start_seg.start_offset;
-      unsigned end_length;
+      wxString loopError;
 
-      if (fade_len > end_seg.end_offset - start_seg.start_offset)
-        throw(wxString) _("Loop too short for crossfade");
+      if (fade_len > loop_length - 1)
+        loopError
+          = wxString::Format(_("Loop %u is too short for crossfade"), i + 1);
+      else if (start_seg.start_offset < fade_len)
+        loopError = wxString::Format(
+          _("Not enough samples for crossfade before loop %u "), i + 1);
 
-      if (start_seg.start_offset < fade_len)
-        throw(wxString) _("Not enough samples for a crossfade");
+      if (loopError.IsEmpty()) {
+        unsigned end_length;
 
-      // calculate the fade segment size and offsets
-      if (end_seg.end_offset - start_seg.start_offset > SHORT_LOOP_LENGTH) {
-        end_seg.transition_offset
-          = end_seg.end_offset - MAX_READAHEAD - fade_len + 1;
-        end_seg.read_end = end_seg.end_offset - fade_len;
-        end_length = 2 * MAX_READAHEAD + fade_len;
-      } else {
-        end_seg.transition_offset = start_seg.start_offset;
-        end_seg.read_end = end_seg.end_offset;
-        end_length = SHORT_LOOP_LENGTH + MAX_READAHEAD;
-        if (
-          end_length < MAX_READAHEAD
-            + (SHORT_LOOP_LENGTH / loop_length) * SHORT_LOOP_LENGTH + fade_len)
-          end_length = MAX_READAHEAD
-            + (SHORT_LOOP_LENGTH / loop_length) * SHORT_LOOP_LENGTH + fade_len;
-      }
-      end_seg.end_size = end_length * m_BytesPerSample;
+        // calculate the fade segment size and offsets
+        if (end_seg.end_offset - start_seg.start_offset > SHORT_LOOP_LENGTH) {
+          end_seg.transition_offset
+            = end_seg.end_offset - MAX_READAHEAD - fade_len + 1;
+          end_seg.read_end = end_seg.end_offset - fade_len;
+          end_length = 2 * MAX_READAHEAD + fade_len;
+        } else {
+          end_seg.transition_offset = start_seg.start_offset;
+          end_seg.read_end = end_seg.end_offset;
+          end_length = SHORT_LOOP_LENGTH + MAX_READAHEAD;
+          if (
+            end_length < MAX_READAHEAD
+              + (SHORT_LOOP_LENGTH / loop_length) * SHORT_LOOP_LENGTH
+              + fade_len)
+            end_length = MAX_READAHEAD
+              + (SHORT_LOOP_LENGTH / loop_length) * SHORT_LOOP_LENGTH
+              + fade_len;
+        }
+        end_seg.end_size = end_length * m_BytesPerSample;
 
-      // Allocate the fade segment
-      end_seg.end_data = (unsigned char *)m_Pool.Alloc(end_seg.end_size, true);
-      if (!end_seg.end_data)
-        throw GOOutOfMemory();
-      end_seg.end_ptr
-        = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;
+        // Allocate the fade segment
+        end_seg.end_data
+          = (unsigned char *)m_Pool.Alloc(end_seg.end_size, true);
+        if (!end_seg.end_data)
+          throw GOOutOfMemory();
+        end_seg.end_ptr
+          = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;
 
-      const unsigned copy_len
-        = 1 + end_seg.end_offset - end_seg.transition_offset;
+        const unsigned copy_len
+          = 1 + end_seg.end_offset - end_seg.transition_offset;
 
-      // Fill the fade seg with transition data, then with the loop start data
-      memcpy(
-        end_seg.end_data,
-        ((const unsigned char *)pcm_data)
-          + end_seg.transition_offset * m_BytesPerSample,
-        copy_len * m_BytesPerSample);
-      loop_memcpy(
-        ((unsigned char *)end_seg.end_data) + copy_len * m_BytesPerSample,
-        ((const unsigned char *)pcm_data)
-          + loop.m_StartPosition * m_BytesPerSample,
-        loop_length * m_BytesPerSample,
-        (end_length - copy_len) * m_BytesPerSample);
-      if (fade_len > 0)
-        // TODO: Remove the parameter names from the comment and reduce the
-        // number of parameters of DoCrossfade that the call would be easy
-        // readable without additional comments
-        DoCrossfade(
-          end_seg.end_data,                  // dest
-          MAX_READAHEAD,                     // dest_offset
-          (const unsigned char *)pcm_data,   // src
-          start_seg.start_offset - fade_len, // src_offset
-          pcm_data_channels,                 // channels
-          m_BitsPerSample,                   // bits_per_sample
-          fade_len,                          // fade_length
-          loop_length,                       // loop_length
-          end_length);                       // length
+        // Fill the fade seg with transition data, then with the loop start data
+        memcpy(
+          end_seg.end_data,
+          ((const unsigned char *)pcm_data)
+            + end_seg.transition_offset * m_BytesPerSample,
+          copy_len * m_BytesPerSample);
+        loop_memcpy(
+          ((unsigned char *)end_seg.end_data) + copy_len * m_BytesPerSample,
+          ((const unsigned char *)pcm_data)
+            + loop.m_StartPosition * m_BytesPerSample,
+          loop_length * m_BytesPerSample,
+          (end_length - copy_len) * m_BytesPerSample);
+        if (fade_len > 0)
+          // TODO: Remove the parameter names from the comment and reduce the
+          // number of parameters of DoCrossfade that the call would be easy
+          // readable without additional comments
+          DoCrossfade(
+            end_seg.end_data,                  // dest
+            MAX_READAHEAD,                     // dest_offset
+            (const unsigned char *)pcm_data,   // src
+            start_seg.start_offset - fade_len, // src_offset
+            pcm_data_channels,                 // channels
+            m_BitsPerSample,                   // bits_per_sample
+            fade_len,                          // fade_length
+            loop_length,                       // loop_length
+            end_length);                       // length
 
-      end_seg.end_loop_length = loop_length;
-      end_seg.end_pos = end_length + end_seg.transition_offset;
-      assert(end_length >= MAX_READAHEAD);
+        end_seg.end_loop_length = loop_length;
+        end_seg.end_pos = end_length + end_seg.transition_offset;
+        assert(end_length >= MAX_READAHEAD);
 
-      m_StartSegments.push_back(start_seg);
-      m_EndSegments.push_back(end_seg);
+        m_StartSegments.push_back(start_seg);
+        m_EndSegments.push_back(end_seg);
+      } else
+        wxLogWarning(GOCacheObject::generateMessage(
+          pObjectFor, pLoaderFilename, loopError));
     }
 
     /* There is no need to store any samples after the end of the last loop. */

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -693,11 +693,13 @@ void GOAudioSection::Setup(
       wxString loopError;
 
       if (fade_len > loop_length - 1)
-        loopError
-          = wxString::Format(_("Loop %u is too short for crossfade"), i + 1);
+        loopError = wxString::Format(
+          _("The loop %u is ignored: it is too short for crossfade"), i + 1);
       else if (start_seg.start_offset < fade_len)
         loopError = wxString::Format(
-          _("Not enough samples for crossfade before loop %u "), i + 1);
+          _("The loop %u is ignored: not enough samples for crossfade before "
+            "it's start"),
+          i + 1);
 
       if (loopError.IsEmpty()) {
         unsigned end_length;
@@ -769,6 +771,8 @@ void GOAudioSection::Setup(
       } else
         wxLogWarning(GOCacheObject::generateMessage(
           pObjectFor, pLoaderFilename, loopError));
+      if (!m_EndSegments.size())
+        throw(wxString) _("No valid loops exist in the file");
     }
 
     /* There is no need to store any samples after the end of the last loop. */

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -748,19 +748,18 @@ void GOAudioSection::Setup(
           loop_length * m_BytesPerSample,
           (end_length - copy_len) * m_BytesPerSample);
         if (fade_len > 0)
-          // TODO: Remove the parameter names from the comment and reduce the
-          // number of parameters of DoCrossfade that the call would be easy
-          // readable without additional comments
+          // TODO: reduce the number of parameters of DoCrossfade that the call
+          // would be easy readable without additional comments
           DoCrossfade(
-            end_seg.end_data,                  // dest
-            MAX_READAHEAD,                     // dest_offset
-            (const unsigned char *)pcm_data,   // src
-            start_seg.start_offset - fade_len, // src_offset
-            pcm_data_channels,                 // channels
-            m_BitsPerSample,                   // bits_per_sample
-            fade_len,                          // fade_length
-            loop_length,                       // loop_length
-            end_length);                       // length
+            end_seg.end_data,
+            MAX_READAHEAD,
+            (const unsigned char *)pcm_data,
+            start_seg.start_offset - fade_len,
+            pcm_data_channels,
+            m_BitsPerSample,
+            fade_len,
+            loop_length,
+            end_length);
 
         end_seg.end_loop_length = loop_length;
         end_seg.end_pos = end_length + end_seg.transition_offset;

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -19,7 +19,9 @@
 
 class GOAudioSection;
 class GOCache;
+class GOCacheObject;
 class GOCacheWriter;
+class GOLoaderFilename;
 class GOMemoryPool;
 class GOSoundReleaseAlignTable;
 class GOSampleStatistic;
@@ -197,6 +199,8 @@ public:
     int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]);
 
   void Setup(
+    const GOCacheObject *pObjectFor,
+    const GOLoaderFilename *pLoaderFilename,
     const void *pcm_data,
     GOWave::SAMPLE_FORMAT pcm_data_format,
     unsigned pcm_data_channels,

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
@@ -89,6 +89,8 @@ void GOSoundProviderSynthedTrem::Create(
   m_AttackInfo.push_back(attack_info);
   m_Attack.push_back(new GOAudioSection(pool));
   m_Attack[0]->Setup(
+    nullptr,
+    nullptr,
     data.get(),
     GOWave::SF_SIGNEDSHORT_16,
     1,
@@ -105,6 +107,8 @@ void GOSoundProviderSynthedTrem::Create(
   m_ReleaseInfo.push_back(release_info);
   m_Release.push_back(new GOAudioSection(pool));
   m_Release[0]->Setup(
+    nullptr,
+    nullptr,
     data.get() + attack_samples + loop_samples,
     GOWave::SF_SIGNEDSHORT_16,
     1,

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -35,6 +35,7 @@ unsigned GOSoundProviderWave::GetBytesPerSample(unsigned bits_per_sample) {
 
 void GOSoundProviderWave::CreateAttack(
   GOMemoryPool &pool,
+  const GOLoaderFilename &loaderFilename,
   const char *data,
   GOWave &wave,
   int attack_start,
@@ -120,6 +121,8 @@ void GOSoundProviderWave::CreateAttack(
   GOAudioSection *section = new GOAudioSection(pool);
   m_Attack.push_back(section);
   section->Setup(
+    p_ObjectFor,
+    &loaderFilename,
     data + attack_pos * GetBytesPerSample(bits_per_sample) * channels,
     (GOWave::SAMPLE_FORMAT)bits_per_sample,
     channels,
@@ -132,6 +135,7 @@ void GOSoundProviderWave::CreateAttack(
 
 void GOSoundProviderWave::CreateRelease(
   GOMemoryPool &pool,
+  const GOLoaderFilename &loaderFilename,
   const char *data,
   GOWave &wave,
   int sample_group,
@@ -163,6 +167,8 @@ void GOSoundProviderWave::CreateRelease(
   GOAudioSection *section = new GOAudioSection(pool);
   m_Release.push_back(section);
   section->Setup(
+    p_ObjectFor,
+    &loaderFilename,
     data + release_offset * GetBytesPerSample(bits_per_sample) * channels,
     (GOWave::SAMPLE_FORMAT)bits_per_sample,
     channels,
@@ -243,6 +249,7 @@ void GOSoundProviderWave::LoadFromOneFile(
     if (is_attack)
       CreateAttack(
         pool,
+        loaderFilename,
         data.get(),
         wave,
         attack_start,
@@ -262,6 +269,7 @@ void GOSoundProviderWave::LoadFromOneFile(
       && (!is_attack || (wave.GetNbLoops() > 0 && wave.HasReleaseMarker() && !percussive)))
       CreateRelease(
         pool,
+        loaderFilename,
         data.get(),
         wave,
         sample_group,
@@ -281,7 +289,7 @@ void GOSoundProviderWave::LoadFromOneFile(
     excText = _("Unknown exception");
   }
   if (!excText.IsEmpty())
-    throw wxString::Format("%s: %s", loaderFilename.GetPath(), excText);
+    throw loaderFilename.GenerateMessage(excText);
 }
 
 unsigned GOSoundProviderWave::GetFaderLength(unsigned MidiKeyNumber) {

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -17,6 +17,7 @@
 #include "GOSoundProvider.h"
 #include "GOWaveLoop.h"
 
+class GOCacheObject;
 class GOWave;
 
 class GOSoundProviderWave : public GOSoundProvider {
@@ -61,10 +62,14 @@ public:
   };
 
 private:
+  // Used for error messages
+  GOCacheObject *p_ObjectFor;
+
   unsigned GetBytesPerSample(unsigned bits_per_sample);
 
   void CreateAttack(
     GOMemoryPool &pool,
+    const GOLoaderFilename &loaderFilename,
     const char *data,
     GOWave &wave,
     int attack_start,
@@ -81,6 +86,7 @@ private:
 
   void CreateRelease(
     GOMemoryPool &pool,
+    const GOLoaderFilename &loaderFilename,
     const char *data,
     GOWave &wave,
     int sample_group,
@@ -120,6 +126,9 @@ private:
   unsigned GetFaderLength(unsigned MidiKeyNumber);
 
 public:
+  GOSoundProviderWave(GOCacheObject *pObjectFor = nullptr)
+    : p_ObjectFor(pObjectFor) {}
+
   /*
    * Load all attack and release samples from corresponding .wav files or from
    * an archive


### PR DESCRIPTION
Resolves: #1724 

This PR adds capanility to load a pipe even some (but not all) loops are bad for using with Pipe999LoopCrossfadeLength specified. These loops are just ignored and worning messages appear in the Log window.

