### PR TITLE
Renamed Sample Group to WaveTremulantState

### DIFF
--- a/src/grandorgue/model/GOPipeWindchestCallback.h
+++ b/src/grandorgue/model/GOPipeWindchestCallback.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,7 +12,7 @@ class GOPipeWindchestCallback {
 public:
   virtual ~GOPipeWindchestCallback() {}
 
-  virtual void SetTremulant(bool on) = 0;
+  virtual void SetWaveTremulant(bool on) = 0;
 };
 
 #endif

--- a/src/grandorgue/model/GOSoundingPipe.cpp
+++ b/src/grandorgue/model/GOSoundingPipe.cpp
@@ -412,21 +412,21 @@ void GOSoundingPipe::Validate() {
   if (!m_PipeConfigNode.GetEffectiveChannels())
     return;
 
-  if (m_SoundProvider.СheckForMissingAttack()) {
+  if (m_SoundProvider.CheckForMissingAttack()) {
     wxLogWarning(
       _("rank %s pipe %s: attack with MaxTimeSinceLastRelease=-1 missing"),
       m_Rank->GetName().c_str(),
       GetLoadTitle().c_str());
   }
 
-  if (m_SoundProvider.СheckForMissingRelease()) {
+  if (m_SoundProvider.CheckForMissingRelease()) {
     wxLogWarning(
       _("rank %s pipe %s: default release is missing"),
       m_Rank->GetName().c_str(),
       GetLoadTitle().c_str());
   }
 
-  if (m_SoundProvider.СheckMissingRelease()) {
+  if (m_SoundProvider.CheckMissingRelease()) {
     wxLogWarning(
       _("rank %s pipe %s: no release defined"),
       m_Rank->GetName().c_str(),
@@ -435,7 +435,7 @@ void GOSoundingPipe::Validate() {
 
   if (
     !m_PipeConfigNode.IsEffectiveIndependentRelease()
-    && m_SoundProvider.СheckNotNecessaryRelease()) {
+    && m_SoundProvider.CheckNotNecessaryRelease()) {
     wxLogWarning(
       _("rank %s pipe %s: percussive sample with a release"),
       m_Rank->GetName().c_str(),

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -30,7 +30,7 @@ private:
   uint64_t m_LastStart;
   uint64_t m_LastStop;
   int m_Instances;
-  bool m_Tremulant;
+  bool m_IsWaveTremulantActive;
   std::vector<GOSoundProviderWave::AttackFileInfo> m_AttackFileInfos;
   std::vector<GOSoundProviderWave::ReleaseFileInfo> m_ReleaseFileInfos;
   wxString m_Filename;
@@ -100,10 +100,10 @@ private:
 
   // Callbacks from the console
   /**
-   * Called when the tremulant is switched on or off
+   * Called when a wave tremulant is switched on or off
    * @param on the new tremulant state
    */
-  void SetTremulant(bool on) override;
+  void SetWaveTremulant(bool on) override;
   /**
    * Called when the key is just pressed, released or the velocity is changed
    * @param velocity the velocity of key pressing. 0 means release

--- a/src/grandorgue/model/GOWindchest.cpp
+++ b/src/grandorgue/model/GOWindchest.cpp
@@ -119,7 +119,7 @@ void GOWindchest::UpdateTremulant(GOTremulant *tremulant) {
         continue;
       bool on = t->IsActive();
       for (unsigned j = 0; j < m_pipes.size(); j++)
-        m_pipes[j]->SetTremulant(on);
+        m_pipes[j]->SetWaveTremulant(on);
       return;
     }
 }

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -81,7 +81,7 @@ bool GOSoundAudioSection::LoadCache(GOCache &cache) {
     return false;
   if (!cache.Read(&m_BytesPerSample, sizeof(m_BytesPerSample)))
     return false;
-  if (!cache.Read(&m_SampleGroup, sizeof(m_SampleGroup)))
+  if (!cache.Read(&m_WaveTremulantStateFor, sizeof(m_WaveTremulantStateFor)))
     return false;
   if (!cache.Read(&m_IsCompressed, sizeof(m_IsCompressed)))
     return false;
@@ -160,7 +160,7 @@ bool GOSoundAudioSection::SaveCache(GOCacheWriter &cache) const {
     return false;
   if (!cache.Write(&m_BytesPerSample, sizeof(m_BytesPerSample)))
     return false;
-  if (!cache.Write(&m_SampleGroup, sizeof(m_SampleGroup)))
+  if (!cache.Write(&m_WaveTremulantStateFor, sizeof(m_WaveTremulantStateFor)))
     return false;
   if (!cache.Write(&m_IsCompressed, sizeof(m_IsCompressed)))
     return false;
@@ -658,7 +658,7 @@ void GOSoundAudioSection::Setup(
   const unsigned pcm_data_sample_rate,
   const unsigned pcm_data_nb_samples,
   const std::vector<GOWaveLoop> *loop_points,
-  int8_t sampleGroup,
+  GOBool3 waveTremulantStateFor,
   bool compress,
   unsigned loopCrossfadeLength,
   unsigned releaseCrossfadeLength) {
@@ -835,7 +835,7 @@ void GOSoundAudioSection::Setup(
   m_SampleFracBits = m_BitsPerSample - 1;
   m_Channels = pcm_data_channels;
   m_IsCompressed = false;
-  m_SampleGroup = sampleGroup;
+  m_WaveTremulantStateFor = waveTremulantStateFor;
 
   /* Store the main data blob. */
   memcpy(m_Data, pcm_data, m_AllocSize);

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -50,6 +50,7 @@ void GOSoundAudioSection::ClearData() {
   m_SampleRate = 0;
   m_BitsPerSample = 0;
   m_BytesPerSample = 0;
+  m_WaveTremulantStateFor = BOOL3_DEFAULT;
   m_IsCompressed = false;
   m_Channels = 0;
   if (m_Data) {

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <math.h>
 
+#include "GOBool3.h"
 #include "GOInt.h"
 #include "GOSoundCompress.h"
 #include "GOSoundDefs.h"
@@ -160,7 +161,7 @@ private:
   unsigned m_BytesPerSample;
   unsigned m_Channels;
 
-  int8_t m_SampleGroup;
+  GOBool3 m_WaveTremulantStateFor;
   bool m_IsCompressed;
 
   /* Size of the section in BYTES */
@@ -177,7 +178,7 @@ public:
   ~GOSoundAudioSection();
   void ClearData();
   inline unsigned GetChannels() const { return m_Channels; }
-  inline int8_t GetSampleGroup() const { return m_SampleGroup; }
+  inline int8_t GetSampleGroup() const { return m_WaveTremulantStateFor; }
 
   unsigned GetBytesPerSample() const;
   unsigned GetLength() const;
@@ -216,7 +217,7 @@ public:
     unsigned pcm_data_sample_rate,
     unsigned pcm_data_nb_samples,
     const std::vector<GOWaveLoop> *loop_points,
-    int8_t sampleGroup,
+    GOBool3 waveTremulantStateFor,
     bool compress,
     unsigned loopCrossfadeLength,
     unsigned releaseCrossfadeLength);

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -178,7 +178,9 @@ public:
   ~GOSoundAudioSection();
   void ClearData();
   inline unsigned GetChannels() const { return m_Channels; }
-  inline int8_t GetSampleGroup() const { return m_WaveTremulantStateFor; }
+  inline GOBool3 GetWaveTremulantStateFor() const {
+    return m_WaveTremulantStateFor;
+  }
 
   unsigned GetBytesPerSample() const;
   unsigned GetLength() const;

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -410,7 +410,7 @@ GOSoundSampler *GOSoundEngine::StartSample(
 
   GOSoundSampler *sampler = nullptr;
   const GOSoundAudioSection *section = isRelease
-    ? pipe->GetRelease(-1, eventIntervalMs)
+    ? pipe->GetRelease(BOOL3_DEFAULT, eventIntervalMs)
     : pipe->GetAttack(velocity, eventIntervalMs);
 
   if (pStartTimeSamples) {
@@ -490,7 +490,7 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
    * zero. */
   const GOSoundProvider *this_pipe = handle->pipe;
   const GOSoundAudioSection *release_section = this_pipe->GetRelease(
-    handle->stream.audio_section->GetSampleGroup(),
+    handle->stream.audio_section->GetWaveTremulantStateFor(),
     SamplesDiffToMs(handle->time, m_CurrentTime));
   unsigned cross_fade_len = release_section
     ? release_section->GetReleaseCrossfadeLength()

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -217,13 +217,13 @@ const GOSoundAudioSection *GOSoundProvider::GetAttack(
 }
 
 const GOSoundAudioSection *GOSoundProvider::GetRelease(
-  int8_t sampleGroup, unsigned playbackDurationMs) const {
+  GOBool3 waveTremulantStateFor, unsigned playbackDurationMs) const {
   const unsigned x = abs(rand());
   int best_match = -1;
 
   for (unsigned i = 0; i < m_Release.size(); i++) {
     const unsigned idx = (i + x) % m_Release.size();
-    if (m_ReleaseInfo[idx].m_WaveTremulantStateFor != sampleGroup)
+    if (m_ReleaseInfo[idx].m_WaveTremulantStateFor != waveTremulantStateFor)
       continue;
     if (m_ReleaseInfo[idx].max_playback_time < playbackDurationMs)
       continue;

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -35,7 +35,7 @@ GOSoundProvider::GOSoundProvider()
   : m_MidiKeyNumber(0),
     m_MidiPitchFract(0),
     m_Tuning(1),
-    m_SampleGroup(false),
+    m_IsWaveTremulantActive(BOOL3_FALSE),
     m_ReleaseTail(0),
     m_Attack(),
     m_AttackInfo(),
@@ -128,21 +128,21 @@ bool GOSoundProvider::SaveCache(GOCacheWriter &cache) const {
 
 void GOSoundProvider::ComputeReleaseAlignmentInfo() {
   std::vector<const GOSoundAudioSection *> sections;
-  for (int k = -1; k < 2; k++) {
+  for (int8_t k = BOOL3_MIN; k <= BOOL3_MAX; ++k) {
     sections.clear();
     for (unsigned i = 0; i < m_Attack.size(); i++)
-      if (m_AttackInfo[i].sample_group == k)
+      if (m_AttackInfo[i].m_WaveTremulantStateFor == k)
         sections.push_back(m_Attack[i]);
     for (unsigned i = 0; i < m_Release.size(); i++)
-      if (m_ReleaseInfo[i].sample_group == k)
+      if (m_ReleaseInfo[i].m_WaveTremulantStateFor == k)
         m_Release[i]->SetupStreamAlignment(sections, 0);
 
     sections.clear();
     for (unsigned i = 0; i < m_Attack.size(); i++)
-      if (m_AttackInfo[i].sample_group != k)
+      if (m_AttackInfo[i].m_WaveTremulantStateFor != k)
         sections.push_back(m_Attack[i]);
     for (unsigned i = 0; i < m_Attack.size(); i++)
-      if (m_AttackInfo[i].sample_group == k)
+      if (m_AttackInfo[i].m_WaveTremulantStateFor == k)
         m_Attack[i]->SetupStreamAlignment(sections, 1);
   }
 
@@ -193,8 +193,9 @@ const GOSoundAudioSection *GOSoundProvider::GetAttack(
   for (unsigned i = 0; i < m_Attack.size(); i++) {
     const unsigned idx = (i + x) % m_Attack.size();
     if (
-      m_AttackInfo[idx].sample_group != -1
-      && m_AttackInfo[idx].sample_group != (int8_t)m_SampleGroup)
+      m_AttackInfo[idx].m_WaveTremulantStateFor != BOOL3_DEFAULT
+      && m_AttackInfo[idx].m_WaveTremulantStateFor
+        != to_bool3(m_IsWaveTremulantActive))
       continue;
     if (m_AttackInfo[idx].min_attack_velocity > velocity)
       continue;
@@ -222,7 +223,7 @@ const GOSoundAudioSection *GOSoundProvider::GetRelease(
 
   for (unsigned i = 0; i < m_Release.size(); i++) {
     const unsigned idx = (i + x) % m_Release.size();
-    if (m_ReleaseInfo[idx].sample_group != sampleGroup)
+    if (m_ReleaseInfo[idx].m_WaveTremulantStateFor != sampleGroup)
       continue;
     if (m_ReleaseInfo[idx].max_playback_time < playbackDurationMs)
       continue;
@@ -240,12 +241,12 @@ const GOSoundAudioSection *GOSoundProvider::GetRelease(
   return NULL;
 }
 
-bool GOSoundProvider::checkForMissingRelease() {
-  for (int k = -1; k < 2; k++) {
+bool GOSoundProvider::СheckForMissingRelease() {
+  for (int8_t k = BOOL3_MIN; k <= BOOL3_MAX; k++) {
     unsigned cnt = 0;
     bool max_release = false;
     for (unsigned i = 0; i < m_Release.size(); i++)
-      if (m_ReleaseInfo[i].sample_group == k) {
+      if (m_ReleaseInfo[i].m_WaveTremulantStateFor == k) {
         cnt++;
         if (m_ReleaseInfo[i].max_playback_time == (unsigned)-1)
           max_release = true;
@@ -256,12 +257,12 @@ bool GOSoundProvider::checkForMissingRelease() {
   return false;
 }
 
-bool GOSoundProvider::checkForMissingAttack() {
-  for (int k = -1; k < 2; k++) {
+bool GOSoundProvider::СheckForMissingAttack() {
+  for (int8_t k = BOOL3_MIN; k <= BOOL3_MAX; k++) {
     unsigned cnt = 0;
     bool max_release = false;
     for (unsigned i = 0; i < m_Attack.size(); i++)
-      if (m_AttackInfo[i].sample_group == k) {
+      if (m_AttackInfo[i].m_WaveTremulantStateFor == k) {
         cnt++;
         if (m_AttackInfo[i].max_released_time == (unsigned)-1)
           max_release = true;
@@ -272,26 +273,26 @@ bool GOSoundProvider::checkForMissingAttack() {
   return false;
 }
 
-bool GOSoundProvider::checkMissingRelease() {
+bool GOSoundProvider::СheckMissingRelease() {
   if (IsOneshot())
     return false;
-  for (int k = -1; k < 2; k++) {
+  for (int8_t k = BOOL3_MIN; k <= BOOL3_MAX; k++) {
     bool found = false;
     for (unsigned i = 0; i < m_Attack.size() && !found; i++)
-      if (m_AttackInfo[i].sample_group == k)
+      if (m_AttackInfo[i].m_WaveTremulantStateFor == k)
         found = true;
     if (!found)
       continue;
     found = false;
     for (unsigned i = 0; i < m_Release.size() && !found; i++)
-      if (m_ReleaseInfo[i].sample_group == k)
+      if (m_ReleaseInfo[i].m_WaveTremulantStateFor == k)
         found = true;
     if (!found)
       return true;
   }
   return false;
 }
-bool GOSoundProvider::checkNotNecessaryRelease() {
+bool GOSoundProvider::СheckNotNecessaryRelease() {
   if (IsOneshot() && m_Release.size())
     return true;
   return false;

--- a/src/grandorgue/sound/GOSoundProvider.cpp
+++ b/src/grandorgue/sound/GOSoundProvider.cpp
@@ -241,7 +241,7 @@ const GOSoundAudioSection *GOSoundProvider::GetRelease(
   return NULL;
 }
 
-bool GOSoundProvider::СheckForMissingRelease() {
+bool GOSoundProvider::CheckForMissingRelease() {
   for (int8_t k = BOOL3_MIN; k <= BOOL3_MAX; k++) {
     unsigned cnt = 0;
     bool max_release = false;
@@ -257,7 +257,7 @@ bool GOSoundProvider::СheckForMissingRelease() {
   return false;
 }
 
-bool GOSoundProvider::СheckForMissingAttack() {
+bool GOSoundProvider::CheckForMissingAttack() {
   for (int8_t k = BOOL3_MIN; k <= BOOL3_MAX; k++) {
     unsigned cnt = 0;
     bool max_release = false;
@@ -273,7 +273,7 @@ bool GOSoundProvider::СheckForMissingAttack() {
   return false;
 }
 
-bool GOSoundProvider::СheckMissingRelease() {
+bool GOSoundProvider::CheckMissingRelease() {
   if (IsOneshot())
     return false;
   for (int8_t k = BOOL3_MIN; k <= BOOL3_MAX; k++) {
@@ -292,7 +292,7 @@ bool GOSoundProvider::СheckMissingRelease() {
   }
   return false;
 }
-bool GOSoundProvider::СheckNotNecessaryRelease() {
+bool GOSoundProvider::CheckNotNecessaryRelease() {
   if (IsOneshot() && m_Release.size())
     return true;
   return false;

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -87,10 +87,10 @@ public:
 
   float GetVelocityVolume(unsigned velocity) const;
 
-  bool СheckForMissingAttack();
-  bool СheckForMissingRelease();
-  bool СheckMissingRelease();
-  bool СheckNotNecessaryRelease();
+  bool CheckForMissingAttack();
+  bool CheckForMissingRelease();
+  bool CheckMissingRelease();
+  bool CheckNotNecessaryRelease();
 
   GOSampleStatistic GetStatistic();
 };

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -11,8 +11,10 @@
 #include <cstdint>
 #include <vector>
 
-#include "GOStatisticCallback.h"
 #include "ptrvector.h"
+
+#include "GOBool3.h"
+#include "GOStatisticCallback.h"
 
 class GOSoundAudioSection;
 class GOCache;
@@ -27,19 +29,19 @@ protected:
   struct AttackSelector {
     unsigned min_attack_velocity;
     unsigned max_released_time;
-    int8_t sample_group;
+    GOBool3 m_WaveTremulantStateFor;
   };
 
   struct ReleaseSelector {
     unsigned max_playback_time;
-    int8_t sample_group;
+    GOBool3 m_WaveTremulantStateFor;
   };
 
   unsigned m_MidiKeyNumber;
   float m_MidiPitchFract;
   float m_Gain;
   float m_Tuning;
-  bool m_SampleGroup;
+  bool m_IsWaveTremulantActive;
   unsigned m_ReleaseTail;
   ptr_vector<GOSoundAudioSection> m_Attack;
   std::vector<AttackSelector> m_AttackInfo;
@@ -61,7 +63,7 @@ public:
   virtual bool LoadCache(GOMemoryPool &pool, GOCache &cache);
   virtual bool SaveCache(GOCacheWriter &cache) const;
 
-  void UseSampleGroup(bool sampleGroup) { m_SampleGroup = sampleGroup; }
+  void SetWaveTremulant(bool isActive) { m_IsWaveTremulantActive = isActive; }
 
   void SetVelocityParameter(float min_volume, float max_volume);
 
@@ -85,10 +87,10 @@ public:
 
   float GetVelocityVolume(unsigned velocity) const;
 
-  bool checkForMissingAttack();
-  bool checkForMissingRelease();
-  bool checkMissingRelease();
-  bool checkNotNecessaryRelease();
+  bool СheckForMissingAttack();
+  bool СheckForMissingRelease();
+  bool СheckMissingRelease();
+  bool СheckNotNecessaryRelease();
 
   GOSampleStatistic GetStatistic();
 };

--- a/src/grandorgue/sound/GOSoundProvider.h
+++ b/src/grandorgue/sound/GOSoundProvider.h
@@ -70,7 +70,7 @@ public:
   const GOSoundAudioSection *GetAttack(
     unsigned velocity, unsigned releasedDurationMs) const;
   const GOSoundAudioSection *GetRelease(
-    int8_t sampleGroup, unsigned playbackDurationMs) const;
+    GOBool3 waveTremulantStateFor, unsigned playbackDurationMs) const;
   float GetGain() const;
   int IsOneshot() const;
 

--- a/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
+++ b/src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp
@@ -83,7 +83,7 @@ void GOSoundProviderSynthedTrem::Create(
   std::vector<GOWaveLoop> trem_loops;
   trem_loops.push_back(trem_loop);
   AttackSelector attack_info;
-  attack_info.sample_group = -1;
+  attack_info.m_WaveTremulantStateFor = BOOL3_DEFAULT;
   attack_info.min_attack_velocity = 0;
   attack_info.max_released_time = -1;
   m_AttackInfo.push_back(attack_info);
@@ -97,14 +97,14 @@ void GOSoundProviderSynthedTrem::Create(
     sample_freq,
     trem_loop.m_EndPosition,
     &trem_loops,
-    -1,
+    BOOL3_DEFAULT,
     false,
     0,
     0);
 
   /* Release section */
   ReleaseSelector release_info;
-  release_info.sample_group = -1;
+  release_info.m_WaveTremulantStateFor = BOOL3_DEFAULT;
   release_info.max_playback_time = -1;
   m_ReleaseInfo.push_back(release_info);
   m_Release.push_back(new GOSoundAudioSection(pool));
@@ -117,7 +117,7 @@ void GOSoundProviderSynthedTrem::Create(
     sample_freq,
     release_samples,
     NULL,
-    -1,
+    BOOL3_DEFAULT,
     false,
     0,
     0);

--- a/src/grandorgue/sound/GOSoundProviderWave.h
+++ b/src/grandorgue/sound/GOSoundProviderWave.h
@@ -50,7 +50,7 @@ public:
     int release_end;
     unsigned m_LoopCrossfadeLength;
     unsigned m_ReleaseCrossfadeLength;
-    int8_t sample_group;
+    GOBool3 m_WaveTremulantStateFor;
     bool load_release;
     bool percussive;
   };
@@ -61,7 +61,7 @@ public:
     int cue_point;
     int release_end;
     unsigned m_ReleaseCrossfadeLength;
-    int8_t sample_group;
+    GOBool3 m_WaveTremulantStateFor;
   };
 
 private:
@@ -76,7 +76,7 @@ private:
     GOWave &wave,
     int attack_start,
     const std::vector<GOWaveLoop> *pSrcLoops,
-    int sample_group,
+    GOBool3 waveTremulantStateFor,
     unsigned bits_per_sample,
     unsigned channels,
     bool compress,
@@ -91,7 +91,7 @@ private:
     const GOLoaderFilename &loaderFilename,
     const char *data,
     GOWave &wave,
-    int sample_group,
+    GOBool3 waveTremulantStateFor,
     unsigned max_playback_time,
     int cue_point,
     int release_end,
@@ -110,7 +110,7 @@ private:
     const std::vector<GOWaveLoop> *loops,
     bool is_attack,
     bool is_release,
-    int sample_group,
+    GOBool3 waveTremulantStateFor,
     unsigned max_playback_time,
     int attack_start,
     int cue_point,

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -93,7 +93,7 @@ void GOPerfTestApp::RunTest(
         GOSoundProviderWave::AttackFileInfo ainfo;
 
         ainfo.filename.Assign(wxString::Format(wxT("%02d.wav"), i % 3));
-        ainfo.sample_group = -1;
+        ainfo.m_WaveTremulantStateFor = BOOL3_DEFAULT;
         ainfo.load_release = true;
         ainfo.percussive = false;
         ainfo.min_attack_velocity = 0;


### PR DESCRIPTION
This is the second PR relared to #1855

It renames all forms of `Sample Group` that are used for wave tremulant states to `Wave Tremulant` in different forms.
Another PR eliminating `Sampler Group`  is #1856.

This PR alsu uses the `GOBool3` type for stoting `IsTremulant`.

It is just renaming with a small code enchancement. No GO behavior should be changed.