### PR TITLE
Added capability of playing release of percussive pipes with Pipe999HasIndependentRelease=Y https://github.com/GrandOrgue/grandorgue/issues/1385

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added capability of playing release of percussive pipes with Pipe999HasIndependentRelease=Y https://github.com/GrandOrgue/grandorgue/issues/1385
 - Fixed different encoding of combination .yaml files on Windows, Linux and MacOS https://github.com/GrandOrgue/grandorgue/issues/1818
 - Added support of "Couple Through" mode of Virtual Couplers https://github.com/GrandOrgue/grandorgue/issues/1657
 - Added capability of loading only GUI panels without audio samples by specifying the "-g" switch from the command line https://github.com/GrandOrgue/grandorgue/issues/1602

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added capability of specifying AmplitudeLevel, Gain, PitchTuning, PitchCorrection and TrackerDelay, Percussive, HasIndependentRelease at the WindchestGroup level of ODF
+- Added capability of specifying Percussive and HasIndependentRelease at the Organ level of ODF
 - Added capability of playing release of percussive pipes with Pipe999HasIndependentRelease=Y https://github.com/GrandOrgue/grandorgue/issues/1385
 - Fixed different encoding of combination .yaml files on Windows, Linux and MacOS https://github.com/GrandOrgue/grandorgue/issues/1818
 - Added support of "Couple Through" mode of Virtual Couplers https://github.com/GrandOrgue/grandorgue/issues/1657

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -9913,9 +9913,22 @@ on which the pipes of the are placed.
           <term>Percussive</term>
           <listitem>
             <para>
-(boolean, required) If false, the samples are played as is (without
-any loop/release handling)
-     </para>
+	      (boolean, required) If false, the samples are played as is
+	      (without any loop/release handling).
+	    </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>HasIndependentRelease</term>
+          <listitem>
+            <para>
+	      (boolean, default false or inherited from the Organ, Windchest or
+	      Rank). If true than release is played independently on the attack.
+	    </para>
+            <para>
+	      If HasIndependentRelease is true then Percussive must also be set
+	      to true.
+	    </para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -9955,12 +9968,36 @@ attributes are:
       </para>
       <variablelist>
         <varlistentry>
+          <term>Pipe999</term>
+          <listitem>
+            <para>
+(string, required) Relative path to the sample WAV file of the first
+attack. It may be listed as REF:aa:bb:cc too. In that case, it means
+that this pipe is borrowed from manual aa, first rank of stop bb, the pipe cc.
+It may contain DUMMY, which defines a non-sounding placeholder.
+     </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term>Pipe999Percussive</term>
           <listitem>
             <para>
 (boolean, default: rank percussive setting) If false, the samples are
 played as is (without any loop/release handling)
      </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Pipe999HasIndependentRelease</term>
+          <listitem>
+            <para>
+	      (boolean, default: rank HasIndependentRelease setting). If true
+	      then the release is played independently on the attack.
+	    </para>
+            <para>
+	      If HasIndependentRelease is true then Pipe999Percussive must be
+	      also true and Pipe999ReleaseCount must be greater than 0.
+	    </para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -9996,17 +10033,6 @@ number of cents (in addition to the organ/rank factor).
             <para>
 (integer 0 - 10000, default: 0) Delay introduced by the tracker for
 that pipe.
-     </para>
-          </listitem>
-        </varlistentry>
-        <varlistentry>
-          <term>Pipe999</term>
-          <listitem>
-            <para>
-(string, required) Relative path to the sample WAV file of the first
-attack. It may be listed as REF:aa:bb:cc too. In that case, it means
-that this pipe is borrowed from manual aa, first rank of stop bb, the pipe cc.
-It may contain DUMMY, which defines a non-sounding placeholder.
      </para>
           </listitem>
         </varlistentry>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -7288,7 +7288,7 @@ number of cents.
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>PitchTuning</term>
+          <term>PitchCorrection</term>
           <listitem>
             <para>
 (float -1800 - 1800, default: 0) Correction factor in cent for the pitch
@@ -7304,6 +7304,28 @@ temperaments.
 (integer 0 - 10000, default: 0) Delay introduced by the tracker applied to
 the whole organ.
      </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Percussive</term>
+          <listitem>
+            <para>
+	      (boolean, default false) If true, the samples are played as is
+	      (without any loop/release handling).
+	    </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>HasIndependentRelease</term>
+          <listitem>
+            <para>
+	      (boolean, default false). If true, releases are played
+	      independently of the attacks.
+	    </para>
+            <para>
+	      If HasIndependentRelease is true then Percussive must also be set
+	      to true.
+	    </para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -9913,8 +9935,8 @@ on which the pipes of the are placed.
           <term>Percussive</term>
           <listitem>
             <para>
