### PR TITLE
Fixed loading controller without GOSetter

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -123,6 +123,7 @@ GOOrganController::GOOrganController(
     m_MainWindowData(this, wxT("MainWindow")) {
   GOOrganModel::SetMidiDialogCreator(pMidiDialogCreator);
   GOOrganModel::SetModelModificationListener(this);
+  m_setter = new GOSetter(this);
   m_pool.SetMemoryLimit(m_config.MemoryLimit() * 1024 * 1024);
 }
 
@@ -248,7 +249,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   // It must be created before GOOrganModel::Load because lots of objects
   // reference to it
-  m_setter = new GOSetter(this);
   GOOrganModel::SetCombinationController(m_setter);
   m_elementcreators.push_back(m_setter);
 

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -1213,7 +1213,8 @@ void GOSetter::SetTranspose(int value) {
 }
 
 void GOSetter::UpdateModified(bool modified) {
-  m_buttons[ID_SETTER_SAVE_SETTINGS]->Display(modified);
+  if (m_buttons.size())
+    m_buttons[ID_SETTER_SAVE_SETTINGS]->Display(modified);
 }
 
 GOEnclosure *GOSetter::GetEnclosure(const wxString &name, bool is_panel) {


### PR DESCRIPTION
As the controller methods should access to Modifiers like 'SetOrganModified', GOSetter object should be initialized without calling ReadConfigFile() method


Following https://github.com/GrandOrgue/grandorgue/pull/1268#discussion_r1500375471