### PR TITLE
Added capability of saving column sizes in Settings/Organs

### DIFF
--- a/src/grandorgue/dialogs/settings/GOSettingsDialog.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsDialog.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -63,8 +63,9 @@ GOSettingsDialog::GOSettingsDialog(
   AddTab(m_MidiDevicePage, PAGE_MIDI_DEVICES, _("MIDI Devices"));
   m_MidiMessagePage = new GOSettingsMidiMessage(config, midi, notebook);
   AddTab(m_MidiMessagePage, PAGE_INITIAL_MIDI, _("Initial MIDI"));
-  m_OrgansPage = new GOSettingsOrgans(config, midi, notebook);
-  AddTab(m_OrgansPage, PAGE_ORGANS, _("Organs"));
+  m_OrgansPage
+    = new GOSettingsOrgans(config, midi, this, PAGE_ORGANS, _("Organs"));
+  AddTab(m_OrgansPage);
   m_ReverbPage = new GOSettingsReverb(config, notebook);
   AddTab(m_ReverbPage, PAGE_REVERB, _("Reverb"));
   m_TemperamentsPage = new GOSettingsTemperaments(config, notebook);

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
@@ -30,6 +30,7 @@
 #include "config/GOConfig.h"
 #include "dialogs/midi-event/GOMidiEventDialog.h"
 #include "files/GOStdFileName.h"
+#include "size/GOAdditionalSizeKeeperProxy.h"
 #include "wxcontrols/GOGrid.h"
 
 #include "GOOrgan.h"
@@ -54,8 +55,12 @@ END_EVENT_TABLE()
 enum { GRID_COL_NAME = 0, GRID_COL_MIDI, GRID_COL_PATH, GRID_N_COLS };
 
 GOSettingsOrgans::GOSettingsOrgans(
-  GOConfig &settings, GOMidi &midi, wxWindow *parent)
-  : wxPanel(parent, wxID_ANY),
+  GOConfig &settings,
+  GOMidi &midi,
+  GOTabbedDialog *pDlg,
+  const wxString &name,
+  const wxString &label)
+  : GODialogTab(pDlg, name, label),
     m_config(settings),
     m_midi(midi),
     m_OrigOrganList(settings.GetOrganList()),
@@ -658,6 +663,23 @@ void GOSettingsOrgans::ReplaceOrganPath(
     pOrganSlot->m_CurrentPath = newPath;
     m_OrganSlotByPath[newPath] = pOrganSlot;
   }
