### PR TITLE
Fixed an error that occurred when trying to install the GrandOrgue RPM package https://github.com/GrandOrgue/grandorgue/issues/1859

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed an error that occurred when trying to install the GrandOrgue RPM package https://github.com/GrandOrgue/grandorgue/issues/1859
 # 3.14.0 (2024-03-29)
 - Fixed crash on loading an organ without a pedal but wit a unison-off coupler https://github.com/GrandOrgue/grandorgue/issues/1846
 - Changed displaying of the right part of paths https://github.com/GrandOrgue/grandorgue/issues/1663

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,7 +360,12 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   # In Fedora libcurl is based on openssl, but libcurl package does not provide such symbol.
   # As a workaround, we set the right symbol manually.
   set(CPACK_RPM_SPEC_MORE_DEFINE "%global __requires_exclude libcurl.*")
-  set(CPACK_RPM_PACKAGE_REQUIRES "libcurl.so.4")
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    # dnf tries to install the 32-bit package on x86_64 if '()(64bit)' is omitted
+    set(CPACK_RPM_PACKAGE_REQUIRES "libcurl.so.4()(64bit)")
+  else()
+    set(CPACK_RPM_PACKAGE_REQUIRES "libcurl.so.4")
+  endif()
 
   # prevent rpmlint errors
   set(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,12 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(CPACK_RPM_DEMO_FILE_NAME RPM-DEFAULT)
   string (REPLACE ";" " " CPACK_RPM_PACKAGE_OBSOLETES "${OTHER_PACKAGE_NAMES}")
 
+  # On Ubuntu rpmbuild generates a libcurl.so.4(CURL_OPENSSL_4)(64bit) requirement for libcurl.
+  # In Fedora libcurl is based on openssl, but libcurl package does not provide such symbol.
+  # As a workaround, we set the right symbol manually.
+  set(CPACK_RPM_SPEC_MORE_DEFINE "%global __requires_exclude libcurl.*")
+  set(CPACK_RPM_PACKAGE_REQUIRES "libcurl.so.4")
+
   # prevent rpmlint errors
   set(
     CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION


### PR DESCRIPTION
Resolves: #1859

When building on Ubuntu, rpmbuild incorrectly assumes the libcurl symbol name. [The actual package](https://rpmfind.net/linux/RPM/fedora/devel/rawhide/x86_64/l/libcurl-8.6.0-7.fc41.x86_64.html) in Fedora does not provide the `libcurl.so.4(CURL_OPENSSL_4)(64bit)` symbol.