### PR TITLE
Added capability of loading only GUI panels without audio samples by specifying the "-g" switch from the command line https://github.com/GrandOrgue/grandorgue/issues/1602

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added capability of loading only GUI panels without audio samples by specifying the "-g" switch from the command line https://github.com/GrandOrgue/grandorgue/issues/1602
 - Removed support of MacOS 11 https://github.com/GrandOrgue/grandorgue/issues/1791
 - Fixed crash on loading an organ with a crescendo in Add mode https://github.com/GrandOrgue/grandorgue/issues/1772
 - Fixed crash with rtaudio/asio https://github.com/GrandOrgue/grandorgue/issues/1772

--- a/src/grandorgue/GOApp.cpp
+++ b/src/grandorgue/GOApp.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,12 +14,13 @@
 #include <wx/regex.h>
 #include <wx/stopwatch.h>
 
+#include "config/GOConfig.h"
+#include "sound/GOSound.h"
+
 #include "GOFrame.h"
 #include "GOLog.h"
 #include "GOStdPath.h"
-#include "config/GOConfig.h"
 #include "go_defs.h"
-#include "sound/GOSound.h"
 
 #ifdef __WXMAC__
 #include <ApplicationServices/ApplicationServices.h>
@@ -39,27 +40,38 @@ GOApp::GOApp()
     m_soundSystem(NULL),
     m_Log(NULL),
     m_FileName(),