+}
+
+const wxString WX_GRID_ORGANS = wxT("GridOrgans");
+
+void GOSettingsOrgans::ApplyAdditionalSizes(
+  const GOAdditionalSizeKeeper &sizeKeeper) {
+  GOAdditionalSizeKeeperProxy proxyGridOrgans(
+    const_cast<GOAdditionalSizeKeeper &>(sizeKeeper), WX_GRID_ORGANS);
+
+  m_GridOrgans->ApplyColumnSizes(proxyGridOrgans);
+}
+
+void GOSettingsOrgans::CaptureAdditionalSizes(
+  GOAdditionalSizeKeeper &sizeKeeper) const {
+  GOAdditionalSizeKeeperProxy proxyGridOrgans(sizeKeeper, WX_GRID_ORGANS);
+
+  m_GridOrgans->CaptureColumnSizes(proxyGridOrgans);
 }
 
 void GOSettingsOrgans::OnOrganUp(wxCommandEvent &event) {

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.h
@@ -12,7 +12,8 @@
 #include <unordered_set>
 
 #include <wx/hashset.h>
-#include <wx/panel.h>
+
+#include "dialogs/common/GODialogTab.h"
 
 #include "ptrvector.h"
 
@@ -22,12 +23,13 @@ class wxGridEvent;
 class wxGridRangeSelectEvent;
 class wxTextCtrl;
 
+class GOAdditionalSizeKeeper;
 class GOArchiveFile;
 class GOConfig;
 class GOGrid;
 class GOOrgan;
 
-class GOSettingsOrgans : public wxPanel {
+class GOSettingsOrgans : public GODialogTab {
 public:
   enum {
     ID_ORGANS = 200,
@@ -116,6 +118,10 @@ private:
   void DelSelectedOrgans();
   void ReplaceOrganPath(const unsigned index, const wxString &newPath);
 
+  void ApplyAdditionalSizes(const GOAdditionalSizeKeeper &sizeKeeper) override;
+  void CaptureAdditionalSizes(
+    GOAdditionalSizeKeeper &sizeKeeper) const override;
+
   void OnCharHook(wxKeyEvent &ev);
 
   void OnOrganSelectCell(wxGridEvent &event);
@@ -130,7 +136,12 @@ private:
   void OnDelPreset(wxCommandEvent &event);
 
 public:
-  GOSettingsOrgans(GOConfig &settings, GOMidi &midi, wxWindow *parent);
+  GOSettingsOrgans(
+    GOConfig &settings,
+    GOMidi &midi,
+    GOTabbedDialog *pDlg,
+    const wxString &name,
+    const wxString &label);
 
   virtual bool TransferDataToWindow() override;
   virtual bool TransferDataFromWindow() override;

--- a/src/grandorgue/size/GOSizeKeeper.cpp
+++ b/src/grandorgue/size/GOSizeKeeper.cpp
@@ -61,6 +61,8 @@ void GOSizeKeeper::Load(GOConfigReader &cfg, const wxString &group) {
         CMBSetting,
         m_group,
         wxString::Format(WX_ADDITIONAL_SIZE_VALUE_FMT, i),
+        0,
+        32000,
         false,
         -1);
   }

--- a/src/grandorgue/wxcontrols/GOGrid.cpp
+++ b/src/grandorgue/wxcontrols/GOGrid.cpp
@@ -9,6 +9,8 @@
 
 #include <wx/dc.h>
 
+#include "size/GOAdditionalSizeKeeper.h"
+
 class RightVisibleCellRenderer : public wxGridCellStringRenderer {
   virtual void Draw(
     wxGrid &grid,
@@ -199,6 +201,24 @@ void GOGrid::SetColumnRightVisible(unsigned colN, bool isRightVisible) {
   while (m_AreColumnsRightVisible.size() <= colN)
     m_AreColumnsRightVisible.push_back(false);
   m_AreColumnsRightVisible[colN] = isRightVisible;
+}
+
+const wxString WX_COL_SIZE_KEY_FMT = wxT("Column%03dSize");
+
+void GOGrid::ApplyColumnSizes(const GOAdditionalSizeKeeper &sizeKeeper) {
+  for (int l = GetNumberCols(), i = 0; i < l; i++) {
+    int newSize
+      = sizeKeeper.GetAdditionalSize(wxString::Format(WX_COL_SIZE_KEY_FMT, i));
+
+    if (newSize > 0)
+      SetColSize(i, newSize);
+  }
+}
+
+void GOGrid::CaptureColumnSizes(GOAdditionalSizeKeeper &sizeKeeper) const {
+  for (int l = GetNumberCols(), i = 0; i < l; i++)
+    sizeKeeper.SetAdditionalSize(
+      wxString::Format(WX_COL_SIZE_KEY_FMT, i), GetColSize(i));
 }
 
 wxGridCellRenderer *GOGrid::GetDefaultRendererForCell(int row, int col) const {

--- a/src/grandorgue/wxcontrols/GOGrid.h
+++ b/src/grandorgue/wxcontrols/GOGrid.h
@@ -12,6 +12,8 @@
 
 #include <wx/grid.h>
 
+class GOAdditionalSizeKeeper;
+
 class GOGrid : public wxGrid {
 private:
   wxGridCellStringRenderer *p_RightVisibleRenderer;
@@ -29,6 +31,9 @@ public:
 
   bool IsColumnRightVisible(unsigned colN) const;
   void SetColumnRightVisible(unsigned colN, bool isRightVisible);
+
+  void ApplyColumnSizes(const GOAdditionalSizeKeeper &sizeKeeper);
+  void CaptureColumnSizes(GOAdditionalSizeKeeper &sizeKeeper) const;
 
   virtual wxGridCellRenderer *GetDefaultRendererForCell(
     int row, int col) const override;


### PR DESCRIPTION
This PR utilizes the new GOAdditionalSizeKeeper features for remembering grid column sizes in Settings/Organs

