### PR TITLE
Allowed to init GOConfig without loading defaults

### DIFF
--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -217,31 +217,7 @@ GOConfig::GOConfig(wxString instance)
     CheckForUpdatesAtStartup(
       this, wxT("General"), wxT("CheckForUpdatesAtStartup"), true),
     m_MidiIn(MIDI_IN),
-    m_MidiOut(MIDI_OUT) {
-  m_ConfigFileName = GOStdPath::GetConfigDir() + wxFileName::GetPathSeparator()
-    + wxT("GrandOrgueConfig") + m_InstanceName;
-  for (unsigned i = 0; i < GetEventCount(); i++)
-    m_MIDIEvents.push_back(new GOMidiReceiverBase(m_MIDISettings[i].type));
-  m_ResourceDir = GOStdPath::GetResourceDir();
-
-  OrganPath.setDefaultValue(GOStdPath::GetGrandOrgueSubDir(_("Organs")));
-  OrganPackagePath.setDefaultValue(
-    GOStdPath::GetGrandOrgueSubDir(_("Organ packages")));
-  OrganCachePath.setDefaultValue(
-    GOStdPath::GetGrandOrgueSubDir(wxT("Cache") + m_InstanceName));
-  OrganSettingsPath.setDefaultValue(
-    GOStdPath::GetGrandOrgueSubDir(wxT("Data") + m_InstanceName));
-  OrganCombinationsPath.setDefaultValue(
-    GOStdPath::GetGrandOrgueSubDir(_("Combinations")));
-  ExportImportPath.setDefaultValue(
-    GOStdPath::GetGrandOrgueSubDir(_("Settings")));
-  AudioRecorderPath.setDefaultValue(
-    GOStdPath::GetGrandOrgueSubDir(_("Audio recordings")));
-  MidiRecorderPath.setDefaultValue(
-    GOStdPath::GetGrandOrgueSubDir(_("MIDI recordings")));
-  MidiPlayerPath.setDefaultValue(
-    GOStdPath::GetGrandOrgueSubDir(_("MIDI recordings")));
-}
+    m_MidiOut(MIDI_OUT) {}
 
 GOConfig::~GOConfig() { /* Flush(); */
 }
@@ -286,6 +262,9 @@ void save_ports_config(
 }
 
 void GOConfig::Load() {
+  if (m_ConfigFileName.IsEmpty()) {
+    LoadDefaults();
+  }
   GOConfigFileReader cfg_file;
   if (wxFileExists(m_ConfigFileName)) {
     if (!cfg_file.Read(m_ConfigFileName))
@@ -439,6 +418,40 @@ void GOConfig::Load() {
     }
     m_AudioDeviceConfig.push_back(conf);
   }
+}
+
+void GOConfig::LoadDefaults() {
+
+  /* This has to be called in the wxApp context
+     e.g.: after having done the wxApp::OnInit() call.
+
+     As wx is waiting for the wxApp to have been initialized
+     before calling th Get() method.
+  */
+
+  m_ConfigFileName = GOStdPath::GetConfigDir() + wxFileName::GetPathSeparator()
+    + wxT("GrandOrgueConfig") + m_InstanceName;
+  for (unsigned i = 0; i < GetEventCount(); i++)
+    m_MIDIEvents.push_back(new GOMidiReceiverBase(m_MIDISettings[i].type));
+  m_ResourceDir = GOStdPath::GetResourceDir();
+
+  OrganPath.setDefaultValue(GOStdPath::GetGrandOrgueSubDir(_("Organs")));
+  OrganPackagePath.setDefaultValue(
+    GOStdPath::GetGrandOrgueSubDir(_("Organ packages")));
+  OrganCachePath.setDefaultValue(
+    GOStdPath::GetGrandOrgueSubDir(wxT("Cache") + m_InstanceName));
+  OrganSettingsPath.setDefaultValue(
+    GOStdPath::GetGrandOrgueSubDir(wxT("Data") + m_InstanceName));
+  OrganCombinationsPath.setDefaultValue(
+    GOStdPath::GetGrandOrgueSubDir(_("Combinations")));
+  ExportImportPath.setDefaultValue(
+    GOStdPath::GetGrandOrgueSubDir(_("Settings")));
+  AudioRecorderPath.setDefaultValue(
+    GOStdPath::GetGrandOrgueSubDir(_("Audio recordings")));
+  MidiRecorderPath.setDefaultValue(
+    GOStdPath::GetGrandOrgueSubDir(_("MIDI recordings")));
+  MidiPlayerPath.setDefaultValue(
+    GOStdPath::GetGrandOrgueSubDir(_("MIDI recordings")));
 }
 
 int GOConfig::GetLanguageId() const {

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -76,6 +76,8 @@ private:
 
   wxString GetEventSection(unsigned index);
 
+  void LoadDefaults();
+
 public:
   GOConfig(wxString instance);
   ~GOConfig();


### PR DESCRIPTION
As default paths loading is relying on wxApp to be loaded, it does not allow to load a GOConfig object to load a controller without loading the wx App. This is useful for tests but also decouple GO from wx.

This avoids those logs: 

![image](https://github.com/GrandOrgue/grandorgue/assets/19529533/35a999e7-e244-4fce-b779-3f7d0021b848)
