### PR TITLE
Fixed the order of sending midi events from an On indicator. Now they are sent after sending all events from another controls https://github.com/GrandOrgue/grandorgue/issues/1762

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Fixed the order of sending midi events from an On indicator. Now they are sent after sending all events from another controls https://github.com/GrandOrgue/grandorgue/issues/1762
+- Fixed the order of sending midi events from an On indicator. Now they are sent after sending all events from other controls https://github.com/GrandOrgue/grandorgue/issues/1762
 # 3.14.1 (2024-04-17)
 - Fixed changing sound of a playing pipe without Pipe999IsTremulant when a wave tremulant state is changed https://github.com/GrandOrgue/grandorgue/issues/1855
 - Fixed crash on opening a very old config https://github.com/GrandOrgue/grandorgue/discussions/1869

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed the order of sending midi events from an On indicator. Now they are sent after sending all events from another controls https://github.com/GrandOrgue/grandorgue/issues/1762
 # 3.14.1 (2024-04-17)
 - Fixed changing sound of a playing pipe without Pipe999IsTremulant when a wave tremulant state is changed https://github.com/GrandOrgue/grandorgue/issues/1855
 - Fixed crash on opening a very old config https://github.com/GrandOrgue/grandorgue/discussions/1869

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -285,8 +285,8 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   p_OnStateButton = GetButtonControl(GOSetter::KEY_ON_STATE);
 
   if (p_OnStateButton) {
-    // we do not want to send midi events on m_OnStateButton togeather with
-    // other events. They will be sent separatelly
+    // we do not want to send midi events on m_OnStateButton together with
+    // other events. They will be sent separately.
     UnRegisterSoundStateHandler(p_OnStateButton);
   }
 

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -98,6 +98,7 @@ GOOrganController::GOOrganController(
     m_AudioRecorder(NULL),
     m_MidiPlayer(NULL),
     m_MidiRecorder(NULL),
+    p_OnStateButton(nullptr),
     m_volume(0),
     m_b_customized(false),
     m_CurrentPitch(999999.0), // for enforcing updating the label first time
@@ -128,6 +129,7 @@ GOOrganController::GOOrganController(
 }
 
 GOOrganController::~GOOrganController() {
+  p_OnStateButton = nullptr;
   m_FileStore.CloseArchives();
   GOEventHandlerList::Cleanup();
   // Just to be sure, that the sound providers are freed before the pool
@@ -279,6 +281,14 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
 
   for (unsigned i = 0; i < m_elementcreators.size(); i++)
     m_elementcreators[i]->Load(cfg);
+
+  p_OnStateButton = GetButtonControl(GOSetter::KEY_ON_STATE);
+
+  if (p_OnStateButton) {
+    // we do not want to send midi events on m_OnStateButton togeather with
+    // other events. They will be sent separatelly
+    UnRegisterSoundStateHandler(p_OnStateButton);
+  }
 
   m_PitchLabel.Load(cfg, wxT("SetterMasterPitch"), _("organ pitch"));
   m_TemperamentLabel.Load(
@@ -1014,6 +1024,8 @@ void GOOrganController::Abort() {
   m_MidiRecorder->StopRecording();
   m_AudioRecorder->StopRecording();
   m_AudioRecorder->SetAudioRecorder(NULL);
+  if (p_OnStateButton)
+    p_OnStateButton->AbortPlaybackExt();
   GOOrganModel::SetMidi(nullptr, nullptr);
   m_midi = NULL;
 }
@@ -1045,6 +1057,13 @@ void GOOrganController::PreparePlayback(
 
   GOEventDistributor::StartPlayback();
   GOEventDistributor::PrepareRecording();
+
+  // Light the OnState button
+  if (p_OnStateButton) {
+    p_OnStateButton->PreparePlaybackExt(engine);
+    p_OnStateButton->StartPlaybackExt();
+    p_OnStateButton->PrepareRecordingExt();
+  }
 }
 
 void GOOrganController::PrepareRecording() {

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -73,6 +73,7 @@ private:
   GOAudioRecorder *m_AudioRecorder;
   GOMidiPlayer *m_MidiPlayer;
   GOMidiRecorder *m_MidiRecorder;
+  GOButtonControl *p_OnStateButton;
   int m_volume;
   wxString m_Temperament;
 

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -154,6 +154,8 @@ const wxString GOSetter::KEY_LOAD_FILE = wxT("LoadFile");
 const wxString GOSetter::KEY_SAVE_FILE = wxT("SaveFile");
 const wxString GOSetter::KEY_SAVE_SETTINGS = wxT("Save");
 
+const wxString GOSetter::KEY_ON_STATE = wxT("OnState");
+
 const wxString GOSetter::GROUP_REFRESH_FILES = wxT("SetterRefreshFiles");
 const wxString GOSetter::GROUP_PREV_FILE = wxT("SetterPrevFile");
 const wxString GOSetter::GROUP_CURR_FILE_NAME = wxT("SetterCurrFileName");
@@ -263,7 +265,7 @@ const struct GOElementCreator::ButtonDefinitionEntry GOSetter::m_element_types[]
     {wxT("TransposeUp"), ID_SETTER_TRANSPOSE_UP, true, true, false},
 
     {KEY_SAVE_SETTINGS, ID_SETTER_SAVE_SETTINGS, true, true, false},
-    {wxT("OnState"), ID_SETTER_ON, false, true, false},
+    {KEY_ON_STATE, ID_SETTER_ON, false, true, false},
 
     {wxT("CrescendoA"), ID_SETTER_CRESCENDO_A, true, true, false},
     {wxT("CrescendoB"), ID_SETTER_CRESCENDO_B, true, true, false},

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -130,6 +130,8 @@ public:
   static const wxString KEY_LOAD_FILE;
   static const wxString KEY_SAVE_FILE;
   static const wxString KEY_SAVE_SETTINGS;
+
+  static const wxString KEY_ON_STATE;
 
   static const wxString GROUP_REFRESH_FILES;
   static const wxString GROUP_PREV_FILE;

--- a/src/grandorgue/control/GOButtonControl.h
+++ b/src/grandorgue/control/GOButtonControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -27,7 +27,7 @@ class GOOrganModel;
 
 class GOButtonControl : private GOEventHandler,
                         public GOSaveableObject,
-                        protected GOSoundStateHandler,
+                        public GOSoundStateHandler,
                         public GOMidiConfigurator {
 private:
   GOMidiMap &r_MidiMap;

--- a/src/grandorgue/gui/GOGUIMasterPanel.cpp
+++ b/src/grandorgue/gui/GOGUIMasterPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,6 +8,8 @@
 #include "GOGUIMasterPanel.h"
 
 #include <wx/intl.h>
+
+#include "combinations/GOSetter.h"
 
 #include "GOGUIButton.h"
 #include "GOGUIHW1Background.h"
@@ -94,7 +96,7 @@ GOGUIPanel *GOGUIMasterPanel::CreateMasterPanel(GOConfigReader &cfg) {
   panel->AddControl(button);
 
   button = new GOGUIButton(
-    panel, m_OrganController->GetButtonControl(wxT("OnState")), true);
+    panel, m_OrganController->GetButtonControl(GOSetter::KEY_ON_STATE), true);
   button->Init(cfg, wxT("SetterOn"), 1, 100, 4);
   panel->AddControl(button);
 

--- a/src/grandorgue/model/GOEventHandlerList.cpp
+++ b/src/grandorgue/model/GOEventHandlerList.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -36,6 +36,17 @@ void GOEventHandlerList::RegisterMidiConfigurator(GOMidiConfigurator *obj) {
 void GOEventHandlerList::RegisterSoundStateHandler(
   GOSoundStateHandler *handler) {
   m_SoundStateHandlers.push_back(handler);
+}
+
+void GOEventHandlerList::UnRegisterSoundStateHandler(
+  GOSoundStateHandler *handler) {
+  auto it = std::find(
+    m_SoundStateHandlers.begin(), m_SoundStateHandlers.end(), handler);
+
+  if (it != m_SoundStateHandlers.end()) {
+    *it = nullptr;
+    m_SoundStateHandlers.erase(it);
+  }
 }
 
 void GOEventHandlerList::RegisterSaveableObject(GOSaveableObject *obj) {

--- a/src/grandorgue/model/GOEventHandlerList.h
+++ b/src/grandorgue/model/GOEventHandlerList.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -55,6 +55,7 @@ public:
   void RegisterMidiConfigurator(GOMidiConfigurator *obj);
   void RegisterEventHandler(GOEventHandler *handler);
   void RegisterSoundStateHandler(GOSoundStateHandler *handler);
+  void UnRegisterSoundStateHandler(GOSoundStateHandler *handler);
   void RegisterSaveableObject(GOSaveableObject *obj);
   void UnregisterSaveableObject(GOSaveableObject *obj);
 


### PR DESCRIPTION
This is the first PR related to #1762

It fixes the order of sending midi messages on loading/closing an organ: `On` after sending all other midi messages.