### PR TITLE
Removed dependency of GOPipeConfig on GOOrganModel

### DIFF
--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -16,6 +16,7 @@
 #include "midi/GOMidiSendProxy.h"
 #include "midi/dialog-creator/GOMidiDialogCreatorProxy.h"
 #include "modification/GOModificationProxy.h"
+#include "pipe-config/GOPipeConfigListener.h"
 #include "pipe-config/GOPipeConfigTreeNode.h"
 
 #include "GOEventHandlerList.h"
@@ -36,7 +37,8 @@ class GOOrganModel : private GOCombinationButtonSet,
                      public GOCombinationControllerProxy,
                      public GOEventHandlerList,
                      public GOMidiDialogCreatorProxy,
-                     public GOMidiSendProxy {
+                     public GOMidiSendProxy,
+                     public GOPipeConfigListener {
 private:
   GOConfig &m_config;
 
@@ -123,7 +125,7 @@ public:
 
   bool IsOrganModelModified() const { return m_OrganModelModified; }
   void SetOrganModelModified(bool modified);
-  void SetOrganModelModified() { SetOrganModelModified(true); }
+  void NotifyPipeConfigModified() override { SetOrganModelModified(true); }
   void ResetOrganModelModified() { SetOrganModelModified(false); }
 
   void SetModelModificationListener(GOModificationListener *listener) {

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -60,7 +60,7 @@ GOSoundingPipe::GOSoundingPipe(
     m_IsTemperamentOriginalBased(true),
     m_SoundProvider(this),
     m_PipeConfigNode(
-      &rank->GetPipeConfig(), pOrganModel, this, &m_SoundProvider) {}
+      &rank->GetPipeConfig(), *pOrganModel, this, &m_SoundProvider) {}
 
 void GOSoundingPipe::Init(
   GOConfigReader &cfg,

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -9,6 +9,7 @@
 #define GOSOUNDINGPIPE_H
 
 #include "pipe-config/GOPipeConfigNode.h"
+#include "pipe-config/GOPipeUpdateCallback.h"
 #include "sound/GOSoundProviderWave.h"
 
 #include "GOCacheObject.h"

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -10,6 +10,9 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
+#include "GOPipeConfigListener.h"
+#include "GOPipeUpdateCallback.h"
+
 GOPipeConfig::GOPipeConfig(
   GOPipeConfigListener &listener, GOPipeUpdateCallback *callback)
   : r_listener(listener),

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -9,11 +9,10 @@
 
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
-#include "model/GOOrganModel.h"
 
 GOPipeConfig::GOPipeConfig(
-  GOOrganModel *organModel, GOPipeUpdateCallback *callback)
-  : m_OrganModel(organModel),
+  GOPipeConfigListener &listener, GOPipeUpdateCallback *callback)
+  : r_listener(listener),
     m_Callback(callback),
     m_Group(),
     m_NamePrefix(),
@@ -42,7 +41,7 @@ static const wxString WX_MANUAL_TUNING = wxT("ManualTuning");
 static const wxString WX_AUTO_TUNING_CORRECTION = wxT("AutoTuningCorrection");
 
 void GOPipeConfig::ReadTuning(
-  GOConfigReader &cfg, wxString group, wxString prefix) {
+  GOConfigReader &cfg, const wxString &group, const wxString &prefix) {
   // m_PitchTuning must be read before calling GOPipeConfig::ReadTuning
   float legacyTuning = cfg.ReadFloat(
     CMBSetting, group, prefix + WX_TUNING, -1800, 1800, false, m_PitchTuning);
@@ -65,7 +64,8 @@ void GOPipeConfig::ReadTuning(
     0);
 }
 
-void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
+void GOPipeConfig::Init(
+  GOConfigReader &cfg, const wxString &group, const wxString &prefix) {
   m_Group = group;
   m_NamePrefix = prefix;
   m_AudioGroup
@@ -124,7 +124,8 @@ void GOPipeConfig::Init(GOConfigReader &cfg, wxString group, wxString prefix) {
   m_Callback->UpdateAudioGroup();
 }
 
-void GOPipeConfig::Load(GOConfigReader &cfg, wxString group, wxString prefix) {
+void GOPipeConfig::Load(
+  GOConfigReader &cfg, const wxString &group, const wxString &prefix) {
   m_Group = group;
   m_NamePrefix = prefix;
   m_AudioGroup
@@ -215,7 +216,7 @@ GOPipeUpdateCallback *GOPipeConfig::GetCallback() { return m_Callback; }
 void GOPipeConfig::SetAudioGroup(const wxString &str) {
   m_AudioGroup = str;
   m_Callback->UpdateAudioGroup();
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 float GOPipeConfig::GetAmplitude() { return m_Amplitude; }
@@ -225,7 +226,7 @@ float GOPipeConfig::GetDefaultAmplitude() { return m_DefaultAmplitude; }
 void GOPipeConfig::SetAmplitude(float amp) {
   m_Amplitude = amp;
   m_Callback->UpdateAmplitude();
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 float GOPipeConfig::GetGain() { return m_Gain; }
@@ -235,7 +236,7 @@ float GOPipeConfig::GetDefaultGain() { return m_DefaultGain; }
 void GOPipeConfig::SetGain(float gain) {
   m_Gain = gain;
   m_Callback->UpdateAmplitude();
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetManualTuning(float cent) {
@@ -245,7 +246,7 @@ void GOPipeConfig::SetManualTuning(float cent) {
     cent = 1800;
   m_ManualTuning = cent;
   m_Callback->UpdateTuning();
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetAutoTuningCorrection(float cent) {
@@ -255,51 +256,51 @@ void GOPipeConfig::SetAutoTuningCorrection(float cent) {
     cent = 1800;
   m_AutoTuningCorrection = cent;
   m_Callback->UpdateTuning();
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetDelay(unsigned delay) {
   m_Delay = delay;
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetBitsPerSample(int value) {
   m_BitsPerSample = value;
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetCompress(int value) {
   m_Compress = value;
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetChannels(int value) {
   m_Channels = value;
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetLoopLoad(int value) {
   m_LoopLoad = value;
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetAttackLoad(int value) {
   m_AttackLoad = value;
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetReleaseLoad(int value) {
   m_ReleaseLoad = value;
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetIgnorePitch(int value) {
   m_IgnorePitch = value;
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }
 
 void GOPipeConfig::SetReleaseTail(unsigned releaseTail) {
   m_ReleaseTail = releaseTail;
   m_Callback->UpdateReleaseTail();
-  m_OrganModel->SetOrganModelModified();
+  r_listener.NotifyPipeConfigModified();
 }

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,15 +10,15 @@
 
 #include <wx/string.h>
 
+#include "GOPipeConfigListener.h"
 #include "GOPipeUpdateCallback.h"
 
 class GOConfigReader;
 class GOConfigWriter;
-class GOOrganModel;
 
 class GOPipeConfig {
 private:
-  GOOrganModel *m_OrganModel;
+  GOPipeConfigListener &r_listener;
   GOPipeUpdateCallback *m_Callback;
   wxString m_Group;
   wxString m_NamePrefix;
@@ -44,13 +44,14 @@ private:
   int m_IgnorePitch;
   unsigned m_ReleaseTail; // the max release length in ms
 
-  void ReadTuning(GOConfigReader &cfg, wxString group, wxString prefix);
+  void ReadTuning(
+    GOConfigReader &cfg, const wxString &group, const wxString &prefix);
 
 public:
-  GOPipeConfig(GOOrganModel *organModel, GOPipeUpdateCallback *callback);
+  GOPipeConfig(GOPipeConfigListener &listener, GOPipeUpdateCallback *callback);
 
-  void Init(GOConfigReader &cfg, wxString group, wxString prefix);
-  void Load(GOConfigReader &cfg, wxString group, wxString prefix);
+  void Init(GOConfigReader &cfg, const wxString &group, const wxString &prefix);
+  void Load(GOConfigReader &cfg, const wxString &group, const wxString &prefix);
   void Save(GOConfigWriter &cfg);
 
   GOPipeUpdateCallback *GetCallback();

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -10,11 +10,10 @@
 
 #include <wx/string.h>
 
-#include "GOPipeConfigListener.h"
-#include "GOPipeUpdateCallback.h"
-
 class GOConfigReader;
 class GOConfigWriter;
+class GOPipeConfigListener;
+class GOPipeUpdateCallback;
 
 class GOPipeConfig {
 private:

--- a/src/grandorgue/model/pipe-config/GOPipeConfigListener.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigListener.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOPIPECONFIGLISTENER_H
+#define GOPIPECONFIGLISTENER_H
+
+class GOPipeConfigListener {
+public:
+  virtual void NotifyPipeConfigModified() = 0;
+};
+
+#endif /* GOPIPECONFIGLISTENER_H */

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -15,11 +15,11 @@
 
 GOPipeConfigNode::GOPipeConfigNode(
   GOPipeConfigNode *parent,
-  GOOrganModel *organModel,
+  GOOrganModel &organModel,
   GOPipeUpdateCallback *callback,
   GOStatisticCallback *statistic)
-  : m_OrganModel(organModel),
-    m_config(organModel->GetConfig()),
+  : r_OrganModel(organModel),
+    m_config(organModel.GetConfig()),
     m_parent(parent),
     m_PipeConfig(organModel, callback),
     m_StatisticCallback(statistic),
@@ -42,13 +42,13 @@ void GOPipeConfigNode::SetName(wxString name) { m_Name = name; }
 
 void GOPipeConfigNode::Init(
   GOConfigReader &cfg, wxString group, wxString prefix) {
-  m_OrganModel->RegisterSaveableObject(this);
+  r_OrganModel.RegisterSaveableObject(this);
   m_PipeConfig.Init(cfg, group, prefix);
 }
 
 void GOPipeConfigNode::Load(
   GOConfigReader &cfg, wxString group, wxString prefix) {
-  m_OrganModel->RegisterSaveableObject(this);
+  r_OrganModel.RegisterSaveableObject(this);
   m_PipeConfig.Load(cfg, group, prefix);
 }
 

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -18,7 +18,7 @@ class GOStatisticCallback;
 
 class GOPipeConfigNode : private GOSaveableObject {
 private:
-  GOOrganModel *m_OrganModel;
+  GOOrganModel &r_OrganModel;
   const GOConfig &m_config;
   GOPipeConfigNode *m_parent;
   GOPipeConfig m_PipeConfig;
@@ -30,7 +30,7 @@ private:
 public:
   GOPipeConfigNode(
     GOPipeConfigNode *parent,
-    GOOrganModel *organModel,
+    GOOrganModel &organModel,
     GOPipeUpdateCallback *callback,
     GOStatisticCallback *statistic);
   virtual ~GOPipeConfigNode();

--- a/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,7 +13,7 @@ GOPipeConfigTreeNode::GOPipeConfigTreeNode(
   GOPipeConfigNode *parent,
   GOOrganModel *organModel,
   GOPipeUpdateCallback *callback)
-  : GOPipeConfigNode(parent, organModel, this, NULL),
+  : GOPipeConfigNode(parent, *organModel, this, NULL),
     m_Childs(),
     m_Callback(callback) {}
 

--- a/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "GOPipeConfigNode.h"
+#include "GOPipeUpdateCallback.h"
 
 class GOPipeConfigTreeNode : public GOPipeConfigNode,
                              private GOPipeUpdateCallback {


### PR DESCRIPTION
This PR 
- renames `GOOrganModel::SetOrganModelModified()` to `NotifyPipeConfigModified()`
- creates an abstract class `GOPipeConfigListener` with the single method `NotifyPipeConfigModified()`
- replaced dependency of `GOPipeConfig` on `GOOrganModel` with one on `GOPipeConfigListener`
- changed some members and method parameters to references

It is just refactoring. No GO behavior should be changed.