### PR TITLE
Fixed displaying long file paths in the Paths and Reverb tabs of the settings dialog https://github.com/GrandOrgue/grandorgue/issues/1663

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -203,6 +203,7 @@ sound/GOSound.cpp
 yaml/GOSaveableToYaml.cpp
 yaml/go-wx-yaml.cpp
 wxcontrols/GOAudioGauge.cpp
+wxcontrols/GORightVisiblePicker.cpp
 GOAudioRecorder.cpp
 GOBitmapCache.cpp
 GOEvent.cpp

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 include(${CMAKE_SOURCE_DIR}/cmake/AddLinkerOption.cmake)

--- a/src/grandorgue/dialogs/settings/GOSettingsPaths.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsPaths.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,6 +14,7 @@
 #include <wx/string.h>
 
 #include "config/GOConfig.h"
+#include "wxcontrols/GODirPickerCtrl.h"
 
 GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
   : wxPanel(parent, wxID_ANY), m_config(settings) {
@@ -27,10 +28,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_Samplesets = new wxDirPickerCtrl(
+    m_Samplesets = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for open new organs at"),
       wxDefaultPosition,
       wxDefaultSize,
@@ -43,10 +43,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_OrganPackages = new wxDirPickerCtrl(
+    m_OrganPackages = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for load new organ packages from"),
       wxDefaultPosition,
       wxDefaultSize,
@@ -59,10 +58,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_OrganCache = new wxDirPickerCtrl(
+    m_OrganCache = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for storing organ cache"),
       wxDefaultPosition,
       wxDefaultSize,
@@ -74,10 +72,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_OrganSettings = new wxDirPickerCtrl(
+    m_OrganSettings = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for storing organ settings"),
       wxDefaultPosition,
       wxDefaultSize,
@@ -90,10 +87,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_OrganCombinations = new wxDirPickerCtrl(
+    m_OrganCombinations = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for export/import organ combinations"),
       wxDefaultPosition,
       wxDefaultSize,
@@ -106,10 +102,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_ExportImport = new wxDirPickerCtrl(
+    m_ExportImport = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for export/import organ settings"),
       wxDefaultPosition,
       wxDefaultSize,
@@ -122,10 +117,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_AudioRecorder = new wxDirPickerCtrl(
+    m_AudioRecorder = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for your audio recordings"),
       wxDefaultPosition,
       wxDefaultSize,
@@ -138,10 +132,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_MidiRecorder = new wxDirPickerCtrl(
+    m_MidiRecorder = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for your MIDI recording"),
       wxDefaultPosition,
       wxDefaultSize,
@@ -154,10 +147,9 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(
-    m_MidiPlayer = new wxDirPickerCtrl(
+    m_MidiPlayer = new GODirPickerCtrl(
       this,
       wxID_ANY,
-      wxEmptyString,
       _("Select directory for the MIDI player"),
       wxDefaultPosition,
       wxDefaultSize,

--- a/src/grandorgue/dialogs/settings/GOSettingsReverb.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsReverb.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/dialogs/settings/GOSettingsReverb.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsReverb.cpp
@@ -19,6 +19,7 @@
 
 #include "config/GOConfig.h"
 #include "files/GOStandardFile.h"
+#include "wxcontrols/GOFilePickerCtrl.h"
 
 #include "GOWave.h"
 
@@ -53,10 +54,9 @@ GOSettingsReverb::GOSettingsReverb(GOConfig &settings, wxWindow *parent)
     new wxStaticText(this, wxID_ANY, _("Impulse response:")),
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
-  m_File = new wxFilePickerCtrl(
+  m_File = new GOFilePickerCtrl(
     this,
     ID_FILE,
-    wxEmptyString,
     _("Select an impulse file"),
     _("*.wav"),
     wxDefaultPosition,

--- a/src/grandorgue/wxcontrols/GODirPickerCtrl.h
+++ b/src/grandorgue/wxcontrols/GODirPickerCtrl.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GODIRPICKERCTRL_H
+#define GODIRPICKERCTRL_H
+
+#include <wx/filepicker.h>
+
+#include "GORightVisiblePicker.h"
+
+class GODirPickerCtrl : public wxDirPickerCtrl, private GORightVisiblePicker {
+public:
+  GODirPickerCtrl(
+    wxWindow *parent,
+    wxWindowID id,
+    const wxString &title,
+    const wxPoint &pos = wxDefaultPosition,
+    const wxSize &size = wxDefaultSize,
+    long style = 0)
+    : wxDirPickerCtrl(parent, id, wxEmptyString, title, pos, size, style),
+      GORightVisiblePicker(this) {}
+
+  OVERRIDE_UPDATE_TEXTCTRL(wxDirPickerCtrl)
+};
+
+#endif /* GODIRPICKERCTRL_H */

--- a/src/grandorgue/wxcontrols/GOFilePickerCtrl.h
+++ b/src/grandorgue/wxcontrols/GOFilePickerCtrl.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOFILEPICKERCTRL_H
+#define GOFILEPICKERCTRL_H
+
+#include <wx/filepicker.h>
+
+#include "GORightVisiblePicker.h"
+
+class GOFilePickerCtrl : public wxFilePickerCtrl, private GORightVisiblePicker {
+public:
+  GOFilePickerCtrl(
+    wxWindow *parent,
+    wxWindowID id,
+    const wxString &title,
+    const wxString &wildcard,
+    const wxPoint &pos = wxDefaultPosition,
+    const wxSize &size = wxDefaultSize,
+    long style = 0)
+    : wxFilePickerCtrl(
+      parent, id, wxEmptyString, title, wildcard, pos, size, style),
+      GORightVisiblePicker(this) {}
+
+  OVERRIDE_UPDATE_TEXTCTRL(wxFilePickerCtrl)
+};
+
+#endif /* GOFILEPICKERCTRL_H */

--- a/src/grandorgue/wxcontrols/GORightVisiblePicker.cpp
+++ b/src/grandorgue/wxcontrols/GORightVisiblePicker.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GORightVisiblePicker.h"
+
+#include <wx/pickerbase.h>
+#include <wx/textctrl.h>
+
+void GORightVisiblePicker::EnsureRigtIsVisible() {
+  wxTextCtrl *pTxt = p_picker->GetTextCtrl();
+
+  if (pTxt) {
+    pTxt->ShowPosition(pTxt->GetValue().length());
+  }
+}

--- a/src/grandorgue/wxcontrols/GORightVisiblePicker.h
+++ b/src/grandorgue/wxcontrols/GORightVisiblePicker.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GORIGHTVISIBLEPICKER_H
+#define GORIGHTVISIBLEPICKER_H
+
+class wxPickerBase;
+
+/**
+ * This class is designed for enchancing the standard wx*PickerCtrl classes
+ * If the file name is too long to fit in the text control, it makes visible
+ * the rightmost part of the filename
+ *
+ * Usage:
+ *   1. make a subclass of wx*PickerCtrl and GORightVisiblePicker
+ *   2. use the OVERRIDE_UPDATE_TEXTCTRL macro
+ */
+
+class GORightVisiblePicker {
+private:
+  wxPickerBase *p_picker;
+
+protected:
+  GORightVisiblePicker(wxPickerBase *pPicker) : p_picker(pPicker) {}
+
+  // Scrolls the text in the text control of the p_picker to right
+  void EnsureRigtIsVisible();
+};
+
+// This macro must be used in the class declaration for overriding the standard
+// UpdatePickerFromTextCtrl() method
+#define OVERRIDE_UPDATE_TEXTCTRL(baseClass)                                    \
+  void UpdateTextCtrlFromPicker() override {                                   \
+    baseClass::UpdateTextCtrlFromPicker();                                     \
+    EnsureRigtIsVisible();                                                     \
+  }
+
+#endif /* GORIGHTVISIBLEPICKER_H */


### PR DESCRIPTION
This is the first PR related to #1663.

It makes the rightmost part of filenames visible in the `Paths` and `Reverb` tabs of the settings dialog.