-	      (boolean, required) If false, the samples are played as is
-	      (without any loop/release handling).
+	      (boolean, default inherited from the Windchest section) If true,
+	      the samples are played as is (without any loop/release handling).
 	    </para>
           </listitem>
         </varlistentry>
@@ -9922,8 +9944,8 @@ on which the pipes of the are placed.
           <term>HasIndependentRelease</term>
           <listitem>
             <para>
-	      (boolean, default false or inherited from the Organ, Windchest or
-	      Rank). If true, releases are played independently of the attacks.
+	      (boolean, default inherited from the Windchest section). If true,
+	      releases are played independently of the attacks.
 	    </para>
             <para>
 	      If HasIndependentRelease is true then Percussive must also be set
@@ -9982,9 +10004,9 @@ It may contain DUMMY, which defines a non-sounding placeholder.
           <term>Pipe999Percussive</term>
           <listitem>
             <para>
-(boolean, default: rank percussive setting) If false, the samples are
-played as is (without any loop/release handling)
-     </para>
+	      (boolean, default: rank Percussive setting) If true, the samples
+	      are played as is (without any loop/release handling)
+	    </para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -10005,7 +10027,7 @@ played as is (without any loop/release handling)
           <listitem>
             <para>
 (float 0 - 1000, default: 100) Linear amplitude scale factor applied to
-the pipe (in addition to the organ/rank factor). 100 means no change.
+the pipe (in addition to the organ/windchest/rank factor). 100 means no change.
      </para>
           </listitem>
         </varlistentry>
@@ -10014,7 +10036,7 @@ the pipe (in addition to the organ/rank factor). 100 means no change.
           <listitem>
             <para>
 (float -120 - 40, default: 0) Amplitude scale factor in dB applied to
-the pipe (in addition to the organ/rank factor). 0 means no change.
+the pipe (in addition to the organ/windchest/rank factor). 0 means no change.
      </para>
           </listitem>
         </varlistentry>
@@ -10023,7 +10045,7 @@ the pipe (in addition to the organ/rank factor). 0 means no change.
           <listitem>
             <para>
 (float -1800 - 1800, default: 0) Retune this pipe the specified
-number of cents (in addition to the organ/rank factor).
+number of cents (in addition to the organ/windchest/rank factor).
      </para>
           </listitem>
         </varlistentry>
@@ -10704,6 +10726,80 @@ influences this windchest.
 (integer 1 - tremulant count, required) Number of a tremulant, which
 influences this windchest.
      </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>AmplitudeLevel</term>
+          <listitem>
+            <para>
+	      (float 0 - 1000, default: 100) Linear amplitude scale factor in
+	      percents applied to the windchest. It is multilied to the
+	      AmplitudeLevel value of the Organ section. 100 means no change.
+	    </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Gain</term>
+          <listitem>
+            <para>
+	      (float -120 - 40, default: 0) Amplitude scale factor in dB applied
+	      to the windchest. It is added to the Gain value of the Organ
+	      section. 0 means no change.
+	    </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>PitchTuning</term>
+          <listitem>
+            <para>
+	      (float -1800 - 1800, default: 0) Retune the windchest by the
+	      specified number of cents. It is added to the PitchTuning value of
+	      the Organ section. 0 means no change. This setting is used only
+	      for the original temperament.
+	    </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>PitchCorrection</term>
+          <listitem>
+            <para>
+	      (float -1800 - 1800, default: 0) Correction factor in cent for the
+	      pitch of the windchest. It is added to the PitchTuning value of
+	      the Organ section. 0 means no change. This setting is used for
+	      retuning to other temperaments.
+	    </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>TrackerDelay</term>
+          <listitem>
+            <para>
+	      (integer 0 - 10000, default: 0) Delay in miliseconds introduced by
+	      the tracker applied to the windchest. It is added to the
+	      TrackerDelay value of the Organ section.
+	    </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Percussive</term>
+          <listitem>
+            <para>
+	      (boolean, default inherited from the Organ section) If true, the
+	      samples are played as is (without any loop/release handling).
+	    </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>HasIndependentRelease</term>
+          <listitem>
+            <para>
+	      (boolean, default inherited from the Organ section). If true,
+	      releases are played independently of the attacks.
+	    </para>
+            <para>
+	      If HasIndependentRelease is true then Percussive must also be set
+	      to true.
+	    </para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -9923,7 +9923,7 @@ on which the pipes of the are placed.
           <listitem>
             <para>
 	      (boolean, default false or inherited from the Organ, Windchest or
-	      Rank). If true than release is played independently on the attack.
+	      Rank). If true, releases are played independently of the attacks.
 	    </para>
             <para>
 	      If HasIndependentRelease is true then Percussive must also be set