-    m_InstanceName() {}
+    m_InstanceName(),
+    m_IsGuiOnly(false) {}
+
+static const wxString SWITCH_GUI = wxT("g");
+static const wxString SWITCH_HELP = wxT("h");
+static const wxString OPTION_INSTANCE = wxT("i");
 
 static const wxCmdLineEntryDesc cmd_line_desc[] = {
   {wxCMD_LINE_SWITCH,
-   "h",
+   SWITCH_GUI,
+   "gui-only",
+   wxTRANSLATE("Load just GUI. Not to load any sound samples"),
+   wxCMD_LINE_VAL_NONE,
+   0},
+  {wxCMD_LINE_SWITCH,
+   SWITCH_HELP,
    "help",
    wxTRANSLATE("displays help on the command line parameters"),
    wxCMD_LINE_VAL_NONE,
    wxCMD_LINE_OPTION_HELP},
   {wxCMD_LINE_OPTION,
-   "i",
+   OPTION_INSTANCE,
    "instance",
    wxTRANSLATE("specify GrandOrgue instance name"),
    wxCMD_LINE_VAL_STRING,
    wxCMD_LINE_PARAM_OPTIONAL},
   {wxCMD_LINE_SWITCH,
-   "j",
-   "justgui",
-   wxTRANSLATE("Load just GUI. Not to load any sound samples"),
+   "v",
+   "verbose",
+   wxTRANSLATE("generate verbose log messages"),
    wxCMD_LINE_VAL_NONE,
-   0},
+   0x0},
   {wxCMD_LINE_PARAM,
    NULL,
    NULL,
@@ -75,18 +87,28 @@ void GOApp::OnInitCmdLine(wxCmdLineParser &parser) {
 }
 
 bool GOApp::OnCmdLineParsed(wxCmdLineParser &parser) {
-  wxString str;
-  if (parser.Found(wxT("i"), &str)) {
-    wxRegEx r(wxT("^[A-Za-z0-9]+$"), wxRE_ADVANCED);
-    if (!r.Matches(str)) {
-      wxMessageOutput::Get()->Printf(_("Invalid instance name"));
-      return false;
+  bool res = wxApp::OnCmdLineParsed(parser);
+
+  if (res)
+    m_IsGuiOnly = parser.FoundSwitch(SWITCH_GUI) == wxCMD_SWITCH_ON;
+  if (res) {
+    wxString str;
+
+    if (parser.Found(OPTION_INSTANCE, &str)) {
+      wxRegEx r(wxT("^[A-Za-z0-9]+$"), wxRE_ADVANCED);
+
+      if (r.Matches(str))
+        m_InstanceName = wxT("-") + str;
+      else {
+        wxMessageOutput::Get()->Printf(_("Invalid instance name"));
+        res = false;
+      }
     }
-    m_InstanceName = wxT("-") + str;
   }
-  for (unsigned i = 0; i < parser.GetParamCount(); i++)
-    m_FileName = parser.GetParam(i);
-  return true;
+  if (res)
+    for (unsigned i = 0; i < parser.GetParamCount(); i++)
+      m_FileName = parser.GetParam(i);
+  return res;
 }
 
 bool GOApp::OnInit() {
@@ -147,7 +169,7 @@ bool GOApp::OnInit() {
   SetTopWindow(m_Frame);
   m_Log = new GOLog(m_Frame);
   wxLog::SetActiveTarget(m_Log);
-  m_Frame->Init(m_FileName);
+  m_Frame->Init(m_FileName, m_IsGuiOnly);
 
   return true;
 }

--- a/src/grandorgue/GOApp.cpp
+++ b/src/grandorgue/GOApp.cpp
@@ -7,6 +7,7 @@
 
 #include "GOApp.h"
 
+#include <wx/cmdline.h>
 #include <wx/filesys.h>
 #include <wx/fs_zip.h>
 #include <wx/image.h>
@@ -40,19 +41,25 @@ GOApp::GOApp()
     m_FileName(),
     m_InstanceName() {}
 
-const wxCmdLineEntryDesc GOApp::m_cmdLineDesc[] = {
+static const wxCmdLineEntryDesc cmd_line_desc[] = {
   {wxCMD_LINE_SWITCH,
-   wxTRANSLATE("h"),
-   wxTRANSLATE("help"),
+   "h",
+   "help",
    wxTRANSLATE("displays help on the command line parameters"),
    wxCMD_LINE_VAL_NONE,
    wxCMD_LINE_OPTION_HELP},
   {wxCMD_LINE_OPTION,
-   wxTRANSLATE("i"),
-   wxTRANSLATE("instance"),
+   "i",
+   "instance",
    wxTRANSLATE("specify GrandOrgue instance name"),
    wxCMD_LINE_VAL_STRING,
    wxCMD_LINE_PARAM_OPTIONAL},
+  {wxCMD_LINE_SWITCH,
+   "j",
+   "justgui",
+   wxTRANSLATE("Load just GUI. Not to load any sound samples"),
+   wxCMD_LINE_VAL_NONE,
+   0},
   {wxCMD_LINE_PARAM,
    NULL,
    NULL,
@@ -64,7 +71,7 @@ const wxCmdLineEntryDesc GOApp::m_cmdLineDesc[] = {
 void GOApp::OnInitCmdLine(wxCmdLineParser &parser) {
   parser.SetLogo(wxString::Format(
     _("GrandOrgue %s - Virtual Pipe Organ Software"), wxT(APP_VERSION)));
-  parser.SetDesc(m_cmdLineDesc);
+  parser.SetDesc(cmd_line_desc);
 }
 
 bool GOApp::OnCmdLineParsed(wxCmdLineParser &parser) {

--- a/src/grandorgue/GOApp.cpp
+++ b/src/grandorgue/GOApp.cpp
@@ -43,9 +43,9 @@ GOApp::GOApp()
     m_InstanceName(),
     m_IsGuiOnly(false) {}
 
-static const wxString SWITCH_GUI = wxT("g");
-static const wxString SWITCH_HELP = wxT("h");
-static const wxString OPTION_INSTANCE = wxT("i");
+static const char *const SWITCH_GUI = "g";
+static const char *const SWITCH_HELP = "h";
+static const char *const OPTION_INSTANCE = "i";
 
 static const wxCmdLineEntryDesc cmd_line_desc[] = {
   {wxCMD_LINE_SWITCH,

--- a/src/grandorgue/GOApp.h
+++ b/src/grandorgue/GOApp.h
@@ -23,7 +23,6 @@
 #define GOAPP_H
 
 #include <wx/app.h>
-#include <wx/cmdline.h>
 
 class GOFrame;
 class GOLog;
@@ -50,8 +49,6 @@ protected:
   GOLog *m_Log;
   wxString m_FileName;
   wxString m_InstanceName;
-
-  static const wxCmdLineEntryDesc m_cmdLineDesc[];
 
 public:
   GOApp();

--- a/src/grandorgue/GOApp.h
+++ b/src/grandorgue/GOApp.h
@@ -2,7 +2,7 @@
  * GrandOrgue - a free pipe organ simulator
  *
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -49,6 +49,7 @@ protected:
   GOLog *m_Log;
   wxString m_FileName;
   wxString m_InstanceName;
+  bool m_IsGuiOnly;
 
 public:
   GOApp();

--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -46,13 +46,16 @@ bool GODocument::IsModified() const {
 }
 
 bool GODocument::LoadOrgan(
-  GOProgressDialog *dlg, const GOOrgan &organ, const wxString &cmb) {
+  GOProgressDialog *dlg,
+  const GOOrgan &organ,
+  const wxString &cmb,
+  bool isGuiOnly) {
   wxBusyCursor busy;
   GOConfig &cfg = m_sound.GetSettings();
 
   CloseOrgan();
   m_OrganController = new GOOrganController(cfg, this);
-  wxString error = m_OrganController->Load(dlg, organ, cmb);
+  wxString error = m_OrganController->Load(dlg, organ, cmb, isGuiOnly);
   if (!error.IsEmpty()) {
     if (error != wxT("!")) {
       wxLogError(wxT("%s\n"), error.c_str());

--- a/src/grandorgue/GODocument.h
+++ b/src/grandorgue/GODocument.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -58,7 +58,10 @@ public:
   bool Save();
   bool Export(const wxString &cmb);
   bool LoadOrgan(
-    GOProgressDialog *dlg, const GOOrgan &organ, const wxString &cmb);
+    GOProgressDialog *dlg,
+    const GOOrgan &organ,
+    const wxString &cmb,
+    bool isGuiOnly);
   bool UpdateCache(GOProgressDialog *dlg, bool compress);
 
   void ShowMIDIEventDialog(

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -149,6 +149,7 @@ GOFrame::GOFrame(
     m_Label(),
     m_MidiMonitor(false),
     m_isMeterReady(false),
+    m_IsGuiOnly(false),
     m_InSettings(false),
     m_AfterSettingsEventType(wxEVT_NULL),
     m_AfterSettingsEventId(0),
@@ -493,7 +494,8 @@ void GOFrame::UpdateVolumeControlWithSettings() {
   m_isMeterReady = true;
 }
 
-void GOFrame::Init(wxString filename) {
+void GOFrame::Init(const wxString &filename, bool isGuiOnly) {
+  m_IsGuiOnly = isGuiOnly;
   Show(true);
 
   SettingsReasons settingsReasons;
@@ -602,7 +604,7 @@ bool GOFrame::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
   if (m_doc) {
     GOProgressDialog dlg;
 
-    retCode = m_doc->LoadOrgan(&dlg, organ, cmb);
+    retCode = m_doc->LoadOrgan(&dlg, organ, cmb, m_IsGuiOnly);
     OnIsModifiedChanged(false);
 
     // for reflecting model changes

--- a/src/grandorgue/GOFrame.h
+++ b/src/grandorgue/GOFrame.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -69,6 +69,7 @@ private:
   wxString m_Label;
   bool m_MidiMonitor;
   bool m_isMeterReady;
+  bool m_IsGuiOnly;
 
   // to avoid event processing when the settings dialog is open
   bool m_InSettings;
@@ -182,7 +183,7 @@ public:
     GOSound &sound);
   virtual ~GOFrame(void);
 
-  void Init(wxString filename);
+  void Init(const wxString &filename, bool isGuiOnly);
 
   void DoSplash(bool timeout = true);
 

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -151,7 +151,8 @@ public:
   wxString Load(
     GOProgressDialog *dlg,
     const GOOrgan &organ,
-    const wxString &cmb = wxEmptyString);
+    const wxString &cmb,
+    bool isGuiOnly);
   /**
    * Exports organ combinations in the yaml file
    * @param fileName - the path to the taml file to export


### PR DESCRIPTION
Resolves: #1602

This PR
- Reworks parsing the command line
- Implements the `-h` (`--help`) option that displays all possible command line options
- Implements the `-g` (`--gui-only`) option that disables loading sound samples