### PR TITLE
Simplified code of GOPipeConfig and GOPipeConfigNode

### DIFF
--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -10,9 +10,6 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
-#include "GOPipeConfigListener.h"
-#include "GOPipeUpdateCallback.h"
-
 GOPipeConfig::GOPipeConfig(
   GOPipeConfigListener &listener, GOPipeUpdateCallback *callback)
   : r_listener(listener),
@@ -20,24 +17,24 @@ GOPipeConfig::GOPipeConfig(
     m_Group(),
     m_NamePrefix(),
     m_AudioGroup(),
-    m_Amplitude(0),
     m_DefaultAmplitude(0),
+    m_Amplitude(0),
     m_DefaultGain(0),
+    m_Gain(0),
     m_PitchTuning(0),
     m_PitchCorrection(0),
-    m_Gain(0),
     m_ManualTuning(0),
     m_AutoTuningCorrection(0),
-    m_Delay(0),
     m_DefaultDelay(0),
+    m_Delay(0),
+    m_ReleaseTail(0),
     m_BitsPerSample(-1),
-    m_Compress(-1),
     m_Channels(-1),
     m_LoopLoad(-1),
+    m_Compress(-1),
     m_AttackLoad(-1),
     m_ReleaseLoad(-1),
-    m_IgnorePitch(-1),
-    m_ReleaseTail(0) {}
+    m_IgnorePitch(-1) {}
 
 static const wxString WX_TUNING = wxT("Tuning");
 static const wxString WX_MANUAL_TUNING = wxT("ManualTuning");
@@ -214,96 +211,10 @@ void GOPipeConfig::Save(GOConfigWriter &cfg) {
     m_Group, m_NamePrefix + wxT("ReleaseTail"), (int)m_ReleaseTail);
 }
 
