### PR TITLE
Simplified GOArchiveFile::IsUsable() and GOArchiveFile::IsComplete()

### DIFF
--- a/src/core/GOOrganList.cpp
+++ b/src/core/GOOrganList.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -60,8 +60,11 @@ void GOOrganList::RemoveInvalidTmpOrgans() {
   }
   for (int i = m_ArchiveList.size() - 1; i >= 0; i--) {
     const GOArchiveFile &aF = *m_ArchiveList[i];
+    const wxString &archivePath = aF.GetPath();
 
-    if (!aF.IsUsable(*this) && aF.GetPath().StartsWith(tmpDirPrefix))
+    if (
+      !archivePath.IsEmpty() && !aF.IsUsable()
+      && archivePath.StartsWith(tmpDirPrefix))
       m_ArchiveList.erase(i);
   }
 }
@@ -107,7 +110,7 @@ const GOArchiveFile *GOOrganList::GetArchiveByID(
   const wxString &id, bool useable) const {
   for (unsigned i = 0; i < m_ArchiveList.size(); i++)
     if (m_ArchiveList[i]->GetID() == id)
-      if (!useable || m_ArchiveList[i]->IsUsable(*this))
+      if (!useable || m_ArchiveList[i]->IsUsable())
         return m_ArchiveList[i];
   return NULL;
 }

--- a/src/core/archive/GOArchiveFile.cpp
+++ b/src/core/archive/GOArchiveFile.cpp
@@ -113,16 +113,16 @@ bool GOArchiveFile::IsUsable() const {
 }
 
 bool GOArchiveFile::IsComplete(const GOOrganList &organs) const {
-  bool isOk = IsUsable();
+  bool isComplete = IsUsable();
 
-  if (isOk)
+  if (isComplete)
     for (auto &dep : m_Dependencies) {
       const GOArchiveFile *archive = organs.GetArchiveByID(dep, true);
 
-      isOk = archive && archive->IsUsable();
+      isComplete = archive && archive->IsUsable();
 
-      if (!isOk)
+      if (!isComplete)
         break;
     }
-  return isOk;
+  return isComplete;
 }

--- a/src/core/archive/GOArchiveFile.cpp
+++ b/src/core/archive/GOArchiveFile.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -108,20 +108,21 @@ const std::vector<wxString> &GOArchiveFile::GetDependencyTitles() const {
   return m_DependencyTitles;
 }
 
-bool GOArchiveFile::IsUsable(const GOOrganList &organs) const {
-  return wxFileExists(m_Path);
+bool GOArchiveFile::IsUsable() const {
+  return !m_Path.IsEmpty() && wxFileExists(m_Path);
 }
 
 bool GOArchiveFile::IsComplete(const GOOrganList &organs) const {
-  if (!IsUsable(organs))
-    return false;
-  for (unsigned i = 0; i < m_Dependencies.size(); i++) {
-    const GOArchiveFile *archive
-      = organs.GetArchiveByID(m_Dependencies[i], true);
-    if (!archive)
-      return false;
-    if (!archive->IsUsable(organs))
-      return false;
-  }
-  return true;
+  bool isOk = IsUsable();
+
+  if (isOk)
+    for (auto &dep : m_Dependencies) {
+      const GOArchiveFile *archive = organs.GetArchiveByID(dep, true);
+
+      isOk = archive && archive->IsUsable();
+
+      if (!isOk)
+        break;
+    }
+  return isOk;
 }

--- a/src/core/archive/GOArchiveFile.h
+++ b/src/core/archive/GOArchiveFile.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -52,7 +52,7 @@ public:
   const std::vector<wxString> &GetDependencies() const;
   const std::vector<wxString> &GetDependencyTitles() const;
 
-  bool IsUsable(const GOOrganList &organs) const;
+  bool IsUsable() const;
   bool IsComplete(const GOOrganList &organs) const;
 };
 

--- a/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp
@@ -404,7 +404,7 @@ void GOSettingsOrgans::RefreshFocused(const int currOrganIndex) {
   wxString archiveInfo = EMPTY_STRING;
 
   if (a) {
-    if (!a->IsUsable(m_config))
+    if (!a->IsUsable())
       archiveInfo = _("MISSING - ");
     else if (!a->IsComplete(m_config)) {
       archiveInfo = _("INCOMPLETE - ");


### PR DESCRIPTION
This PR
- Removed an unusable parameter in GOArchiveFile::IsUsable()
- changes the code style of GOArchiveFile::IsUsable() and GOArchiveFile::IsComplete()

This is just refactoring. No GO behavior should be changed.