@@ -9991,8 +9991,8 @@ played as is (without any loop/release handling)
           <term>Pipe999HasIndependentRelease</term>
           <listitem>
             <para>
-	      (boolean, default: rank HasIndependentRelease setting). If true
-	      then the release is played independently on the attack.
+	      (boolean, default: rank HasIndependentRelease setting). If true,
+	      releases are played independently of attacks in this pipe.
 	    </para>
             <para>
 	      If HasIndependentRelease is true then Pipe999Percussive must be

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -27,6 +27,7 @@ class GOSoundingPipe : public GOPipe,
 private:
   GOOrganModel *p_OrganModel;
   GOSoundSampler *m_Sampler;
+  uint64_t m_LastStart;
   uint64_t m_LastStop;
   int m_Instances;
   bool m_Tremulant;

--- a/src/grandorgue/model/GOWindchest.cpp
+++ b/src/grandorgue/model/GOWindchest.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/model/GOWindchest.cpp
+++ b/src/grandorgue/model/GOWindchest.cpp
@@ -76,7 +76,7 @@ void GOWindchest::Load(GOConfigReader &cfg, wxString group, unsigned index) {
     wxT("Name"),
     false,
     wxString::Format(_("Windchest %d"), index + 1));
-  m_PipeConfig.Init(cfg, group, wxEmptyString);
+  m_PipeConfig.Load(cfg, group, wxEmptyString);
   m_PipeConfig.SetName(GetName());
 }
 

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.cpp
@@ -31,6 +31,8 @@ GOPipeConfig::GOPipeConfig(
     m_BitsPerSample(-1),
     m_Channels(-1),
     m_LoopLoad(-1),
+    m_Percussive(BOOL3_DEFAULT),
+    m_IndependentRelease(BOOL3_DEFAULT),
     m_Compress(BOOL3_DEFAULT),
     m_AttackLoad(BOOL3_DEFAULT),
     m_ReleaseLoad(BOOL3_DEFAULT),
@@ -124,11 +126,15 @@ void GOPipeConfig::Init(
   m_PitchCorrection = 0;
   m_DefaultDelay = 0;
   m_Percussive = BOOL3_DEFAULT;
+  m_IndependentRelease = BOOL3_DEFAULT;
   LoadFromCmb(cfg, group, prefix);
 }
 
 void GOPipeConfig::Load(
-  GOConfigReader &cfg, const wxString &group, const wxString &prefix) {
+  GOConfigReader &cfg,
+  const wxString &group,
+  const wxString &prefix,
+  bool isParentPercussive) {
   m_DefaultAmplitude = cfg.ReadFloat(
     ODFSetting, group, prefix + wxT("AmplitudeLevel"), 0, 1000, false, 100);
   m_DefaultGain = cfg.ReadFloat(
@@ -141,6 +147,10 @@ void GOPipeConfig::Load(
     ODFSetting, group, prefix + wxT("TrackerDelay"), 0, 10000, false, 0);
   m_Percussive = cfg.ReadBooleanTriple(
     ODFSetting, group, prefix + wxT("Percussive"), false);
+  m_IndependentRelease = to_bool(m_Percussive, isParentPercussive)
+    ? cfg.ReadBooleanTriple(
+      ODFSetting, group, prefix + wxT("HasIndependentRelease"), false)
+    : BOOL3_DEFAULT;
   LoadFromCmb(cfg, group, prefix);
 }
 

--- a/src/grandorgue/model/pipe-config/GOPipeConfig.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfig.h
@@ -44,6 +44,7 @@ private:
   int8_t m_Channels;
   int8_t m_LoopLoad;
   GOBool3 m_Percussive;
+  GOBool3 m_IndependentRelease;
   GOBool3 m_Compress;
   GOBool3 m_AttackLoad;
   GOBool3 m_ReleaseLoad;
@@ -88,7 +89,11 @@ public:
 
   // Load default values from the ODF and and load all customizable values from
   // the .cmb
-  void Load(GOConfigReader &cfg, const wxString &group, const wxString &prefix);
+  void Load(
+    GOConfigReader &cfg,
+    const wxString &group,
+    const wxString &prefix,
+    bool isParentPercussive);
 
   // Save all customizable values to the .cmb
   void Save(GOConfigWriter &cfg);
@@ -147,6 +152,8 @@ public:
   GOBool3 GetPercussive() const { return m_Percussive; }
   // does not send notifications
   void SetPercussiveFromInit(GOBool3 value) { m_Percussive = value; }
+
+  GOBool3 GetIndependentRelease() const { return m_IndependentRelease; }
 
   GOBool3 GetCompress() const { return m_Compress; }
   void SetCompress(GOBool3 value) { SetSmallMember(value, m_Compress); }

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp
@@ -43,7 +43,8 @@ void GOPipeConfigNode::Init(
 void GOPipeConfigNode::Load(
   GOConfigReader &cfg, const wxString &group, const wxString &prefix) {
   r_OrganModel.RegisterSaveableObject(this);
-  m_PipeConfig.Load(cfg, group, prefix);
+  m_PipeConfig.Load(
+    cfg, group, prefix, m_parent && m_parent->GetEffectivePercussive());
 }
 
 wxString GOPipeConfigNode::GetEffectiveAudioGroup() const {

--- a/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
+++ b/src/grandorgue/model/pipe-config/GOPipeConfigNode.h
@@ -140,6 +140,13 @@ public:
       (const GOSettingUnsigned GOConfig::*)nullptr);
   }
 
+  bool IsEffectiveIndependentRelease() const {
+    return GetEffectiveBool(
+      &GOPipeConfig::GetIndependentRelease,
+      &GOPipeConfigNode::IsEffectiveIndependentRelease,
+      (const GOSettingUnsigned GOConfig::*)nullptr);
+  }
+
   bool GetEffectiveCompress() const {
     return GetEffectiveBool(
       &GOPipeConfig::GetCompress,

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -112,7 +112,9 @@ public:
     unsigned audio_group,
     unsigned velocity,
     unsigned delay,
-    uint64_t last_stop);
+    uint64_t prevEventTime,
+    bool isRelease = false,
+    uint64_t *pStartTimeSamples = nullptr);
   uint64_t StopSample(const GOSoundProvider *pipe, GOSoundSampler *handle);
   void SwitchSample(const GOSoundProvider *pipe, GOSoundSampler *handle);
   void UpdateVelocity(

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -35,7 +35,7 @@ GOSoundProvider::GOSoundProvider()
   : m_MidiKeyNumber(0),
     m_MidiPitchFract(0),
     m_Tuning(1),
-    m_SampleGroup(0),
+    m_SampleGroup(false),
     m_ReleaseTail(0),
     m_Attack(),
     m_AttackInfo(),
@@ -92,10 +92,6 @@ bool GOSoundProvider::LoadCache(GOMemoryPool &pool, GOCache &cache) {
   }
 
   return true;
-}
-
-void GOSoundProvider::UseSampleGroup(unsigned sample_group) {
-  m_SampleGroup = sample_group;
 }
 
 bool GOSoundProvider::SaveCache(GOCacheWriter &cache) const {
@@ -198,7 +194,7 @@ const GOSoundAudioSection *GOSoundProvider::GetAttack(
     const unsigned idx = (i + x) % m_Attack.size();
     if (
       m_AttackInfo[idx].sample_group != -1
-      && m_AttackInfo[idx].sample_group != m_SampleGroup)
+      && m_AttackInfo[idx].sample_group != (int8_t)m_SampleGroup)
       continue;
     if (m_AttackInfo[idx].min_attack_velocity > velocity)
       continue;

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -61,7 +61,8 @@ public:
   virtual bool LoadCache(GOMemoryPool &pool, GOCache &cache);
   virtual bool SaveCache(GOCacheWriter &cache) const;
 
-  void UseSampleGroup(unsigned sample_group);
+  void UseSampleGroup(bool sampleGroup) { m_SampleGroup = sampleGroup; }
+
   void SetVelocityParameter(float min_volume, float max_volume);
 
   const GOSoundAudioSection *GetAttack(

--- a/src/grandorgue/sound/GOSoundSampler.h
+++ b/src/grandorgue/sound/GOSoundSampler.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/sound/GOSoundSampler.h
+++ b/src/grandorgue/sound/GOSoundSampler.h
@@ -14,8 +14,7 @@
 class GOSoundProvider;
 class GOSoundWindchestWorkItem;
 
-class GOSoundSampler {
-public:
+struct GOSoundSampler {
   GOSoundSampler *next;
   const GOSoundProvider *pipe;
   int sampler_group_id;


### PR DESCRIPTION
Resolves: #1385

This PR introduces the new Pipe999HasIndependentRelease and HasIndependentRelease keys. They are used only with Pipe999Percussive=Y and Percussive=Y.

The main two changes for HasIndependentRelease:
- GOSoundingPipe::VelocityChanged() starts playing a release sample instead of stopping playing the attack sample
- GOSoundEngine::StartSample() now can start a release sample as well as an attack sample depending on the `isRelease` parameter value