### PR TITLE
Fixed not sounding of pipe after an enclosure has closed to zero and then opened https://github.com/GrandOrgue/grandorgue/issues/1813

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed not sounding of pipe after an enclosure has closed to zero and then opened https://github.com/GrandOrgue/grandorgue/issues/1813
 - Added Midi listener for Panic button and Exit GO function. https://github.com/GrandOrgue/grandorgue/issues/1905
 - Added a tone balance (bass/treble harmonics balance) voicing option
 # 3.14.2 (2024-04-29)

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -43,7 +43,7 @@ void GOEnclosure::Init(
   m_midi.Load(cfg, m_group, r_MidiMap);
   m_sender.Load(cfg, m_group, r_MidiMap);
   m_shortcut.Load(cfg, m_group);
-  m_AmpMinimumLevel = 1;
+  m_AmpMinimumLevel = 0;
 }
 
 void GOEnclosure::Load(GOConfigReader &cfg, wxString group, int enclosure_nb) {

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -69,7 +69,9 @@ private:
 
   std::atomic_bool m_HasBeenSetup;
 
-  unsigned SamplesDiffToMs(uint64_t fromSamples, uint64_t toSamples);
+  unsigned MsToSamples(unsigned ms) const { return m_SampleRate * ms / 1000; }
+
+  unsigned SamplesDiffToMs(uint64_t fromSamples, uint64_t toSamples) const;
 
   /* samplerTaskId:
      -1 .. -n Tremulants

--- a/src/grandorgue/sound/GOSoundFader.cpp
+++ b/src/grandorgue/sound/GOSoundFader.cpp
@@ -7,26 +7,26 @@
 
 #include "GOSoundFader.h"
 
-#include "GOSoundDefs.h"
+#include <algorithm>
 
-void GOSoundFader::SetupForIncreasingVolume(
-  float target_gain, unsigned n_frames) {
-  m_IncreasingFrames = n_frames;
+void GOSoundFader::Setup(
+  float targetVolume, float velocityVolume, unsigned nFramesToIncreaseIn) {
+  m_TargetVolume = targetVolume;
+
+  if (nFramesToIncreaseIn) {
+    m_LastTargetVolumePoint = 0.0f;
+    m_IncreasingDeltaPerFrame = targetVolume / nFramesToIncreaseIn;
+  } else {
+    m_LastTargetVolumePoint = targetVolume;
+    m_IncreasingDeltaPerFrame = 0.0f;
+  }
   m_DecreasingDeltaPerFrame = 0.0f;
-  m_LastTotalVolumePoint = 0.0f;
-  m_TargetVolume = target_gain;
-  m_IncreasingDeltaPerFrame = target_gain / n_frames;
-  m_LastExternalVolumePoint = -1;
-  m_VelocityVolume = 1;
+  m_VelocityVolume = velocityVolume;
+  m_LastExternalVolumePoint = -1; // will be set on the first Process() call
 }
 
-void GOSoundFader::SetupForConstantVolume(float gain) {
-  m_IncreasingFrames = 0;
-  m_IncreasingDeltaPerFrame = m_DecreasingDeltaPerFrame = 0.0f;
-  m_LastTotalVolumePoint = m_TargetVolume = gain;
-  m_LastExternalVolumePoint = -1;
-  m_VelocityVolume = 1;
-}
+// if the external volume is changed, do it smoothly in this number of frames
+static constexpr unsigned EXTERNAL_VOLUME_CHANGE_FRAMES = 1024;
 
 void GOSoundFader::Process(
   unsigned nFrames, float *buffer, float externalVolume) {
@@ -34,72 +34,63 @@ void GOSoundFader::Process(
 
   // Consider the velocity volume as part of the external volume
   externalVolume *= m_VelocityVolume;
-  if (m_LastExternalVolumePoint < 0) {
-    m_LastExternalVolumePoint = externalVolume;
-    m_TotalVolume = m_TargetVolume * externalVolume;
-    m_LastTotalVolumePoint *= externalVolume;
-  }
 
+  float startTargetVolumePoint = m_LastTargetVolumePoint;
+  // Calculate new m_LastTargetVolumePoint
+  // the target volume will be changed from startTargetVolumePoint to
+  // m_LastTargetVolumePoint during the nFrames
   float targetVolumeDeltaPerFrame
     = m_IncreasingDeltaPerFrame + m_DecreasingDeltaPerFrame;
-  float frameTotalVolume
-    = m_LastTotalVolumePoint;      // the volume for the first frame
-  float frameTotalVolumeDelta = 0; // changing the volume by one frame
 
+  if (targetVolumeDeltaPerFrame != 0.0f) {
+    m_LastTargetVolumePoint = std::clamp(
+      startTargetVolumePoint + targetVolumeDeltaPerFrame * nFrames,
+      0.0f,
+      m_TargetVolume);
+
+    if (m_LastTargetVolumePoint >= m_TargetVolume)
+      // target volume is reached. Stop increasing
+      m_IncreasingDeltaPerFrame = 0.0f;
+    else if (m_LastTargetVolumePoint <= 0.0f)
+      // Decreasing is finished. Stop it.
+      m_DecreasingDeltaPerFrame = 0.0f;
+  }
+
+  if (m_LastExternalVolumePoint < 0.0f) // The first Process() call
+    m_LastExternalVolumePoint = externalVolume;
+
+  float startExternalVolumePoint = m_LastExternalVolumePoint;
+  // Calculate new m_LastExternalVolumePoint
+  // the target volume will be changed from startExternalVolumePoint to
+  // m_LastExternalVolumePoint during the nFrames period
+  if (externalVolume != startExternalVolumePoint)
+    m_LastExternalVolumePoint += (externalVolume - startExternalVolumePoint)
+      // Assume that external volume is to be reached in MAX_FRAME_SIZE frames
+      * std::max(nFrames, EXTERNAL_VOLUME_CHANGE_FRAMES)
+      / EXTERNAL_VOLUME_CHANGE_FRAMES;
+
+  float frameTotalVolume = startTargetVolumePoint * startExternalVolumePoint;
+
+  // Process data
   if (
-    externalVolume != m_LastExternalVolumePoint
-    || targetVolumeDeltaPerFrame != 0) {
-    /*
-     * the volume is changed during the buffer.
-     * Calculate frameVolumeDelta and other m_lasTotalVolume
-     *
-     * Because totalVol = targetVolume * externalVolume,
-     * totalVolumeDiff = targetVolumeDiff * externalVolume
-     *   + externalVolumeDiff * targetVolume
-     */
-
-    float targetVolumeChange = targetVolumeDeltaPerFrame * nFrames;
-    // Assume that external volume is fully changed in MAX_FRAME_SIZE frames
-    float externalVolumeChange
-      = (externalVolume - m_LastExternalVolumePoint) * nFrames / MAX_FRAME_SIZE;
-    float targetVolumeDiff = targetVolumeChange * externalVolume;
-    float externalVolumeDiff = externalVolumeChange * m_TargetVolume;
-    float newLastExternalVolume
-      = m_LastExternalVolumePoint + externalVolumeChange;
-
-    m_TotalVolume = m_TargetVolume * newLastExternalVolume;
-
-    float end = m_LastTotalVolumePoint + externalVolumeDiff + targetVolumeDiff;
-
-    if (end < 0) {
-      end = 0;
-      m_DecreasingDeltaPerFrame = 0;
-    } else if (end > m_TotalVolume) {
-      end = m_TotalVolume;
-      m_IncreasingDeltaPerFrame = 0.0f;
+    (m_LastTargetVolumePoint == startTargetVolumePoint)
+    && (m_LastExternalVolumePoint == startExternalVolumePoint)) {
+    // Adjust the buffer by frameTotalVolume
+    for (unsigned int i = 0; i < nFrames; i++, buffer += 2) {
+      buffer[0] *= frameTotalVolume;
+      buffer[1] *= frameTotalVolume;
     }
-    frameTotalVolumeDelta = (end - m_LastTotalVolumePoint) / (nFrames);
-    m_LastExternalVolumePoint = newLastExternalVolume;
-    m_LastTotalVolumePoint = end;
-  }
-  if (m_IncreasingDeltaPerFrame > 0.0f) {
-    if (m_IncreasingFrames >= nFrames)
-      m_IncreasingFrames -= nFrames;
-    else
-      m_IncreasingDeltaPerFrame = 0.0f;
-  }
+  } else {
+    // Adjust the buffer smoothly from frameTotalVolume to
+    // m_LastTargetVolumePoint * m_LastExternalVolumePoint
+    float frameTotalVolumeDelta // changing the volume by one frame
+      = (m_LastTargetVolumePoint * m_LastExternalVolumePoint - frameTotalVolume)
+      / nFrames;
 
-  // Procedss data
-  if (frameTotalVolumeDelta) {
     for (unsigned int i = 0; i < nFrames; i++, buffer += 2) {
       buffer[0] *= frameTotalVolume;
       buffer[1] *= frameTotalVolume;
       frameTotalVolume += frameTotalVolumeDelta;
-    }
-  } else {
-    for (unsigned int i = 0; i < nFrames; i++, buffer += 2) {
-      buffer[0] *= frameTotalVolume;
-      buffer[1] *= frameTotalVolume;
     }
   }
 }

