### PR TITLE
Switched to the c++17 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -30,6 +30,10 @@ elseif(NOT BUILD_VERSION)
 endif()
 
 set(FULL_VERSION "${PROJECT_VERSION}-${BUILD_VERSION}")
+
+# Define a c++ standard
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard whose features are requested to build this project")
 
 # Build configuration options
 option(RTAUDIO_USE_CORE       "Enable RtAudio support for Core Audio (Rt and PortAudio - OS X only)" ON)
@@ -67,8 +71,6 @@ include(${CMAKE_SOURCE_DIR}/cmake/AddCXXOption.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/FindTools.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/BuildLibrary.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/BuildExecutable.cmake)
-
-add_cxx_option(-std=c++11)
 
 IF (APPLE)
   set(BININSTDIR "${PROJECT_NAME}.app/Contents/MacOS")

--- a/src/grandorgue/dialogs/GOSplash.h
+++ b/src/grandorgue/dialogs/GOSplash.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -15,7 +15,7 @@
 
 class GOSplashBitmap;
 
-class GOSplash : private wxDialog, private GODialogCloser {
+class GOSplash : public wxDialog, private GODialogCloser {
 private:
   GOSplashBitmap *m_Image;
   wxTimer m_Timer;


### PR DESCRIPTION
Last time I have been aught to reimplement some standard library functions that are already present in a newer c++ standards. It would be better to use their standard implementation instead.

So I switched GrandOrgue to the c++17. It is fully supported in GCC 9 shiped with ubuntu 20, where GitHub builds occur.

It is still able to build locally with an older c++ passing `-CMAKE_CXX_STANDARD 11` to cmake unless the c++17 features are actually used in the code.