### PR TITLE
Allowed loading non standard compliant WAV files which lack zero padding of last chunk

### DIFF
--- a/src/core/GOWave.cpp
+++ b/src/core/GOWave.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/core/GOWave.cpp
+++ b/src/core/GOWave.cpp
@@ -256,8 +256,11 @@ void GOWave::Open(const GOBuffer<uint8_t> &content, const wxString fileName) {
         check_for_bounds(fileName, header, offset, length, chunkOffset);
         LoadSamplerChunk(ptr + offset, size);
       }
-      /* Move to next chunk respecting word alignment */
-      offset += size + (size & 1);
+      /* Move to next chunk respecting word alignment
+         Unless lack of final padding (non spec-compliant) */
+      offset += size;
+      if (offset < length)
+        offset += size & 1;
     }
 
     if (offset != length)


### PR DESCRIPTION
This avoids padding the offset past the length of file.

Otherwise, the check `(offset != length)` fails, being 1 byte off, and the loader throws an error.

I find a marginal number of files to be affected, but since these are copyrighted, I don't attach them.

`aplay` describes such a file as: `Signed 24 bit Little Endian in 3bytes, Rate 48000 Hz, Stereo`
