### PR TITLE
Clarified usage of DivisionalIndex

### DIFF
--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -329,9 +329,9 @@ void GODivisionalSetter::FromYaml(const YAML::Node &yamlNode) {
         unsigned i
           = banked_divisional_yaml_key_to_index(cmbEntry.first.as<wxString>());
         GODivisionalCombination *pCmb = new GODivisionalCombination(
-          *m_OrganController, odfManualIndex, false);
+          *m_OrganController, odfManualIndex, true, i);
 
-        pCmb->Init(GetDivisionalButtonName(odfManualIndex, i), i);
+        pCmb->Init(GetDivisionalButtonName(odfManualIndex, i));
         cmbNode >> *pCmb;
         divMap[i] = pCmb;
       }
@@ -354,9 +354,9 @@ void GODivisionalSetter::SwitchDivisionalTo(
       // create a new combination
       const unsigned manualIndex = m_FirstManualIndex + manualN;
 
-      pCmb = new GODivisionalCombination(*m_OrganController, manualIndex, true);
-      pCmb->Init(
-        GetDivisionalButtonName(manualIndex, divisionalIdx), divisionalIdx);
+      pCmb = new GODivisionalCombination(
+        *m_OrganController, manualIndex, true, divisionalIdx);
+      pCmb->Init(GetDivisionalButtonName(manualIndex, divisionalIdx));
       divMap[divisionalIdx] = pCmb;
     }
 

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -1026,7 +1026,7 @@ void GOSetter::PushDivisional(
     /* only use divisional couples, if not in setter mode */
     if (!m_state.m_IsActive) {
       unsigned cmbManualNumber = cmb.GetManualNumber();
-      unsigned divisionalNumber = cmb.GetDivisionalNumber();
+      unsigned divisionalNumber = cmb.GetDivisionalIndex();
 
       for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
            k++) {

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -1026,7 +1026,7 @@ void GOSetter::PushDivisional(
     /* only use divisional couples, if not in setter mode */
     if (!m_state.m_IsActive) {
       unsigned cmbManualNumber = cmb.GetManualNumber();
-      unsigned divisionalNumber = cmb.GetDivisionalIndex();
+      unsigned divisionalIndex = cmb.GetDivisionalIndex();
 
       for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
            k++) {
@@ -1042,7 +1042,7 @@ void GOSetter::PushDivisional(
           for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++) {
             GODivisionalButtonControl *coupledDivisional
               = m_OrganController->GetManual(coupler->GetManual(j))
-                  ->GetDivisional(divisionalNumber);
+                  ->GetDivisional(divisionalIndex);
 
             PushDivisional(
               usedCmbs, coupledDivisional->GetCombination(), coupledDivisional);
@@ -1057,7 +1057,7 @@ void GOSetter::PushDivisional(
 
               GODivisionalButtonControl *coupledDivisional
                 = m_OrganController->GetManual(coupledManualIndex)
-                    ->GetDivisional(divisionalNumber);
+                    ->GetDivisional(divisionalIndex);
 
               PushDivisional(
                 usedCmbs,

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,10 +13,10 @@
 #include "model/GOOrganModel.h"
 
 GODivisionalButtonControl::GODivisionalButtonControl(
-  GOOrganModel &organModel, unsigned manualNumber, bool isSetter)
+  GOOrganModel &organModel, unsigned manualNumber, unsigned divisionalIndex)
   : GOPushbuttonControl(organModel),
     r_OrganModel(organModel),
-    m_combination(organModel, manualNumber, isSetter) {}
+    m_combination(organModel, manualNumber, false, divisionalIndex) {}
 
 const wxString WX_MIDI_TYPE_CODE = wxT("Divisional");
 const wxString WX_MIDI_TYPE = _("Divisional");
@@ -30,17 +30,15 @@ const wxString &GODivisionalButtonControl::GetMidiType() const {
 }
 
 void GODivisionalButtonControl::Init(
-  GOConfigReader &cfg,
-  const wxString &group,
-  int divisionalNumber,
-  const wxString &name) {
+  GOConfigReader &cfg, const wxString &group, const wxString &name) {
   GOPushbuttonControl::Init(cfg, group, name);
-  m_combination.Init(group, divisionalNumber);
+  m_combination.Init(group);
 }
+
 void GODivisionalButtonControl::Load(
-  GOConfigReader &cfg, const wxString &group, int divisionalNumber) {
+  GOConfigReader &cfg, const wxString &group) {
   GOPushbuttonControl::Load(cfg, group);
-  m_combination.Load(cfg, group, divisionalNumber);
+  m_combination.Load(cfg, group);
 }
 
 void GODivisionalButtonControl::LoadCombination(GOConfigReader &cfg) {

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.h
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -23,19 +23,15 @@ private:
 
 public:
   GODivisionalButtonControl(
-    GOOrganModel &organModel, unsigned manualNumber, bool isSetter);
+    GOOrganModel &organModel, unsigned manualNumber, unsigned divisionalIndex);
 
   GODivisionalCombination &GetCombination() { return m_combination; }
   const wxString &GetMidiTypeCode() const override;
   const wxString &GetMidiType() const override;
 
-  void Init(
-    GOConfigReader &cfg,
-    const wxString &group,
-    int divisionalNumber,
-    const wxString &name);
+  void Init(GOConfigReader &cfg, const wxString &group, const wxString &name);
 
-  void Load(GOConfigReader &cfg, const wxString &group, int divisionalNumber);
+  void Load(GOConfigReader &cfg, const wxString &group);
 
   void LoadCombination(GOConfigReader &cfg);
   void Save(GOConfigWriter &cfg);

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -21,24 +21,24 @@
 #include "yaml/go-wx-yaml.h"
 
 GODivisionalCombination::GODivisionalCombination(
-  GOOrganModel &organModel, unsigned manualNumber, bool isSetter)
+  GOOrganModel &organModel,
+  unsigned manualNumber,
+  bool isSetter,
+  unsigned divisionalIndex)
   : GOCombination(
     organModel, organModel.GetManual(manualNumber)->GetDivisionalTemplate()),
     r_OrganModel(organModel),
     m_odfManualNumber(manualNumber),
-    m_DivisionalNumber(0),
-    m_IsSetter(isSetter) {}
+    m_IsSetter(isSetter),
+    m_DivisionalIndex(divisionalIndex) {}
 
-void GODivisionalCombination::Init(
-  const wxString &group, int divisionalNumber) {
+void GODivisionalCombination::Init(const wxString &group) {
   m_group = group;
-  m_DivisionalNumber = divisionalNumber;
   m_Protected = false;
 }
 
-void GODivisionalCombination::Load(
-  GOConfigReader &cfg, const wxString &group, int divisionalNumber) {
-  Init(group, divisionalNumber);
+void GODivisionalCombination::Load(GOConfigReader &cfg, const wxString &group) {
+  m_group = group;
   m_Protected
     = cfg.ReadBoolean(ODFSetting, group, wxT("Protected"), false, false);
 
@@ -242,15 +242,16 @@ GODivisionalCombination *GODivisionalCombination::loadFrom(
   GOConfigReader &cfg,
   const wxString &group,
   const wxString &readGroup,
-  int manualNumber,
-  int divisionalNumber) {
+  unsigned manualNumber,
+  unsigned divisionalIndex) {
   GODivisionalCombination *pCmb = nullptr;
   bool isCmbOnGroup = isCmbOnFile(cfg, group);
   bool isCmbOnReadGroup = !readGroup.IsEmpty() && isCmbOnFile(cfg, readGroup);
 
   if (isCmbOnGroup || isCmbOnReadGroup) {
-    pCmb = new GODivisionalCombination(organModel, manualNumber, false);
-    pCmb->Load(cfg, isCmbOnReadGroup ? readGroup : group, divisionalNumber);
+    pCmb = new GODivisionalCombination(
+      organModel, manualNumber, true, divisionalIndex);
+    pCmb->Load(cfg, isCmbOnReadGroup ? readGroup : group);
     pCmb->LoadCombination(cfg);
     if (isCmbOnReadGroup) {  // The combination was loaded from the legacy group
       pCmb->m_group = group; // It will be saved to the normal group

--- a/src/grandorgue/combinations/model/GODivisionalCombination.h
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -21,8 +21,19 @@ class GODivisionalCombination : public GOCombination {
 protected:
   GOOrganModel &r_OrganModel;
   unsigned m_odfManualNumber;
-  int m_DivisionalNumber;
+
+  /* true - this combination belongs to the divisional setter
+   * false - this combination belongs to a manual divisional
+   */
   bool m_IsSetter;
+
+  /* the divisional index.
+   * if m_IsSetter then it is the index in the divisional setter across all
+   *   banks.
+   * else it is the index in the manual. It may be obtained with
+   *   manual->GetDivisional()
+   */
+  unsigned m_DivisionalIndex;
 
   // It is not registered as saveable object because
   // GOdivisionalSetter::LoadCombination creates the combinations dynamically
@@ -43,16 +54,20 @@ protected:
 
 public:
   GODivisionalCombination(
-    GOOrganModel &organModel, unsigned manualNumber, bool isSetter);
+    GOOrganModel &organModel,
+    unsigned manualNumber,
+    bool isSetter,
+    unsigned divisionalIndex);
 
   unsigned GetManualNumber() const { return m_odfManualNumber; }
-  int GetDivisionalNumber() const { return m_DivisionalNumber; }
+  unsigned GetDivisionalIndex() const { return m_DivisionalIndex; }
 
-  void Init(const wxString &group, int divisionalNumber);
-  void Load(GOConfigReader &cfg, const wxString &group, int divisionalNumber);
+  void Init(const wxString &group);
+  void Load(GOConfigReader &cfg, const wxString &group);
 
   // checks if the combination exists in the config file
   // returns the loaded combination if it exists else returns nullptr
+  // used only for the devisional setter combinations
   static GODivisionalCombination *loadFrom(
     GOOrganModel &organModel,
     GOConfigReader &cfg,
@@ -60,8 +75,8 @@ public:
     // for compatibility with the old preset: load the combination with the old
     // group name
     const wxString &readGroup,
-    int manualNumber,
-    int divisionalNumber);
+    unsigned manualNumber,
+    unsigned divisionalIndex);
 };
 
 #endif

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -242,14 +242,14 @@ void GOManual::LoadDivisionals(GOConfigReader &cfg) {
   m_divisionals.resize(0);
   for (unsigned i = 0; i < nDivisionals; i++) {
     m_divisionals.push_back(
-      new GODivisionalButtonControl(r_OrganModel, m_manual_number, false));
+      new GODivisionalButtonControl(r_OrganModel, m_manual_number, i));
 
     buffer.Printf(wxT("Divisional%03d"), i + 1);
     buffer.Printf(
       wxT("Divisional%03d"),
       cfg.ReadInteger(ODFSetting, m_group, buffer, 1, 999));
     cfg.MarkGroupInUse(buffer);
-    m_divisionals[i]->Load(cfg, buffer, i);
+    m_divisionals[i]->Load(cfg, buffer);
   }
 }
 


### PR DESCRIPTION
This is the first PR related to #1787

GrandOrgue supports two types of divisionals combinations:
- a manual ("old style") divisional. GODivisionalCombination::m_IsSetter == false
- a setter element ("banked") divisional. GODivisionalCombination::m_IsSetter == true

This PR
- renames GODivisionalCombination::m_DivisionalNumber to m_DivisionalIndex, because if it is a setter element, it is an index including the bank number
- changes it's type to unsigned
- moves it's initialising from Init() and Load() to the constructor. It is essential that it is set together with m_IsSetter
- sets GODivisionalCombination::m_IsSetter to true in all GODivisionalSetter combinations.

It is just refactoring. No GO behavior should be changed.

