### PR TITLE
Added a github build for MacOs/arm64 https://github.com/GrandOrgue/grandorgue/discussions/1153

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,11 @@ jobs:
             prepare: osx
             build_on: osx
 
+          - run_on: macos-14
+            for: osx
+            prepare: osx
+            build_on: osx
+
           - run_on: ubuntu-latest
             for: win64
             prepare: "debian-based"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,11 +113,13 @@ jobs:
             build_on: linux
             pkg_suffix: wx32
 
+          # A build for MacOs/x86_64
           - run_on: macos-12
             for: osx
             prepare: osx
             build_on: osx
 
+          # A build for MacOs/arm64
           - run_on: macos-14
             for: osx
             prepare: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added a github build for MacOs/M1 https://github.com/GrandOrgue/grandorgue/discussions/1153
 - Fixed different encoding of combination .yaml files on Windows, Linux and MacOS https://github.com/GrandOrgue/grandorgue/issues/1818
 - Added support of "Couple Through" mode of Virtual Couplers https://github.com/GrandOrgue/grandorgue/issues/1657
 - Added capability of loading only GUI panels without audio samples by specifying the "-g" switch from the command line https://github.com/GrandOrgue/grandorgue/issues/1602


### PR DESCRIPTION
This PR adds building GrandOrgue for MacOs/arm64.

Unfortunally I cannot test it because I don't have an apple/M1 device. So if something doesn't work on M1/M2, it will be fixed in separate issues.