### PR TITLE
Introduced a new type GOBool3 for working with three-valued booleans

### DIFF
--- a/src/core/GOBool3.h
+++ b/src/core/GOBool3.h
@@ -12,10 +12,10 @@
 
 // 3-value booleans
 enum GOBool3 : int8_t {
-  BOOL3_UNDEF = -1,
+  BOOL3_DEFAULT = -1,
   BOOL3_FALSE = 0, // must be the same as ``(int8_t) false``
   BOOL3_TRUE = 1,  // must be the same as ``(int8_t) true``
-  BOOL3_MIN = BOOL3_UNDEF,
+  BOOL3_MIN = BOOL3_DEFAULT,
   BOOL3_MAX = BOOL3_TRUE
 };
 

--- a/src/core/GOBool3.h
+++ b/src/core/GOBool3.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOBOOL3_H
+#define GOBOOL3_H
+
+#include <cstdint>
+
+// 3-value booleans
+enum GOBool3 : int8_t {
+  BOOL3_UNDEF = -1,
+  BOOL3_FALSE = 0, // must be the same as ``(int8_t) false``
+  BOOL3_TRUE = 1,  // must be the same as ``(int8_t) true``
+  BOOL3_MIN = BOOL3_UNDEF,
+  BOOL3_MAX = BOOL3_TRUE
+};
+
+// conversion from any number and bool
+template <typename T> GOBool3 to_bool3(T from) { return (GOBool3)(int8_t)from; }
+
+#define CONVERT_BOOL3_TO_BOOL(fromBool3, defaultBoolExpr)                      \
+  fromBool3 >= BOOL3_FALSE ? (bool)(int8_t)(fromBool3) : defaultBoolExpr
+
+// conversion with lazy calculation of default
+template <typename F> inline bool to_bool(GOBool3 from, F defaultFunc) {
+  return CONVERT_BOOL3_TO_BOOL(from, defaultFunc());
+}
+
+// conversion with a simple default
+inline bool to_bool(GOBool3 from, bool defaultValue = false) {
+  /*
+    we don't implement it as
+    ``return to_bool(from, [&]() { return defaultValue; });``
+    because the performance reason: gcc does't inline calling a trivial lambda
+   */
+  return CONVERT_BOOL3_TO_BOOL(from, defaultValue);
+}
+
+#undef CONVERT_BOOL3_TO_BOOL
+
+#endif /* GOBOOL3_H */

--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,8 +11,9 @@
 #include <wx/intl.h>
 #include <wx/log.h>
 
+#include "GOBool3.h"
+#include "GOConfigReaderDB.h"
 #include "GOUtil.h"
-#include "config/GOConfigReaderDB.h"
 
 GOConfigReader::GOConfigReader(
   GOConfigReaderDB &cfg, bool strict, bool hw1Check)
@@ -156,7 +157,7 @@ bool GOConfigReader::ReadBoolean(
   return ReadBoolean(type, group, key, required, false);
 }
 
-int GOConfigReader::ReadBooleanTriple(
+GOBool3 GOConfigReader::ReadBooleanTriple(
   GOSettingType type,
   const wxString &group,
   const wxString &key,
@@ -164,7 +165,7 @@ int GOConfigReader::ReadBooleanTriple(
   wxString value;
 
   if (!Read(type, group, key, required, value))
-    return -1;
+    return BOOL3_UNDEF;
 
   if (value.length() > 0 && value[value.length() - 1] == ' ') {
     if (m_Strict)
@@ -176,9 +177,9 @@ int GOConfigReader::ReadBooleanTriple(
     value.Trim();
   }
   if (value == wxT("Y") || value == wxT("y"))
-    return 1;
+    return BOOL3_TRUE;
   if (value == wxT("N") || value == wxT("n"))
-    return 0;
+    return BOOL3_FALSE;
   value.MakeUpper();
   wxLogWarning(
     _("Strange boolean value for section '%s' entry '%s': %s"),
@@ -186,9 +187,9 @@ int GOConfigReader::ReadBooleanTriple(
     key.c_str(),
     value.c_str());
   if (value.Length() && value[0] == wxT('Y'))
-    return 1;
+    return BOOL3_TRUE;
   else if (value.Length() && value[0] == wxT('N'))
-    return 0;
+    return BOOL3_FALSE;
 
   wxString error;
   error.Printf(
@@ -205,9 +206,7 @@ bool GOConfigReader::ReadBoolean(
   const wxString &key,
   bool required,
   bool defaultValue) {
-  int tripleValue = ReadBooleanTriple(type, group, key, required);
-
-  return tripleValue < 0 ? defaultValue : (tripleValue);
+  return to_bool(ReadBooleanTriple(type, group, key, required), defaultValue);
 }
 
 GOLogicalColour GOConfigReader::ReadColor(

--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -165,7 +165,7 @@ GOBool3 GOConfigReader::ReadBooleanTriple(
   wxString value;
 
   if (!Read(type, group, key, required, value))
-    return BOOL3_UNDEF;
+    return BOOL3_DEFAULT;
 
   if (value.length() > 0 && value[value.length() - 1] == ' ') {
     if (m_Strict)

--- a/src/core/config/GOConfigReader.h
+++ b/src/core/config/GOConfigReader.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,6 +13,7 @@
 #include <wx/hashmap.h>
 #include <wx/string.h>
 
+#include "GOBool3.h"
 #include "GOLogicalColour.h"
 
 class GOConfigReaderDB;
@@ -47,7 +48,7 @@ public:
   /**
    * Reads a triple-value boolean (-1 - not defined, 0 - false, 1 - true)
    */
-  int ReadBooleanTriple(
+  GOBool3 ReadBooleanTriple(
     GOSettingType type,
     const wxString &group,
     const wxString &key,
@@ -127,6 +128,14 @@ public:
     int nmax,
     bool required,
     int defaultValue);
+  GOBool3 ReadBool3FromInt(
+    GOSettingType type,
+    const wxString &group,
+    const wxString &key,
+    bool required) {
+    return to_bool3(ReadInteger(
+      type, group, key, BOOL3_MIN, BOOL3_MAX, required, BOOL3_UNDEF));
+  }
   int ReadLong(
     GOSettingType type,
     const wxString &group,

--- a/src/core/config/GOConfigReader.h
+++ b/src/core/config/GOConfigReader.h
@@ -134,7 +134,7 @@ public:
     const wxString &key,
     bool required) {
     return to_bool3(ReadInteger(
-      type, group, key, BOOL3_MIN, BOOL3_MAX, required, BOOL3_UNDEF));
+      type, group, key, BOOL3_MIN, BOOL3_MAX, required, BOOL3_DEFAULT));
   }
   int ReadLong(
     GOSettingType type,


### PR DESCRIPTION
GrandOrgue has a lot of code that works with three-valued booleans. Now they are stored as integers that causes
- they take 4 bytes instead of 1 byte
- there is a lot of duplicated code of substituting default values

This PR introduces a new type GOBool3 for incapsulating this concept and reusing it's code.

I'm going to use this type (in future PR's) at least in
- `GOCombitation` - for storing element states
- `GOPipeConfig` and `GOPipeConfigNode`

Now the new type is used only in `GOConfigReader.cpp`.

No GO behavior should be changed.