### PR TITLE
Added using a pre-commit hook to automatically update the years in copyright headers of the source files

### DIFF
--- a/.copyright-updater.yaml
+++ b/.copyright-updater.yaml
@@ -1,0 +1,2 @@
+pattern: ' Copyright {years} GrandOrgue contributors (see AUTHORS)'
+ignore_commits_before: 2024-01-01

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
+          # load full history for nanoufo/copyright-hook pre-commit hook
           fetch-depth: 0
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
       - id: clang-format
         args: [--style=file, -i]
   - repo: https://github.com/nanoufo/copyright-hook
-    rev: e1c3332dfcb4afa9f3c69db2da8f269984bce38f
+    rev: v1.1.0
     hooks:
       - id: update-copyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,7 @@ repos:
     hooks:
       - id: clang-format
         args: [--style=file, -i]
+  - repo: https://github.com/nanoufo/copyright-hook
+    rev: e1c3332dfcb4afa9f3c69db2da8f269984bce38f
+    hooks:
+      - id: update-copyright


### PR DESCRIPTION
I have developed [a tool for updating copyright headers](https://github.com/nanoufo/copyright-hook).

It is a unique tool that:
1. is written in Python, so it does not require the installation of any additional dependencies as pre-commit is also written in Python.
2. capable of examining the old git history to detect files where the copyright years remain outdated.
3. is fast. My tool does not launch a separate git subprocess for each file. On my computer, it analyzes the entire GO git history in just 2 seconds, with only 0.3 seconds needed to analyze the history for the year 2024.
4. does not categorize file movements as modifications.
5. enables users to 'forget' about incorrect years in copyright headers for files last modified before a specified date.

My previous pull request, #1834, was generated using this tool. This pull request adds the execution of this tool to pre-commit hooks.