### PR TITLE
Switched the github build to the new actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
       run: ${{github.workspace}}/build-scripts/for-${{ matrix.for }}/build-on-${{ matrix.build_on }}.sh ${{needs.calc_ver.outputs.project_ver}} ${{needs.calc_ver.outputs.build_ver}} ${{github.workspace}} "${{ matrix.pkg_suffix }}"
 
     - name: Upload result
-      uses: nanoufo/action-upload-artifacts-and-release-assets@v1.5
+      uses: nanoufo/action-upload-artifacts-and-release-assets@v2
       with:
         path: |
           ${{github.workspace}}/build/${{ matrix.for }}/grandorgue*${{needs.calc_ver.outputs.full_ver}}*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
 
     - name: Set git tags and compose RELNOTES.md
       shell: bash
@@ -125,7 +125,7 @@ jobs:
 
     runs-on: ${{ matrix.run_on }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
       with:
         submodules: true
     


### PR DESCRIPTION
The old ones caused lots of warinings like 'NodeJs 16 is deprecated'

NO GO behavior should be changed