### PR TITLE
Replaced int with GOBool3 in GOCombination and subclasses

### DIFF
--- a/src/grandorgue/combinations/model/GOCombination.h
+++ b/src/grandorgue/combinations/model/GOCombination.h
@@ -11,9 +11,10 @@
 #include <unordered_set>
 #include <vector>
 
+#include "config/GOConfigReader.h"
 #include "yaml/GOSaveableToYaml.h"
 
-#include "config/GOConfigReader.h"
+#include "GOBool3.h"
 
 #include "GOCombinationDefinition.h"
 #include "GOSaveableObject.h"
@@ -33,12 +34,12 @@ private:
 
   /**
    *  States of the elements.
-   *  1 - enabled
-   *  0 - disabled
-   *  -1 - not to touch. Usually this state is used for invisible elements that
-   *    are not stored in the combination normally.
+   *  BOOL3_TRUE - enabled
+   *  BOOL3_FALSE - disabled
+   *  BOOL3_DEFAULT - not to touch. Usually this state is used for invisible
+   *    elements that are not stored in the combination normally.
    */
-  std::vector<int> m_ElementStates;
+  std::vector<GOBool3> m_ElementStates;
 
   /**
    * Whether the combination has been captured when `Full` was engaged or not
@@ -52,7 +53,7 @@ private:
    */
   bool m_HasScope;
 
-  void PutElementsToYaml(YAML::Node &yamlMap, int stateFrom) const;
+  void PutElementsToYaml(YAML::Node &yamlMap, GOBool3 stateFrom) const;
 
 protected:
   const std::vector<GOCombinationDefinition::Element> &r_ElementDefinitions;
@@ -135,11 +136,11 @@ public:
   virtual ~GOCombination();
 
   bool IsEmpty() const;
-  int GetElementState(unsigned no) const { return m_ElementStates[no]; }
+  GOBool3 GetElementState(unsigned no) const { return m_ElementStates[no]; }
   void GetExtraSetState(ExtraElementsSet &extraSet);
   void GetEnabledElements(GOCombination::ExtraElementsSet &enabledElements);
 
-  void Copy(GOCombination *combination);
+  void Copy(const GOCombination *combination);
   void Clear();
 
   // if present, read from CMB, else read from ODF, else clear

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -133,10 +133,11 @@ void GODivisionalCombination::SaveInt(GOConfigWriter &cfg) {
   EnsureElementStatesAllocated();
   for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
     const GOCombinationDefinition::Element &e = r_ElementDefinitions[i];
-    int state = GetElementState(i);
+    GOBool3 state = GetElementState(i);
 
-    if (state >= 0) {
-      int value = state == 1 ? e.index : -e.index;
+    if (state >= BOOL3_FALSE) {
+      int value = to_bool(state) ? e.index : -e.index;
+
       switch (e.type) {
       case GOCombinationDefinition::COMBINATION_STOP:
         stop_count++;

--- a/src/grandorgue/combinations/model/GOGeneralCombination.cpp
+++ b/src/grandorgue/combinations/model/GOGeneralCombination.cpp
@@ -177,10 +177,11 @@ void GOGeneralCombination::SaveInt(GOConfigWriter &cfg) {
 
   for (unsigned i = 0; i < r_ElementDefinitions.size(); i++) {
     const GOCombinationDefinition::Element &e = r_ElementDefinitions[i];
-    int state = GetElementState(i);
+    GOBool3 state = GetElementState(i);
 
-    if (state >= 0) {
-      int value = state == 1 ? e.index : -e.index;
+    if (state >= BOOL3_FALSE) {
+      int value = to_bool(state) ? e.index : -e.index;
+
       switch (e.type) {
       case GOCombinationDefinition::COMBINATION_STOP:
         stop_count++;


### PR DESCRIPTION
Thist PR reduces the memory usage of combinations: from 4 bytes to one byte for each element state.

It is just refactoring. No GO behavior should be changed.