### PR TITLE
Updated visible copyright year in preparation for a new release.

### DIFF
--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -14,7 +14,7 @@ License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
       <holder>Milan Digital Audio LLC</holder>
     </copyright>
     <copyright>
-      <year>2009-2023</year>
+      <year>2009-2024</year>
       <holder>GrandOrgue contributors (see AUTHORS)</holder>
     </copyright>
     <legalnotice>

--- a/src/grandorgue/dialogs/GOSplash.cpp
+++ b/src/grandorgue/dialogs/GOSplash.cpp
@@ -119,7 +119,7 @@ void GOSplash::DrawText(wxBitmap &bitmap) {
   font.SetPointSize(7);
   dc.SetFont(font);
   wxString msg
-    = _("Copyright 2006 Milan Digital Audio LLC\nCopyright 2009-2021 "
+    = _("Copyright 2006 Milan Digital Audio LLC\nCopyright 2009-2024 "
         "GrandOrgue contributors\n\nThis software comes with no warranty");
   dc.DrawLabel(
     msg,


### PR DESCRIPTION
At a very minimum, the copyright year that's visible in the application, should be changed to reflect the year the release was finished.