### PR TITLE
Changed types of GOPipeConfig members

### DIFF
--- a/src/grandorgue/dialogs/GOOrganSettingsDialog.cpp
+++ b/src/grandorgue/dialogs/GOOrganSettingsDialog.cpp
@@ -1013,6 +1013,21 @@ void GOOrganSettingsDialog::OnEventApply(wxCommandEvent &e) {
     }
     if (m_AudioGroup->GetValue() != m_LastAudioGroup)
       e->config->SetAudioGroup(m_AudioGroup->GetValue().Trim());
+    if (m_BitsPerSample->GetSelection() != m_LastBitsPerSample)
+      e->config->SetBitsPerSample(
+        m_BitsPerSample->GetSelection() == 0
+          ? (int8_t)-1
+          : (int8_t)(m_BitsPerSample->GetSelection() + 7));
+    if (m_Channels->GetSelection() != m_LastChannels)
+      e->config->SetChannels((int8_t)(m_Channels->GetSelection() - 1));
+    if (m_LoopLoad->GetSelection() != m_LastLoopLoad)
+      e->config->SetLoopLoad((int8_t)(m_LoopLoad->GetSelection() - 1));
+    if (m_Compress->GetSelection() != m_LastCompress)
+      e->config->SetCompress(to_bool3(m_Compress->GetSelection() - 1));
+    if (m_AttackLoad->GetSelection() != m_LastAttackLoad)
+      e->config->SetAttackLoad(to_bool3(m_AttackLoad->GetSelection() - 1));
+    if (m_ReleaseLoad->GetSelection() != m_LastReleaseLoad)
+      e->config->SetReleaseLoad(to_bool3(m_ReleaseLoad->GetSelection() - 1));
 
     bool ignorePitch = m_IgnorePitch->IsChecked();
 
@@ -1021,23 +1036,9 @@ void GOOrganSettingsDialog::OnEventApply(wxCommandEvent &e) {
         = parent ? parent->GetEffectiveIgnorePitch() : false;
 
       e->config->SetIgnorePitch(
-        ignorePitch == parentIgnorePitch ? -1 : (int)ignorePitch);
+        ignorePitch == parentIgnorePitch ? BOOL3_DEFAULT
+                                         : to_bool3(ignorePitch));
     }
-    if (m_BitsPerSample->GetSelection() != m_LastBitsPerSample)
-      e->config->SetBitsPerSample(
-        m_BitsPerSample->GetSelection() == 0
-          ? -1
-          : m_BitsPerSample->GetSelection() + 7);
-    if (m_Compress->GetSelection() != m_LastCompress)
-      e->config->SetCompress(m_Compress->GetSelection() - 1);
-    if (m_Channels->GetSelection() != m_LastChannels)
-      e->config->SetChannels(m_Channels->GetSelection() - 1);
-    if (m_LoopLoad->GetSelection() != m_LastLoopLoad)
-      e->config->SetLoopLoad(m_LoopLoad->GetSelection() - 1);
-    if (m_AttackLoad->GetSelection() != m_LastAttackLoad)
-      e->config->SetAttackLoad(m_AttackLoad->GetSelection() - 1);
-    if (m_ReleaseLoad->GetSelection() != m_LastReleaseLoad)
-      e->config->SetReleaseLoad(m_ReleaseLoad->GetSelection() - 1);
   }
 
   m_Discard->Disable();
