### PR TITLE
Renamed members of GOWindchestWorkItem

### DIFF
--- a/src/grandorgue/sound/scheduler/GOSoundWindchestTask.h
+++ b/src/grandorgue/sound/scheduler/GOSoundWindchestTask.h
@@ -11,6 +11,8 @@
 #include <atomic>
 
 #include "ptrvector.h"
+
+#include "model/GOWindchest.h"
 #include "sound/scheduler/GOSoundTask.h"
 #include "threading/GOMutex.h"
 
@@ -20,31 +22,34 @@ class GOWindchest;
 
 class GOSoundWindchestTask : public GOSoundTask {
 private:
-  GOSoundEngine &m_engine;
-  GOMutex m_Mutex;
-  float m_Volume;
-  std::atomic_bool m_Done;
-  GOWindchest *m_Windchest;
-  std::vector<GOSoundTremulantTask *> m_Tremulants;
+  GOSoundEngine &r_engine;
+  GOMutex m_mutex;
+  float m_volume;
+  std::atomic_bool m_done;
+  GOWindchest *p_windchest;
+  std::vector<GOSoundTremulantTask *> m_pTremulantTasks;
 
 public:
   GOSoundWindchestTask(GOSoundEngine &sound_engine, GOWindchest *windchest);
 
-  unsigned GetGroup();
-  unsigned GetCost();
-  bool GetRepeat();
-  void Run(GOSoundThread *thread = nullptr);
-  void Exec();
+  unsigned GetGroup() override { return WINDCHEST; }
+  unsigned GetCost() override { return 0; }
+  bool GetRepeat() override { return false; }
+  void Run(GOSoundThread *pThread = nullptr) override;
+  void Exec() override {}
 
-  void Clear();
-  void Reset();
-  void Init(ptr_vector<GOSoundTremulantTask> &tremulants);
+  void Clear() override { Reset(); }
+  void Reset() override;
+  void Init(ptr_vector<GOSoundTremulantTask> &tremulantTasks);
 
-  float GetWindchestVolume();
+  float GetWindchestVolume() const {
+    return p_windchest ? p_windchest->GetVolume() : 1;
+  }
+
   float GetVolume() {
-    if (!m_Done.load())
+    if (!m_done.load())
       Run();
-    return m_Volume;
+    return m_volume;
   }
 };
 


### PR DESCRIPTION
This PR:
- Renames `GOSoundWindchestWorkItem` members according to the GO naming conventions
- Updated the `GOSoundWindchestWorkItem` methods code style, including moving some simple method implementation to the header.

It is just refactoring. No GO behavior shoud be changed.