### PR TITLE
Moved m_percussive to GOPipeConfig

### DIFF
--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -108,17 +108,18 @@ void GOMetronome::Load(GOConfigReader &cfg) {
 
   m_rank = new GORank(*m_OrganController);
   m_rank->Init(cfg, wxT("MetronomSounds"), _("Metronome"), 36, samplegroup);
+  m_rank->GetPipeConfig().GetPipeConfig().SetPercussive(BOOL3_TRUE);
   m_StopID = m_rank->RegisterStop(NULL);
   m_OrganController->AddRank(m_rank);
 
   GOSoundingPipe *pipe;
   pipe = new GOSoundingPipe(
-    m_OrganController, m_rank, true, samplegroup, 36, 8, 100, 100, false);
+    m_OrganController, m_rank, samplegroup, 36, 8, 100, 100, false);
   m_rank->AddPipe(pipe);
   pipe->Init(
     cfg, wxT("MetronomSounds"), wxT("A"), wxT("sounds\\metronome\\beat.wv"));
   pipe = new GOSoundingPipe(
-    m_OrganController, m_rank, true, samplegroup, 37, 8, 100, 100, false);
+    m_OrganController, m_rank, samplegroup, 37, 8, 100, 100, false);
   m_rank->AddPipe(pipe);
   pipe->Init(
     cfg,

--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -104,11 +104,11 @@ void GOMetronome::Load(GOConfigReader &cfg) {
 
   GOWindchest *windchest = new GOWindchest(*m_OrganController);
   windchest->Init(cfg, wxT("MetronomeWindchest"), _("Metronome"));
+  windchest->GetPipeConfig().GetPipeConfig().SetPercussiveFromInit(BOOL3_TRUE);
   unsigned samplegroup = m_OrganController->AddWindchest(windchest);
 
   m_rank = new GORank(*m_OrganController);
   m_rank->Init(cfg, wxT("MetronomSounds"), _("Metronome"), 36, samplegroup);
-  m_rank->GetPipeConfig().GetPipeConfig().SetPercussive(BOOL3_TRUE);
   m_StopID = m_rank->RegisterStop(NULL);
   m_OrganController->AddRank(m_rank);
 

--- a/src/grandorgue/model/GORank.cpp
+++ b/src/grandorgue/model/GORank.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -30,7 +30,6 @@ GORank::GORank(GOOrganModel &organModel)
     m_NoteStopVelocities(),
     m_MaxNoteVelocities(),
     m_FirstMidiNoteNumber(0),
-    m_Percussive(false),
     m_WindchestGroup(0),
     m_HarmonicNumber(8),
     m_MinVolume(100),
@@ -65,7 +64,6 @@ void GORank::Init(
 
   m_PipeConfig.Init(cfg, group, wxEmptyString);
   m_WindchestGroup = windchest_nr;
-  m_Percussive = false;
   m_HarmonicNumber = 8;
   m_MinVolume = 100;
   m_MaxVolume = 100;
@@ -105,7 +103,6 @@ void GORank::Load(
     wxT("WindchestGroup"),
     1,
     r_OrganModel.GetWindchestGroupCount());
-  m_Percussive = cfg.ReadBoolean(ODFSetting, group, wxT("Percussive"));
   m_HarmonicNumber = cfg.ReadInteger(
     ODFSetting, group, wxT("HarmonicNumber"), 1, 1024, false, 8);
   m_MinVolume = cfg.ReadFloat(
@@ -134,7 +131,6 @@ void GORank::Load(
       m_Pipes.push_back(new GOSoundingPipe(
         &r_OrganModel,
         this,
-        m_Percussive,
         m_WindchestGroup,
         m_FirstMidiNoteNumber + i,
         m_HarmonicNumber,

--- a/src/grandorgue/model/GORank.h
+++ b/src/grandorgue/model/GORank.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -44,7 +44,6 @@ private:
    */
   std::vector<unsigned> m_MaxNoteVelocities;
   unsigned m_FirstMidiNoteNumber;
-  bool m_Percussive;
   unsigned m_WindchestGroup;
   unsigned m_HarmonicNumber;
   float m_MinVolume;

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -27,7 +27,6 @@
 GOSoundingPipe::GOSoundingPipe(
   GOOrganModel *pOrganModel,
   GORank *rank,
-  bool percussive,
   int sampler_group_id,
   unsigned midi_key_number,
   unsigned harmonic_number,
@@ -45,7 +44,6 @@ GOSoundingPipe::GOSoundingPipe(
     m_Filename(),
     m_SamplerGroupID(sampler_group_id),
     m_AudioGroupID(0),
-    m_Percussive(percussive),
     m_TemperamentOffset(0),
     m_HarmonicNumber(harmonic_number),
     m_MinVolume(min_volume),
@@ -78,8 +76,8 @@ void GOSoundingPipe::Init(
 
   ainfo.filename.AssignResource(m_Filename);
   ainfo.sample_group = -1;
-  ainfo.load_release = !m_Percussive;
-  ainfo.percussive = m_Percussive;
+  ainfo.percussive = m_PipeConfigNode.GetEffectivePercussive();
+  ainfo.load_release = !ainfo.percussive;
   ainfo.max_playback_time = -1;
   ainfo.cue_point = -1;
   ainfo.min_attack_velocity = 0;
@@ -105,9 +103,9 @@ void GOSoundingPipe::LoadAttackFileInfo(
   ainfo.filename.Assign(cfg.ReadFileName(ODFSetting, group, prefix));
   ainfo.sample_group = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("IsTremulant"), -1, 1, false, -1);
+  ainfo.percussive = m_PipeConfigNode.GetEffectivePercussive();
   ainfo.load_release = cfg.ReadBoolean(
-    ODFSetting, group, prefix + wxT("LoadRelease"), false, !m_Percussive);
-  ainfo.percussive = m_Percussive;
+    ODFSetting, group, prefix + wxT("LoadRelease"), false, !ainfo.percussive);
   ainfo.max_playback_time = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("MaxKeyPressTime"), -1, 100000, false, -1);
   ainfo.cue_point = cfg.ReadInteger(
@@ -241,8 +239,6 @@ void GOSoundingPipe::Load(
     p_OrganModel->GetWindchestGroupCount(),
     false,
     m_SamplerGroupID);
-  m_Percussive = cfg.ReadBoolean(
-    ODFSetting, group, prefix + wxT("Percussive"), false, m_Percussive);
   m_OdfMidiKeyNumber = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("MIDIKeyNumber"), -1, 127, false, -1);
   m_OdfMidiPitchFraction = cfg.ReadFloat(

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -38,7 +38,6 @@ private:
    * GOSoundEngine::StartSampler */
   int m_SamplerGroupID;
   unsigned m_AudioGroupID;
-  bool m_Percussive;
   float m_TemperamentOffset;
   unsigned m_HarmonicNumber;
   float m_MinVolume;
@@ -115,7 +114,6 @@ public:
   GOSoundingPipe(
     GOOrganModel *pOrganModel,
     GORank *rank,
-    bool percussive,
     int sampler_group_id,
     unsigned midi_key_number,
     unsigned harmonic_number,

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -123,6 +123,7 @@ void GOPipeConfig::Init(
   m_PitchTuning = 0;
   m_PitchCorrection = 0;
   m_DefaultDelay = 0;
+  m_Percussive = BOOL3_DEFAULT;
   LoadFromCmb(cfg, group, prefix);
 }
 
@@ -138,6 +139,8 @@ void GOPipeConfig::Load(
     ODFSetting, group, prefix + wxT("PitchCorrection"), -1800, 1800, false, 0);
   m_DefaultDelay = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("TrackerDelay"), 0, 10000, false, 0);
+  m_Percussive = cfg.ReadBooleanTriple(
+    ODFSetting, group, prefix + wxT("Percussive"), false);
   LoadFromCmb(cfg, group, prefix);
 }
 

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -43,6 +43,7 @@ private:
   int8_t m_BitsPerSample;
   int8_t m_Channels;
   int8_t m_LoopLoad;
+  GOBool3 m_Percussive;
   GOBool3 m_Compress;
   GOBool3 m_AttackLoad;
   GOBool3 m_ReleaseLoad;
@@ -142,6 +143,9 @@ public:
 
   int8_t GetLoopLoad() const { return m_LoopLoad; }
   void SetLoopLoad(int8_t value) { SetSmallMember(value, m_LoopLoad); }
+
+  GOBool3 GetPercussive() const { return m_Percussive; }
+  void SetPercussive(GOBool3 value) { SetSmallMember(value, m_Percussive); }
 
   GOBool3 GetCompress() const { return m_Compress; }
   void SetCompress(GOBool3 value) { SetSmallMember(value, m_Compress); }

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -145,7 +145,8 @@ public:
   void SetLoopLoad(int8_t value) { SetSmallMember(value, m_LoopLoad); }
 
   GOBool3 GetPercussive() const { return m_Percussive; }
-  void SetPercussive(GOBool3 value) { SetSmallMember(value, m_Percussive); }
+  // does not send notifications
+  void SetPercussiveFromInit(GOBool3 value) { m_Percussive = value; }
 
   GOBool3 GetCompress() const { return m_Compress; }
   void SetCompress(GOBool3 value) { SetSmallMember(value, m_Compress); }

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -133,6 +133,13 @@ public:
       &GOConfig::LoopLoad);
   }
 
+  bool GetEffectivePercussive() const {
+    return GetEffectiveBool(
+      &GOPipeConfig::GetPercussive,
+      &GOPipeConfigNode::GetEffectivePercussive,
+      (const GOSettingUnsigned GOConfig::*)nullptr);
+  }
+
   bool GetEffectiveCompress() const {
     return GetEffectiveBool(
       &GOPipeConfig::GetCompress,


### PR DESCRIPTION
This is a next PR related to #1385

This PR moves m_Percussive from GOPipe and GORank to GOPipeConfig for future compatibility of checking HasIndependentRelease at any level.

It is just refactoring. No GO behavior should be changed.
