### PR TITLE
Fixed behavior of "Detect complex MIDI setup" with Note events in different cases https://github.com/GrandOrgue/grandorgue/issues/1762

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed behavior of "Detect complex MIDI setup" with Note events in different cases https://github.com/GrandOrgue/grandorgue/issues/1762
 - Fixed the order of sending midi events from an On indicator. Now they are sent after sending all events from other controls https://github.com/GrandOrgue/grandorgue/issues/1762
 # 3.14.1 (2024-04-17)
 - Fixed changing sound of a playing pipe without Pipe999IsTremulant when a wave tremulant state is changed https://github.com/GrandOrgue/grandorgue/issues/1855

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -54,6 +54,8 @@ const struct IniFileEnumEntry GOMidiReceiverBase::m_MidiTypes[] = {
   {wxT("NoteOn"), MIDI_M_NOTE_ON},
   {wxT("NoteOff"), MIDI_M_NOTE_OFF},
   {wxT("NoteOnOff"), MIDI_M_NOTE_ON_OFF},
+  {wxT("NoteFixedOn"), MIDI_M_NOTE_FIXED_ON},
+  {wxT("NoteFixedOff"), MIDI_M_NOTE_FIXED_OFF},
   {wxT("NoteNoVelocity"), MIDI_M_NOTE_NO_VELOCITY},
   {wxT("NoteShortOctave"), MIDI_M_NOTE_SHORT_OCTAVE},
   {wxT("NoteNormal"), MIDI_M_NOTE_NORMAL},
@@ -251,6 +253,7 @@ bool GOMidiReceiverBase::HasChannel(GOMidiReceiverMessageType type) {
     || type == MIDI_M_CTRL_BIT || type == MIDI_M_CTRL_CHANGE_FIXED
     || type == MIDI_M_RPN || type == MIDI_M_NRPN || type == MIDI_M_NOTE_ON
     || type == MIDI_M_NOTE_OFF || type == MIDI_M_NOTE_ON_OFF
+    || type == MIDI_M_NOTE_FIXED_ON || type == MIDI_M_NOTE_FIXED_OFF
     || type == MIDI_M_CTRL_CHANGE_ON || type == MIDI_M_CTRL_CHANGE_OFF
     || type == MIDI_M_CTRL_CHANGE_ON_OFF || type == MIDI_M_CTRL_CHANGE_FIXED_ON
     || type == MIDI_M_CTRL_CHANGE_FIXED_OFF
@@ -272,6 +275,7 @@ bool GOMidiReceiverBase::HasKey(GOMidiReceiverMessageType type) {
     || type == MIDI_M_SYSEX_RODGERS_STOP_CHANGE || type == MIDI_M_CTRL_BIT
     || type == MIDI_M_CTRL_CHANGE_FIXED || type == MIDI_M_RPN
     || type == MIDI_M_NRPN || type == MIDI_M_NOTE_ON || type == MIDI_M_NOTE_OFF
+    || type == MIDI_M_NOTE_FIXED_ON || type == MIDI_M_NOTE_FIXED_OFF
     || type == MIDI_M_NOTE_ON_OFF || type == MIDI_M_CTRL_CHANGE_ON
     || type == MIDI_M_CTRL_CHANGE_OFF || type == MIDI_M_CTRL_CHANGE_ON_OFF
     || type == MIDI_M_CTRL_CHANGE_FIXED_ON
@@ -313,6 +317,7 @@ bool GOMidiReceiverBase::HasDebounce(GOMidiReceiverMessageType type) {
   if (
     type == MIDI_M_PGM_CHANGE || type == MIDI_M_NOTE_ON
     || type == MIDI_M_NOTE_OFF || type == MIDI_M_NOTE_ON_OFF
+    || type == MIDI_M_NOTE_FIXED_ON || type == MIDI_M_NOTE_FIXED_OFF
     || type == MIDI_M_CTRL_CHANGE || type == MIDI_M_CTRL_CHANGE_ON
     || type == MIDI_M_CTRL_CHANGE_OFF || type == MIDI_M_CTRL_CHANGE_ON_OFF
     || type == MIDI_M_CTRL_CHANGE_FIXED_ON
@@ -332,8 +337,9 @@ bool GOMidiReceiverBase::HasLowerLimit(GOMidiReceiverMessageType type) {
     || type == MIDI_M_NRPN_RANGE || type == MIDI_M_CTRL_CHANGE
     || type == MIDI_M_CTRL_CHANGE_FIXED || type == MIDI_M_CTRL_BIT
     || type == MIDI_M_RPN || type == MIDI_M_NRPN || type == MIDI_M_NOTE_OFF
-    || type == MIDI_M_NOTE_ON_OFF || type == MIDI_M_CTRL_CHANGE_OFF
-    || type == MIDI_M_CTRL_CHANGE_ON_OFF || type == MIDI_M_CTRL_CHANGE_FIXED_OFF
+    || type == MIDI_M_NOTE_FIXED_OFF || type == MIDI_M_NOTE_ON_OFF
+    || type == MIDI_M_CTRL_CHANGE_OFF || type == MIDI_M_CTRL_CHANGE_ON_OFF
+    || type == MIDI_M_CTRL_CHANGE_FIXED_OFF
     || type == MIDI_M_CTRL_CHANGE_FIXED_ON_OFF || type == MIDI_M_RPN_OFF
     || type == MIDI_M_RPN_ON_OFF || type == MIDI_M_NRPN_OFF
     || type == MIDI_M_NRPN_ON_OFF || type == MIDI_M_NOTE_NO_VELOCITY
@@ -354,8 +360,9 @@ bool GOMidiReceiverBase::HasUpperLimit(GOMidiReceiverMessageType type) {
     || type == MIDI_M_NRPN_RANGE || type == MIDI_M_CTRL_CHANGE
     || type == MIDI_M_CTRL_CHANGE_FIXED || type == MIDI_M_RPN
     || type == MIDI_M_NRPN || type == MIDI_M_NOTE_ON
-    || type == MIDI_M_NOTE_ON_OFF || type == MIDI_M_CTRL_CHANGE_ON
-    || type == MIDI_M_CTRL_CHANGE_ON_OFF || type == MIDI_M_CTRL_CHANGE_FIXED_ON
+    || type == MIDI_M_NOTE_FIXED_ON || type == MIDI_M_NOTE_ON_OFF
+    || type == MIDI_M_CTRL_CHANGE_ON || type == MIDI_M_CTRL_CHANGE_ON_OFF
+    || type == MIDI_M_CTRL_CHANGE_FIXED_ON
     || type == MIDI_M_CTRL_CHANGE_FIXED_ON_OFF || type == MIDI_M_RPN_ON
     || type == MIDI_M_RPN_ON_OFF || type == MIDI_M_NRPN_ON
     || type == MIDI_M_NRPN_ON_OFF || type == MIDI_M_NOTE_NO_VELOCITY
@@ -702,13 +709,16 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       continue;
     }
     if (
-      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
-      && pattern.type == MIDI_M_CTRL_CHANGE_FIXED_ON
-      && pattern.key == e.GetKey() && e.GetValue() == pattern.high_value)
+      ((eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
+        && pattern.type == MIDI_M_CTRL_CHANGE_FIXED_ON)
+       || (eMidiType == GOMidiEvent::MIDI_NOTE && pattern.type == MIDI_M_NOTE_FIXED_ON))
+      && pattern.key == e.GetKey() 
+      && e.GetValue() == pattern.high_value)
       return debounce(e, MIDI_MATCH_ON, i);
     if (
-      eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
-      && pattern.type == MIDI_M_CTRL_CHANGE_FIXED_OFF
+      ((eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
+        && pattern.type == MIDI_M_CTRL_CHANGE_FIXED_OFF)
+       || (eMidiType == GOMidiEvent::MIDI_NOTE && pattern.type == MIDI_M_NOTE_FIXED_OFF))
       && pattern.key == e.GetKey() && e.GetValue() == pattern.low_value)
       return debounce(e, MIDI_MATCH_OFF, i);
     if (

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -712,8 +712,7 @@ GOMidiMatchType GOMidiReceiverBase::Match(
       ((eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE
         && pattern.type == MIDI_M_CTRL_CHANGE_FIXED_ON)
        || (eMidiType == GOMidiEvent::MIDI_NOTE && pattern.type == MIDI_M_NOTE_FIXED_ON))
-      && pattern.key == e.GetKey() 
-      && e.GetValue() == pattern.high_value)
+      && pattern.key == e.GetKey() && e.GetValue() == pattern.high_value)
       return debounce(e, MIDI_MATCH_ON, i);
     if (
       ((eMidiType == GOMidiEvent::MIDI_CTRL_CHANGE

--- a/src/core/midi/GOMidiReceiverMessageType.h
+++ b/src/core/midi/GOMidiReceiverMessageType.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -30,6 +30,8 @@ enum GOMidiReceiverMessageType {
   MIDI_M_NOTE_ON,
   MIDI_M_NOTE_OFF,
   MIDI_M_NOTE_ON_OFF,
+  MIDI_M_NOTE_FIXED_ON,
+  MIDI_M_NOTE_FIXED_OFF,
   MIDI_M_CTRL_CHANGE_ON,
   MIDI_M_CTRL_CHANGE_OFF,
   MIDI_M_CTRL_CHANGE_ON_OFF,


### PR DESCRIPTION
Resolves: #1762

This is the second (and the last) PR related to #1762

It fixes behavior of "Detect complex MIDI setup"
- for a manual now the lowest value is detected as 1 instead of 0, that was preventing sound to stopp when the kewy was released
- for a button - introduces the new events: ``9x Note Fixed On`` and ``9x Note Fixed Off``, that allow to use different notes for ON and OFF