### PR TITLE
Fixed crash on a divisional coupler

### DIFF
--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -349,10 +349,10 @@ void GODivisionalSetter::SwitchDivisionalTo(
     // whether the combination is defined
     bool isExist = divMap.find(divisionalIdx) != divMap.end();
     GODivisionalCombination *pCmb = isExist ? divMap[divisionalIdx] : nullptr;
+    const unsigned manualIndex = m_FirstManualIndex + manualN;
 
     if (!isExist && r_SetterState.m_IsActive) {
       // create a new combination
-      const unsigned manualIndex = m_FirstManualIndex + manualN;
 
       pCmb = new GODivisionalCombination(*m_OrganController, manualIndex, true);
       pCmb->Init(
@@ -362,8 +362,11 @@ void GODivisionalSetter::SwitchDivisionalTo(
 
     if (pCmb)
       // the combination was existing or has just been created
-      m_OrganController->GetSetter()->PushDivisional(
-        *pCmb, m_buttons[N_BUTTONS * manualN + divisionalN]);
+      m_OrganController->PushDivisional(
+        *pCmb,
+        manualIndex,
+        manualIndex,
+        m_buttons[N_BUTTONS * manualN + divisionalN]);
   }
 }
 

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -1013,71 +1013,19 @@ void GOSetter::PushGeneral(
 }
 
 void GOSetter::PushDivisional(
-  std::unordered_set<GODivisionalCombination *> &usedCmbs,
   GODivisionalCombination &cmb,
+  unsigned startManual,
+  unsigned cmbManual,
   GOButtonControl *pButtonToLight) {
-  // protection against infinite recursion
-  if (usedCmbs.insert(&cmb).second) {
+  if (cmbManual == startManual || !m_state.m_IsActive) {
     GOCombination::ExtraElementsSet elementSet;
     const GOCombination::ExtraElementsSet *pExtraSet
       = GetCrescendoAddSet(elementSet);
 
     NotifyCmbPushed(cmb.Push(m_state, pExtraSet));
-    /* only use divisional couples, if not in setter mode */
-    if (!m_state.m_IsActive) {
-      unsigned cmbManualNumber = cmb.GetManualNumber();
-      unsigned divisionalNumber = cmb.GetDivisionalNumber();
-
-      for (unsigned k = 0; k < m_OrganController->GetDivisionalCouplerCount();
-           k++) {
-        GODivisionalCoupler *coupler
-          = m_OrganController->GetDivisionalCoupler(k);
-        if (!coupler->IsEngaged())
-          continue;
-
-        for (unsigned i = 0; i < coupler->GetNumberOfManuals(); i++) {
-          if (coupler->GetManual(i) != cmbManualNumber)
-            continue;
-
-          for (unsigned int j = i + 1; j < coupler->GetNumberOfManuals(); j++) {
-            GODivisionalButtonControl *coupledDivisional
-              = m_OrganController->GetManual(coupler->GetManual(j))
-                  ->GetDivisional(divisionalNumber);
-
-            PushDivisional(
-              usedCmbs, coupledDivisional->GetCombination(), coupledDivisional);
-          }
-
-          if (coupler->IsBidirectional())
-            for (unsigned j = 0; j < coupler->GetNumberOfManuals(); j++) {
-              unsigned coupledManualIndex = coupler->GetManual(j);
-
-              if (coupledManualIndex == cmbManualNumber)
-                break;
-
-              GODivisionalButtonControl *coupledDivisional
-                = m_OrganController->GetManual(coupledManualIndex)
-                    ->GetDivisional(divisionalNumber);
-
-              PushDivisional(
-                usedCmbs,
-                coupledDivisional->GetCombination(),
-                coupledDivisional);
-            }
-          break;
-        }
-      }
-    }
     if (!pExtraSet)
-      UpdateAllSetsButtonsLight(pButtonToLight, cmb.GetManualNumber());
+      UpdateAllSetsButtonsLight(pButtonToLight, cmbManual);
   }
-}
-
-void GOSetter::PushDivisional(
-  GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) {
-  std::unordered_set<GODivisionalCombination *> usedCmbs;
-
-  PushDivisional(usedCmbs, cmb, pButtonToLight);
 }
 
 void GOSetter::Next() { SetPosition(m_pos + 1); }

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -198,11 +198,10 @@ public:
   void PushGeneral(
     GOGeneralCombination &cmb, GOButtonControl *pButtonToLight) override;
   void PushDivisional(
-    std::unordered_set<GODivisionalCombination *> &usedCmbs,
     GODivisionalCombination &cmb,
-    GOButtonControl *pButtonToLight);
-  void PushDivisional(
-    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) override;
+    unsigned startManual,
+    unsigned cmbManual,
+    GOButtonControl *pButtonToLight) override;
 
   /*
    * If current crescendo is in override mode then returns nullptr

--- a/src/grandorgue/combinations/control/GOCombinationController.h
+++ b/src/grandorgue/combinations/control/GOCombinationController.h
@@ -29,7 +29,7 @@ public:
     = 0;
 
   /**
-   * Activate the divisional cmb. Does not process duvisional couplers
+   * Activate the divisional cmb. Does not process divisional couplers
    * @param cmb the cmb to activate or to set
    * @param startManual the manual that is pushed manually.
    * @param cmbManual the manual where to push the divisional. It may differ

--- a/src/grandorgue/combinations/control/GOCombinationController.h
+++ b/src/grandorgue/combinations/control/GOCombinationController.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -21,14 +21,27 @@ public:
    * If isFromCrescendo and it is in add mode then then does not depress other
    * buttons
    * @param cmb the cmb to activate or to set
-   * @param pButton the button to light on
-   * return if anything is changed
+   * @param pButtonToLight the button to light on. All other buttons are
+   *   ligthed off
    */
   virtual void PushGeneral(
     GOGeneralCombination &cmb, GOButtonControl *pButtonToLight)
     = 0;
+
+  /**
+   * Activate the divisional cmb. Does not process duvisional couplers
+   * @param cmb the cmb to activate or to set
+   * @param startManual the manual that is pushed manually.
+   * @param cmbManual the manual where to push the divisional. It may differ
+   *   from startManual if cmbManual has a divisional coupler with startManual
+   * @param pButtonToLight the button to light on. All other buttons on the
+   *   cmbManual are ligthed off
+   */
   virtual void PushDivisional(
-    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight)
+    GODivisionalCombination &cmb,
+    unsigned startManual,
+    unsigned cmbManual,
+    GOButtonControl *pButtonToLight)
     = 0;
 };
 