--- a/src/grandorgue/sound/GOSoundFader.h
+++ b/src/grandorgue/sound/GOSoundFader.h
@@ -9,10 +9,10 @@
 #define GOSOUNDFADER_H_
 
 /**
- * This class is responsible of smooth changing a volume of samples.
+ * This class is responsible for smoothly changing a volume of samples.
  *
  * There are different types of volumes
- * - Target volume. It is defined by total capacity of the asmple size and may
+ * - Target volume. It is defined by total capacity of the sample size and may
  *   be adjusted in odf and settings.
  * - External volume. It may be changed by an enclosure during playback.
  * - VelocityVolume. It is defined when a key is pressed and may be changed if
@@ -20,13 +20,13 @@
  *   It is considered as part of an
  * - Total volume. It is a production of of all volumes above.
  *
- * There are three staging of playing one sample related to the target volume:
+ * There are three stages of playing one sample related to the target volume:
  * - Increasing: from 0 to m_TargetVolume during m_IncreasingFrames. It is used
  *   only for crossfade between two samples.
  * - Constant playing: the volume is not changed. Usually it is used for the
  *   attack sample (because the increasing is already sampled).
- * - Decreasing: from m_СurrentVolume to 0. It is used for bothe crossfade from
- *   a loop to a release sample and when playing the release sample when
+ * - Decreasing: from m_СurrentVolume to 0. It is used for both the crossfade
+ *   from a loop to a release sample and when playing the release sample when
  *   ReleseTail limitation is used
  *
  * totalVol = targetVolume * externalVolume
@@ -52,7 +52,7 @@ private:
 
 public:
   /**
-   * Setup the fadef for constant volume of for increasing from 0 to
+   * Setup the fader for constant volume or for increasing from 0 to
    * targetVolume
    * @param targetVolume target volume to reach
    * @param velocityVolume the initial velocity volume. It may be changed later
@@ -69,7 +69,7 @@ public:
    * @param nFrames number of frames for full decay
    */
   inline void StartDecreasingVolume(unsigned nFrames) {
-    // may be m_TargetVolume has not yet been reached, but the velocity of
+    // maybe m_TargetVolume has not yet been reached, but the velocity of
     // decreasing should be the same as it has reached
     m_DecreasingDeltaPerFrame = -(m_TargetVolume / nFrames);
   }

