### PR TITLE
Supported GOSoundProvider::GetRelease without an attack handle

### DIFF
--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -24682,106 +24682,25 @@
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOApp.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>../../src/grandorgue/help</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
             <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -25100,116 +25019,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/core/threading</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/help</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -25301,124 +25129,25 @@
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOFrame.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/dialogs</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/help</pElem>
-            <pElem>../../src/core/archive</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>../../src/grandorgue/loader/cache</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -26963,6 +26692,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOOrganDialog.cpp"
@@ -27014,8 +26801,62 @@
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
             <Elem>__GNUC_RH_RELEASE__=4</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231011 (Red Hat 13.2.1-4)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -27067,6 +26908,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOProgressDialog.cpp"
@@ -27097,6 +26996,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSelectOrganDialog.cpp"
@@ -27127,6 +27084,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOSplash.cpp"
@@ -27157,6 +27172,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/common/GODialogCloser.cpp"
@@ -27470,41 +27543,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsDialog.cpp"
@@ -27513,6 +27570,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -27545,6 +27603,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiDeviceList.cpp"
@@ -27553,6 +27669,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -27575,6 +27692,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiDevices.cpp"
@@ -27583,6 +27758,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -27612,6 +27788,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiMatchDialog.cpp"
@@ -27620,6 +27854,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -27641,6 +27876,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsMidiMessage.cpp"
@@ -27649,6 +27942,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -27681,6 +27975,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsOptions.cpp"
@@ -27689,6 +28041,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -27717,6 +28070,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp"
@@ -27725,6 +28136,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -27769,6 +28181,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPaths.cpp"
@@ -27777,6 +28247,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -27804,6 +28275,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPorts.cpp"
@@ -27812,6 +28341,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -27832,6 +28362,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsReverb.cpp"
@@ -27840,6 +28428,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -27868,6 +28457,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsTemperaments.cpp"
@@ -27876,6 +28523,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/settings</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -27903,6 +28551,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/document-base/GODocumentBase.cpp"
@@ -31179,103 +31885,24 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -31494,111 +32121,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -31606,94 +32147,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/grandorgue/loader/cache</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -31701,108 +32173,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/core/threading</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -31810,90 +32199,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/loader/cache</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -31901,88 +32225,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -31990,93 +32251,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -32177,89 +32370,25 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/loader/cache</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -32460,9 +32589,6 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>_REENTRANT</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundReverbPartition.cpp"
@@ -32483,97 +32609,31 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>_REENTRANT</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundSamplerPool.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
@@ -32656,6 +32716,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -32678,39 +32739,89 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/ports/GOSoundPort.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/ports/GOSoundPortFactory.cpp"
@@ -32719,6 +32830,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -32741,6 +32853,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp"
@@ -32749,6 +32919,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -32769,6 +32940,64 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/ports/GOSoundRtPort.cpp"
@@ -32777,6 +33006,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/sound/ports</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -32799,32 +33029,82 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -32835,6 +33115,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -32849,32 +33130,85 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundReleaseWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -32885,6 +33219,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -32898,6 +33233,67 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundThread.cpp"
@@ -32906,6 +33302,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
             <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -32927,6 +33324,67 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundTouchWorkItem.cpp"
@@ -32935,6 +33393,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/sound/scheduler</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -32947,32 +33406,85 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundTremulantWorkItem.cpp"
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -32981,36 +33493,18 @@
             ex="false"
             tool="1"
             flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
@@ -33144,46 +33638,13 @@
         </ccTool>
       </item>
       <item path="../../src/tools/GOPerfTest.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="0">
+        <ccTool flags="5">
           <incDir>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue</pElem>
+            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/tools</pElem>
           </incDir>
         </ccTool>
@@ -33191,6 +33652,7 @@
       <item path="../../src/tools/GOTool.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/tools</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -33213,6 +33675,66 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/tools</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../submodules/PortAudio/src/common/pa_allocation.c"
@@ -34668,6 +35190,16 @@
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
+            <Elem>__WXGTK__=1</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/grandorgue/dialogs/common">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/dialogs/common</pElem>
+          </incDir>
+          <preprocessorList>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -34722,17 +35254,9 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/dialogs/common">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-          </incDir>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/dialogs/midi-event">
@@ -34740,13 +35264,64 @@
           <incDir>
             <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
           </incDir>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/dialogs/settings">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
-          </incDir>
+          <preprocessorList>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__SSE3__=1</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/document-base">
@@ -35267,139 +35842,21 @@
       </folder>
       <folder path="0/src/grandorgue/sound/ports">
         <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/sound/ports</pElem>
-          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
             <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/sound/scheduler">
         <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/sound/scheduler</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -35551,69 +36008,10 @@
       </folder>
       <folder path="0/src/tools">
         <ccTool>