--- a/src/grandorgue/combinations/control/GOCombinationControllerProxy.cpp
+++ b/src/grandorgue/combinations/control/GOCombinationControllerProxy.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,7 +14,10 @@ void GOCombinationControllerProxy::PushGeneral(
 }
 
 void GOCombinationControllerProxy::PushDivisional(
-  GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) {
+  GODivisionalCombination &cmb,
+  unsigned startManual,
+  unsigned cmbManual,
+  GOButtonControl *pButtonToLight) {
   if (p_controller)
-    p_controller->PushDivisional(cmb, pButtonToLight);
+    p_controller->PushDivisional(cmb, startManual, cmbManual, pButtonToLight);
 }

--- a/src/grandorgue/combinations/control/GOCombinationControllerProxy.h
+++ b/src/grandorgue/combinations/control/GOCombinationControllerProxy.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -22,7 +22,10 @@ public:
   void PushGeneral(
     GOGeneralCombination &cmb, GOButtonControl *pButtonToLight) override;
   void PushDivisional(
-    GODivisionalCombination &cmb, GOButtonControl *pButtonToLight) override;
+    GODivisionalCombination &cmb,
+    unsigned startManual,
+    unsigned cmbManual,
+    GOButtonControl *pButtonToLight) override;
 };
 
 #endif /* GOCOMBINATIONCONTROLLERPROXY_H */

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -9,14 +9,16 @@
 
 #include "wx/intl.h"
 
-#include "combinations/GOSetter.h"
+#include "model/GOManual.h"
 #include "model/GOOrganModel.h"
 
 GODivisionalButtonControl::GODivisionalButtonControl(
-  GOOrganModel &organModel, unsigned manualNumber, bool isSetter)
+  GOOrganModel &organModel, unsigned manualNumber, unsigned divisionalIndex)
   : GOPushbuttonControl(organModel),
     r_OrganModel(organModel),
-    m_combination(organModel, manualNumber, isSetter) {}
+    m_ManualN(manualNumber),
+    m_DivisionalIndex(divisionalIndex),
+    m_combination(organModel, manualNumber, false) {}
 
 const wxString WX_MIDI_TYPE_CODE = wxT("Divisional");
 const wxString WX_MIDI_TYPE = _("Divisional");
