### PR TITLE
Rewrote GOSelectOrganDialog with the GOSimpleDialog

### DIFF
--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -18,6 +18,7 @@
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
 #include <wx/splash.h>
+#include <wx/textctrl.h>
 #include <wx/toolbar.h>
 
 #include <algorithm>
@@ -849,10 +850,10 @@ void GOFrame::OnLoadRecent(wxCommandEvent &event) {
 }
 
 void GOFrame::OnLoad(wxCommandEvent &event) {
-  GOSelectOrganDialog dlg(this, _("Select organ to load"), m_config);
-  if (dlg.ShowModal() != wxID_OK)
-    return;
-  Open(*dlg.GetSelection());
+  GOSelectOrganDialog dlg(this, m_config);
+
+  if (dlg.ShowModal() == wxID_OK)
+    Open(*dlg.GetSelection());
 }
 
 void GOFrame::OnOpen(wxCommandEvent &event) {

--- a/src/grandorgue/dialogs/GOSelectOrganDialog.cpp
+++ b/src/grandorgue/dialogs/GOSelectOrganDialog.cpp
@@ -17,6 +17,8 @@
 #include "GOOrgan.h"
 #include "GOOrganList.h"
 
+enum { ID_ORGANS = 200 };
+
 BEGIN_EVENT_TABLE(GOSelectOrganDialog, GOSimpleDialog)
 EVT_LIST_ITEM_ACTIVATED(ID_ORGANS, GOSelectOrganDialog::OnDoubleClick)
 END_EVENT_TABLE()

--- a/src/grandorgue/dialogs/GOSelectOrganDialog.cpp
+++ b/src/grandorgue/dialogs/GOSelectOrganDialog.cpp
@@ -1,34 +1,35 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
 #include "GOSelectOrganDialog.h"
 
+#include <wx/listctrl.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 
+#include "archive/GOArchiveFile.h"
+#include "config/GOConfig.h"
+
 #include "GOOrgan.h"
 #include "GOOrganList.h"
-#include "archive/GOArchiveFile.h"
 
-BEGIN_EVENT_TABLE(GOSelectOrganDialog, wxDialog)
-EVT_BUTTON(wxID_OK, GOSelectOrganDialog::OnOK)
+BEGIN_EVENT_TABLE(GOSelectOrganDialog, GOSimpleDialog)
 EVT_LIST_ITEM_ACTIVATED(ID_ORGANS, GOSelectOrganDialog::OnDoubleClick)
 END_EVENT_TABLE()
 
-GOSelectOrganDialog::GOSelectOrganDialog(
-  wxWindow *parent, wxString title, const GOOrganList &organList)
-  : wxDialog(
-    NULL,
-    wxID_ANY,
-    title,
-    wxDefaultPosition,
-    wxSize(600, 480),
-    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxDIALOG_NO_PARENT),
-    m_OrganList(organList) {
+GOSelectOrganDialog::GOSelectOrganDialog(wxWindow *parent, GOConfig &config)
+  : GOSimpleDialog(
+    nullptr,
+    wxT("Load"),
+    _("Select organ to load"),
+    config.m_DialogSizes,
+    wxEmptyString,
+    wxDIALOG_NO_PARENT),
+    r_OrganList(config) {
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   topSizer->AddSpacer(5);
 
@@ -48,23 +49,20 @@ GOSelectOrganDialog::GOSelectOrganDialog(
   m_Organs->SetColumnWidth(2, 300);
 
   topSizer->AddSpacer(5);
-  topSizer->Add(
-    CreateButtonSizer(wxOK | wxCANCEL), 0, wxALIGN_RIGHT | wxALL, 5);
-
-  SetSizerAndFit(topSizer);
+  LayoutWithInnerSizer(topSizer);
 }
 
 bool GOSelectOrganDialog::TransferDataToWindow() {
-  for (unsigned i = 0, j = 0; j < m_OrganList.GetOrganList().size(); j++) {
-    const GOOrgan *o = m_OrganList.GetOrganList()[j];
+  for (unsigned i = 0, j = 0; j < r_OrganList.GetOrganList().size(); j++) {
+    const GOOrgan *o = r_OrganList.GetOrganList()[j];
 
-    if (o->IsUsable(m_OrganList)) {
+    if (o->IsUsable(r_OrganList)) {
       const bool isArchive = o->GetArchiveID() != wxEmptyString;
 
       m_Organs->InsertItem(i, o->GetChurchName());
       m_Organs->SetItemPtrData(i, (wxUIntPtr)o);
       if (isArchive) {
-        const GOArchiveFile *a = m_OrganList.GetArchiveByID(o->GetArchiveID());
+        const GOArchiveFile *a = r_OrganList.GetArchiveByID(o->GetArchiveID());
 
         m_Organs->SetItem(i, 1, a ? a->GetName() : o->GetArchiveID());
       }
@@ -76,20 +74,18 @@ bool GOSelectOrganDialog::TransferDataToWindow() {
   return true;
 }
 
-void GOSelectOrganDialog::OnOK(wxCommandEvent &event) {
-  if (m_Organs->GetItemData(m_Organs->GetFirstSelected()) == 0) {
+bool GOSelectOrganDialog::Validate() {
+  bool isValid = true;
+  long index = m_Organs->GetFirstSelected();
+
+  if (index < 0 || !m_Organs->GetItemData(index)) {
     wxMessageBox(
       _("Please select an organ"), _("Error"), wxOK | wxICON_ERROR, this);
-    return;
+    isValid = false;
   }
-  EndModal(wxID_OK);
+  return isValid;
 }
 
 const GOOrgan *GOSelectOrganDialog::GetSelection() {
   return (const GOOrgan *)m_Organs->GetItemData(m_Organs->GetFirstSelected());
-}
-
-void GOSelectOrganDialog::OnDoubleClick(wxListEvent &event) {
-  wxCommandEvent e;
-  OnOK(event);
 }

--- a/src/grandorgue/dialogs/GOSelectOrganDialog.h
+++ b/src/grandorgue/dialogs/GOSelectOrganDialog.h
@@ -24,8 +24,6 @@ private:
   const GOOrganList &r_OrganList;
   wxListView *m_Organs;
 
-  enum { ID_ORGANS = 200 };
-
   bool Validate() override;
 
   void OnDoubleClick(wxListEvent &event) { CloseAdvanced(wxID_OK); }

--- a/src/grandorgue/dialogs/GOSelectOrganDialog.h
+++ b/src/grandorgue/dialogs/GOSelectOrganDialog.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,25 +8,30 @@
 #ifndef GOSELECTORGANDIALOG_H_
 #define GOSELECTORGANDIALOG_H_
 
-#include <wx/dialog.h>
-#include <wx/listctrl.h>
+#include <wx/event.h>
 
+#include "common/GOSimpleDialog.h"
+
+class wxListEvent;
+class wxListView;
+
+class GOConfig;
 class GOOrgan;
 class GOOrganList;
 
-class GOSelectOrganDialog : public wxDialog {
+class GOSelectOrganDialog : public GOSimpleDialog {
 private:
-  const GOOrganList &m_OrganList;
+  const GOOrganList &r_OrganList;
   wxListView *m_Organs;
 
   enum { ID_ORGANS = 200 };
 
-  void OnOK(wxCommandEvent &event);
-  void OnDoubleClick(wxListEvent &event);
+  bool Validate() override;
+
+  void OnDoubleClick(wxListEvent &event) { CloseAdvanced(wxID_OK); }
 
 public:
-  GOSelectOrganDialog(
-    wxWindow *parent, wxString title, const GOOrganList &organList);
+  GOSelectOrganDialog(wxWindow *parent, GOConfig &config);
 
   bool TransferDataToWindow() override;
 


### PR DESCRIPTION
This is a preparatory PR for the next commit for #1663

This PR reimplementing the Organ Selection dialog with `GOSelectOrganDialog`.

As a result
- it receives the right icon
- it's position and size are stored
- it receives the `Help` button