-          <incDir>
-            <pElem>../../src/tools</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>WXUSINGDLL</Elem>
             <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </folder>

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -177,7 +177,7 @@ GOHashType GOOrganController::GenerateCacheHash() {
   GOHash hash;
 
   UpdateHash(hash);
-  hash.Update(sizeof(GOAudioSection));
+  hash.Update(sizeof(GOSoundAudioSection));
   hash.Update(sizeof(GOSoundingPipe));
   hash.Update(sizeof(GOSoundReleaseAlignTable));
   hash.Update(BLOCK_HISTORY);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -175,6 +175,7 @@ bool GOOrganController::IsCacheable() { return m_Cacheable; }
 
 GOHashType GOOrganController::GenerateCacheHash() {
   GOHash hash;
+
   UpdateHash(hash);
   hash.Update(sizeof(GOAudioSection));
   hash.Update(sizeof(GOSoundingPipe));
@@ -182,11 +183,9 @@ GOHashType GOOrganController::GenerateCacheHash() {
   hash.Update(BLOCK_HISTORY);
   hash.Update(MAX_READAHEAD);
   hash.Update(SHORT_LOOP_LENGTH);
-  hash.Update(sizeof(attack_section_info));
-  hash.Update(sizeof(release_section_info));
+  GOSoundProvider::UpdateCacheHash(hash);
   hash.Update(sizeof(audio_start_data_segment));
   hash.Update(sizeof(audio_end_data_segment));
-
   return hash.getHash();
 }
 

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -34,7 +34,7 @@ static unsigned limited_diff(unsigned a, unsigned b) {
     return 0;
 }
 
-GOAudioSection::GOAudioSection(GOMemoryPool &pool)
+GOSoundAudioSection::GOSoundAudioSection(GOMemoryPool &pool)
   : m_Data(NULL),
     m_ReleaseAligner(NULL),
     m_ReleaseStartSegment(0),
@@ -42,9 +42,9 @@ GOAudioSection::GOAudioSection(GOMemoryPool &pool)
   ClearData();
 }
 
-GOAudioSection::~GOAudioSection() { ClearData(); }
+GOSoundAudioSection::~GOSoundAudioSection() { ClearData(); }
 
-void GOAudioSection::ClearData() {
+void GOSoundAudioSection::ClearData() {
   m_AllocSize = 0;
   m_SampleCount = 0;
   m_SampleRate = 0;
@@ -70,7 +70,7 @@ void GOAudioSection::ClearData() {
   m_ReleaseCrossfadeLength = 0;
 }
 
-bool GOAudioSection::LoadCache(GOCache &cache) {
+bool GOSoundAudioSection::LoadCache(GOCache &cache) {
   if (!cache.Read(&m_AllocSize, sizeof(m_AllocSize)))
     return false;
   if (!cache.Read(&m_SampleCount, sizeof(m_SampleCount)))
@@ -149,7 +149,7 @@ bool GOAudioSection::LoadCache(GOCache &cache) {
   return true;
 }
 
-bool GOAudioSection::SaveCache(GOCacheWriter &cache) const {
+bool GOSoundAudioSection::SaveCache(GOCacheWriter &cache) const {
   if (!cache.Write(&m_AllocSize, sizeof(m_AllocSize)))
     return false;
   if (!cache.Write(&m_SampleCount, sizeof(m_SampleCount)))
@@ -231,7 +231,7 @@ bool GOAudioSection::SaveCache(GOCacheWriter &cache) const {
  * into the correct range. */
 
 template <class T>
-inline void GOAudioSection::MonoUncompressedLinear(
+inline void GOSoundAudioSection::MonoUncompressedLinear(
   audio_section_stream *stream, float *output, unsigned int n_blocks) {
   // copy the sample buffer
   T *input = (T *)(stream->ptr);
@@ -254,7 +254,7 @@ inline void GOAudioSection::MonoUncompressedLinear(
 }
 
 template <class T>
-inline void GOAudioSection::StereoUncompressedLinear(
+inline void GOSoundAudioSection::StereoUncompressedLinear(
   audio_section_stream *stream, float *output, unsigned int n_blocks) {
   typedef T stereoSample[][2];
 
@@ -285,7 +285,7 @@ inline void GOAudioSection::StereoUncompressedLinear(
 }
 
 template <class T>
-inline void GOAudioSection::MonoUncompressedPolyphase(
+inline void GOSoundAudioSection::MonoUncompressedPolyphase(
   audio_section_stream *stream, float *output, unsigned int n_blocks) {
   // copy the sample buffer
   T *input = ((T *)stream->ptr);
@@ -317,7 +317,7 @@ inline void GOAudioSection::MonoUncompressedPolyphase(
 }
 
 template <class T>
-inline void GOAudioSection::StereoUncompressedPolyphase(
+inline void GOSoundAudioSection::StereoUncompressedPolyphase(
   audio_section_stream *stream, float *output, unsigned int n_blocks) {
   typedef T stereoSample[][2];
 
@@ -355,7 +355,7 @@ inline void GOAudioSection::StereoUncompressedPolyphase(
 }
 
 template <bool format16>
-inline void GOAudioSection::MonoCompressedLinear(
+inline void GOSoundAudioSection::MonoCompressedLinear(
   audio_section_stream *stream, float *output, unsigned int n_blocks) {
   for (unsigned int i = 0; i < n_blocks; i++,
                     stream->position_fraction += stream->increment_fraction,
@@ -380,7 +380,7 @@ inline void GOAudioSection::MonoCompressedLinear(
 }
 
 template <bool format16>
-inline void GOAudioSection::StereoCompressedLinear(
+inline void GOSoundAudioSection::StereoCompressedLinear(
   audio_section_stream *stream, float *output, unsigned int n_blocks) {
   // copy the sample buffer
   for (unsigned int i = 0; i < n_blocks;
@@ -409,7 +409,7 @@ inline void GOAudioSection::StereoCompressedLinear(
   stream->position_fraction = stream->position_fraction & (UPSAMPLE_FACTOR - 1);
 }
 
-inline DecodeBlockFunction GOAudioSection::GetDecodeBlockFunction(
+inline DecodeBlockFunction GOSoundAudioSection::GetDecodeBlockFunction(
   unsigned channels,
   unsigned bits_per_sample,
   bool compressed,
@@ -471,7 +471,7 @@ inline DecodeBlockFunction GOAudioSection::GetDecodeBlockFunction(
   return NULL;
 }
 
-inline unsigned GOAudioSection::PickEndSegment(
+inline unsigned GOSoundAudioSection::PickEndSegment(
   unsigned start_segment_index) const {
   const unsigned x = abs(rand());
   for (unsigned i = 0; i < m_EndSegments.size(); i++) {
@@ -486,7 +486,7 @@ inline unsigned GOAudioSection::PickEndSegment(
   return 0;
 }
 
-bool GOAudioSection::ReadBlock(
+bool GOSoundAudioSection::ReadBlock(
   audio_section_stream *stream, float *buffer, unsigned int n_blocks) {
   while (n_blocks > 0) {
     if (stream->position_index >= stream->transition_position) {
@@ -593,7 +593,7 @@ static inline void loop_memcpy(
   memcpy(dest, source, count);
 }
 
-void GOAudioSection::GetMaxAmplitudeAndDerivative() {
+void GOSoundAudioSection::GetMaxAmplitudeAndDerivative() {
   DecompressionCache cache;
 
   InitDecompressionCache(cache);
@@ -625,7 +625,7 @@ void GOAudioSection::GetMaxAmplitudeAndDerivative() {
   }
 }
 
-void GOAudioSection::DoCrossfade(
+void GOSoundAudioSection::DoCrossfade(
   unsigned char *dest,
   unsigned dest_offset,
   const unsigned char *src,
@@ -649,7 +649,7 @@ void GOAudioSection::DoCrossfade(
       }
 }
 
-void GOAudioSection::Setup(
+void GOSoundAudioSection::Setup(
   const GOCacheObject *pObjectFor,
   const GOLoaderFilename *pLoaderFilename,
   const void *pcm_data,
@@ -846,7 +846,7 @@ void GOAudioSection::Setup(
     Compress(m_BitsPerSample > 16);
 }
 
-void GOAudioSection::Compress(bool format16) {
+void GOSoundAudioSection::Compress(bool format16) {
   unsigned char *data = (unsigned char *)m_Pool.Alloc(m_AllocSize, false);
   if (data == NULL)
     throw GOOutOfMemory();
@@ -904,8 +904,9 @@ void GOAudioSection::Compress(bool format16) {
     throw GOOutOfMemory();
 }
 
-void GOAudioSection::SetupStreamAlignment(
-  const std::vector<const GOAudioSection *> &joinables, unsigned start_index) {
+void GOSoundAudioSection::SetupStreamAlignment(
+  const std::vector<const GOSoundAudioSection *> &joinables,
+  unsigned start_index) {
   if (m_ReleaseAligner) {
     delete m_ReleaseAligner;
     m_ReleaseAligner = NULL;
@@ -936,7 +937,7 @@ void GOAudioSection::SetupStreamAlignment(
   }
 }
 
-unsigned GOAudioSection::GetMargin(
+unsigned GOSoundAudioSection::GetMargin(
   bool compressed, interpolation_type interpolation) {
   if (interpolation == GO_POLYPHASE_INTERPOLATION && !compressed)
     return POLYPHASE_READAHEAD;
@@ -946,7 +947,7 @@ unsigned GOAudioSection::GetMargin(
     return LINEAR_READAHEAD;
 }
 
-void GOAudioSection::InitStream(
+void GOSoundAudioSection::InitStream(
   const struct resampler_coefs_s *resampler_coefs,
   audio_section_stream *stream,
   float sample_rate_adjustment) const {
@@ -986,7 +987,7 @@ void GOAudioSection::InitStream(
     = stream->audio_section->m_Data + (intptr_t)stream->cache.ptr;
 }
 
-void GOAudioSection::InitAlignedStream(
+void GOSoundAudioSection::InitAlignedStream(
   audio_section_stream *stream,
   const audio_section_stream *existing_stream) const {
   stream->audio_section = this;
@@ -1035,9 +1036,9 @@ void GOAudioSection::InitAlignedStream(
   m_ReleaseAligner->SetupRelease(*stream, *existing_stream);
 }
 
-unsigned GOAudioSection::GetSampleRate() const { return m_SampleRate; }
+unsigned GOSoundAudioSection::GetSampleRate() const { return m_SampleRate; }
 
-void GOAudioSection::GetHistory(
+void GOSoundAudioSection::GetHistory(
   const audio_section_stream *stream,
   int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]) {
   memset(
@@ -1075,7 +1076,7 @@ void GOAudioSection::GetHistory(
   }
 }
 
-GOSampleStatistic GOAudioSection::GetStatistic() {
+GOSampleStatistic GOSoundAudioSection::GetStatistic() {
   GOSampleStatistic stat;
 
   size_t size = 0;

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -156,10 +156,12 @@ private:
   unsigned m_SampleRate;
 
   /* Type of the data which is stored in the data pointer */
-  unsigned m_Compressed;
   unsigned m_BitsPerSample;
   unsigned m_BytesPerSample;
   unsigned m_Channels;
+
+  int8_t m_SampleGroup;
+  bool m_IsCompressed;
 
   /* Size of the section in BYTES */
   GOMemoryPool &m_Pool;
@@ -174,7 +176,9 @@ public:
   GOAudioSection(GOMemoryPool &pool);
   ~GOAudioSection();
   void ClearData();
-  unsigned GetChannels() const;
+  inline unsigned GetChannels() const { return m_Channels; }
+  inline int8_t GetSampleGroup() const { return m_SampleGroup; }
+
   unsigned GetBytesPerSample() const;
   unsigned GetLength() const;
   unsigned GetReleaseCrossfadeLength() const {
@@ -212,6 +216,7 @@ public:
     unsigned pcm_data_sample_rate,
     unsigned pcm_data_nb_samples,
     const std::vector<GOWaveLoop> *loop_points,
+    int8_t sampleGroup,
     bool compress,
     unsigned loopCrossfadeLength,
     unsigned releaseCrossfadeLength);
@@ -246,10 +251,8 @@ public:
   GOSampleStatistic GetStatistic();
 };
 
-inline unsigned GOAudioSection::GetChannels() const { return m_Channels; }
-
 inline unsigned GOAudioSection::GetBytesPerSample() const {
-  return (m_Compressed) ? 0 : (m_BitsPerSample / 8);
+  return (m_IsCompressed) ? 0 : (m_BitsPerSample / 8);
 }
 
 inline unsigned GOAudioSection::GetLength() const { return m_SampleCount; }
@@ -283,7 +286,7 @@ inline int GOAudioSection::GetSampleData(
 
 inline int GOAudioSection::GetSample(
   unsigned position, unsigned channel, DecompressionCache *cache) const {
-  if (!m_Compressed) {
+  if (!m_IsCompressed) {
     return GetSampleData(
       position, channel, m_BitsPerSample, m_Channels, m_Data);
   } else {

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -17,7 +17,7 @@
 #include "GOSoundResample.h"
 #include "GOWave.h"
 
-class GOAudioSection;
+class GOSoundAudioSection;
 class GOCache;
 class GOCacheObject;
 class GOCacheWriter;
@@ -63,7 +63,7 @@ typedef struct audio_end_data_segment_s {
 } audio_end_data_segment;
 
 typedef struct audio_section_stream_s {
-  const GOAudioSection *audio_section;
+  const GOSoundAudioSection *audio_section;
   const struct resampler_coefs_s *resample_coefs;
 
   /* Method used to decode stream */
@@ -93,7 +93,7 @@ typedef struct audio_section_stream_s {
   DecompressionCache cache;
 } audio_section_stream;
 
-class GOAudioSection {
+class GOSoundAudioSection {
 private:
   template <class T>
   static void MonoUncompressedLinear(
@@ -173,8 +173,8 @@ private:
   unsigned m_ReleaseCrossfadeLength; // in ms
 
 public:
-  GOAudioSection(GOMemoryPool &pool);
-  ~GOAudioSection();
+  GOSoundAudioSection(GOMemoryPool &pool);
+  ~GOSoundAudioSection();
   void ClearData();
   inline unsigned GetChannels() const { return m_Channels; }
   inline int8_t GetSampleGroup() const { return m_SampleGroup; }
@@ -246,23 +246,24 @@ public:
   unsigned GetSampleRate() const;
   bool SupportsStreamAlignment() const;
   void SetupStreamAlignment(
-    const std::vector<const GOAudioSection *> &joinables, unsigned start_index);
+    const std::vector<const GOSoundAudioSection *> &joinables,
+    unsigned start_index);
 
   GOSampleStatistic GetStatistic();
 };
 
-inline unsigned GOAudioSection::GetBytesPerSample() const {
+inline unsigned GOSoundAudioSection::GetBytesPerSample() const {
   return (m_IsCompressed) ? 0 : (m_BitsPerSample / 8);
 }
 
-inline unsigned GOAudioSection::GetLength() const { return m_SampleCount; }
+inline unsigned GOSoundAudioSection::GetLength() const { return m_SampleCount; }
 
-inline bool GOAudioSection::IsOneshot() const {
+inline bool GOSoundAudioSection::IsOneshot() const {
   return (m_EndSegments.size() == 1)
     && (m_EndSegments[0].next_start_segment_index < 0);
 }
 
-inline int GOAudioSection::GetSampleData(
+inline int GOSoundAudioSection::GetSampleData(
   unsigned position,
   unsigned channel,
   unsigned bits_per_sample,
@@ -284,7 +285,7 @@ inline int GOAudioSection::GetSampleData(
   return 0;
 }
 
-inline int GOAudioSection::GetSample(
+inline int GOSoundAudioSection::GetSample(
   unsigned position, unsigned channel, DecompressionCache *cache) const {
   if (!m_IsCompressed) {
     return GetSampleData(
@@ -302,7 +303,7 @@ inline int GOAudioSection::GetSample(
   }
 }
 
-inline void GOAudioSection::SetSampleData(
+inline void GOSoundAudioSection::SetSampleData(
   unsigned position,
   unsigned channel,
   unsigned bits_per_sample,
@@ -327,11 +328,11 @@ inline void GOAudioSection::SetSampleData(
   assert(0 && "broken sampler type");
 }
 
-inline float GOAudioSection::GetNormGain() const {
+inline float GOSoundAudioSection::GetNormGain() const {
   return scalbnf(1.0f, -((int)m_SampleFracBits));
 }
 
-inline bool GOAudioSection::SupportsStreamAlignment() const {
+inline bool GOSoundAudioSection::SupportsStreamAlignment() const {
   return (m_ReleaseAligner != NULL);
 }
 

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -246,7 +246,7 @@ bool GOSoundEngine::ProcessSampler(
      *
      *     playback gain * (2 ^ -sampler->pipe_section->sample_bits)
      */
-    if (!GOAudioSection::ReadBlock(&sampler->stream, temp, n_frames))
+    if (!GOSoundAudioSection::ReadBlock(&sampler->stream, temp, n_frames))
       sampler->pipe = NULL;
 
     sampler->fader.Process(n_frames, temp, volume);
@@ -400,7 +400,7 @@ GOSoundSampler *GOSoundEngine::StartSample(
   if (released_time > (unsigned)-1)
     released_time = (unsigned)-1;
 
-  const GOAudioSection *attack = pipe->GetAttack(velocity, released_time);
+  const GOSoundAudioSection *attack = pipe->GetAttack(velocity, released_time);
   if (!attack || attack->GetChannels() == 0)
     return NULL;
   GOSoundSampler *sampler = m_SamplerPool.GetSampler();
@@ -429,7 +429,8 @@ void GOSoundEngine::SwitchAttackSampler(GOSoundSampler *handle) {
   unsigned time = 1000;
 
   const GOSoundProvider *this_pipe = handle->pipe;
-  const GOAudioSection *section = this_pipe->GetAttack(handle->velocity, time);
+  const GOSoundAudioSection *section
+    = this_pipe->GetAttack(handle->velocity, time);
   if (!section)
     return;
   if (handle->is_release)
@@ -470,7 +471,7 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
    * automatically be placed back in the pool when the fade restores to
    * zero. */
   const GOSoundProvider *this_pipe = handle->pipe;
-  const GOAudioSection *release_section = this_pipe->GetRelease(
+  const GOSoundAudioSection *release_section = this_pipe->GetRelease(
     handle->stream.audio_section->GetSampleGroup(),
     ((double)(m_CurrentTime - handle->time)) / m_SampleRate);
   unsigned cross_fade_len = release_section

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -389,7 +389,7 @@ void GOSoundEngine::NextPeriod() {
 
 GOSoundSampler *GOSoundEngine::StartSample(
   const GOSoundProvider *pipe,
-  int sampler_group_id,
+  int8_t sampler_group_id,
   unsigned audio_group,
   unsigned velocity,
   unsigned delay,
@@ -471,7 +471,8 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
    * zero. */
   const GOSoundProvider *this_pipe = handle->pipe;
   const GOAudioSection *release_section = this_pipe->GetRelease(
-    &handle->stream, ((double)(m_CurrentTime - handle->time)) / m_SampleRate);
+    handle->stream.audio_section->GetSampleGroup(),
+    ((double)(m_CurrentTime - handle->time)) / m_SampleRate);
   unsigned cross_fade_len = release_section
     ? release_section->GetReleaseCrossfadeLength()
     : this_pipe->GetAttackSwitchCrossfadeLength();

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -104,7 +104,7 @@ public:
 
   GOSoundSampler *StartSample(
     const GOSoundProvider *pipe,
-    int sampler_group_id,
+    int8_t sampler_group_id,
     unsigned audio_group,
     unsigned velocity,
     unsigned delay,

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -46,6 +46,8 @@ private:
   unsigned m_SamplesPerBuffer;
   float m_Gain;
   unsigned m_SampleRate;
+
+  // time in samples
   uint64_t m_CurrentTime;
   GOSoundSamplerPool m_SamplerPool;
   unsigned m_AudioGroupCount;
@@ -65,6 +67,8 @@ private:
   struct resampler_coefs_s m_ResamplerCoefs;
 
   std::atomic_bool m_HasBeenSetup;
+
+  unsigned SamplesDiffToMs(uint64_t fromSamples, uint64_t toSamples);
 
   /* samplerGroupID:
      -1 .. -n Tremulants

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -73,7 +73,7 @@ bool GOSoundProvider::LoadCache(GOMemoryPool &pool, GOCache &cache) {
     if (!cache.Read(&info, sizeof(info)))
       return false;
     m_AttackInfo.push_back(info);
-    m_Attack.push_back(new GOAudioSection(pool));
+    m_Attack.push_back(new GOSoundAudioSection(pool));
     if (!m_Attack[i]->LoadCache(cache))
       return false;
   }
@@ -86,7 +86,7 @@ bool GOSoundProvider::LoadCache(GOMemoryPool &pool, GOCache &cache) {
     if (!cache.Read(&info, sizeof(info)))
       return false;
     m_ReleaseInfo.push_back(info);
-    m_Release.push_back(new GOAudioSection(pool));
+    m_Release.push_back(new GOSoundAudioSection(pool));
     if (!m_Release[i]->LoadCache(cache))
       return false;
   }
@@ -131,7 +131,7 @@ bool GOSoundProvider::SaveCache(GOCacheWriter &cache) const {
 }
 
 void GOSoundProvider::ComputeReleaseAlignmentInfo() {
-  std::vector<const GOAudioSection *> sections;
+  std::vector<const GOSoundAudioSection *> sections;
   for (int k = -1; k < 2; k++) {
     sections.clear();
     for (unsigned i = 0; i < m_Attack.size(); i++)
@@ -189,7 +189,7 @@ float GOSoundProvider::GetVelocityVolume(unsigned velocity) const {
   return m_VelocityVolumeBase + (velocity * m_VelocityVolumeIncrement);
 }
 
-const GOAudioSection *GOSoundProvider::GetAttack(
+const GOSoundAudioSection *GOSoundProvider::GetAttack(
   unsigned velocity, unsigned released_time) const {
   const unsigned x = abs(rand());
   int best_match = -1;
@@ -218,7 +218,7 @@ const GOAudioSection *GOSoundProvider::GetAttack(
   return NULL;
 }
 
-const GOAudioSection *GOSoundProvider::GetRelease(
+const GOSoundAudioSection *GOSoundProvider::GetRelease(
   uint8_t sampleGroup, double playback_time) const {
   unsigned time = std::min(playback_time, 3600.0) * 1000;
 

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -190,9 +190,10 @@ float GOSoundProvider::GetVelocityVolume(unsigned velocity) const {
 }
 
 const GOSoundAudioSection *GOSoundProvider::GetAttack(
-  unsigned velocity, unsigned released_time) const {
+  unsigned velocity, unsigned releasedDurationMs) const {
   const unsigned x = abs(rand());
   int best_match = -1;
+
   for (unsigned i = 0; i < m_Attack.size(); i++) {
     const unsigned idx = (i + x) % m_Attack.size();
     if (
@@ -201,7 +202,7 @@ const GOSoundAudioSection *GOSoundProvider::GetAttack(
       continue;
     if (m_AttackInfo[idx].min_attack_velocity > velocity)
       continue;
-    if (m_AttackInfo[idx].max_released_time < released_time)
+    if (m_AttackInfo[idx].max_released_time < releasedDurationMs)
       continue;
     if (best_match == -1)
       best_match = idx;
@@ -219,16 +220,15 @@ const GOSoundAudioSection *GOSoundProvider::GetAttack(
 }
 
 const GOSoundAudioSection *GOSoundProvider::GetRelease(
-  uint8_t sampleGroup, double playback_time) const {
-  unsigned time = std::min(playback_time, 3600.0) * 1000;
-
+  uint8_t sampleGroup, unsigned playbackDurationMs) const {
   const unsigned x = abs(rand());
   int best_match = -1;
+
   for (unsigned i = 0; i < m_Release.size(); i++) {
     const unsigned idx = (i + x) % m_Release.size();
     if (m_ReleaseInfo[idx].sample_group != sampleGroup)
       continue;
-    if (m_ReleaseInfo[idx].max_playback_time < time)
+    if (m_ReleaseInfo[idx].max_playback_time < playbackDurationMs)
       continue;
     if (best_match == -1)
       best_match = idx;

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -220,7 +220,7 @@ const GOSoundAudioSection *GOSoundProvider::GetAttack(
 }
 
 const GOSoundAudioSection *GOSoundProvider::GetRelease(
-  uint8_t sampleGroup, unsigned playbackDurationMs) const {
+  int8_t sampleGroup, unsigned playbackDurationMs) const {
   const unsigned x = abs(rand());
   int best_match = -1;
 

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -65,9 +65,9 @@ public:
   void SetVelocityParameter(float min_volume, float max_volume);
 
   const GOSoundAudioSection *GetAttack(
-    unsigned velocity, unsigned released_time) const;
+    unsigned velocity, unsigned releasedDurationMs) const;
   const GOSoundAudioSection *GetRelease(
-    uint8_t sampleGroup, double playback_time) const;
+    uint8_t sampleGroup, unsigned playbackDurationMs) const;
   float GetGain() const;
   int IsOneshot() const;
 

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -14,7 +14,7 @@
 #include "GOStatisticCallback.h"
 #include "ptrvector.h"
 
-class GOAudioSection;
+class GOSoundAudioSection;
 class GOCache;
 class GOCacheWriter;
 class GOHash;
@@ -41,9 +41,9 @@ protected:
   float m_Tuning;
   bool m_SampleGroup;
   unsigned m_ReleaseTail;
-  ptr_vector<GOAudioSection> m_Attack;
+  ptr_vector<GOSoundAudioSection> m_Attack;
   std::vector<AttackSelector> m_AttackInfo;
-  ptr_vector<GOAudioSection> m_Release;
+  ptr_vector<GOSoundAudioSection> m_Release;
   std::vector<ReleaseSelector> m_ReleaseInfo;
   void ComputeReleaseAlignmentInfo();
   float m_VelocityVolumeBase;
@@ -64,9 +64,9 @@ public:
   void UseSampleGroup(unsigned sample_group);
   void SetVelocityParameter(float min_volume, float max_volume);
 
-  const GOAudioSection *GetAttack(
+  const GOSoundAudioSection *GetAttack(
     unsigned velocity, unsigned released_time) const;
-  const GOAudioSection *GetRelease(
+  const GOSoundAudioSection *GetRelease(
     uint8_t sampleGroup, double playback_time) const;
   float GetGain() const;
   int IsOneshot() const;

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -67,7 +67,7 @@ public:
   const GOSoundAudioSection *GetAttack(
     unsigned velocity, unsigned releasedDurationMs) const;
   const GOSoundAudioSection *GetRelease(
-    uint8_t sampleGroup, unsigned playbackDurationMs) const;
+    int8_t sampleGroup, unsigned playbackDurationMs) const;
   float GetGain() const;
   int IsOneshot() const;
 

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
@@ -82,7 +82,7 @@ void GOSoundProviderSynthedTrem::Create(
   trem_loop.m_EndPosition = (attack_samples + loop_samples) - 1;
   std::vector<GOWaveLoop> trem_loops;
   trem_loops.push_back(trem_loop);
-  attack_section_info attack_info;
+  AttackSelector attack_info;
   attack_info.sample_group = -1;
   attack_info.min_attack_velocity = 0;
   attack_info.max_released_time = -1;
@@ -97,12 +97,13 @@ void GOSoundProviderSynthedTrem::Create(
     sample_freq,
     trem_loop.m_EndPosition,
     &trem_loops,
+    -1,
     false,
     0,
     0);
 
   /* Release section */
-  release_section_info release_info;
+  ReleaseSelector release_info;
   release_info.sample_group = -1;
   release_info.max_playback_time = -1;
   m_ReleaseInfo.push_back(release_info);
@@ -116,6 +117,7 @@ void GOSoundProviderSynthedTrem::Create(
     sample_freq,
     release_samples,
     NULL,
+    -1,
     false,
     0,
     0);

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
@@ -87,7 +87,7 @@ void GOSoundProviderSynthedTrem::Create(
   attack_info.min_attack_velocity = 0;
   attack_info.max_released_time = -1;
   m_AttackInfo.push_back(attack_info);
-  m_Attack.push_back(new GOAudioSection(pool));
+  m_Attack.push_back(new GOSoundAudioSection(pool));
   m_Attack[0]->Setup(
     nullptr,
     nullptr,
@@ -107,7 +107,7 @@ void GOSoundProviderSynthedTrem::Create(
   release_info.sample_group = -1;
   release_info.max_playback_time = -1;
   m_ReleaseInfo.push_back(release_info);
-  m_Release.push_back(new GOAudioSection(pool));
+  m_Release.push_back(new GOSoundAudioSection(pool));
   m_Release[0]->Setup(
     nullptr,
     nullptr,

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -118,7 +118,7 @@ void GOSoundProviderWave::AddAttackSection(
   attack_info.min_attack_velocity = min_attack_velocity;
   attack_info.max_released_time = max_released_time;
   m_AttackInfo.push_back(attack_info);
-  GOAudioSection *section = new GOAudioSection(pool);
+  GOSoundAudioSection *section = new GOSoundAudioSection(pool);
   m_Attack.push_back(section);
   section->Setup(
     p_ObjectFor,
@@ -167,7 +167,7 @@ void GOSoundProviderWave::AddReleaseSection(
   release_info.sample_group = sample_group;
   release_info.max_playback_time = max_playback_time;
   m_ReleaseInfo.push_back(release_info);
-  GOAudioSection *section = new GOAudioSection(pool);
+  GOSoundAudioSection *section = new GOSoundAudioSection(pool);
   m_Release.push_back(section);
   section->Setup(
     p_ObjectFor,

--- a/src/grandorgue/sound/GOSoundProviderWave.cpp
+++ b/src/grandorgue/sound/GOSoundProviderWave.cpp
@@ -113,7 +113,7 @@ void GOSoundProviderWave::AddAttackSection(
     }
   }
 
-  attack_section_info attack_info;
+  AttackSelector attack_info;
   attack_info.sample_group = sample_group;
   attack_info.min_attack_velocity = min_attack_velocity;
   attack_info.max_released_time = max_released_time;
@@ -129,6 +129,7 @@ void GOSoundProviderWave::AddAttackSection(
     wave.GetSampleRate(),
     wave.GetLength(),
     &loops,
+    sample_group,
     compress,
     loop_crossfade_length,
     0);
@@ -162,7 +163,7 @@ void GOSoundProviderWave::AddReleaseSection(
   if (release_offset >= release_end_marker)
     throw(wxString) _("Invalid release position");
 
-  release_section_info release_info;
+  ReleaseSelector release_info;
   release_info.sample_group = sample_group;
   release_info.max_playback_time = max_playback_time;
   m_ReleaseInfo.push_back(release_info);
@@ -177,6 +178,7 @@ void GOSoundProviderWave::AddReleaseSection(
     wave.GetSampleRate(),
     release_samples,
     NULL,
+    sample_group,
     compress,
     0,
     releaseCrossfadeLength);

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -41,27 +41,27 @@ public:
 
   struct AttackFileInfo {
     GOLoaderFilename filename;
-    int sample_group;
-    bool load_release;
-    bool percussive;
+    std::vector<GOWaveLoop> loops;
     unsigned min_attack_velocity;
     unsigned max_released_time;
     int max_playback_time;
     int attack_start;
     int cue_point;
     int release_end;
-    std::vector<GOWaveLoop> loops;
     unsigned m_LoopCrossfadeLength;
     unsigned m_ReleaseCrossfadeLength;
+    int8_t sample_group;
+    bool load_release;
+    bool percussive;
   };
 
   struct ReleaseFileInfo {
     GOLoaderFilename filename;
-    int sample_group;
     int max_playback_time;
     int cue_point;
     int release_end;
     unsigned m_ReleaseCrossfadeLength;
+    int8_t sample_group;
   };
 
 private:

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -50,7 +50,7 @@ bool GOSoundReleaseAlignTable::Save(GOCacheWriter &cache) {
 }
 
 void GOSoundReleaseAlignTable::ComputeTable(
-  const GOAudioSection &release,
+  const GOSoundAudioSection &release,
   int phase_align_max_amplitude,
   int phase_align_max_derivative,
   unsigned int sample_rate,
@@ -176,7 +176,7 @@ void GOSoundReleaseAlignTable::SetupRelease(
   audio_section_stream &release_sampler,
   const audio_section_stream &old_sampler) const {
   int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS];
-  GOAudioSection::GetHistory(&old_sampler, history);
+  GOSoundAudioSection::GetHistory(&old_sampler, history);
 
   /* Get combined release f's and v's */
   int f_mod = 0;

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.h
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,7 +8,7 @@
 #ifndef GOSOUNDRELEASEALIGNTABLE_H
 #define GOSOUNDRELEASEALIGNTABLE_H
 
-class GOAudioSection;
+class GOSoundAudioSection;
 class GOCache;
 class GOCacheWriter;
 typedef struct audio_section_stream_s audio_section_stream;
@@ -31,7 +31,7 @@ public:
   bool Save(GOCacheWriter &cache);
 
   void ComputeTable(
-    const GOAudioSection &m_release,
+    const GOSoundAudioSection &m_release,
     int phase_align_max_amplitude,
     int phase_align_max_derivative,
     unsigned int sample_rate,


### PR DESCRIPTION
This is the next PR related to #1385.

For supporting independent releases, `GOSoundProvider::GetRelease` has not to use the attack sampler. So this PR

- replaces the first parameter of `GOSoundProvider::GetRelease` with sampleGroup
- changed the type of the second parameter of `GOSoundProvider::GetRelease`
- renames `GOAudioSection` to `GOSoundAudioSection`
- addes `GOSoundAudioSection::m_SampleGroup` and `GOSoundAudioSection::GetSampleGroup`
- renames `GOSoundAudioSection::m_Compressed` to `GOSoundAudioSection::m_IsCompressed`
- removes an old disabled code from `GOSoundAudioSection.cpp`
- changed type of `GOSoundAudioSection::m_IsCompressed` to `bool`
- changed type of sample_group from int to int8_t everywhere
- moves structs `attack_section_info` and `release_section_info` inside the `GOSoundProvider` class and renames them to `AttackSelector` and `ReleaseSelector` 


It is just refactoring. No GO behavior should be changed.