@@ -30,17 +32,14 @@ const wxString &GODivisionalButtonControl::GetMidiType() const {
 }
 
 void GODivisionalButtonControl::Init(
-  GOConfigReader &cfg,
-  const wxString &group,
-  int divisionalNumber,
-  const wxString &name) {
+  GOConfigReader &cfg, const wxString &group, const wxString &name) {
   GOPushbuttonControl::Init(cfg, group, name);
-  m_combination.Init(group, divisionalNumber);
+  m_combination.Init(group, m_DivisionalIndex);
 }
 void GODivisionalButtonControl::Load(
-  GOConfigReader &cfg, const wxString &group, int divisionalNumber) {
+  GOConfigReader &cfg, const wxString &group) {
   GOPushbuttonControl::Load(cfg, group);
-  m_combination.Load(cfg, group, divisionalNumber);
+  m_combination.Load(cfg, group, m_DivisionalIndex);
 }
 
 void GODivisionalButtonControl::LoadCombination(GOConfigReader &cfg) {
@@ -53,5 +52,21 @@ void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
 }
 
 void GODivisionalButtonControl::Push() {
-  r_OrganModel.PushDivisional(m_combination, this);
+  std::set<unsigned> coupledManuals;
+
+  r_OrganModel.FillCoupledManualsForDivisional(m_ManualN, coupledManuals);
+  for (unsigned coupledManualN : coupledManuals) {
+    GOManual *pManual = r_OrganModel.GetManual(coupledManualN);
+
+    if (m_DivisionalIndex < pManual->GetDivisionalCount()) {
+      GODivisionalButtonControl *pCoupledButton
+        = pManual->GetDivisional(m_DivisionalIndex);
+
+      r_OrganModel.PushDivisional(
+        pCoupledButton->GetCombination(),
+        m_ManualN,
+        coupledManualN,
+        pCoupledButton);
+    }
+  }
 }

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -52,10 +52,8 @@ void GODivisionalButtonControl::Save(GOConfigWriter &cfg) {
 }
 
 void GODivisionalButtonControl::Push() {
-  std::set<unsigned> coupledManuals;
-
-  r_OrganModel.FillCoupledManualsForDivisional(m_ManualN, coupledManuals);
-  for (unsigned coupledManualN : coupledManuals) {
+  for (unsigned coupledManualN :
+       r_OrganModel.GetCoupledManualsForDivisional(m_ManualN)) {
     GOManual *pManual = r_OrganModel.GetManual(coupledManualN);
 
     if (m_DivisionalIndex < pManual->GetDivisionalCount()) {

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.h
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.h
@@ -17,7 +17,7 @@ class GOConfigReader;
 class GOOrganModel;
 
 /**
- * A divisional combination button for a manual. It is uses only for odf-defined
+ * A divisional combination button for a manual. It is used only for odf-defined
  * (old style) divisionals and not for setter (banked) divisionals
  */
 class GODivisionalButtonControl : public GOPushbuttonControl {

--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.h
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -16,26 +16,32 @@
 class GOConfigReader;
 class GOOrganModel;
 
+/**
+ * A divisional combination button for a manual. It is uses only for odf-defined
+ * (old style) divisionals and not for setter (banked) divisionals
+ */
 class GODivisionalButtonControl : public GOPushbuttonControl {
 private:
   GOOrganModel &r_OrganModel;
+
+  // A manual the divisional button belongs to
+  unsigned m_ManualN;
+  // An index of divisionals in this manual
+  unsigned m_DivisionalIndex;
+  // A combination for this divisional
   GODivisionalCombination m_combination;
 
 public:
   GODivisionalButtonControl(
-    GOOrganModel &organModel, unsigned manualNumber, bool isSetter);
+    GOOrganModel &organModel, unsigned manualNumber, unsigned divisionalIndex);
 
   GODivisionalCombination &GetCombination() { return m_combination; }
   const wxString &GetMidiTypeCode() const override;
   const wxString &GetMidiType() const override;
 
-  void Init(
-    GOConfigReader &cfg,
-    const wxString &group,
-    int divisionalNumber,
-    const wxString &name);
+  void Init(GOConfigReader &cfg, const wxString &group, const wxString &name);
 
-  void Load(GOConfigReader &cfg, const wxString &group, int divisionalNumber);
+  void Load(GOConfigReader &cfg, const wxString &group);
 
   void LoadCombination(GOConfigReader &cfg);
   void Save(GOConfigWriter &cfg);

--- a/src/grandorgue/model/GODivisionalCoupler.cpp
+++ b/src/grandorgue/model/GODivisionalCoupler.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,6 +12,10 @@
 #include "config/GOConfigReader.h"
 
 #include "GOOrganModel.h"
+
+const wxString GODivisionalCoupler::WX_MIDI_TYPE_CODE
+  = wxT("DivisionalCoupler");
+const wxString GODivisionalCoupler::WX_MIDI_TYPE_DESC = _("Divisional Coupler");
 
 GODivisionalCoupler::GODivisionalCoupler(GOOrganModel &organModel)
   : GODrawstop(organModel), m_BiDirectionalCoupling(false), m_manuals(0) {}
@@ -47,23 +51,23 @@ void GODivisionalCoupler::SetupIsToStoreInCmb() {
   m_IsToStoreInGeneral = r_OrganModel.GeneralsStoreDivisionalCouplers();
 }
 
-void GODivisionalCoupler::ChangeState(bool on) {}
+std::set<unsigned> GODivisionalCoupler::GetCoupledManuals(
+  unsigned startManual) const {
+  std::set<unsigned> res;
 
-unsigned GODivisionalCoupler::GetNumberOfManuals() { return m_manuals.size(); }
+  if (IsEngaged()) {
+    auto firstIt = m_manuals.cbegin();
+    auto lastIt = m_manuals.cend();
+    auto startIt = std::find(firstIt, lastIt, startManual);
 
-unsigned GODivisionalCoupler::GetManual(unsigned index) {
-  return m_manuals[index];
-}
+    if (startIt != lastIt) { // startManual participates in the coupler
+      auto copyIt = m_BiDirectionalCoupling ? firstIt : startIt;
 
-bool GODivisionalCoupler::IsBidirectional() { return m_BiDirectionalCoupling; }
-
-const wxString WX_MIDI_TYPE_CODE = wxT("DivisionalCoupler");
-const wxString WX_MIDI_TYPE = _("Divisional Coupler");
-
-const wxString &GODivisionalCoupler::GetMidiTypeCode() const {
-  return WX_MIDI_TYPE_CODE;
-}
-
-const wxString &GODivisionalCoupler::GetMidiType() const {
-  return WX_MIDI_TYPE;
+      std::copy_if(
+        copyIt, lastIt, std::inserter(res, res.begin()), [=](auto x) {
+          return x != startManual;
+        });
+    }
+  }
+  return res;
 }

--- a/src/grandorgue/model/GODivisionalCoupler.cpp
+++ b/src/grandorgue/model/GODivisionalCoupler.cpp
@@ -7,6 +7,8 @@
 
 #include "GODivisionalCoupler.h"
 
+#include <algorithm>
+
 #include <wx/intl.h>
 
 #include "config/GOConfigReader.h"

--- a/src/grandorgue/model/GODivisionalCoupler.h
+++ b/src/grandorgue/model/GODivisionalCoupler.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,28 +8,38 @@
 #ifndef GODIVISIONALCOUPLER_H
 #define GODIVISIONALCOUPLER_H
 
+#include <set>
 #include <vector>
 
 #include "GODrawStop.h"
 
+class GOOrganModel;
+
 class GODivisionalCoupler : public GODrawstop {
 private:
+  static const wxString WX_MIDI_TYPE_CODE;
+  static const wxString WX_MIDI_TYPE_DESC;
+
   bool m_BiDirectionalCoupling;
   std::vector<unsigned> m_manuals;
 
-  void ChangeState(bool on);
+  void ChangeState(bool on) override {}
   void SetupIsToStoreInCmb() override;
 
 public:
   GODivisionalCoupler(GOOrganModel &organModel);
   void Load(GOConfigReader &cfg, wxString group);
 
-  unsigned GetNumberOfManuals();
-  unsigned GetManual(unsigned index);
-  bool IsBidirectional();
+  /**
+   * If the coupler is engaged and start manual participates in the coupler
+   * then returns other manuals in the coupler. Otherwise returns an empty set
+   * @param startManual The manual that is checked for coupling
+   * @return the resulting set of other manuals
+   */
+  std::set<unsigned> GetCoupledManuals(unsigned startManual) const;
 
-  const wxString &GetMidiTypeCode() const override;
-  const wxString &GetMidiType() const override;
+  const wxString &GetMidiTypeCode() const override { return WX_MIDI_TYPE_CODE; }
+  const wxString &GetMidiType() const override { return WX_MIDI_TYPE_DESC; }
 };
 
 #endif /* GODIVISIONALCOUPLER_H */

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -242,14 +242,14 @@ void GOManual::LoadDivisionals(GOConfigReader &cfg) {
   m_divisionals.resize(0);
   for (unsigned i = 0; i < nDivisionals; i++) {
     m_divisionals.push_back(
-      new GODivisionalButtonControl(r_OrganModel, m_manual_number, false));
+      new GODivisionalButtonControl(r_OrganModel, m_manual_number, i));
 
     buffer.Printf(wxT("Divisional%03d"), i + 1);
     buffer.Printf(
       wxT("Divisional%03d"),
       cfg.ReadInteger(ODFSetting, m_group, buffer, 1, 999));
     cfg.MarkGroupInUse(buffer);
-    m_divisionals[i]->Load(cfg, buffer, i);
+    m_divisionals[i]->Load(cfg, buffer);
   }
 }
 
@@ -387,8 +387,6 @@ int GOManual::FindCouplerByName(const wxString &name) const {
 }
 
 void GOManual::AddCoupler(GOCoupler *coupler) { m_couplers.push_back(coupler); }
-
-unsigned GOManual::GetDivisionalCount() { return m_divisionals.size(); }
 
 GODivisionalButtonControl *GOManual::GetDivisional(unsigned index) {
   assert(index < m_divisionals.size());

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -153,7 +153,7 @@ public:
    */
   int FindCouplerByName(const wxString &name) const;
   void AddCoupler(GOCoupler *coupler);
-  unsigned GetDivisionalCount();
+  unsigned GetDivisionalCount() const { return m_divisionals.size(); }
   GODivisionalButtonControl *GetDivisional(unsigned index);
   void AddDivisional(GODivisionalButtonControl *divisional);
   unsigned GetTremulantCount() const { return m_tremulant_ids.size(); }

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -290,6 +290,17 @@ GOPistonControl *GOOrganModel::GetPiston(unsigned index) {
   return m_pistons[index];
 }
 
+void GOOrganModel::FillCoupledManualsForDivisional(
+  unsigned startManual, std::set<unsigned> &manualSet) const {
+  // protection against infinite recursion
+  if (manualSet.insert(startManual).second) {
+    // walk on the couplers
+    for (const GODivisionalCoupler *coupler : m_DivisionalCoupler)
+      for (auto otherManual : coupler->GetCoupledManuals(startManual))
+        FillCoupledManualsForDivisional(otherManual, manualSet);
+  }
+}
+
 int GOOrganModel::FindDivisionalCouplerByName(const wxString &name) const {
   int resIndex = -1;
 

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -290,17 +290,6 @@ GOPistonControl *GOOrganModel::GetPiston(unsigned index) {
   return m_pistons[index];
 }
 
-void GOOrganModel::FillCoupledManualsForDivisional(
-  unsigned startManual, std::set<unsigned> &manualSet) const {
-  // protection against infinite recursion
-  if (manualSet.insert(startManual).second) {
-    // walk on the couplers
-    for (const GODivisionalCoupler *coupler : m_DivisionalCoupler)
-      for (auto otherManual : coupler->GetCoupledManuals(startManual))
-        FillCoupledManualsForDivisional(otherManual, manualSet);
-  }
-}
-
 int GOOrganModel::FindDivisionalCouplerByName(const wxString &name) const {
   int resIndex = -1;
 
@@ -316,6 +305,25 @@ unsigned GOOrganModel::GetGeneralCount() { return m_generals.size(); }
 
 GOGeneralButtonControl *GOOrganModel::GetGeneral(unsigned index) {
   return m_generals[index];
+}
+
+void GOOrganModel::FillCoupledManualsForDivisional(
+  unsigned startManual, std::set<unsigned> &manualSet) const {
+  // protection against infinite recursion
+  if (manualSet.insert(startManual).second) {
+    // walk on the couplers
+    for (const GODivisionalCoupler *coupler : m_DivisionalCoupler)
+      for (auto otherManual : coupler->GetCoupledManuals(startManual))
+        FillCoupledManualsForDivisional(otherManual, manualSet);
+  }
+}
+
+std::set<unsigned> GOOrganModel::GetCoupledManualsForDivisional(
+  unsigned startManual) const {
+  std::set<unsigned> res;
+
+  FillCoupledManualsForDivisional(startManual, res);
+  return res;
 }
 
 void GOOrganModel::UpdateAllButtonsLight(

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -57,6 +57,16 @@ private:
 
   bool m_OrganModelModified;
 
+  /**
+   * Walks across all manuals with divisional coupler engaged and returns the
+   *   set of manuals where the divisional with the same number should be pushed
+   * @param startManual the first manual index where a divisional is pushed
+   * @param manualSet the resulting set of manuals. It always contains
+   *   startManual
+   */
+  void FillCoupledManualsForDivisional(
+    unsigned startManual, std::set<unsigned> &manualSet) const;
+
 protected:
   ptr_vector<GOWindchest> m_windchests;
   ptr_vector<GOManual> m_manuals;
@@ -185,14 +195,13 @@ public:
   }
 
   /**
-   * Walks across all manuals with divisional coupler engaged and returns the
-   *   set of manuals where the divisional with the same number should be pushed
+   * Walks recursivelly across all manuals with divisional coupler engaged and
+   *   returns a set of manuals where the divisional with the same number should
+   *   be pushed
    * @param startManual the first manual index where a divisional is pushed
-   * @param manualSet the resulting set of manuals. It always contains
-   *   startManual
+   * @return the resulting set of manuals. It always contains startManual
    */
-  void FillCoupledManualsForDivisional(
-    unsigned startManual, std::set<unsigned> &manualSet) const;
+  std::set<unsigned> GetCoupledManualsForDivisional(unsigned startManual) const;
 
   /**
    * Find a divisional coupler by it's name

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -195,7 +195,7 @@ public:
   }
 
   /**
-   * Walks recursivelly across all manuals with divisional coupler engaged and
+   * Walks recursively across all manuals with divisional coupler engaged and
    *   returns a set of manuals where the divisional with the same number should
    *   be pushed
    * @param startManual the first manual index where a divisional is pushed

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -8,6 +8,8 @@
 #ifndef GOORGANMODEL_H
 #define GOORGANMODEL_H
 
+#include <set>
+
 #include "ptrvector.h"
 
 #include "combinations/control/GOCombinationButtonSet.h"
@@ -181,6 +183,16 @@ public:
   GODivisionalCoupler *GetDivisionalCoupler(unsigned index) {
     return m_DivisionalCoupler[index];
   }
+
+  /**
+   * Walks across all manuals with divisional coupler engaged and returns the
+   *   set of manuals where the divisional with the same number should be pushed
+   * @param startManual the first manual index where a divisional is pushed
+   * @param manualSet the resulting set of manuals. It always contains
+   *   startManual
+   */
+  void FillCoupledManualsForDivisional(
+    unsigned startManual, std::set<unsigned> &manualSet) const;
 
   /**
    * Find a divisional coupler by it's name


### PR DESCRIPTION
This is the first PR related to #1787.

GO supports two types of divisionals: manual divisionals ("old style") and setter divisionals ("banked").

Processing divisional couplers was made in GOSetter::PushDivisional(). Unfortunally it supported only the first type (manual) divisionals and knew nothing about the setter divisionals. So when a setter divisional was poshed, GOSetter::PushDivisional tried to couple it with a manual divisional with the same number without checking whether it exist. It caused a crash.

This PR
- Extracts collecting coupled manuals from ``GOSetter::PushDivisional()`` to ``GOOrganModel::FillCoupledManualsForDivisional`` and ``GODivisionalCoupler::GetCoupledManuals``
- Extract the current processing of divisional coupler with manual divisionals from ``GOSetter::PushDivisional()`` to ``GODivisionalButtonControl::Push()``
- ``GOSetter::PushDivisional()`` becomes very simple without any coupler processing. It fixes the crash mentioned in #1787

Because ``GODivisionalSetter::SwitchDivisionalTo`` calls ``GOSetter::PushDivisional()`` that stops processing couplers, the divisional couplers still do not work with the setter divisionals, but they do not more cause crash.

Fix of working divisional couplers with the setter divisionals will be submitted after merging this PR.