### PR TITLE
Fixed crash on opening a very old config https://github.com/GrandOrgue/grandorgue/discussions/1869

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on opening a very old config https://github.com/GrandOrgue/grandorgue/discussions/1869
 - Fixed ignoring initial midi setup when loading an organ with a preset without midi events configured https://github.com/GrandOrgue/grandorgue/issues/1785
 - Fixed saving Max release tail to the organ preset https://github.com/GrandOrgue/grandorgue/issues/1804
 - Fixed required package names in the BUILD.md file https://github.com/GrandOrgue/grandorgue/issues/1799

--- a/src/core/GOOrgan.cpp
+++ b/src/core/GOOrgan.cpp
@@ -126,7 +126,7 @@ bool GOOrgan::IsUsable(const GOOrganList &organs) const {
       ? organs.GetArchiveByID(m_ArchiveID, true)
       : organs.GetArchiveByPath(m_ArchivePath);
 
-    res = (archive != nullptr) && archive->IsComplete(organs);
+    res = archive && archive->IsComplete(organs);
   } else
     res = wxFileExists(m_ODF);
   return res;

--- a/src/core/GOOrgan.cpp
+++ b/src/core/GOOrgan.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -126,9 +126,7 @@ bool GOOrgan::IsUsable(const GOOrganList &organs) const {
       ? organs.GetArchiveByID(m_ArchiveID, true)
       : organs.GetArchiveByPath(m_ArchivePath);
 
-    if (!archive)
-      res = false;
-    res = archive->IsComplete(organs);
+    res = (archive != nullptr) && archive->IsComplete(organs);
   } else
     res = wxFileExists(m_ODF);
   return res;

--- a/src/grandorgue/GOFrame.cpp
+++ b/src/grandorgue/GOFrame.cpp
@@ -540,13 +540,16 @@ void GOFrame::Init(const wxString &filename, bool isGuiOnly) {
     GetEventHandler()->AddPendingEvent(event);
   }
 
-  // Remove demo organs that have been registered from temporary (appimage)
-  // directories and they are not more valid
-  m_config.RemoveInvalidTmpOrgans();
-
   GOArchiveManager manager(m_config, m_config.OrganCachePath());
+
   manager.RegisterPackageDirectory(m_config.GetPackageDirectory());
   manager.RegisterPackageDirectory(m_config.OrganPackagePath());
+
+  // Remove demo organs that have been registered from temporary (appimage)
+  // directories and they are not more valid
+  m_config.AddOrgansFromArchives();
+  m_config.RemoveInvalidTmpOrgans();
+
   if (!filename.IsEmpty())
     SendLoadFile(filename);
   else


### PR DESCRIPTION
This PR
- fixes crash if the `GrandOrgueConfig` file was made with an old GrandOrgue version
- filles package path of organs registered with an old  GrandOrgue version