### PR TITLE
Changed displaying an organ path in the Organs tab of the Settings dialog https://github.com/GrandOrgue/grandorgue/issues/1663

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -203,6 +203,7 @@ sound/GOSound.cpp
 yaml/GOSaveableToYaml.cpp
 yaml/go-wx-yaml.cpp
 wxcontrols/GOAudioGauge.cpp
+wxcontrols/GOGrid.cpp
 wxcontrols/GORightVisiblePicker.cpp
 GOAudioRecorder.cpp
 GOBitmapCache.cpp

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
@@ -30,6 +30,7 @@
 #include "config/GOConfig.h"
 #include "dialogs/midi-event/GOMidiEventDialog.h"
 #include "files/GOStdFileName.h"
+#include "wxcontrols/GOGrid.h"
 
 #include "GOOrgan.h"
 #include "GOOrganController.h"
@@ -63,16 +64,18 @@ GOSettingsOrgans::GOSettingsOrgans(
   wxGridBagSizer *const gbSizer = new wxGridBagSizer(5, 5);
 
   m_GridOrgans
-    = new wxGrid(this, ID_ORGANS, wxDefaultPosition, wxSize(100, 40));
+    = new GOGrid(this, ID_ORGANS, wxDefaultPosition, wxSize(100, 40));
   m_GridOrgans->CreateGrid(0, GRID_N_COLS, wxGrid::wxGridSelectRows);
+  m_GridOrgans->HideRowLabels();
+  m_GridOrgans->EnableEditing(false);
   m_GridOrgans->SetColSize(GRID_COL_NAME, 200);
   m_GridOrgans->SetColLabelValue(GRID_COL_NAME, _("Name"));
   m_GridOrgans->SetColSize(GRID_COL_MIDI, 50);
   m_GridOrgans->SetColLabelValue(GRID_COL_MIDI, _("MIDI"));
   m_GridOrgans->SetColSize(GRID_COL_PATH, 300);
   m_GridOrgans->SetColLabelValue(GRID_COL_PATH, _("Path"));
-  m_GridOrgans->HideRowLabels();
-  m_GridOrgans->EnableEditing(false);
+  m_GridOrgans->SetColumnRightVisible(GRID_COL_PATH, true);
+
   gbSizer->Add(
     m_GridOrgans, wxGBPosition(0, 0), wxGBSpan(1, 4), wxALL | wxEXPAND, 5);
 
@@ -309,8 +312,6 @@ void GOSettingsOrgans::FillGridRow(unsigned rowN, OrganSlot &organSlot) {
   m_GridOrgans->SetCellValue(rowN, GRID_COL_NAME, title);
   DisplayMidiCell(rowN, o);
   DisplayPathCell(rowN, organSlot.m_CurrentPath);
-  m_GridOrgans->SetCellAlignment(
-    rowN, GRID_COL_PATH, wxALIGN_RIGHT, wxALIGN_TOP);
 }
 
 bool GOSettingsOrgans::TransferDataToWindow() {

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
@@ -50,6 +50,8 @@ EVT_BUTTON(ID_DEL_CACHE, GOSettingsOrgans::OnDelCache)
 EVT_BUTTON(ID_DEL_PRESET, GOSettingsOrgans::OnDelPreset)
 END_EVENT_TABLE()
 
+enum { GRID_COL_NAME = 0, GRID_COL_MIDI, GRID_COL_PATH, GRID_N_COLS };
+
 GOSettingsOrgans::GOSettingsOrgans(
   GOConfig &settings, GOMidi &midi, wxWindow *parent)
   : wxPanel(parent, wxID_ANY),
@@ -62,13 +64,13 @@ GOSettingsOrgans::GOSettingsOrgans(
 
   m_GridOrgans
     = new wxGrid(this, ID_ORGANS, wxDefaultPosition, wxSize(100, 40));
-  m_GridOrgans->CreateGrid(0, 3, wxGrid::wxGridSelectRows);
-  m_GridOrgans->SetColLabelValue(0, _("Name"));
-  m_GridOrgans->SetColLabelValue(1, _("MIDI"));
-  m_GridOrgans->SetColLabelValue(2, _("Path"));
-  m_GridOrgans->SetColSize(0, 200);
-  m_GridOrgans->SetColSize(1, 50);
-  m_GridOrgans->SetColSize(2, 300);
+  m_GridOrgans->CreateGrid(0, GRID_N_COLS, wxGrid::wxGridSelectRows);
+  m_GridOrgans->SetColSize(GRID_COL_NAME, 200);
+  m_GridOrgans->SetColLabelValue(GRID_COL_NAME, _("Name"));
+  m_GridOrgans->SetColSize(GRID_COL_MIDI, 50);
+  m_GridOrgans->SetColLabelValue(GRID_COL_MIDI, _("MIDI"));
+  m_GridOrgans->SetColSize(GRID_COL_PATH, 300);
+  m_GridOrgans->SetColLabelValue(GRID_COL_PATH, _("Path"));
   m_GridOrgans->HideRowLabels();
   m_GridOrgans->EnableEditing(false);
   gbSizer->Add(
@@ -218,7 +220,7 @@ GOSettingsOrgans::GOSettingsOrgans(
 
 using StringSet = std::unordered_set<wxString, wxStringHash, wxStringEqual>;
 
-StringSet collect_hashes_from_organ_files(
+static StringSet collect_hashes_from_organ_files(
   const wxString &dirPath, const wxString &pattern) {
   StringSet hashSet;
   wxArrayString files;
@@ -283,12 +285,12 @@ GOSettingsOrgans::PackageSlotSet GOSettingsOrgans::GetUsedPackages(
 void GOSettingsOrgans::DisplayMidiCell(unsigned rowN, GOOrgan *pOrgan) {
   m_GridOrgans->SetCellValue(
     rowN,
-    1,
+    GRID_COL_MIDI,
     pOrgan->GetMIDIReceiver().GetEventCount() > 0 ? _("Yes") : _("No"));
 }
 
 void GOSettingsOrgans::DisplayPathCell(unsigned rowN, const wxString &path) {
-  m_GridOrgans->SetCellValue(rowN, 2, path);
+  m_GridOrgans->SetCellValue(rowN, GRID_COL_PATH, path);
 }
 
 void GOSettingsOrgans::FillGridRow(unsigned rowN, OrganSlot &organSlot) {
@@ -304,10 +306,11 @@ void GOSettingsOrgans::FillGridRow(unsigned rowN, OrganSlot &organSlot) {
 
   m_OrganSlotPtrsByGridLine[rowN] = &organSlot;
 
-  m_GridOrgans->SetCellValue(rowN, 0, title);
+  m_GridOrgans->SetCellValue(rowN, GRID_COL_NAME, title);
   DisplayMidiCell(rowN, o);
   DisplayPathCell(rowN, organSlot.m_CurrentPath);
-  m_GridOrgans->SetCellAlignment(rowN, 2, wxALIGN_RIGHT, wxALIGN_TOP);
+  m_GridOrgans->SetCellAlignment(
+    rowN, GRID_COL_PATH, wxALIGN_RIGHT, wxALIGN_TOP);
 }
 
 bool GOSettingsOrgans::TransferDataToWindow() {

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
@@ -385,10 +385,11 @@ bool GOSettingsOrgans::TransferDataToWindow() {
   return true;
 }
 
-void GOSettingsOrgans::RefreshFocused() {
-  const int currOrganIndex = m_GridOrgans->GetGridCursorRow();
-  const OrganSlot *pSlot
-    = currOrganIndex >= 0 ? m_OrganSlotPtrsByGridLine[currOrganIndex] : nullptr;
+void GOSettingsOrgans::RefreshFocused(const int currOrganIndex) {
+  const OrganSlot *pSlot = currOrganIndex >= 0
+      && currOrganIndex < (int)m_OrganSlotPtrsByGridLine.size()
+    ? m_OrganSlotPtrsByGridLine[currOrganIndex]
+    : nullptr;
   const GOOrgan *o = pSlot ? pSlot->p_CurrentOrgan : NULL;
   const bool isPackage = pSlot && pSlot->is_packaged;
   const GOArchiveFile *a = isPackage && pSlot->p_PackageSlot
@@ -427,7 +428,7 @@ void GOSettingsOrgans::OnCharHook(wxKeyEvent &ev) {
 }
 
 void GOSettingsOrgans::OnOrganSelectCell(wxGridEvent &event) {
-  RefreshFocused();
+  RefreshFocused(event.GetRow());
   RefreshButtons();
 }
 
@@ -604,7 +605,7 @@ void GOSettingsOrgans::DelSelectedOrgans() {
           m_PackageSlotByPath.erase(pkgSlot->p_CurrentPkg->GetPath());
         }
 
-        RefreshFocused();
+        RefreshFocused(m_GridOrgans->GetGridCursorRow());
       }
     }
   }
@@ -759,7 +760,7 @@ void GOSettingsOrgans::OnOrganRelocate(wxCommandEvent &event) {
               ReplaceOrganPath(i, newPath);
         } else {
           ReplaceOrganPath(currOrganIndex, newPath);
-          RefreshFocused();
+          RefreshFocused(m_GridOrgans->GetGridCursorRow());
         }
       }
     }

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
@@ -109,10 +109,12 @@ private:
   void RefreshButtons();
   VisibleOrganRecs GetCurrentOrganRecs();
 
+  void DisplayMidiCell(unsigned rowN, GOOrgan *pOrgan);
+  void DisplayPathCell(unsigned rowN, const wxString &path);
   void FillGridRow(unsigned rowN, OrganSlot &organSlot);
   void ReorderOrgans(const VisibleOrganRecs &newSortedRecs);
   void DelSelectedOrgans();
-  void ReplaceOrganPath(const long index, const wxString &newPath);
+  void ReplaceOrganPath(const unsigned index, const wxString &newPath);
 
   void OnCharHook(wxKeyEvent &ev);
 

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
@@ -105,7 +105,7 @@ private:
   PackageSlotSet GetUsedPackages(
     std::unordered_set<unsigned> itemsToExtract
     = std::unordered_set<unsigned>());
-  void RefreshFocused();
+  void RefreshFocused(const int currOrganIndex);
   void RefreshButtons();
   VisibleOrganRecs GetCurrentOrganRecs();
 

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -18,8 +18,9 @@
 
 class GOMidi;
 class wxButton;
-class wxListEvent;
-class wxListView;
+class wxGrid;
+class wxGridEvent;
+class wxGridRangeSelectEvent;
 class wxTextCtrl;
 
 class GOArchiveFile;
@@ -63,7 +64,7 @@ private:
   using OrganSlotToLongMap
     = std::unordered_map<const GOSettingsOrgans::OrganSlot *, long>;
   struct VisibleOrganRec {
-    const OrganSlot *p_OrganSlot;
+    OrganSlot *p_OrganSlot;
     bool is_selected;
     bool is_focused;
   };
@@ -78,10 +79,11 @@ private:
   std::unordered_map<const wxString, PackageSlot *, wxStringHash, wxStringEqual>
     m_PackageSlotByPath;
   std::vector<OrganSlot> m_OrganSlots;
+  std::vector<OrganSlot *> m_OrganSlotPtrsByGridLine;
   std::unordered_map<const wxString, OrganSlot *, wxStringHash, wxStringEqual>
     m_OrganSlotByPath;
 
-  wxListView *m_Organs;
+  wxGrid *m_GridOrgans;
   wxTextCtrl *m_Builder;
   wxTextCtrl *m_Recording;
   wxTextCtrl *m_OrganHash;
@@ -101,22 +103,21 @@ private:
   wxButton *m_DelPreset;
 
   PackageSlotSet GetUsedPackages(
-    std::unordered_set<long> itemsToExtract = std::unordered_set<long>());
+    std::unordered_set<unsigned> itemsToExtract
+    = std::unordered_set<unsigned>());
   void RefreshFocused();
   void RefreshButtons();
   VisibleOrganRecs GetCurrentOrganRecs();
 
-  static int wxCALLBACK
-  organOrdCompareCallback(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData);
-
+  void FillGridRow(unsigned rowN, OrganSlot &organSlot);
   void ReorderOrgans(const VisibleOrganRecs &newSortedRecs);
   void DelSelectedOrgans();
   void ReplaceOrganPath(const long index, const wxString &newPath);
 
   void OnCharHook(wxKeyEvent &ev);
 
-  void OnOrganFocused(wxListEvent &event);
-  void OnOrganSelected(wxListEvent &event);
+  void OnOrganSelectCell(wxGridEvent &event);
+  void OnOrganRangeSelect(wxGridRangeSelectEvent &event);
   void OnOrganUp(wxCommandEvent &event);
   void OnOrganDown(wxCommandEvent &event);
   void OnOrganTop(wxCommandEvent &event);

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
@@ -18,13 +18,13 @@
 
 class GOMidi;
 class wxButton;
-class wxGrid;
 class wxGridEvent;
 class wxGridRangeSelectEvent;
 class wxTextCtrl;
 
 class GOArchiveFile;
 class GOConfig;
+class GOGrid;
 class GOOrgan;
 
 class GOSettingsOrgans : public wxPanel {
@@ -83,7 +83,7 @@ private:
   std::unordered_map<const wxString, OrganSlot *, wxStringHash, wxStringEqual>
     m_OrganSlotByPath;
 
-  wxGrid *m_GridOrgans;
+  GOGrid *m_GridOrgans;
   wxTextCtrl *m_Builder;
   wxTextCtrl *m_Recording;
   wxTextCtrl *m_OrganHash;

--- a/src/grandorgue/wxcontrols/GOGrid.cpp
+++ b/src/grandorgue/wxcontrols/GOGrid.cpp
@@ -184,6 +184,11 @@ GOGrid::GOGrid(
   : wxGrid(parent, id, pos, size, style, name),
     p_RightVisibleRenderer(new RightVisibleCellRenderer()) {}
 
+GOGrid::~GOGrid() {
+  // force deleting p_RightVisibleRenderer after deletion of all columns
+  p_RightVisibleRenderer->DecRef();
+}
+
 bool GOGrid::IsColumnRightVisible(unsigned colN) const {
   return colN < m_AreColumnsRightVisible.size()
     && m_AreColumnsRightVisible[colN];

--- a/src/grandorgue/wxcontrols/GOGrid.cpp
+++ b/src/grandorgue/wxcontrols/GOGrid.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOGrid.h"
+
+#include <wx/dc.h>
+
+class RightVisibleCellRenderer : public wxGridCellStringRenderer {
+  virtual void Draw(
+    wxGrid &grid,
+    wxGridCellAttr &attr,
+    wxDC &dc,
+    const wxRect &rectCell,
+    int row,
+    int col,
+    bool isSelected) override;
+};
+
+static size_t clamp(size_t v, size_t l, size_t u) {
+  // std::clamp in C++17
+  return v < l ? l : v > u ? u : v;
+}
+
+static wxString truncate_line_left(
+  wxDC &dc, const wxString &line, wxCoord targetWidth) {
+  // Measure line
+  wxCoord lineWidth, lineHeight;
+  dc.GetTextExtent(line, &lineWidth, &lineHeight);
+  if (lineWidth <= targetWidth || line.empty()) {
+    return line;
+  }
+  // Need to truncate
+  wxString ellipsis(wxT("..."));
+  wxCoord ellipsisW, ellipsisH;
+  dc.GetTextExtent(ellipsis, &ellipsisW, &ellipsisH);
+  if (ellipsisW > targetWidth) {
+    while (ellipsisW > targetWidth && ellipsis.size() >= 1) {
+      ellipsis = ellipsis.Mid(1);
+      dc.GetTextExtent(ellipsis, &ellipsisW, &ellipsisH);
+    }
+    return ellipsis;
+  }
+  // Find the number of first characters to remove
+  // Invariant: l is too low (lW > targetWidth), u is enough (uW <= targetWidth)
+  size_t l = 0, u = line.size();
+  wxCoord lW = lineWidth, uW = ellipsisW;
+  while (l + 1 < u) {
+    // Heuristic: consider average character width
+    wxCoord avgCharW = (lW - uW) / (u - l);
+    size_t mid = avgCharW != 0
+      ? clamp(l + (lW - targetWidth) / avgCharW, l + 1, u - 1)
+      : (l + u) / 2;
+    wxCoord midW, midH;
+    wxString midLine = ellipsis + line.Mid(mid);
+    dc.GetTextExtent(midLine, &midW, &midH);
+    if (midW <= targetWidth) {
+      u = mid;
+      uW = midW;
+    } else {
+      l = mid;
+      lW = midW;
+    }
+  }
+  return ellipsis + line.Mid(u);
+}
+
+static void draw_text_rectangle(
+  wxGrid &grid,
+  wxDC &dc,
+  const wxArrayString &lines,
+  const wxRect &rect,
+  int horizAlign,
+  int vertAlign) {
+  // Based on wxGrid::DrawTextRectangle(wxDC, wxArrayString, ...).
+  // Simplified for HORIZONTAL text orientation
+  if (lines.empty()) {
+    return;
+  }
+
+  // from anonymous namespace in grid.cpp
+  const int GRID_TEXT_MARGIN = 1;
+
+  wxDCClipper clip(dc, rect);
+  long textWidth, textHeight;
+  grid.GetTextBoxSize(dc, lines, &textWidth, &textHeight);
+
+  int x = 0, y = 0;
+  switch (vertAlign) {
+  case wxALIGN_BOTTOM:
+    y = rect.y + (rect.height - textHeight - GRID_TEXT_MARGIN);
+    break;
+  case wxALIGN_CENTRE:
+    y = rect.y + ((rect.height - textHeight) / 2);
+    break;
+  case wxALIGN_TOP:
+  default:
+    y = rect.y + GRID_TEXT_MARGIN;
+    break;
+  }
+
+  size_t nLines = lines.GetCount();
+  for (size_t l = 0; l < nLines; l++) {
+    const wxString &line = lines[l];
+    if (line.empty()) {
+      y += dc.GetCharHeight();
+      continue;
+    }
+    wxCoord lineWidth = 0, lineHeight = 0;
+    dc.GetTextExtent(line, &lineWidth, &lineHeight);
+
+    switch (horizAlign) {
+    case wxALIGN_RIGHT:
+      x = rect.x + (rect.width - lineWidth - GRID_TEXT_MARGIN);
+      break;
+    case wxALIGN_CENTRE:
+      x = rect.x + ((rect.width - lineWidth) / 2);
+      if (textWidth > rect.width) {
+        // if text box is too wide, prefer showing its right part
+        x -= (textWidth - rect.width) / 2;
+      }
+      break;
+    case wxALIGN_LEFT:
+    default:
+      x = rect.x + GRID_TEXT_MARGIN;
+      if (textWidth > rect.width) {
+        // if text box is too wide, prefer showing its right part
+        x -= textWidth - rect.width;
+      }
+      break;
+    }
+
+    if (x >= rect.x) {
+      // Text fits
+      dc.DrawText(line, x, y);
+    } else {
+      wxCoord availableWidth = std::min(rect.width, x + lineWidth - rect.x);
+      wxString truncatedLine = truncate_line_left(dc, line, availableWidth);
+      wxCoord truncatedLineW, truncatedLineH;
+      dc.GetTextExtent(truncatedLine, &truncatedLineW, &truncatedLineH);
+      x += lineWidth - truncatedLineW;
+      dc.DrawText(truncatedLine, x, y);
+    }
+    y += lineHeight;
+  }
+}
+
+void RightVisibleCellRenderer::Draw(
+  wxGrid &grid,
+  wxGridCellAttr &attr,
+  wxDC &dc,
+  const wxRect &rectCell,
+  int row,
+  int col,
+  bool isSelected) {
+  /* Based on wxGridCellStringRenderer::Draw with overflow-related code
+   * removed */
+  // Erase background
+  wxGridCellRenderer::Draw(grid, attr, dc, rectCell, row, col, isSelected);
+
+  // Prepare for rendering text
+  SetTextColoursAndFont(grid, attr, dc, isSelected);
+  wxArrayString lines;
+  grid.StringToLines(grid.GetCellValue(row, col), lines);
+  int horizAlign, vertAlign;
+  attr.GetAlignment(&horizAlign, &vertAlign);
+
+  // Render text
+  wxRect rect = rectCell;
+  rect.Inflate(-1);
+  draw_text_rectangle(grid, dc, lines, rect, horizAlign, vertAlign);
+}
+
+GOGrid::GOGrid(
+  wxWindow *parent,
+  wxWindowID id,
+  const wxPoint &pos,
+  const wxSize &size,
+  long style,
+  const wxString &name)
+  : wxGrid(parent, id, pos, size, style, name),
+    p_RightVisibleRenderer(new RightVisibleCellRenderer()) {}
+
+bool GOGrid::IsColumnRightVisible(unsigned colN) const {
+  return colN < m_AreColumnsRightVisible.size()
+    && m_AreColumnsRightVisible[colN];
+}
+
+void GOGrid::SetColumnRightVisible(unsigned colN, bool isRightVisible) {
+  // ensure that m_AreColumnsRightVisible contains colN
+  while (m_AreColumnsRightVisible.size() <= colN)
+    m_AreColumnsRightVisible.push_back(false);
+  m_AreColumnsRightVisible[colN] = isRightVisible;
+}
+
+wxGridCellRenderer *GOGrid::GetDefaultRendererForCell(int row, int col) const {
+  wxGridCellRenderer *pRenderer;
+
+  if (IsColumnRightVisible(col)) {
+    p_RightVisibleRenderer->IncRef();
+    pRenderer = p_RightVisibleRenderer;
+  } else
+    pRenderer = wxGrid::GetDefaultRendererForCell(row, col);
+  return pRenderer;
+}

--- a/src/grandorgue/wxcontrols/GOGrid.h
+++ b/src/grandorgue/wxcontrols/GOGrid.h
@@ -25,6 +25,7 @@ public:
     const wxSize &size = wxDefaultSize,
     long style = wxWANTS_CHARS,
     const wxString &name = wxGridNameStr);
+  virtual ~GOGrid();
 
   bool IsColumnRightVisible(unsigned colN) const;
   void SetColumnRightVisible(unsigned colN, bool isRightVisible);

--- a/src/grandorgue/wxcontrols/GOGrid.h
+++ b/src/grandorgue/wxcontrols/GOGrid.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOGRID_H
+#define GOGRID_H
+
+#include <vector>
+
+#include <wx/grid.h>
+
+class GOGrid : public wxGrid {
+private:
+  wxGridCellStringRenderer *p_RightVisibleRenderer;
+  std::vector<bool> m_AreColumnsRightVisible;
+
+public:
+  GOGrid(
+    wxWindow *parent,
+    wxWindowID id,
+    const wxPoint &pos = wxDefaultPosition,
+    const wxSize &size = wxDefaultSize,
+    long style = wxWANTS_CHARS,
+    const wxString &name = wxGridNameStr);
+
+  bool IsColumnRightVisible(unsigned colN) const;
+  void SetColumnRightVisible(unsigned colN, bool isRightVisible);
+
+  virtual wxGridCellRenderer *GetDefaultRendererForCell(
+    int row, int col) const override;
+};
+
+#endif /* GOGRID_H */


### PR DESCRIPTION
This is the second PR related to #1663.

This PR switches displaying to the right part of path instead the left one.

Because `wxListView` does not have such capability, I replaced it with `wxGrid` and I rewrote most of methods manipulating this list.

But `wxGrid` can not store a custom item data. So I introduced the`GOSettingsOrgan::m_OrganSlotPtrsByGridLine` for this purpose.