@@ -1149,13 +1150,13 @@ void GOOrganSettingsDialog::OnEventDefault(wxCommandEvent &e) {
       e->config->SetAutoTuningCorrection(0);
       e->config->SetDelay(e->config->GetDefaultDelay());
       e->config->SetReleaseTail(0);
-      e->config->SetIgnorePitch(-1);
       e->config->SetBitsPerSample(-1);
-      e->config->SetCompress(-1);
       e->config->SetChannels(-1);
       e->config->SetLoopLoad(-1);
-      e->config->SetAttackLoad(-1);
-      e->config->SetReleaseLoad(-1);
+      e->config->SetCompress(BOOL3_DEFAULT);
+      e->config->SetAttackLoad(BOOL3_DEFAULT);
+      e->config->SetReleaseLoad(BOOL3_DEFAULT);
+      e->config->SetIgnorePitch(BOOL3_DEFAULT);
     }
 
     m_Last = NULL;

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -31,10 +31,10 @@ GOPipeConfig::GOPipeConfig(
     m_BitsPerSample(-1),
     m_Channels(-1),
     m_LoopLoad(-1),
-    m_Compress(-1),
-    m_AttackLoad(-1),
-    m_ReleaseLoad(-1),
-    m_IgnorePitch(-1) {}
+    m_Compress(BOOL3_DEFAULT),
+    m_AttackLoad(BOOL3_DEFAULT),
+    m_ReleaseLoad(BOOL3_DEFAULT),
+    m_IgnorePitch(BOOL3_DEFAULT) {}
 
 static const wxString WX_TUNING = wxT("Tuning");
 static const wxString WX_MANUAL_TUNING = wxT("ManualTuning");
@@ -83,9 +83,9 @@ void GOPipeConfig::LoadFromCmb(
     1800,
     false,
     0);
-  m_Delay = cfg.ReadInteger(
+  m_Delay = (uint16_t)cfg.ReadInteger(
     CMBSetting, group, prefix + wxT("Delay"), 0, 10000, false, m_DefaultDelay);
-  m_BitsPerSample = cfg.ReadInteger(
+  m_BitsPerSample = (int8_t)cfg.ReadInteger(
     CMBSetting,
     m_Group,
     m_NamePrefix + wxT("BitsPerSample"),
@@ -95,19 +95,19 @@ void GOPipeConfig::LoadFromCmb(
     -1);
   if (m_BitsPerSample < 8 || m_BitsPerSample > 24)
     m_BitsPerSample = -1;
-  m_Compress = cfg.ReadInteger(
-    CMBSetting, m_Group, m_NamePrefix + wxT("Compress"), -1, 1, false, -1);
-  m_Channels = cfg.ReadInteger(
+  m_Channels = (int8_t)cfg.ReadInteger(
     CMBSetting, m_Group, m_NamePrefix + wxT("Channels"), -1, 2, false, -1);
-  m_LoopLoad = cfg.ReadInteger(
+  m_LoopLoad = (int8_t)cfg.ReadInteger(
     CMBSetting, m_Group, m_NamePrefix + wxT("LoopLoad"), -1, 2, false, -1);
-  m_AttackLoad = cfg.ReadInteger(
-    CMBSetting, m_Group, m_NamePrefix + wxT("AttackLoad"), -1, 1, false, -1);
-  m_ReleaseLoad = cfg.ReadInteger(
-    CMBSetting, m_Group, m_NamePrefix + wxT("ReleaseLoad"), -1, 1, false, -1);
+  m_Compress = cfg.ReadBool3FromInt(
+    CMBSetting, m_Group, m_NamePrefix + wxT("Compress"), false);
+  m_AttackLoad = cfg.ReadBool3FromInt(
+    CMBSetting, m_Group, m_NamePrefix + wxT("AttackLoad"), false);
+  m_ReleaseLoad = cfg.ReadBool3FromInt(
+    CMBSetting, m_Group, m_NamePrefix + wxT("ReleaseLoad"), false);
   m_IgnorePitch = cfg.ReadBooleanTriple(
     CMBSetting, m_Group, m_NamePrefix + wxT("IgnorePitch"), false);
-  m_ReleaseTail = (unsigned)cfg.ReadInteger(
+  m_ReleaseTail = (uint16_t)cfg.ReadInteger(
     CMBSetting, group, m_NamePrefix + wxT("ReleaseTail"), 0, 3000, false, 0);
 
   m_Callback->UpdateAmplitude();

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -8,8 +8,11 @@
 #ifndef GOPIPECONFIG_H
 #define GOPIPECONFIG_H
 
+#include <cstdint>
+
 #include <wx/string.h>
 
+#include "GOBool3.h"
 #include "GOPipeConfigListener.h"
 #include "GOPipeUpdateCallback.h"
 
@@ -34,16 +37,16 @@ private:
   float m_PitchCorrection;
   float m_ManualTuning;
   float m_AutoTuningCorrection;
-  unsigned m_DefaultDelay;
-  unsigned m_Delay;
-  unsigned m_ReleaseTail; // the max release length in ms
-  int m_BitsPerSample;
-  int m_Channels;
-  int m_LoopLoad;
-  int m_Compress;
-  int m_AttackLoad;
-  int m_ReleaseLoad;
-  int m_IgnorePitch;
+  uint16_t m_DefaultDelay;
+  uint16_t m_Delay;
+  uint16_t m_ReleaseTail; // the max release length in ms
+  int8_t m_BitsPerSample;
+  int8_t m_Channels;
+  int8_t m_LoopLoad;
+  GOBool3 m_Compress;
+  GOBool3 m_AttackLoad;
+  GOBool3 m_ReleaseLoad;
+  GOBool3 m_IgnorePitch;
 
   // Load all customizable values from the .cmb
   void LoadFromCmb(
@@ -119,36 +122,38 @@ public:
     SetPitchMember(cents, m_AutoTuningCorrection);
   }
 
-  unsigned GetDefaultDelay() const { return m_DefaultDelay; }
-  unsigned GetDelay() const { return m_Delay; }
-  void SetDelay(unsigned delay) { SetSmallMember(delay, m_Delay); }
+  uint16_t GetDefaultDelay() const { return m_DefaultDelay; }
+  uint16_t GetDelay() const { return m_Delay; }
+  void SetDelay(uint16_t delay) { SetSmallMember(delay, m_Delay); }
 
-  unsigned GetReleaseTail() const { return m_ReleaseTail; }
-  void SetReleaseTail(unsigned releaseTail) {
+  uint16_t GetReleaseTail() const { return m_ReleaseTail; }
+  void SetReleaseTail(uint16_t releaseTail) {
     SetSmallMember(
       releaseTail, m_ReleaseTail, &GOPipeUpdateCallback::UpdateReleaseTail);
   }
 
-  int GetBitsPerSample() const { return m_BitsPerSample; }
-  void SetBitsPerSample(int value) { SetSmallMember(value, m_BitsPerSample); }
+  int8_t GetBitsPerSample() const { return m_BitsPerSample; }
+  void SetBitsPerSample(int8_t value) {
+    SetSmallMember(value, m_BitsPerSample);
+  }
 
-  int GetChannels() const { return m_Channels; }
-  void SetChannels(int value) { SetSmallMember(value, m_Channels); }
+  int8_t GetChannels() const { return m_Channels; }
+  void SetChannels(int8_t value) { SetSmallMember(value, m_Channels); }
 
-  int GetLoopLoad() const { return m_LoopLoad; }
-  void SetLoopLoad(int value) { SetSmallMember(value, m_LoopLoad); }
+  int8_t GetLoopLoad() const { return m_LoopLoad; }
+  void SetLoopLoad(int8_t value) { SetSmallMember(value, m_LoopLoad); }
 
-  int GetCompress() const { return m_Compress; }
-  void SetCompress(int value) { SetSmallMember(value, m_Compress); }
+  GOBool3 GetCompress() const { return m_Compress; }
+  void SetCompress(GOBool3 value) { SetSmallMember(value, m_Compress); }
 
-  int GetAttackLoad() const { return m_AttackLoad; }
-  void SetAttackLoad(int value) { SetSmallMember(value, m_AttackLoad); }
+  GOBool3 GetAttackLoad() const { return m_AttackLoad; }
+  void SetAttackLoad(GOBool3 value) { SetSmallMember(value, m_AttackLoad); }
 
-  int GetReleaseLoad() const { return m_ReleaseLoad; }
-  void SetReleaseLoad(int value) { SetSmallMember(value, m_ReleaseLoad); }
+  GOBool3 GetReleaseLoad() const { return m_ReleaseLoad; }
+  void SetReleaseLoad(GOBool3 value) { SetSmallMember(value, m_ReleaseLoad); }
 
-  int IsIgnorePitch() const { return m_IgnorePitch; }
-  void SetIgnorePitch(int value) { SetSmallMember(value, m_IgnorePitch); }
+  GOBool3 IsIgnorePitch() const { return m_IgnorePitch; }
+  void SetIgnorePitch(GOBool3 value) { SetSmallMember(value, m_IgnorePitch); }
 };
 
 #endif

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -46,16 +46,6 @@ void GOPipeConfigNode::Load(
   m_PipeConfig.Load(cfg, group, prefix);
 }
 
-float GOPipeConfigNode::GetEffectiveFloatSum(
-  float (GOPipeConfig::*getFloat)() const,
-  float (GOPipeConfigNode::*getParentFloat)() const) const {
-  float value = (m_PipeConfig.*getFloat)();
-
-  if (m_parent)
-    value += (m_parent->*getParentFloat)();
-  return value;
-}
-
 wxString GOPipeConfigNode::GetEffectiveAudioGroup() const {
   if (m_PipeConfig.GetAudioGroup() != wxEmptyString)
     return m_PipeConfig.GetAudioGroup();
@@ -73,14 +63,7 @@ float GOPipeConfigNode::GetEffectiveAmplitude() const {
     return m_PipeConfig.GetAmplitude() / 100.0;
 }
 
-unsigned GOPipeConfigNode::GetEffectiveDelay() const {
-  if (m_parent)
-    return m_PipeConfig.GetDelay() + m_parent->GetEffectiveDelay();
-  else
-    return m_PipeConfig.GetDelay();
-}
-
-unsigned GOPipeConfigNode::GetEffectiveReleaseTail() const {
+uint16_t GOPipeConfigNode::GetEffectiveReleaseTail() const {
   unsigned releaseTail = m_parent ? m_parent->GetEffectiveReleaseTail() : 0;
   const unsigned thisReleaseTail = m_PipeConfig.GetReleaseTail();
 
@@ -90,64 +73,15 @@ unsigned GOPipeConfigNode::GetEffectiveReleaseTail() const {
   return releaseTail;
 }
 
-unsigned GOPipeConfigNode::GetEffectiveBitsPerSample() const {
-  if (m_PipeConfig.GetBitsPerSample() != -1)
-    return m_PipeConfig.GetBitsPerSample();
-  if (m_parent)
-    return m_parent->GetEffectiveBitsPerSample();
-  else
-    return m_config.BitsPerSample();
-}
+uint8_t GOPipeConfigNode::GetEffectiveUint8(
+  int8_t (GOPipeConfig::*getThisValue)() const,
+  uint8_t (GOPipeConfigNode::*getParentValue)() const,
+  const GOSettingUnsigned GOConfig::*globalValue) const {
+  int8_t thisValue = (m_PipeConfig.*getThisValue)();
 
-unsigned GOPipeConfigNode::GetEffectiveChannels() const {
-  if (m_PipeConfig.GetChannels() != -1)
-    return m_PipeConfig.GetChannels();
-  if (m_parent)
-    return m_parent->GetEffectiveChannels();
-  else
-    return m_config.LoadChannels();
-}
-
-unsigned GOPipeConfigNode::GetEffectiveLoopLoad() const {
-  if (m_PipeConfig.GetLoopLoad() != -1)
-    return m_PipeConfig.GetLoopLoad();
-  if (m_parent)
-    return m_parent->GetEffectiveLoopLoad();
-  else
-    return m_config.LoopLoad();
-}
-
-bool GOPipeConfigNode::GetEffectiveCompress() const {
-  if (m_PipeConfig.GetCompress() != -1)
-    return m_PipeConfig.GetCompress() ? true : false;
-  if (m_parent)
-    return m_parent->GetEffectiveCompress();
-  else
-    return m_config.LosslessCompression();
-}
-
-bool GOPipeConfigNode::GetEffectiveAttackLoad() const {
-  const int thisConfigValue = m_PipeConfig.GetAttackLoad();
-
-  return thisConfigValue != -1 ? (bool)thisConfigValue
-    : m_parent                 ? m_parent->GetEffectiveAttackLoad()
-                               : m_config.AttackLoad();
-}
-
-bool GOPipeConfigNode::GetEffectiveReleaseLoad() const {
-  const int thisConfigValue = m_PipeConfig.GetReleaseLoad();
-
-  return thisConfigValue != -1 ? (bool)thisConfigValue
-    : m_parent                 ? m_parent->GetEffectiveReleaseLoad()
-                               : m_config.ReleaseLoad();
-}
-
-bool GOPipeConfigNode::GetEffectiveIgnorePitch() const {
-  const int thisConfigValue = m_PipeConfig.IsIgnorePitch();
-
-  return thisConfigValue != -1
-    ? (thisConfigValue)
-    : m_parent && m_parent->GetEffectiveIgnorePitch();
+  return thisValue >= 0 ? (unsigned)thisValue
+    : m_parent          ? (m_parent->*getParentValue)()
+                        : (m_config.*globalValue)();
 }
 
 GOSampleStatistic GOPipeConfigNode::GetStatistic() const {

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -48,12 +48,10 @@ private:
   bool GetEffectiveBool(
     GOBool3 (GOPipeConfig::*getThisValue)() const,
     bool (GOPipeConfigNode::*getParentValue)() const,
-    const T GOConfig::*globalValue,
-    bool defaultValue = false) const {
+    const T GOConfig::*globalValue) const {
     return to_bool((m_PipeConfig.*getThisValue)(), [=]() {
       return m_parent ? (m_parent->*getParentValue)()
-        : globalValue ? (bool)(m_config.*globalValue)()
-                      : defaultValue;
+                      : globalValue && (bool)(m_config.*globalValue)();
     });
   }
 
@@ -160,8 +158,7 @@ public:
     return GetEffectiveBool(
       &GOPipeConfig::IsIgnorePitch,
       &GOPipeConfigNode::GetEffectiveIgnorePitch,
-      (const GOSettingUnsigned GOConfig::*)nullptr,
-      false);
+      (const GOSettingUnsigned GOConfig::*)nullptr);
   }
 
   virtual void AddChild(GOPipeConfigNode *node) {}


### PR DESCRIPTION
This PR

- Replaces the unsigned and int types of members of GOPipeConfig with shorter types: uint16_t, int8_t and GOBool3
- Changes return types of the GetEffectiveXXX methods of GOPipeConfigNode
- Renames GOPipeConfigNode::GetEffectiveFloatSum to GetEffectiveSum and makes it polymorthic
- Extractes a common code from GOPipeConfigNode::GetEffectiveXXX methods to the new methods GetEffectiveUint8 and GetEffectiveBool

It is just refactoring. No GO behavior should be changed.