### PR TITLE
Fixed ignoring initial midi setup when loading an organ with a preset without midi events configured https://github.com/GrandOrgue/grandorgue/issues/1785

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed ignoring initial midi setup when loading an organ with a preset without midi events configured https://github.com/GrandOrgue/grandorgue/issues/1785
 - Fixed saving Max release tail to the organ preset https://github.com/GrandOrgue/grandorgue/issues/1804
 - Fixed required package names in the BUILD.md file https://github.com/GrandOrgue/grandorgue/issues/1799
 - Added support of macOS on Apple silicon. GrandOrgue for macOS on Apple silicon requires macOS 14 or higher. GrandOrgue for macOS on Intel requires macOS 12.1 or higher. https://github.com/GrandOrgue/grandorgue/discussions/1153

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -64,8 +64,9 @@ void GOMidiReceiverBase::Load(
   m_events.resize(0);
 
   int event_cnt = cfg.ReadInteger(
-    CMBSetting, group, wxT("NumberOfMIDIEvents"), -1, 255, false);
-  if (event_cnt >= 0) {
+    CMBSetting, group, wxT("NumberOfMIDIEvents"), 0, 255, false);
+
+  if (event_cnt > 0) {
     m_events.resize(event_cnt);
     for (unsigned i = 0; i < m_events.size(); i++) {
       m_events[i].deviceId = map.GetDeviceIdByLogicalName(cfg.ReadString(


### PR DESCRIPTION
Resolves: #1785

Earlier: initial midi settings were not used when loading a preset .cmb file.
Now: if some element doesn't have any midi events configured in the preset, it uses the midi events from the initial midi config.

When the user saves the preset, these midi events are also saved. So if the user changes the initial midi config, it does not affect the events have already been saved to the preset.