-GOPipeUpdateCallback *GOPipeConfig::GetCallback() { return m_Callback; }
-
-void GOPipeConfig::SetAudioGroup(const wxString &str) {
-  m_AudioGroup = str;
-  m_Callback->UpdateAudioGroup();
-  r_listener.NotifyPipeConfigModified();
-}
-
-float GOPipeConfig::GetAmplitude() { return m_Amplitude; }
-
-float GOPipeConfig::GetDefaultAmplitude() { return m_DefaultAmplitude; }
-
-void GOPipeConfig::SetAmplitude(float amp) {
-  m_Amplitude = amp;
-  m_Callback->UpdateAmplitude();
-  r_listener.NotifyPipeConfigModified();
-}
-
-float GOPipeConfig::GetGain() { return m_Gain; }
-
-float GOPipeConfig::GetDefaultGain() { return m_DefaultGain; }
-
-void GOPipeConfig::SetGain(float gain) {
-  m_Gain = gain;
-  m_Callback->UpdateAmplitude();
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetManualTuning(float cent) {
-  if (cent < -1800)
-    cent = -1800;
-  if (cent > 1800)
-    cent = 1800;
-  m_ManualTuning = cent;
-  m_Callback->UpdateTuning();
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetAutoTuningCorrection(float cent) {
-  if (cent < -1800)
-    cent = -1800;
-  if (cent > 1800)
-    cent = 1800;
-  m_AutoTuningCorrection = cent;
-  m_Callback->UpdateTuning();
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetDelay(unsigned delay) {
-  m_Delay = delay;
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetBitsPerSample(int value) {
-  m_BitsPerSample = value;
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetCompress(int value) {
-  m_Compress = value;
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetChannels(int value) {
-  m_Channels = value;
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetLoopLoad(int value) {
-  m_LoopLoad = value;
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetAttackLoad(int value) {
-  m_AttackLoad = value;
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetReleaseLoad(int value) {
-  m_ReleaseLoad = value;
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetIgnorePitch(int value) {
-  m_IgnorePitch = value;
-  r_listener.NotifyPipeConfigModified();
-}
-
-void GOPipeConfig::SetReleaseTail(unsigned releaseTail) {
-  m_ReleaseTail = releaseTail;
-  m_Callback->UpdateReleaseTail();
-  r_listener.NotifyPipeConfigModified();
+void GOPipeConfig::SetPitchMember(float cents, float &member) {
+  if (cents < -1800)
+    cents = -1800;
+  if (cents > 1800)
+    cents = 1800;
+  SetSmallMember(cents, member, &GOPipeUpdateCallback::UpdateTuning);
 }

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -10,10 +10,12 @@
 
 #include <wx/string.h>
 
+#include "GOPipeConfigListener.h"
+#include "GOPipeUpdateCallback.h"
+
 class GOConfigReader;
 class GOConfigWriter;
 class GOPipeConfigListener;
-class GOPipeUpdateCallback;
 
 class GOPipeConfig {
 private:
@@ -22,29 +24,56 @@ private:
   wxString m_Group;
   wxString m_NamePrefix;
   wxString m_AudioGroup;
-  float m_Amplitude;
   float m_DefaultAmplitude;
+  float m_Amplitude;
   float m_DefaultGain;
+  float m_Gain;
   // ODF pitch tuning offset for using withot auto-tuning
   float m_PitchTuning;
   // ODF pitch tuning offset for using with auto-tuning
   float m_PitchCorrection;
-  float m_Gain;
   float m_ManualTuning;
   float m_AutoTuningCorrection;
-  unsigned m_Delay;
   unsigned m_DefaultDelay;
+  unsigned m_Delay;
+  unsigned m_ReleaseTail; // the max release length in ms
   int m_BitsPerSample;
-  int m_Compress;
   int m_Channels;
   int m_LoopLoad;
+  int m_Compress;
   int m_AttackLoad;
   int m_ReleaseLoad;
   int m_IgnorePitch;
-  unsigned m_ReleaseTail; // the max release length in ms
 
   void ReadTuning(
     GOConfigReader &cfg, const wxString &group, const wxString &prefix);
+
+  /* two generic setters SetSmallMember and SetLargeMember differ only in
+   * passing values */
+
+#define SET_MEMBER_BODY(value, member, callbackFun)                            \
+  member = value;                                                              \
+  if (callbackFun)                                                             \
+    (m_Callback->*callbackFun)();                                              \
+  r_listener.NotifyPipeConfigModified();
+
+  template <typename T>
+  void SetSmallMember(
+    const T value,
+    T &member,
+    void (GOPipeUpdateCallback::*callbackFun)() = nullptr) {
+    SET_MEMBER_BODY(value, member, callbackFun)
+  }
+
+  template <typename T>
+  void SetLargeMember(
+    const T &value,
+    T &member,
+    void (GOPipeUpdateCallback::*callbackFun)() = nullptr) {
+    SET_MEMBER_BODY(value, member, callbackFun)
+  }
+
+  void SetPitchMember(float cents, float &member);
 
 public:
   GOPipeConfig(GOPipeConfigListener &listener, GOPipeUpdateCallback *callback);
@@ -53,54 +82,66 @@ public:
   void Load(GOConfigReader &cfg, const wxString &group, const wxString &prefix);
   void Save(GOConfigWriter &cfg);
 
-  GOPipeUpdateCallback *GetCallback();
+  GOPipeUpdateCallback *GetCallback() const { return m_Callback; }
 
-  float GetAmplitude();
-  float GetDefaultAmplitude();
-  void SetAmplitude(float amp);
+  const wxString &GetAudioGroup() const { return m_AudioGroup; }
+  void SetAudioGroup(const wxString &str) {
+    SetLargeMember(str, m_AudioGroup, &GOPipeUpdateCallback::UpdateAudioGroup);
+  }
 
-  float GetGain();
-  float GetDefaultGain();
-  void SetGain(float gain);
+  float GetDefaultAmplitude() const { return m_DefaultAmplitude; }
+  float GetAmplitude() const { return m_Amplitude; }
+  void SetAmplitude(float amp) {
+    SetSmallMember(amp, m_Amplitude, &GOPipeUpdateCallback::UpdateAmplitude);
+  }
+
+  float GetDefaultGain() const { return m_DefaultGain; }
+  float GetGain() const { return m_Gain; }
+  void SetGain(float gain) {
+    SetSmallMember(gain, m_Gain, &GOPipeUpdateCallback::UpdateAmplitude);
+  }
 
   float GetPitchTuning() const { return m_PitchTuning; }
   float GetPitchCorrection() const { return m_PitchCorrection; }
+
   float GetManualTuning() const { return m_ManualTuning; }
-  void SetManualTuning(float cent);
+  void SetManualTuning(float cents) { SetPitchMember(cents, m_ManualTuning); }
+
   float GetAutoTuningCorrection() const { return m_AutoTuningCorrection; }
-  void SetAutoTuningCorrection(float cent);
+  void SetAutoTuningCorrection(float cents) {
+    SetPitchMember(cents, m_AutoTuningCorrection);
+  }
 
   unsigned GetDefaultDelay() const { return m_DefaultDelay; }
-
   unsigned GetDelay() const { return m_Delay; }
-  void SetDelay(unsigned delay);
-
-  const wxString &GetAudioGroup() const { return m_AudioGroup; }
-  void SetAudioGroup(const wxString &str);
-
-  int GetBitsPerSample() const { return m_BitsPerSample; }
-  void SetBitsPerSample(int value);
-
-  int GetCompress() const { return m_Compress; }
-  void SetCompress(int value);
-
-  int GetChannels() const { return m_Channels; }
-  void SetChannels(int value);
-
-  int GetLoopLoad() const { return m_LoopLoad; }
-  void SetLoopLoad(int value);
-
-  int GetAttackLoad() const { return m_AttackLoad; }
-  void SetAttackLoad(int value);
-
-  int GetReleaseLoad() const { return m_ReleaseLoad; }
-  void SetReleaseLoad(int value);
-
-  int IsIgnorePitch() const { return m_IgnorePitch; }
-  void SetIgnorePitch(int value);
+  void SetDelay(unsigned delay) { SetSmallMember(delay, m_Delay); }
 
   unsigned GetReleaseTail() const { return m_ReleaseTail; }
-  void SetReleaseTail(unsigned releaseTail);
+  void SetReleaseTail(unsigned releaseTail) {
+    SetSmallMember(
+      releaseTail, m_ReleaseTail, &GOPipeUpdateCallback::UpdateReleaseTail);
+  }
+
+  int GetBitsPerSample() const { return m_BitsPerSample; }
+  void SetBitsPerSample(int value) { SetSmallMember(value, m_BitsPerSample); }
+
+  int GetChannels() const { return m_Channels; }
+  void SetChannels(int value) { SetSmallMember(value, m_Channels); }
+
+  int GetLoopLoad() const { return m_LoopLoad; }
+  void SetLoopLoad(int value) { SetSmallMember(value, m_LoopLoad); }
+
+  int GetCompress() const { return m_Compress; }
+  void SetCompress(int value) { SetSmallMember(value, m_Compress); }
+
+  int GetAttackLoad() const { return m_AttackLoad; }
+  void SetAttackLoad(int value) { SetSmallMember(value, m_AttackLoad); }
+
+  int GetReleaseLoad() const { return m_ReleaseLoad; }
+  void SetReleaseLoad(int value) { SetSmallMember(value, m_ReleaseLoad); }
+
+  int IsIgnorePitch() const { return m_IgnorePitch; }
+  void SetIgnorePitch(int value) { SetSmallMember(value, m_IgnorePitch); }
 };
 
 #endif

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -25,7 +25,11 @@ private:
   GOStatisticCallback *m_StatisticCallback;
   wxString m_Name;
 
-  void Save(GOConfigWriter &cfg);
+  void Save(GOConfigWriter &cfg) override { m_PipeConfig.Save(cfg); }
+
+  float GetEffectiveFloatSum(
+    float (GOPipeConfig::*getFloat)() const,
+    float (GOPipeConfigNode::*getParentFloat)() const) const;
 
 public:
   GOPipeConfigNode(
@@ -33,44 +37,67 @@ public:
     GOOrganModel &organModel,
     GOPipeUpdateCallback *callback,
     GOStatisticCallback *statistic);
-  virtual ~GOPipeConfigNode();
 
   GOPipeConfigNode *GetParent() const { return m_parent; }
   void SetParent(GOPipeConfigNode *parent);
-  void Init(GOConfigReader &cfg, wxString group, wxString prefix);
-  void Load(GOConfigReader &cfg, wxString group, wxString prefix);
+  void Init(GOConfigReader &cfg, const wxString &group, const wxString &prefix);
+  void Load(GOConfigReader &cfg, const wxString &group, const wxString &prefix);
 
-  const wxString &GetName();
-  void SetName(wxString name);
+  const wxString &GetName() const { return m_Name; }
+  void SetName(const wxString &name) { m_Name = name; }
 
-  GOPipeConfig &GetPipeConfig();
+  GOPipeConfig &GetPipeConfig() { return m_PipeConfig; }
+
+  wxString GetEffectiveAudioGroup() const;
+
+  float GetEffectiveAmplitude() const;
+
+  float GetEffectiveGain() const {
+    return GetEffectiveFloatSum(
+      &GOPipeConfig::GetGain, &GOPipeConfigNode::GetEffectiveGain);
+  }
+
+  float GetEffectivePitchTuning() const {
+    return GetEffectiveFloatSum(
+      &GOPipeConfig::GetPitchTuning,
+      &GOPipeConfigNode::GetEffectivePitchTuning);
+  }
+
+  float GetEffectivePitchCorrection() const {
+    return GetEffectiveFloatSum(
+      &GOPipeConfig::GetPitchCorrection,
+      &GOPipeConfigNode::GetEffectivePitchCorrection);
+  }
+
+  float GetEffectiveManualTuning() const {
+    return GetEffectiveFloatSum(
+      &GOPipeConfig::GetManualTuning,
+      &GOPipeConfigNode::GetEffectiveManualTuning);
+  }
+
+  float GetEffectiveAutoTuningCorection() const {
+    return GetEffectiveFloatSum(
+      &GOPipeConfig::GetAutoTuningCorrection,
+      &GOPipeConfigNode::GetEffectiveAutoTuningCorection);
+  }
+
+  unsigned GetEffectiveDelay() const;
+  unsigned GetEffectiveReleaseTail() const;
+  unsigned GetEffectiveBitsPerSample() const;
+  unsigned GetEffectiveChannels() const;
+  unsigned GetEffectiveLoopLoad() const;
+  bool GetEffectiveCompress() const;
+  bool GetEffectiveAttackLoad() const;
+  bool GetEffectiveReleaseLoad() const;
+  bool GetEffectiveIgnorePitch() const;
+
+  virtual void AddChild(GOPipeConfigNode *node) {}
+  virtual unsigned GetChildCount() const { return 0; }
+  virtual GOPipeConfigNode *GetChild(unsigned index) const { return nullptr; }
+  virtual GOSampleStatistic GetStatistic() const;
 
   void ModifyManualTuning(float diff);
   void ModifyAutoTuningCorrection(float diff);
-
-  float GetEffectiveAmplitude();
-  float GetEffectiveGain();
-  float GetEffectivePitchTuning() const;
-  float GetEffectivePitchCorrection() const;
-  float GetEffectiveManualTuning() const;
-  float GetEffectiveAutoTuningCorection() const;
-
-  unsigned GetEffectiveDelay() const;
-  wxString GetEffectiveAudioGroup() const;
-
-  unsigned GetEffectiveBitsPerSample() const;
-  bool GetEffectiveCompress() const;
-  unsigned GetEffectiveLoopLoad() const;
-  bool GetEffectiveAttackLoad() const;
-  bool GetEffectiveReleaseLoad() const;
-  unsigned GetEffectiveChannels() const;
-  bool GetEffectiveIgnorePitch() const;
-  unsigned GetEffectiveReleaseTail() const;
-
-  virtual void AddChild(GOPipeConfigNode *node);
-  virtual unsigned GetChildCount();
-  virtual GOPipeConfigNode *GetChild(unsigned index);
-  virtual GOSampleStatistic GetStatistic() const;
 };
 
 #endif

--- a/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp
@@ -17,16 +17,6 @@ GOPipeConfigTreeNode::GOPipeConfigTreeNode(
     m_Childs(),
     m_Callback(callback) {}
 
-void GOPipeConfigTreeNode::AddChild(GOPipeConfigNode *node) {
-  m_Childs.push_back(node);
-}
-
-unsigned GOPipeConfigTreeNode::GetChildCount() { return m_Childs.size(); }
-
-GOPipeConfigNode *GOPipeConfigTreeNode::GetChild(unsigned index) {
-  return m_Childs[index];
-}
-
 void GOPipeConfigTreeNode::UpdateAmplitude() {
   for (unsigned i = 0; i < m_Childs.size(); i++)
     m_Childs[i]->GetPipeConfig().GetCallback()->UpdateAmplitude();

--- a/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.h
@@ -30,10 +30,12 @@ public:
     GOOrganModel *organModel,
     GOPipeUpdateCallback *callback);
 
-  void AddChild(GOPipeConfigNode *node);
-  unsigned GetChildCount();
-  GOPipeConfigNode *GetChild(unsigned index);
-  GOSampleStatistic GetStatistic() const;
+  void AddChild(GOPipeConfigNode *node) override { m_Childs.push_back(node); }
+  unsigned GetChildCount() const override { return m_Childs.size(); }
+  GOPipeConfigNode *GetChild(unsigned index) const override {
+    return m_Childs[index];
+  }
+  GOSampleStatistic GetStatistic() const override;
 };
 
 #endif


### PR DESCRIPTION
This PR:
- Reorders the members and methods of `GOPipeConfig` and `GOPipeConfigNode`
- Introduces template methods `SetSmallMember` and `SetLargeMember`
- Implements all setters with the new template methods

It is just refactoring. No GO behavior should be changed.