### PR TITLE
Moved the implementation of GOMutexLocker to a .cpp file

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 include(UsewxWidgets)
@@ -45,6 +45,7 @@ settings/GOSettingStore.cpp
 settings/GOSettingString.cpp
 threading/GOCondition.cpp
 threading/GOMutex.cpp
+threading/GOMutexLocker.cpp
 threading/GOThread.cpp
 threading/threading_impl.cpp
 temperaments/GOTemperament.cpp

--- a/src/core/threading/GOMutexLocker.cpp
+++ b/src/core/threading/GOMutexLocker.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOMutexLocker.h"
+
+GOMutexLocker::GOMutexLocker(
+  GOMutex &mutex, bool try_lock, const char *lockerInfo, GOThread *pThread)
+  : m_mutex(mutex), m_IsLocked(false) {
+  if (try_lock)
+    m_IsLocked = m_mutex.TryLock(lockerInfo);
+  else if (pThread != NULL)
+    m_IsLocked = m_mutex.LockOrStop(lockerInfo, pThread);
+  else {
+    m_mutex.Lock(lockerInfo);
+    m_IsLocked = true;
+  }
+}
+
+GOMutexLocker::~GOMutexLocker() {
+  if (m_IsLocked)
+    m_mutex.Unlock();
+}
+
+bool GOMutexLocker::TryLock(const char *lockerInfo) {
+  if (!m_IsLocked)
+    m_IsLocked = m_mutex.TryLock(lockerInfo);
+  return m_IsLocked;
+}
+
+void GOMutexLocker::Unlock() {
+  if (m_IsLocked)
+    m_mutex.Unlock();
+  m_IsLocked = false;
+}

--- a/src/core/threading/GOMutexLocker.h
+++ b/src/core/threading/GOMutexLocker.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,8 +12,8 @@
 
 class GOMutexLocker {
 private:
-  GOMutex &m_Mutex;
-  bool m_Locked;
+  GOMutex &m_mutex;
+  bool m_IsLocked;
 
 public:
   /**
@@ -33,37 +33,16 @@ public:
   GOMutexLocker(
     GOMutex &mutex,
     bool try_lock = false,
-    const char *lockerInfo = NULL,
-    GOThread *pThread = NULL)
-    : m_Mutex(mutex), m_Locked(false) {
-    if (try_lock)
-      m_Locked = m_Mutex.TryLock(lockerInfo);
-    else if (pThread != NULL)
-      m_Locked = m_Mutex.LockOrStop(lockerInfo, pThread);
-    else {
-      m_Mutex.Lock(lockerInfo);
-      m_Locked = true;
-    }
-  }
+    const char *lockerInfo = nullptr,
+    GOThread *pThread = nullptr);
 
-  ~GOMutexLocker() {
-    if (m_Locked)
-      m_Mutex.Unlock();
-  }
+  ~GOMutexLocker();
 
-  bool TryLock(const char *lockerInfo = NULL) {
-    if (!m_Locked)
-      m_Locked = m_Mutex.TryLock(lockerInfo);
-    return m_Locked;
-  }
+  bool TryLock(const char *lockerInfo = NULL);
 
-  bool IsLocked() const { return m_Locked; }
+  bool IsLocked() const { return m_IsLocked; }
 
-  void Unlock() {
-    if (m_Locked)
-      m_Mutex.Unlock();
-    m_Locked = false;
-  }
+  void Unlock();
 
   GOMutexLocker(const GOMutexLocker &) = delete;
   GOMutexLocker &operator=(const GOMutexLocker &) = delete;

--- a/src/core/threading/GOMutexLocker.h
+++ b/src/core/threading/GOMutexLocker.h
@@ -38,7 +38,7 @@ public:
 
   ~GOMutexLocker();
 
-  bool TryLock(const char *lockerInfo = NULL);
+  bool TryLock(const char *lockerInfo = nullptr);
 
   bool IsLocked() const { return m_IsLocked; }
 


### PR DESCRIPTION
Having a lot of code in the header file makes debugging quite difficult.

This PR moves all method implementations longer than one line move to the new file `GOMutexLocker.cpp`.

It is just refactoring. No GO behavior should be changed.