### PR TITLE
Renamed some members and parameters and added some comments

### DIFF
--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -105,21 +105,21 @@ void GOMetronome::Load(GOConfigReader &cfg) {
   GOWindchest *windchest = new GOWindchest(*m_OrganController);
   windchest->Init(cfg, wxT("MetronomeWindchest"), _("Metronome"));
   windchest->GetPipeConfig().GetPipeConfig().SetPercussiveFromInit(BOOL3_TRUE);
-  unsigned samplegroup = m_OrganController->AddWindchest(windchest);
+  unsigned windchestN = m_OrganController->AddWindchest(windchest);
 
   m_rank = new GORank(*m_OrganController);
-  m_rank->Init(cfg, wxT("MetronomSounds"), _("Metronome"), 36, samplegroup);
+  m_rank->Init(cfg, wxT("MetronomSounds"), _("Metronome"), 36, windchestN);
   m_StopID = m_rank->RegisterStop(NULL);
   m_OrganController->AddRank(m_rank);
 
   GOSoundingPipe *pipe;
   pipe = new GOSoundingPipe(
-    m_OrganController, m_rank, samplegroup, 36, 8, 100, 100, false);
+    m_OrganController, m_rank, windchestN, 36, 8, 100, 100, false);
   m_rank->AddPipe(pipe);
   pipe->Init(
     cfg, wxT("MetronomSounds"), wxT("A"), wxT("sounds\\metronome\\beat.wv"));
   pipe = new GOSoundingPipe(
-    m_OrganController, m_rank, samplegroup, 37, 8, 100, 100, false);
+    m_OrganController, m_rank, windchestN, 37, 8, 100, 100, false);
   m_rank->AddPipe(pipe);
   pipe->Init(
     cfg,

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -51,7 +51,6 @@ class GODocument;
 class GOSoundEngine;
 class GOSoundProvider;
 class GOSoundRecorder;
-class GOSoundSampler;
 typedef struct _GOHashType GOHashType;
 
 class GOOrganController : public GOEventDistributor,

--- a/src/grandorgue/gui/GOGUIFloatingPanel.cpp
+++ b/src/grandorgue/gui/GOGUIFloatingPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -90,7 +90,7 @@ GOGUIPanel *GOGUIFloatingPanel::CreateFloatingPanel(GOConfigReader &cfg) {
   enclosure->Init(cfg, wxT("SetterMasterVolume"));
   panel->AddControl(enclosure);
 
-  for (unsigned i = 0; i < m_OrganController->GetWindchestGroupCount(); i++) {
+  for (unsigned i = 0; i < m_OrganController->GetWindchestCount(); i++) {
     GOWindchest *windchest = m_OrganController->GetWindchest(i);
     windchest->AddEnclosure(master_enc);
 

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -102,7 +102,7 @@ void GOOrganModel::Load(GOConfigReader &cfg) {
   for (unsigned i = 0; i < NumberOfTremulants; i++) {
     m_tremulants.push_back(new GOTremulant(*this));
     m_tremulants[i]->Load(
-      cfg, wxString::Format(wxT("Tremulant%03d"), i + 1), -((int)(i + 1)));
+      cfg, wxString::Format(wxT("Tremulant%03d"), i + 1), i + 1);
   }
 
   for (unsigned i = 0; i < NumberOfWindchestGroups; i++)
@@ -204,12 +204,6 @@ void GOOrganModel::UpdateVolume() {
   for (unsigned i = 0; i < m_windchests.size(); i++)
     m_windchests[i]->UpdateVolume();
 }
-
-GOWindchest *GOOrganModel::GetWindchest(unsigned index) {
-  return m_windchests[index];
-}
-
-unsigned GOOrganModel::GetWindchestGroupCount() { return m_windchests.size(); }
 
 unsigned GOOrganModel::AddWindchest(GOWindchest *windchest) {
   m_windchests.push_back(windchest);

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -135,9 +135,11 @@ public:
   void UpdateTremulant(GOTremulant *tremulant);
   void UpdateVolume();
 
-  unsigned GetWindchestGroupCount();
+  unsigned GetWindchestCount() const { return m_windchests.size(); }
+  // Returns the windchest number starting with 1
   unsigned AddWindchest(GOWindchest *windchest);
-  GOWindchest *GetWindchest(unsigned index);
+  // Returns the windchest by it's index starting with 0
+  GOWindchest *GetWindchest(unsigned index) { return m_windchests[index]; }
 
   GOEnclosure *GetEnclosureElement(unsigned index);
   unsigned GetEnclosureCount();

--- a/src/grandorgue/model/GORank.h
+++ b/src/grandorgue/model/GORank.h
@@ -44,7 +44,7 @@ private:
    */
   std::vector<unsigned> m_MaxNoteVelocities;
   unsigned m_FirstMidiNoteNumber;
-  unsigned m_WindchestGroup;
+  unsigned m_WindchestN; // starts with 1
   unsigned m_HarmonicNumber;
   float m_MinVolume;
   float m_MaxVolume;
@@ -67,11 +67,19 @@ public:
   ~GORank();
   void Init(
     GOConfigReader &cfg,
-    wxString group,
-    wxString name,
-    int first_midi_note_number,
-    unsigned windchest);
-  void Load(GOConfigReader &cfg, wxString group, int first_midi_note_number);
+    const wxString &group,
+    const wxString &name,
+    unsigned firstMidiNoteNumber,
+    unsigned windchestN);
+  /**
+   * Loads Rank from odf/cmb
+   * @param cfg
+   * @param group
+   * @param firstMidiNoteNumber. -1 means no default and must be specified in
+   *   the ODF
+   */
+  void Load(
+    GOConfigReader &cfg, const wxString &group, int defaultFirstMidiNoteNumber);
   void AddPipe(GOPipe *pipe);
   unsigned RegisterStop(GOStop *stop);
   void SetKey(int note, unsigned velocity, unsigned stopID);

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -27,7 +27,7 @@
 GOSoundingPipe::GOSoundingPipe(
   GOOrganModel *pOrganModel,
   GORank *rank,
-  int sampler_group_id,
+  unsigned windchestN,
   unsigned midi_key_number,
   unsigned harmonic_number,
   float min_volume,
@@ -43,7 +43,7 @@ GOSoundingPipe::GOSoundingPipe(
     m_AttackFileInfos(),
     m_ReleaseFileInfos(),
     m_Filename(),
-    m_SamplerGroupID(sampler_group_id),
+    m_WindchestN(windchestN),
     m_AudioGroupID(0),
     m_TemperamentOffset(0),
     m_HarmonicNumber(harmonic_number),
@@ -71,7 +71,7 @@ void GOSoundingPipe::Init(
   m_OdfMidiKeyNumber = -1;
   m_OdfMidiPitchFraction = -1.0;
   UpdateAmplitude();
-  p_OrganModel->GetWindchest(m_SamplerGroupID - 1)->AddPipe(this);
+  p_OrganModel->GetWindchest(m_WindchestN - 1)->AddPipe(this);
 
   GOSoundProviderWave::AttackFileInfo ainfo;
 
@@ -232,14 +232,14 @@ void GOSoundingPipe::Load(
     1024,
     false,
     m_HarmonicNumber);
-  m_SamplerGroupID = cfg.ReadInteger(
+  m_WindchestN = cfg.ReadInteger(
     ODFSetting,
     group,
     prefix + wxT("WindchestGroup"),
     1,
-    p_OrganModel->GetWindchestGroupCount(),
+    p_OrganModel->GetWindchestCount(),
     false,
-    m_SamplerGroupID);
+    m_WindchestN);
   m_OdfMidiKeyNumber = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("MIDIKeyNumber"), -1, 127, false, -1);
   m_OdfMidiPitchFraction = cfg.ReadFloat(
@@ -253,7 +253,7 @@ void GOSoundingPipe::Load(
   m_RetunePipe = cfg.ReadBoolean(
     ODFSetting, group, prefix + wxT("AcceptsRetuning"), false, m_RetunePipe);
   UpdateAmplitude();
-  p_OrganModel->GetWindchest(m_SamplerGroupID - 1)->AddPipe(this);
+  p_OrganModel->GetWindchest(m_WindchestN - 1)->AddPipe(this);
 
   unsigned attack_count = cfg.ReadInteger(
     ODFSetting, group, prefix + wxT("AttackCount"), 0, 100, false, 0);
@@ -492,9 +492,9 @@ void GOSoundingPipe::VelocityChanged(
 
   if (!m_Instances && velocity) {
     // the key pressed
-    m_Sampler = pSoundEngine ? pSoundEngine->StartSample(
+    m_Sampler = pSoundEngine ? pSoundEngine->StartPipeSample(
                   &m_SoundProvider,
-                  m_SamplerGroupID,
+                  m_WindchestN,
                   m_AudioGroupID,
                   velocity,
                   m_PipeConfigNode.GetEffectiveDelay(),
@@ -515,9 +515,9 @@ void GOSoundingPipe::VelocityChanged(
         : 0;
       m_Sampler = nullptr;
     } else if (m_PipeConfigNode.IsEffectiveIndependentRelease() && pSoundEngine)
-      pSoundEngine->StartSample(
+      pSoundEngine->StartPipeSample(
         &m_SoundProvider,
-        m_SamplerGroupID,
+        m_WindchestN,
         m_AudioGroupID,
         last_velocity,
         m_PipeConfigNode.GetEffectiveDelay(),

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -37,7 +37,7 @@ private:
 
   /* states which windchest this pipe belongs to, see
    * GOSoundEngine::StartSampler */
-  int m_SamplerGroupID;
+  unsigned m_WindchestN; // starts with 1
   unsigned m_AudioGroupID;
   float m_TemperamentOffset;
   unsigned m_HarmonicNumber;
@@ -115,7 +115,7 @@ public:
   GOSoundingPipe(
     GOOrganModel *pOrganModel,
     GORank *rank,
-    int sampler_group_id,
+    unsigned windchestN,
     unsigned midi_key_number,
     unsigned harmonic_number,
     float min_volume,

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -37,7 +37,7 @@ GOTremulant::GOTremulant(GOOrganModel &organModel)
     m_TremProvider(NULL),
     m_PlaybackHandle(0),
     m_LastStop(0),
-    m_SamplerGroupID(0) {}
+    m_TremulantN(0) {}
 
 GOTremulant::~GOTremulant() { DELETE_AND_NULL(m_TremProvider); }
 
@@ -53,7 +53,7 @@ bool GOTremulant::LoadCache(GOMemoryPool &pool, GOCache &cache) {
 }
 
 void GOTremulant::Load(
-  GOConfigReader &cfg, wxString group, int sampler_group_id) {
+  GOConfigReader &cfg, const wxString &group, unsigned tremulantN) {
   SetGroupAndPrefix(group, wxEmptyString);
   m_TremulantType = (GOTremulantType)cfg.ReadEnum(
     ODFSetting,
@@ -70,7 +70,7 @@ void GOTremulant::Load(
     m_StopRate = cfg.ReadInteger(ODFSetting, group, wxT("StopRate"), 1, 100);
     m_AmpModDepth
       = cfg.ReadInteger(ODFSetting, group, wxT("AmpModDepth"), 1, 100);
-    m_SamplerGroupID = sampler_group_id;
+    m_TremulantN = tremulantN;
     m_PlaybackHandle = 0;
   }
   GODrawstop::Load(cfg, group);
@@ -96,11 +96,10 @@ void GOTremulant::ChangeState(bool on) {
     GOSoundEngine *pSoundEngine = GetSoundEngine();
 
     if (on) {
-      assert(m_SamplerGroupID < 0);
-      m_PlaybackHandle = pSoundEngine
-        ? pSoundEngine->StartSample(
-          m_TremProvider, m_SamplerGroupID, 0, 0x7f, 0, m_LastStop)
-        : nullptr;
+      assert(m_TremulantN > 0);
+      m_PlaybackHandle = pSoundEngine ? pSoundEngine->StartTremulantSample(
+                           m_TremProvider, m_TremulantN, m_LastStop)
+                                      : nullptr;
       on = (m_PlaybackHandle != nullptr);
     } else {
       assert(m_PlaybackHandle);
@@ -127,10 +126,10 @@ void GOTremulant::StartPlayback() {
   if (IsActive() && m_TremulantType == GOSynthTrem) {
     GOSoundEngine *pSoundEngine = GetSoundEngine();
 
-    assert(m_SamplerGroupID < 0);
-    m_PlaybackHandle = pSoundEngine ? pSoundEngine->StartSample(
-                         m_TremProvider, m_SamplerGroupID, 0, 0x7f, 0, 0)
-                                    : nullptr;
+    assert(m_TremulantN > 0);
+    m_PlaybackHandle = pSoundEngine
+      ? pSoundEngine->StartTremulantSample(m_TremProvider, m_TremulantN, 0)
+      : nullptr;
   }
   if (m_TremulantType == GOWavTrem) {
     r_OrganModel.UpdateTremulant(this);

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -34,7 +34,7 @@ private:
   GOSoundProvider *m_TremProvider;
   GOSoundSampler *m_PlaybackHandle;
   uint64_t m_LastStop;
-  int m_SamplerGroupID;
+  unsigned m_TremulantN;
 
   void InitSoundProvider(GOMemoryPool &pool);
   void ChangeState(bool on);
@@ -53,7 +53,7 @@ private:
 public:
   GOTremulant(GOOrganModel &organModel);
   ~GOTremulant();
-  void Load(GOConfigReader &cfg, wxString group, int sampler_group_id);
+  void Load(GOConfigReader &cfg, const wxString &group, unsigned tremulantN);
   GOTremulantType GetTremulantType();
 
   const wxString &GetMidiTypeCode() const override;

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -40,17 +40,17 @@ GOSoundEngine::GOSoundEngine()
     m_UsedPolyphony(0),
     m_WorkerSlots(0),
     m_MeterInfo(1),
-    m_Tremulants(),
-    m_Windchests(),
-    m_AudioGroups(),
-    m_AudioOutputs(),
+    m_TremulantTasks(),
+    m_WindchestTasks(),
+    m_AudioGroupTasks(),
+    m_AudioOutputTasks(),
     m_AudioRecorder(NULL),
-    m_TouchProcessor(),
+    m_TouchTask(),
     m_HasBeenSetup(false) {
   memset(&m_ResamplerCoefs, 0, sizeof(m_ResamplerCoefs));
   m_SamplerPool.SetUsageLimit(2048);
   m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
-  m_ReleaseProcessor = new GOSoundReleaseWorkItem(*this, m_AudioGroups);
+  m_ReleaseProcessor = new GOSoundReleaseWorkItem(*this, m_AudioGroupTasks);
   Reset();
 }
 
@@ -61,25 +61,25 @@ GOSoundEngine::~GOSoundEngine() {
 
 void GOSoundEngine::Reset() {
   if (m_HasBeenSetup.load()) {
-    for (unsigned i = 0; i < m_Windchests.size(); i++)
-      m_Windchests[i]->Init(m_Tremulants);
+    for (unsigned i = 0; i < m_WindchestTasks.size(); i++)
+      m_WindchestTasks[i]->Init(m_TremulantTasks);
   }
 
   m_Scheduler.Clear();
 
   if (m_HasBeenSetup.load()) {
-    for (unsigned i = 0; i < m_Tremulants.size(); i++)
-      m_Scheduler.Add(m_Tremulants[i]);
-    for (unsigned i = 0; i < m_Windchests.size(); i++)
-      m_Scheduler.Add(m_Windchests[i]);
-    for (unsigned i = 0; i < m_AudioGroups.size(); i++)
-      m_Scheduler.Add(m_AudioGroups[i]);
-    for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
-      m_Scheduler.Add(m_AudioOutputs[i]);
+    for (unsigned i = 0; i < m_TremulantTasks.size(); i++)
+      m_Scheduler.Add(m_TremulantTasks[i]);
+    for (unsigned i = 0; i < m_WindchestTasks.size(); i++)
+      m_Scheduler.Add(m_WindchestTasks[i]);
+    for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
+      m_Scheduler.Add(m_AudioGroupTasks[i]);
+    for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
+      m_Scheduler.Add(m_AudioOutputTasks[i]);
     m_Scheduler.Add(m_AudioRecorder);
     m_Scheduler.Add(m_ReleaseProcessor);
-    if (m_TouchProcessor)
-      m_Scheduler.Add(m_TouchProcessor.get());
+    if (m_TouchTask)
+      m_Scheduler.Add(m_TouchTask.get());
   }
   m_UsedPolyphony.store(0);
 
@@ -128,9 +128,9 @@ void GOSoundEngine::SetAudioGroupCount(unsigned groups) {
   if (groups < 1)
     groups = 1;
   m_AudioGroupCount = groups;
-  m_AudioGroups.clear();
+  m_AudioGroupTasks.clear();
   for (unsigned i = 0; i < m_AudioGroupCount; i++)
-    m_AudioGroups.push_back(
+    m_AudioGroupTasks.push_back(
       new GOSoundGroupWorkItem(*this, m_SamplesPerBuffer));
 }
 
@@ -156,35 +156,23 @@ float GOSoundEngine::GetRandomFactor() {
 }
 
 void GOSoundEngine::PassSampler(GOSoundSampler *sampler) {
-  if (sampler->sampler_group_id == 0) {
-    m_AudioGroups[sampler->audio_group_id]->Add(sampler);
-  } else if (sampler->sampler_group_id < 0) {
-    m_Tremulants[-1 - sampler->sampler_group_id]->Add(sampler);
-  } else {
-    m_AudioGroups[sampler->audio_group_id]->Add(sampler);
-  }
+  int taskId = sampler->m_SamplerTaskId;
+
+  if (isWindchestTask(taskId))
+    m_AudioGroupTasks[sampler->m_AudioGroupId]->Add(sampler);
+  else
+    m_TremulantTasks[tremulantTaskToIndex(taskId)]->Add(sampler);
 }
 
-void GOSoundEngine::StartSampler(
-  GOSoundSampler *sampler, int sampler_group_id, unsigned audio_group) {
-  if (audio_group >= m_AudioGroupCount)
-    audio_group = 0;
+void GOSoundEngine::StartSampler(GOSoundSampler *sampler) {
+  int taskId = sampler->m_SamplerTaskId;
 
-  sampler->sampler_group_id = sampler_group_id;
-  sampler->audio_group_id = audio_group;
   sampler->stop = 0;
   sampler->new_attack = 0;
-
-  if (sampler_group_id == 0) {
-    sampler->windchest = m_Windchests[sampler_group_id];
-    m_AudioGroups[audio_group]->Add(sampler);
-  } else if (sampler_group_id < 0) {
-    sampler->windchest = NULL;
-    m_Tremulants[-1 - sampler_group_id]->Add(sampler);
-  } else {
-    sampler->windchest = m_Windchests[sampler_group_id];
-    m_AudioGroups[audio_group]->Add(sampler);
-  }
+  sampler->p_WindchestTask = isWindchestTask(taskId)
+    ? m_WindchestTasks[windchestTaskToIndex(taskId)]
+    : nullptr;
+  PassSampler(sampler);
 }
 
 void GOSoundEngine::ClearSetup() {
@@ -192,13 +180,13 @@ void GOSoundEngine::ClearSetup() {
 
   // the winchests may be still used from audio callbacks.
   // clear the pending sound before destroying the windchests
-  for (unsigned i = 0; i < m_AudioGroups.size(); i++)
-    m_AudioGroups[i]->WaitAndClear();
+  for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
+    m_AudioGroupTasks[i]->WaitAndClear();
 
   m_Scheduler.Clear();
-  m_Windchests.clear();
-  m_Tremulants.clear();
-  m_TouchProcessor = NULL;
+  m_WindchestTasks.clear();
+  m_TremulantTasks.clear();
+  m_TouchTask = NULL;
   Reset();
 }
 
@@ -208,16 +196,17 @@ void GOSoundEngine::Setup(
   if (release_count < 1)
     release_count = 1;
   m_Scheduler.SetRepeatCount(release_count);
-  m_Tremulants.clear();
+  m_TremulantTasks.clear();
   for (unsigned i = 0; i < organController->GetTremulantCount(); i++)
-    m_Tremulants.push_back(
+    m_TremulantTasks.push_back(
       new GOSoundTremulantWorkItem(*this, m_SamplesPerBuffer));
-  m_Windchests.clear();
-  m_Windchests.push_back(new GOSoundWindchestWorkItem(*this, NULL));
-  for (unsigned i = 0; i < organController->GetWindchestGroupCount(); i++)
-    m_Windchests.push_back(
+  m_WindchestTasks.clear();
+  // a special windchest task for detached releases
+  m_WindchestTasks.push_back(new GOSoundWindchestWorkItem(*this, NULL));
+  for (unsigned i = 0; i < organController->GetWindchestCount(); i++)
+    m_WindchestTasks.push_back(
       new GOSoundWindchestWorkItem(*this, organController->GetWindchest(i)));
-  m_TouchProcessor = std::unique_ptr<GOSoundTouchWorkItem>(
+  m_TouchTask = std::unique_ptr<GOSoundTouchWorkItem>(
     new GOSoundTouchWorkItem(organController->GetMemoryPool()));
   m_HasBeenSetup.store(true);
   Reset();
@@ -249,7 +238,7 @@ bool GOSoundEngine::ProcessSampler(
      *     playback gain * (2 ^ -sampler->pipe_section->sample_bits)
      */
     if (!GOSoundAudioSection::ReadBlock(&sampler->stream, temp, n_frames))
-      sampler->pipe = NULL;
+      sampler->p_SoundProvider = NULL;
 
     sampler->fader.Process(n_frames, temp, volume);
 
@@ -268,7 +257,9 @@ bool GOSoundEngine::ProcessSampler(
     }
   }
 
-  if (!sampler->pipe || (sampler->fader.IsSilent() && process_sampler)) {
+  if (
+    !sampler->p_SoundProvider
+    || (sampler->fader.IsSilent() && process_sampler)) {
     ReturnSampler(sampler);
     return false;
   } else
@@ -294,7 +285,7 @@ GOSoundScheduler &GOSoundEngine::GetScheduler() { return m_Scheduler; }
 
 void GOSoundEngine::SetAudioOutput(
   std::vector<GOAudioOutputConfiguration> audio_outputs) {
-  m_AudioOutputs.clear();
+  m_AudioOutputTasks.clear();
   {
     std::vector<float> scale_factors;
     scale_factors.resize(m_AudioGroupCount * 2 * 2);
@@ -303,7 +294,7 @@ void GOSoundEngine::SetAudioOutput(
       scale_factors[i * 4] = 1;
       scale_factors[i * 4 + 3] = 1;
     }
-    m_AudioOutputs.push_back(
+    m_AudioOutputTasks.push_back(
       new GOSoundOutputWorkItem(2, scale_factors, m_SamplesPerBuffer));
   }
   unsigned channels = 0;
@@ -322,15 +313,15 @@ void GOSoundEngine::SetAudioOutput(
           factor = 0;
         scale_factors[j * m_AudioGroupCount * 2 + k] = factor;
       }
-    m_AudioOutputs.push_back(new GOSoundOutputWorkItem(
+    m_AudioOutputTasks.push_back(new GOSoundOutputWorkItem(
       audio_outputs[i].channels, scale_factors, m_SamplesPerBuffer));
     channels += audio_outputs[i].channels;
   }
   std::vector<GOSoundBufferItem *> outputs;
-  for (unsigned i = 0; i < m_AudioGroups.size(); i++)
-    outputs.push_back(m_AudioGroups[i]);
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
-    m_AudioOutputs[i]->SetOutputs(outputs);
+  for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
+    outputs.push_back(m_AudioGroupTasks[i]);
+  for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
+    m_AudioOutputTasks[i]->SetOutputs(outputs);
   m_MeterInfo.resize(channels + 1);
 }
 
@@ -338,27 +329,27 @@ void GOSoundEngine::SetAudioRecorder(GOSoundRecorder *recorder, bool downmix) {
   m_AudioRecorder = recorder;
   std::vector<GOSoundBufferItem *> outputs;
   if (downmix)
-    outputs.push_back(m_AudioOutputs[0]);
+    outputs.push_back(m_AudioOutputTasks[0]);
   else {
-    m_Scheduler.Remove(m_AudioOutputs[0]);
-    delete m_AudioOutputs[0];
-    m_AudioOutputs[0] = NULL;
-    for (unsigned i = 1; i < m_AudioOutputs.size(); i++)
-      outputs.push_back(m_AudioOutputs[i]);
+    m_Scheduler.Remove(m_AudioOutputTasks[0]);
+    delete m_AudioOutputTasks[0];
+    m_AudioOutputTasks[0] = NULL;
+    for (unsigned i = 1; i < m_AudioOutputTasks.size(); i++)
+      outputs.push_back(m_AudioOutputTasks[i]);
   }
   m_AudioRecorder->SetOutputs(outputs, m_SamplesPerBuffer);
 }
 
 void GOSoundEngine::SetupReverb(GOConfig &settings) {
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
-    if (m_AudioOutputs[i])
-      m_AudioOutputs[i]->SetupReverb(settings);
+  for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
+    if (m_AudioOutputTasks[i])
+      m_AudioOutputTasks[i]->SetupReverb(settings);
 }
 
 unsigned GOSoundEngine::GetBufferSizeFor(
   unsigned outputIndex, unsigned nFrames) {
   return sizeof(float) * nFrames
-    * m_AudioOutputs[outputIndex + 1]->GetChannels();
+    * m_AudioOutputTasks[outputIndex + 1]->GetChannels();
 }
 
 void GOSoundEngine::GetEmptyAudioOutput(
@@ -369,10 +360,10 @@ void GOSoundEngine::GetEmptyAudioOutput(
 void GOSoundEngine::GetAudioOutput(
   float *output_buffer, unsigned n_frames, unsigned audio_output, bool last) {
   if (m_HasBeenSetup.load()) {
-    m_AudioOutputs[audio_output + 1]->Finish(last);
+    m_AudioOutputTasks[audio_output + 1]->Finish(last);
     memcpy(
       output_buffer,
-      m_AudioOutputs[audio_output + 1]->m_Buffer,
+      m_AudioOutputTasks[audio_output + 1]->m_Buffer,
       GetBufferSizeFor(audio_output, n_frames));
   } else
     GetEmptyAudioOutput(audio_output, n_frames, output_buffer);
@@ -395,10 +386,10 @@ unsigned GOSoundEngine::SamplesDiffToMs(
     (toSamples - fromSamples) * 1000 / m_SampleRate, (uint64_t)UINT_MAX);
 }
 
-GOSoundSampler *GOSoundEngine::StartSample(
-  const GOSoundProvider *pipe,
-  int8_t sampler_group_id,
-  unsigned audio_group,
+GOSoundSampler *GOSoundEngine::StartTaskSample(
+  const GOSoundProvider *pSoundProvider,
+  int samplerTaskId,
+  unsigned audioGroup,
   unsigned velocity,
   unsigned delay,
   uint64_t prevEventTime,
@@ -410,8 +401,8 @@ GOSoundSampler *GOSoundEngine::StartSample(
 
   GOSoundSampler *sampler = nullptr;
   const GOSoundAudioSection *section = isRelease
-    ? pipe->GetRelease(BOOL3_DEFAULT, eventIntervalMs)
-    : pipe->GetAttack(velocity, eventIntervalMs);
+    ? pSoundProvider->GetRelease(BOOL3_DEFAULT, eventIntervalMs)
+    : pSoundProvider->GetAttack(velocity, eventIntervalMs);
 
   if (pStartTimeSamples) {
     *pStartTimeSamples = start_time;
@@ -419,34 +410,37 @@ GOSoundSampler *GOSoundEngine::StartSample(
   if (section && section->GetChannels()) {
     sampler = m_SamplerPool.GetSampler();
     if (sampler) {
-      sampler->pipe = pipe;
+      sampler->p_SoundProvider = pSoundProvider;
       sampler->velocity = velocity;
       section->InitStream(
         &m_ResamplerCoefs,
         &sampler->stream,
-        GetRandomFactor() * pipe->GetTuning() / (float)m_SampleRate);
+        GetRandomFactor() * pSoundProvider->GetTuning() / (float)m_SampleRate);
 
-      const float playback_gain = pipe->GetGain() * section->GetNormGain();
+      const float playback_gain
+        = pSoundProvider->GetGain() * section->GetNormGain();
 
       sampler->fader.NewConstant(playback_gain);
       sampler->delay = delay_samples;
       sampler->time = start_time;
       sampler->fader.SetVelocityVolume(
-        sampler->pipe->GetVelocityVolume(sampler->velocity));
+        sampler->p_SoundProvider->GetVelocityVolume(sampler->velocity));
       sampler->is_release = isRelease;
-      StartSampler(sampler, sampler_group_id, audio_group);
+      sampler->m_SamplerTaskId = samplerTaskId;
+      sampler->m_AudioGroupId = audioGroup;
+      StartSampler(sampler);
     }
   }
   return sampler;
 }
 
 void GOSoundEngine::SwitchAttackSampler(GOSoundSampler *handle) {
-  if (!handle->pipe)
+  if (!handle->p_SoundProvider)
     return;
 
   unsigned time = 1000;
 
-  const GOSoundProvider *this_pipe = handle->pipe;
+  const GOSoundProvider *this_pipe = handle->p_SoundProvider;
   const GOSoundAudioSection *section
     = this_pipe->GetAttack(handle->velocity, time);
   if (!section)
@@ -458,7 +452,7 @@ void GOSoundEngine::SwitchAttackSampler(GOSoundSampler *handle) {
   if (new_sampler != NULL) {
     *new_sampler = *handle;
 
-    handle->pipe = this_pipe;
+    handle->p_SoundProvider = this_pipe;
     handle->time = m_CurrentTime + 1;
 
     float gain_target = this_pipe->GetGain() * section->GetNormGain();
@@ -471,15 +465,14 @@ void GOSoundEngine::SwitchAttackSampler(GOSoundSampler *handle) {
     new_sampler->time = m_CurrentTime;
     new_sampler->fader.StartDecay(cross_fade_len, m_SampleRate);
     new_sampler->fader.SetVelocityVolume(
-      new_sampler->pipe->GetVelocityVolume(new_sampler->velocity));
+      new_sampler->p_SoundProvider->GetVelocityVolume(new_sampler->velocity));
 
-    StartSampler(
-      new_sampler, new_sampler->sampler_group_id, new_sampler->audio_group_id);
+    StartSampler(new_sampler);
   }
 }
 
 void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
-  if (!handle->pipe)
+  if (!handle->p_SoundProvider)
     return;
 
   /* The beloow code creates a new sampler to playback the release, the
@@ -488,7 +481,7 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
    * which will decay this portion of the pipe. The sampler will
    * automatically be placed back in the pool when the fade restores to
    * zero. */
-  const GOSoundProvider *this_pipe = handle->pipe;
+  const GOSoundProvider *this_pipe = handle->p_SoundProvider;
   const GOSoundAudioSection *release_section = this_pipe->GetRelease(
     handle->stream.audio_section->GetWaveTremulantStateFor(),
     SamplesDiffToMs(handle->time, m_CurrentTime));
@@ -499,9 +492,10 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
   handle->fader.StartDecay(cross_fade_len, m_SampleRate);
   handle->is_release = true;
 
-  float vol = (handle->sampler_group_id < 0)
-    ? 1.0f
-    : m_Windchests[handle->sampler_group_id]->GetWindchestVolume();
+  int taskId = handle->m_SamplerTaskId;
+  float vol = isWindchestTask(taskId)
+    ? m_WindchestTasks[windchestTaskToIndex(taskId)]->GetWindchestVolume()
+    : 1.0f;
 
   // FIXME: this is wrong... the intention is to not create a release for a
   // sample being played back with zero amplitude but this is a comparison
@@ -509,13 +503,14 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
   if (vol && release_section) {
     GOSoundSampler *new_sampler = m_SamplerPool.GetSampler();
     if (new_sampler != NULL) {
-      new_sampler->pipe = this_pipe;
+      new_sampler->p_SoundProvider = this_pipe;
       new_sampler->time = m_CurrentTime + 1;
       new_sampler->velocity = handle->velocity;
 
       unsigned gain_decay_length = 0;
       float gain_target = this_pipe->GetGain() * release_section->GetNormGain();
-      const bool not_a_tremulant = (handle->sampler_group_id >= 0);
+      const bool not_a_tremulant = isWindchestTask(handle->m_SamplerTaskId);
+
       if (not_a_tremulant) {
         /* Because this sampler is about to be moved to a detached
          * windchest, we must apply the gain of the existing windchest
@@ -604,20 +599,18 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
       }
       new_sampler->is_release = true;
 
-      int windchest_index;
-      if (not_a_tremulant) {
-        /* detached releases are enabled and the pipe was on a regular
-         * windchest. Play the release on the detached windchest */
-        windchest_index = 0;
-      } else {
+      new_sampler->m_SamplerTaskId = not_a_tremulant
+        ? /* detached releases are enabled and the pipe was on a regular
+           * windchest. Play the release on the detached windchest */
+        DETACHED_RELEASE_TASK_ID
         /* detached releases are disabled (or this isn't really a pipe)
          * so put the release on the same windchest as the pipe (which
          * means it will still be affected by tremulants - yuck). */
-        windchest_index = handle->sampler_group_id;
-      }
+        : handle->m_SamplerTaskId;
+      new_sampler->m_AudioGroupId = handle->m_AudioGroupId;
       new_sampler->fader.SetVelocityVolume(
-        new_sampler->pipe->GetVelocityVolume(new_sampler->velocity));
-      StartSampler(new_sampler, windchest_index, handle->audio_group_id);
+        new_sampler->p_SoundProvider->GetVelocityVolume(new_sampler->velocity));
+      StartSampler(new_sampler);
       handle->time = m_CurrentTime;
     }
   }
@@ -632,7 +625,7 @@ uint64_t GOSoundEngine::StopSample(
   // decays away (and hence the sampler is discarded back into the pool), and
   // then the user releases a key. If the sampler had already been reused
   // with another pipe, that sample would erroneously be told to decay.
-  if (pipe != handle->pipe)
+  if (pipe != handle->p_SoundProvider)
     return 0;
 
   handle->stop = m_CurrentTime + handle->delay;
@@ -648,7 +641,7 @@ void GOSoundEngine::SwitchSample(
   // decays away (and hence the sampler is discarded back into the pool), and
   // then the user releases a key. If the sampler had already been reused
   // with another pipe, that sample would erroneously be told to decay.
-  if (pipe != handle->pipe)
+  if (pipe != handle->p_SoundProvider)
     return;
 
   handle->new_attack = m_CurrentTime + handle->delay;
@@ -659,7 +652,7 @@ void GOSoundEngine::UpdateVelocity(
   assert(handle);
   assert(pipe);
 
-  if (handle->pipe == pipe) {
+  if (handle->p_SoundProvider == pipe) {
     // we've just checked that handle is still playing the same pipe
     // may be handle was switched to another pipe between checking and
     // SetVelocityVolume but we don't want to lock it because this functionality
@@ -675,13 +668,13 @@ const std::vector<double> &GOSoundEngine::GetMeterInfo() {
 
   for (unsigned i = 1; i < m_MeterInfo.size(); i++)
     m_MeterInfo[i] = 0;
-  for (unsigned i = 0, nr = 1; i < m_AudioOutputs.size(); i++) {
-    if (!m_AudioOutputs[i])
+  for (unsigned i = 0, nr = 1; i < m_AudioOutputTasks.size(); i++) {
+    if (!m_AudioOutputTasks[i])
       continue;
-    const std::vector<float> &info = m_AudioOutputs[i]->GetMeterInfo();
+    const std::vector<float> &info = m_AudioOutputTasks[i]->GetMeterInfo();
     for (unsigned j = 0; j < info.size(); j++)
       m_MeterInfo[nr++] = info[j];
-    m_AudioOutputs[i]->ResetMeterInfo();
+    m_AudioOutputTasks[i]->ResetMeterInfo();
   }
   return m_MeterInfo;
 }

--- a/src/grandorgue/sound/GOSoundSampler.h
+++ b/src/grandorgue/sound/GOSoundSampler.h
@@ -16,10 +16,10 @@ class GOSoundWindchestWorkItem;
 
 struct GOSoundSampler {
   GOSoundSampler *next;
-  const GOSoundProvider *pipe;
-  int sampler_group_id;
-  GOSoundWindchestWorkItem *windchest;
-  unsigned audio_group_id;
+  const GOSoundProvider *p_SoundProvider;
+  int m_SamplerTaskId;
+  GOSoundWindchestWorkItem *p_WindchestTask;
+  unsigned m_AudioGroupId;
   audio_section_stream stream;
   GOSoundFader fader;
   uint64_t time;

--- a/src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -53,7 +53,7 @@ void GOSoundGroupWorkItem::ProcessList(
     }
     sampler->drop_counter = 0;
 
-    GOSoundWindchestWorkItem *const windchest = sampler->windchest;
+    GOSoundWindchestWorkItem *const windchest = sampler->p_WindchestTask;
 
     if (
       windchest

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -146,7 +146,8 @@ void GOPerfTestApp::RunTest(
       float output_buffer[samples_per_frame * 2];
 
       for (unsigned i = 0; i < pipes.size(); i++) {
-        GOSoundSampler *handle = engine->StartSample(pipes[i], 1, 0, 127, 0, 0);
+        GOSoundSampler *handle
+          = engine->StartPipeSample(pipes[i], 1, 0, 127, 0, 0);
         if (handle)
           handles.push_back(handle);
       }


### PR DESCRIPTION
Having started working on #1855, I am very difficulted to understand, how the tremulant state is stored because it is encoded to vmembers named `Sampler Group Id`.

But there is another usage of the same name: sometimes a windchest number is also encoded to a member with the similar name ``Sample Group Id``. Sometimes the windchest number starts with 0, sometimes - with 1.

This PR brings some order into the naming. It

1. Renames WindchestGroup to Windchest in GOOrganModel member functions
2. Renames WindchestGroup and SampleGroup to WindchestN where it corresponds to the number from the ODF and starts with 1
3. Renamed some parameter names
4. Added some comments
5. Renamed GOSoundSampler::sampler_group_id to m_SamplerTaskId
6. Encapsulated the conversion between windchest number, tremulant number and m_SamplerTaskId in GOSoundEngine
7. Renamed lots of variables in GOSOundEngine and GOSoundSampler
8. Introduced the new methods GOSoundEngine::StartPipeSample and GOSoundEngine::StartTremulantSample instead the old one StartSample
9. Removed initialising GOSoundSampler::m_SamplerTaskId and GOSoundSampler::m_AudioGroupId from GOSOundEngine::StartSampler to their callers
10. Simplified code of GOSoundEngine::PassSampler and GOSoundEngine::StartSampler


This is just renaming and a small refactoring of GOSoundEngine.  No GO behavior should be changed.