--- a/src/grandorgue/sound/GOSoundFader.h
+++ b/src/grandorgue/sound/GOSoundFader.h
@@ -42,47 +42,44 @@ private:
 
   // a volume delta for one frame when increasing
   float m_IncreasingDeltaPerFrame;
-  unsigned m_IncreasingFrames;
 
   // a volume delta for one frame when decreasing
   float m_DecreasingDeltaPerFrame;
 
   // Last volume points are the volumes at the end of previous Process()
+  float m_LastTargetVolumePoint;
   float m_LastExternalVolumePoint;
-  float m_LastTotalVolumePoint;
-
-  // The final volume with taking external volume into account
-  float m_TotalVolume;
 
 public:
   /**
-   * Setup the fader for constant volume (for the first attack or an
-   * independent release)
-   * @param gain - the volume amplitude coeff
+   * Setup the fadef for constant volume of for increasing from 0 to
+   * targetVolume
+   * @param targetVolume target volume to reach
+   * @param velocityVolume the initial velocity volume. It may be changed later
+   * @param nFramesToIncreaseIn if it is 0 then the target volume will be
+   *   constant. Else it will smoothly increase from 0 to targetVolume in this
+   *   number of frames
    */
-  void SetupForConstantVolume(float targetVolume);
+  void Setup(
+    float targetVolume, float velocityVolume, unsigned nFramesToIncreaseIn = 0);
 
   /**
-   * Setup the increase the volume from 0 to target_gain
-   * Usually it is used together with StartDecreasingVolume for another sampler
-   * @param targetVolume final volume
-   * @param nFrames number of frames to increase the volume for
-   */
-  void SetupForIncreasingVolume(float targetVolume, unsigned nFrames);
-
-  /**
-   * Setup the decrease the volume from the current value (m_target) to 0
+   * Start decreasing the volume from the current value
+   * (m_LastTargetVolumePoint) to 0
    * @param nFrames number of frames for full decay
    */
   inline void StartDecreasingVolume(unsigned nFrames) {
+    // may be m_TargetVolume has not yet been reached, but the velocity of
+    // decreasing should be the same as it has reached
     m_DecreasingDeltaPerFrame = -(m_TargetVolume / nFrames);
   }
 
