### PR TITLE
Fixed saving Max release tail to the organ preset https://github.com/GrandOrgue/grandorgue/issues/1804

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed saving Max release tail to the organ preset https://github.com/GrandOrgue/grandorgue/issues/1804
 - Fixed required package names in the BUILD.md file https://github.com/GrandOrgue/grandorgue/issues/1799
 - Added support of macOS on Apple silicon. GrandOrgue for macOS on Apple silicon requires macOS 14 or higher. GrandOrgue for macOS on Intel requires macOS 12.1 or higher. https://github.com/GrandOrgue/grandorgue/discussions/1153
 - Added ad-hoc code signing of GrandOrgue for macOS https://github.com/GrandOrgue/grandorgue/issues/1835

--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -64,7 +64,8 @@ bool GODocument::LoadOrgan(
     CloseOrgan();
     return false;
   }
-  m_sound.GetSettings().AddOrgan(m_OrganController->GetOrganInfo());
+  cfg.AddOrgan(m_OrganController->GetOrganInfo());
+  cfg.Flush();
   {
     wxCommandEvent event(wxEVT_SETVALUE, ID_METER_AUDIO_SPIN);
     event.SetInt(m_OrganController->GetVolume());
@@ -72,16 +73,6 @@ bool GODocument::LoadOrgan(
 
     m_sound.GetEngine().SetVolume(m_OrganController->GetVolume());
   }
-
-  // synchronize cfg.ReleaseTail with OrganReleaseTail.
-  unsigned cfgReleaseTail = cfg.ReleaseLength();
-  unsigned organReleaseTail = m_OrganController->GetReleaseTail();
-
-  if (organReleaseTail) // organReleaseTail has the priority
-    cfg.ReleaseLength(organReleaseTail);
-  else if (cfgReleaseTail)
-    m_OrganController->SetReleaseTail(cfgReleaseTail);
-  cfg.Flush();
 
   wxCommandEvent event(wxEVT_WINTITLE, 0);
   event.SetString(m_OrganController->GetChurchName());

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -330,7 +330,7 @@ GOFrame::GOFrame(
     wxDefaultSize,
     choices);
   m_ToolBar->AddControl(m_ReleaseLength);
-  UpdateReleaseLength(m_config.ReleaseLength());
+  UpdateReleaseLength(0);
 
   m_ToolBar->AddTool(
     ID_TRANSPOSE,
@@ -492,8 +492,6 @@ void GOFrame::UpdateReleaseLength(unsigned releaseLength) {
 
   if (organController && organController->GetReleaseTail() != releaseLength)
     organController->SetReleaseTail(releaseLength);
-  if (m_config.ReleaseLength() != releaseLength)
-    m_config.ReleaseLength(releaseLength);
   if (m_ReleaseLength->GetSelection() != releaseLengthIndex)
     m_ReleaseLength->SetSelection(releaseLengthIndex);
 }

--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -194,7 +194,6 @@ GOConfig::GOConfig(wxString instance)
     PolyphonyLimit(
       this, wxT("General"), wxT("PolyphonyLimit"), 0, MAX_POLYPHONY, 2048),
     Preset(this, wxT("General"), wxT("Preset"), 0, MAX_PRESET, 0),
-    ReleaseLength(this, wxT("General"), wxT("ReleaseLength"), 0, 3000, 0),
     LanguageCode(this, wxT("General"), wxT("Language"), wxEmptyString),
     BitsPerSample(this, wxT("General"), wxT("BitsPerSample"), 8, 24, 24),
     Transpose(this, wxT("General"), wxT("Transpose"), -11, 11, 0),

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -121,7 +121,6 @@ public:
   GOSettingInteger Volume;
   GOSettingUnsigned PolyphonyLimit;
   GOSettingUnsigned Preset;
-  GOSettingUnsigned ReleaseLength;
   GOSettingString LanguageCode;
 
   class GOSettingUnsignedBit : public GOSettingUnsigned {


### PR DESCRIPTION
Resolves: #1804

Earlier the release tail length was a GrandOrgue config option. If an organ had the `Max` value in it's preset, the GrandOrgue config option was used. It made unabl to set `Max` for particular organs.

Now the release tail length only presents in organ settings, not in the GrandOrgue config. It always reset when another organ is loaded.