### PR TITLE
Always save exported combinations with UTF-8-BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Organ combination .yaml files are now portable across Windows, Linux and MacOS https://github.com/GrandOrgue/grandorgue/issues/1818
+- Fixed different encoding of combination .yaml files on Windows, Linux and MacOS https://github.com/GrandOrgue/grandorgue/issues/1818
 - Added support of "Couple Through" mode of Virtual Couplers https://github.com/GrandOrgue/grandorgue/issues/1657
 - Added capability of loading only GUI panels without audio samples by specifying the "-g" switch from the command line https://github.com/GrandOrgue/grandorgue/issues/1602
 - Removed support of MacOS 11 https://github.com/GrandOrgue/grandorgue/issues/1791

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Organ combination .yaml files are now portable across Windows, Linux and MacOS https://github.com/GrandOrgue/grandorgue/issues/1818
 - Added support of "Couple Through" mode of Virtual Couplers https://github.com/GrandOrgue/grandorgue/issues/1657
 - Added capability of loading only GUI panels without audio samples by specifying the "-g" switch from the command line https://github.com/GrandOrgue/grandorgue/issues/1602
 - Removed support of MacOS 11 https://github.com/GrandOrgue/grandorgue/issues/1791

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -725,8 +725,10 @@ void GOOrganController::LoadCombination(const wxString &file) {
     const wxString fileExt = fileName.GetExt();
 
     if (fileExt == WX_YAML) {
-      wxScopedCharBuffer fileContentInUtf8
-        = loadFileTextWithEncodingDetection(file).utf8_str();
+      wxString fileContent = loadFileTextWithEncodingDetection(file);
+      // Note: wxScopedCharBuffer may point to internals of wxString above
+      // fileContent must not be destructed while fileContentInUtf8 is in use
+      wxScopedCharBuffer fileContentInUtf8 = fileContent.utf8_str();
       YAML::Node cmbNode = YAML::Load(fileContentInUtf8.data());
       YAML::Node cmbInfoNode = cmbNode[INFO];
       const wxString contentType = cmbInfoNode[CONTENT_TYPE].as<wxString>();

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -645,7 +645,9 @@ wxString GOOrganController::ExportCombination(const wxString &fileName) {
     outYaml << YAML::BeginDoc << globalNode;
 
     uint8_t utf8bom[] = {0xEF, 0xBB, 0xBF};
-    if (fOS.WriteAll(utf8bom, sizeof(utf8bom)) && fOS.WriteAll(outYaml.c_str(), outYaml.size()))
+    if (
+      fOS.WriteAll(utf8bom, sizeof(utf8bom))
+      && fOS.WriteAll(outYaml.c_str(), outYaml.size()))
       m_setter->OnCombinationsSaved(fileName);
     else
       errMsg.Printf(
@@ -701,9 +703,11 @@ static std::vector<char> loadFileBytes(const wxString &file) {
 }
 
 static wxString loadFileTextWithEncodingDetection(const wxString &file) {
-  std::vector<char> content = loadFileBytes(file);  
+  std::vector<char> content = loadFileBytes(file);
   std::array<char, 3> utf8bom = {'\xEF', '\xBB', '\xBF'};
-  if (content.size() >= utf8bom.size() && std::equal(utf8bom.begin(), utf8bom.end(), content.begin())) {
+  if (
+    content.size() >= utf8bom.size()
+    && std::equal(utf8bom.begin(), utf8bom.end(), content.begin())) {
     // Newer GO versions export yaml files with UTF-8-BOM.
     // wxConvAuto will detect BOM and decode as UTF-8.
     return wxString(&content[0], wxConvAuto(), content.size());
@@ -721,7 +725,8 @@ void GOOrganController::LoadCombination(const wxString &file) {
     const wxString fileExt = fileName.GetExt();
 
     if (fileExt == WX_YAML) {
-      wxScopedCharBuffer fileContentInUtf8 = loadFileTextWithEncodingDetection(file).utf8_str();
+      wxScopedCharBuffer fileContentInUtf8
+        = loadFileTextWithEncodingDetection(file).utf8_str();
       YAML::Node cmbNode = YAML::Load(fileContentInUtf8.data());
       YAML::Node cmbInfoNode = cmbNode[INFO];
       const wxString contentType = cmbInfoNode[CONTENT_TYPE].as<wxString>();

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -721,8 +721,8 @@ void GOOrganController::LoadCombination(const wxString &file) {
     const wxString fileExt = fileName.GetExt();
 
     if (fileExt == WX_YAML) {
-      std::string fileContentInUtf8 = loadFileTextWithEncodingDetection(file).utf8_string();
-      YAML::Node cmbNode = YAML::Load(fileContentInUtf8);
+      wxScopedCharBuffer fileContentInUtf8 = loadFileTextWithEncodingDetection(file).utf8_str();
+      YAML::Node cmbNode = YAML::Load(fileContentInUtf8.data());
       YAML::Node cmbInfoNode = cmbNode[INFO];
       const wxString contentType = cmbInfoNode[CONTENT_TYPE].as<wxString>();
 

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -644,7 +644,7 @@ wxString GOOrganController::ExportCombination(const wxString &fileName) {
 
     outYaml << YAML::BeginDoc << globalNode;
 
-    uint8_t utf8bom[] = {0xEF, 0xBB, 0xBF};
+    static const uint8_t utf8bom[] = {0xEF, 0xBB, 0xBF};
     if (
       fOS.WriteAll(utf8bom, sizeof(utf8bom))
       && fOS.WriteAll(outYaml.c_str(), outYaml.size()))

--- a/src/grandorgue/yaml/go-wx-yaml.cpp
+++ b/src/grandorgue/yaml/go-wx-yaml.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/yaml/go-wx-yaml.cpp
+++ b/src/grandorgue/yaml/go-wx-yaml.cpp
@@ -27,7 +27,7 @@ bool convert<wxString>::decode(const Node &node, wxString &rhs) {
     if (isNull)
       rhs = wxEmptyString;
     else
-      rhs = wxString::FromUTF8(node.as<std::string>());
+      rhs = wxString::FromUTF8(node.as<std::string>().c_str());
   }
   return isValid;
 }

--- a/src/grandorgue/yaml/go-wx-yaml.cpp
+++ b/src/grandorgue/yaml/go-wx-yaml.cpp
@@ -15,7 +15,7 @@ Node convert<wxString>::encode(const wxString &rhs) {
   Node node;
 
   if (!rhs.IsEmpty())
-    node = rhs.mbc_str().data();
+    node = rhs.utf8_str().data();
   return node;
 }
 
@@ -27,7 +27,7 @@ bool convert<wxString>::decode(const Node &node, wxString &rhs) {
     if (isNull)
       rhs = wxEmptyString;
     else
-      rhs = node.as<std::string>();
+      rhs = wxString::FromUTF8(node.as<std::string>());
   }
   return isValid;
 }

--- a/src/grandorgue/yaml/go-wx-yaml.h
+++ b/src/grandorgue/yaml/go-wx-yaml.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/yaml/go-wx-yaml.h
+++ b/src/grandorgue/yaml/go-wx-yaml.h
@@ -36,7 +36,7 @@ extern YAML::Node get_from_map_or_null(
   const YAML::Node &container, const char *key);
 inline YAML::Node get_from_map_or_null(
   const YAML::Node &container, const wxString &key) {
-  return get_from_map_or_null(container, key.mbc_str().data());
+  return get_from_map_or_null(container, key.utf8_str().data());
 }
 
 /**
@@ -52,7 +52,7 @@ extern void put_to_map_if_not_null(
   YAML::Node &container, const char *key, const YAML::Node &value);
 inline void putToMapIfNotNull(
   YAML::Node &container, const wxString &key, const YAML::Node &value) {
-  put_to_map_if_not_null(container, key.mbc_str().data(), value);
+  put_to_map_if_not_null(container, key.utf8_str().data(), value);
 }
 
 /**
@@ -80,6 +80,6 @@ inline void put_to_map_with_name(
   const char *valueLabel,
   const YAML::Node &value) {
   put_to_map_with_name(
-    container, key.mbc_str().data(), nameValue, valueLabel, value);
+    container, key.utf8_str().data(), nameValue, valueLabel, value);
 }
 #endif /* GOWXYAML_H */


### PR DESCRIPTION
Resolves: #1818.
The problem occurred due to the utilization of the default system encoding for conversions between wxString and strings in YAML. yaml-cpp treats strings as a sequence of bytes and does not perform encoding conversions.

Now UTF-8 encoding is used for conversions. The exported file now begins with a UTF-8 BOM mark.
The UTF-8 BOM mark is used to differentiate documents exported from older GO versions (which use UTF-8 without BOM on Linux/Mac and one of the one-byte encodings on Windows) and to indicate to text editors to use UTF-8 encoding.

<s>While this change has not been tested on Windows yet, it is expected to function properly.</s> <s>Import is broken on Windows, investigating now.</s> Tested on Linux & Windows.