+  inline float GetVelocityVolume() const { return m_VelocityVolume; }
   inline void SetVelocityVolume(float volume) { m_VelocityVolume = volume; }
 
-  void Process(unsigned n_blocks, float *buffer, float externalVolume);
+  void Process(unsigned nFrames, float *buffer, float externalVolume);
 
-  bool IsSilent() const { return (m_LastTotalVolumePoint <= 0.0f); }
+  bool IsSilent() const { return (m_LastTargetVolumePoint <= 0.0f); }
 };
 
 #endif /* GOSOUNDFADER_H_ */

--- a/src/grandorgue/sound/GOSoundFader.h
+++ b/src/grandorgue/sound/GOSoundFader.h
@@ -47,8 +47,9 @@ private:
   // a volume delta for one frame when decreasing
   float m_DecreasingDeltaPerFrame;
 
-  float m_LastExternalVolume;
-  float m_LastTotalVolume;
+  // Last volume points are the volumes at the end of previous Process()
+  float m_LastExternalVolumePoint;
+  float m_LastTotalVolumePoint;
 
   // The final volume with taking external volume into account
   float m_TotalVolume;
@@ -81,7 +82,7 @@ public:
 
   void Process(unsigned n_blocks, float *buffer, float externalVolume);
 
-  bool IsSilent() const { return (m_LastTotalVolume <= 0.0f); }
+  bool IsSilent() const { return (m_LastTotalVolumePoint <= 0.0f); }
 };
 
 #endif /* GOSOUNDFADER_H_ */


### PR DESCRIPTION
Resolves: #1813

For fixing the issue I completelly reworked the `GOSoundFader` class. Earlier it calculated only the total volue that was depending on the enclosure volume. So it was not feasible to differentiate between finishing the decay and setting enclosure volume to 0. 

Now `GOSoundFader` calculates two volumes: target volume and external volume. `GOSoundFader::IsSilent()` takes into account only fade of the target volume, but not the external volume.