### PR TITLE
Renaming some methods, changed the code style

### DIFF
--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -29,8 +29,8 @@ private:
   uint64_t m_LastStop;
   int m_Instances;
   bool m_Tremulant;
-  std::vector<GOSoundProviderWave::AttackFileInfo> m_AttackInfo;
-  std::vector<GOSoundProviderWave::ReleaseFileInfo> m_ReleaseInfo;
+  std::vector<GOSoundProviderWave::AttackFileInfo> m_AttackFileInfos;
+  std::vector<GOSoundProviderWave::ReleaseFileInfo> m_ReleaseFileInfos;
   wxString m_Filename;
 
   /* states which windchest this pipe belongs to, see
@@ -54,7 +54,16 @@ private:
   GOPipeConfigNode m_PipeConfigNode;
 
   // internal functions
-  void LoadAttack(GOConfigReader &cfg, wxString group, wxString prefix);
+  /* Read one attack file info from the odf keys with the prefix specified and
+   * add it to m_AttackFileInfos
+   */
+  void LoadAttackFileInfo(
+    GOConfigReader &cfg, const wxString &group, const wxString &prefix);
+  /* Read one release file info from the odf keys with the prefix specified and
+   * add it to m_AttackFileInfos
+   */
+  void LoadReleaseFileInfo(
+    GOConfigReader &cfg, const wxString &group, const wxString &prefix);
   /**
    * Calculate a pitch offset for manual tuning
    * @return pitch offset in cents
@@ -113,7 +122,10 @@ public:
     bool retune);
 
   void Init(
-    GOConfigReader &cfg, wxString group, wxString prefix, wxString filename);
+    GOConfigReader &cfg,
+    const wxString &group,
+    const wxString &prefix,
+    const wxString &filename);
   void Load(GOConfigReader &cfg, wxString group, wxString prefix);
 };
 

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -155,22 +155,20 @@ unsigned GOPipeConfigNode::GetEffectiveLoopLoad() const {
     return m_config.LoopLoad();
 }
 
-unsigned GOPipeConfigNode::GetEffectiveAttackLoad() const {
-  if (m_PipeConfig.GetAttackLoad() != -1)
-    return m_PipeConfig.GetAttackLoad();
-  if (m_parent)
-    return m_parent->GetEffectiveAttackLoad();
-  else
-    return m_config.AttackLoad();
+bool GOPipeConfigNode::GetEffectiveAttackLoad() const {
+  const int thisConfigValue = m_PipeConfig.GetAttackLoad();
+
+  return thisConfigValue != -1 ? (bool)thisConfigValue
+    : m_parent                 ? m_parent->GetEffectiveAttackLoad()
+                               : m_config.AttackLoad();
 }
 
-unsigned GOPipeConfigNode::GetEffectiveReleaseLoad() const {
-  if (m_PipeConfig.GetReleaseLoad() != -1)
-    return m_PipeConfig.GetReleaseLoad();
-  if (m_parent)
-    return m_parent->GetEffectiveReleaseLoad();
-  else
-    return m_config.ReleaseLoad();
+bool GOPipeConfigNode::GetEffectiveReleaseLoad() const {
+  const int thisConfigValue = m_PipeConfig.GetReleaseLoad();
+
+  return thisConfigValue != -1 ? (bool)thisConfigValue
+    : m_parent                 ? m_parent->GetEffectiveReleaseLoad()
+                               : m_config.ReleaseLoad();
 }
 
 unsigned GOPipeConfigNode::GetEffectiveChannels() const {

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -61,8 +61,8 @@ public:
   unsigned GetEffectiveBitsPerSample() const;
   bool GetEffectiveCompress() const;
   unsigned GetEffectiveLoopLoad() const;
-  unsigned GetEffectiveAttackLoad() const;
-  unsigned GetEffectiveReleaseLoad() const;
+  bool GetEffectiveAttackLoad() const;
+  bool GetEffectiveReleaseLoad() const;
   unsigned GetEffectiveChannels() const;
   bool GetEffectiveIgnorePitch() const;
   unsigned GetEffectiveReleaseTail() const;

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -661,6 +661,7 @@ void GOAudioSection::Setup(
   assert(pcm_data_nb_samples > 0);
 
   const unsigned bytes_per_sample = wave_bytes_per_sample(pcm_data_format);
+
   m_BytesPerSample = bytes_per_sample * pcm_data_channels;
 
   unsigned total_alloc_samples = pcm_data_nb_samples;

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -176,6 +176,7 @@ public:
   unsigned GetChannels() const;
   unsigned GetBytesPerSample() const;
   unsigned GetLength() const;
+
   bool LoadCache(GOCache &cache);
   bool SaveCache(GOCacheWriter &cache) const;
 

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -64,10 +64,9 @@ public:
 private:
   // Used for error messages
   GOCacheObject *p_ObjectFor;
-
   unsigned GetBytesPerSample(unsigned bits_per_sample);
 
-  void CreateAttack(
+  void AddAttackSection(
     GOMemoryPool &pool,
     const GOLoaderFilename &loaderFilename,
     const char *data,
@@ -84,7 +83,7 @@ private:
     unsigned loop_crossfade_length,
     unsigned max_released_time);
 
-  void CreateRelease(
+  void AddReleaseSection(
     GOMemoryPool &pool,
     const GOLoaderFilename &loaderFilename,
     const char *data,
@@ -142,8 +141,8 @@ public:
     int channels,
     bool compress,
     LoopLoadType loop_mode,
-    unsigned attack_load,
-    unsigned release_load,
+    bool isToLoadAttacks,
+    bool isToLoadReleases,
     unsigned loop_crossfade_length,
     unsigned release_crossfase_length);
   void SetAmplitude(float fixed_amplitude, float gain);

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -112,8 +112,8 @@ void GOPerfTestApp::RunTest(
           2,
           compress,
           GOSoundProviderWave::LOOP_LOAD_ALL,
-          1,
-          1,
+          true,
+          true,
           0,
           0);
         pipes.push_back(w);


### PR DESCRIPTION
It is the first PR related to #1760

This PR:
- Renamed some variables and methods
- Reordered methods in `src/grandorgue/model/GOSoundingPipe.cpp` (the `Init` method was moved up)
- Extracted some code from `GOSoundingPipe::Load` to the new method `GOSoundingPipe::LoadReleaseFileInfo` for the symmetry with `GOSoundingPipe::LoadAttackFileInfo`
- Got rid of multiple taking the same array element in `GOSoundingPipe::UpdateHash`
- Changed the result type of `GOPipeConfigNode::GetEffectiveAttackLoad` and `GOPipeConfigNode::GetEffectiveReleaseLoad` and made their code more readable
- Changing usage of blank lines somewhere

It is just refactoring. No GO behavior should be changed.
