### PR TITLE
Fixed wrong filename of the midi recorder file with Hungarian language settings https://github.com/GrandOrgue/grandorgue/issues/1644

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed wrong filename of the midi recorder file with Hungarian language settings https://github.com/GrandOrgue/grandorgue/issues/1644
 - Fixed unability to select the Hungarian language in the Organ Settings dialog
 - Eliminated resetting audio group with the Default button of Organ Settings dialog https://github.com/GrandOrgue/grandorgue/issues/731
 # 3.13.3 (2024-01-07)

--- a/po/hu.po
+++ b/po/hu.po
@@ -4863,7 +4863,7 @@ msgstr "MIDI-hang (*.mid)|*.mid"
 
 #: src/grandorgue/midi/GOMidiRecorder.cpp:340
 msgid "%Y-%m-%d-%H-%M-%S.%l.mid"
-msgstr "%Y-%m-%d-%H-%M-%S.%l.wav"
+msgstr "%Y-%m-%d-%H-%M-%S.%l.mid"
 
 #: src/grandorgue/midi/GOMidiRecorder.cpp:345
 #: src/grandorgue/sound/GOSoundRecorder.cpp:73


### PR DESCRIPTION
Resolves: #1644

The filename pattern is translated. The hungarian translation was wrong.
