### PR TITLE
Fixed unability to select Hungarian in the Organ Settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed unability to select the Hungarian language in the Organ Settings dialog
 - Eliminated resetting audio group with the Default button of Organ Settings dialog https://github.com/GrandOrgue/grandorgue/issues/731
 # 3.13.3 (2024-01-07)
 - Fixed not loading a pipe if some loop was not suitable for crossfade https://github.com/GrandOrgue/grandorgue/issues/1724

--- a/src/grandorgue/dialogs/settings/GOSettingsOptions.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOptions.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/dialogs/settings/GOSettingsOptions.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOptions.cpp
@@ -65,6 +65,10 @@ GOSettingsOptions::GOSettingsOptions(GOConfig &settings, wxWindow *parent)
     new wxStringClientData(
       wxLocale::GetLanguageCanonicalName(wxLANGUAGE_GERMAN)));
   m_Language->Append(
+    wxLocale::GetLanguageName(wxLANGUAGE_HUNGARIAN),
+    new wxStringClientData(
+      wxLocale::GetLanguageCanonicalName(wxLANGUAGE_HUNGARIAN)));
+  m_Language->Append(
     wxLocale::GetLanguageName(wxLANGUAGE_ITALIAN),
     new wxStringClientData(
       wxLocale::GetLanguageCanonicalName(wxLANGUAGE_ITALIAN)));


### PR DESCRIPTION
Hungarian is among supported languages for GrandOrgue, but it was not able to be selected on the Organ Settings dialog.