### PR TITLE
Reorganised code of GOSoundAudioSection

### DIFF
--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -760,6 +760,7 @@
                  commonFlags="-mtune=generic -march=x86-64 -std=c++11 -fPIC"/>
         <element flagsID="5" commonFlags="-std=c++11 -O3 -ffast-math -fPIC"/>
         <element flagsID="6" commonFlags="-std=c++14"/>
+        <element flagsID="7" commonFlags="-std=gnu++17 -fPIC"/>
       </flagsDictionary>
       <codeAssistance>
       </codeAssistance>
@@ -21606,88 +21607,34 @@
         <ccTool flags="3">
         </ccTool>
       </item>
-      <item path="../../src/core/GOCompress.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="4">
+      <item path="../../src/core/GOCompress.cpp" ex="false" tool="1" flavor2="11">
+        <ccTool flags="7">
           <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
+            <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/GOHash.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -21705,6 +21652,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -21768,6 +21717,16 @@
       <item path="../../src/core/GOKeyConvert.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -21783,6 +21742,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -21846,9 +21807,21 @@
       <item path="../../src/core/GOLogicalColour.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -21912,6 +21885,16 @@
       <item path="../../src/core/GOMemoryPool.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -21930,6 +21913,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -21993,6 +21978,16 @@
       <item path="../../src/core/GOOrgan.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/core/midi</pElem>
@@ -22014,6 +22009,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22077,6 +22074,16 @@
       <item path="../../src/core/GOOrganList.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -22096,6 +22103,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22159,6 +22168,16 @@
       <item path="../../src/core/GOPath.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -22176,6 +22195,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22239,6 +22260,16 @@
       <item path="../../src/core/GORodgers.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -22250,6 +22281,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22316,6 +22349,16 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -22325,6 +22368,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22388,6 +22433,16 @@
       <item path="../../src/core/GOStdPath.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -22404,6 +22459,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22467,6 +22524,16 @@
       <item path="../../src/core/GOTimer.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>../../src/core/threading</pElem>
@@ -22484,6 +22551,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22547,6 +22616,16 @@
       <item path="../../src/core/GOUtil.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -22562,6 +22641,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22625,6 +22706,16 @@
       <item path="../../src/core/GOWavPack.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -22637,6 +22728,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22700,6 +22793,16 @@
       <item path="../../src/core/GOWavPackWriter.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -22712,6 +22815,8 @@
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -22772,110 +22877,30 @@
           </preprocessorList>
         </ccTool>
       </item>
-      <item path="../../src/core/GOWave.cpp" ex="false" tool="1" flavor2="8">
-        <ccTool flags="4">
+      <item path="../../src/core/GOWave.cpp" ex="false" tool="1" flavor2="11">
+        <ccTool flags="7">
           <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/wavpack</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
+            <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/archive/GOArchive.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="4">
+            flavor2="11">
+        <ccTool flags="7">
           <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -22883,27 +22908,12 @@
       <item path="../../src/core/archive/GOArchiveCreator.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="4">
+            flavor2="11">
+        <ccTool flags="7">
           <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -22914,6 +22924,17 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/archive</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/core/files</pElem>
@@ -22931,6 +22952,70 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/archive/GOArchiveFile.cpp"
@@ -22939,6 +23024,17 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/archive</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -22957,6 +23053,70 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/archive/GOArchiveIndex.cpp"
@@ -22965,6 +23125,17 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/archive</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -22983,6 +23154,70 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/archive/GOArchiveManager.cpp"
@@ -22991,6 +23226,17 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/archive</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -23011,29 +23257,81 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__WXGTK__=1</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/archive/GOArchiveReader.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="4">
+            flavor2="11">
+        <ccTool flags="7">
           <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/contrib</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23041,22 +23339,12 @@
       <item path="../../src/core/archive/GOArchiveWriter.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="4">
+            flavor2="11">
+        <ccTool flags="7">
           <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23258,6 +23546,17 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
@@ -23272,6 +23571,67 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiEventPattern.cpp"
@@ -23280,6 +23640,17 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -23289,35 +23660,101 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiFileReader.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="4">
+            flavor2="11">
+        <ccTool flags="7">
           <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiMap.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -23332,6 +23769,67 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiReceiverBase.cpp"
@@ -23340,6 +23838,17 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
@@ -23355,6 +23864,67 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiReceiverEventPattern.cpp"
@@ -23363,8 +23933,80 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiSenderEventPattern.cpp"
@@ -23373,8 +24015,80 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/midi/GOMidiWXEvent.cpp"
@@ -23383,6 +24097,17 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -23398,6 +24123,67 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
+            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
+            <Elem>__BFLT16_DIG__=2</Elem>
+            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
+            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
+            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
+            <Elem>__BFLT16_MANT_DIG__=8</Elem>
+            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
+            <Elem>__BFLT16_MAX_EXP__=128</Elem>
+            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
+            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
+            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
+            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
+            <Elem>__DBL_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
+            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
+            <Elem>__FLT16_DIG__=3</Elem>
+            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
+            <Elem>__FLT16_HAS_DENORM__=1</Elem>
+            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
+            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
+            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT16_MANT_DIG__=11</Elem>
+            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
+            <Elem>__FLT16_MAX_EXP__=16</Elem>
+            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
+            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
+            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
+            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
+            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
+            <Elem>__FLT_IS_IEC_60559__=1</Elem>
+            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
+            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
+            <Elem>__GNUC_RH_RELEASE__=6</Elem>
+            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
+            <Elem>__GNUC__=13</Elem>
+            <Elem>__GNUG__=13</Elem>
+            <Elem>__GXX_ABI_VERSION=1018</Elem>
+            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
+            <Elem>__PIC__=2</Elem>
+            <Elem>__REGISTER_PREFIX__=</Elem>
+            <Elem>__STDCPP_THREADS__=1</Elem>
+            <Elem>__STRICT_ANSI__=1</Elem>
+            <Elem>__USER_LABEL_PREFIX__=</Elem>
+            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
+            <Elem>__cplusplus=201103L</Elem>
+            <Elem>__cpp_constexpr=200704L</Elem>
+            <Elem>__pic__=2</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/core/settings/GOSetting.cpp"
@@ -28335,6 +29121,22 @@
       </folder>
       <folder path="0/src/core">
         <ccTool>
+          <preprocessorList>
+            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/core/archive">
+        <ccTool>
+          <preprocessorList>
+            <Elem>GrandOrgueCore_EXPORTS</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/core/config">
+        <ccTool>
           <incDir>
             <pElem>../../src/grandorgue/resource</pElem>
             <pElem>../../src/core</pElem>
@@ -28346,88 +29148,11 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>GrandOrgueCore_EXPORTS=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__WXGTK__=1</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/core/archive">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/core/archive</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/core/config">
-        <ccTool>
-          <incDir>
             <pElem>../../src/core/config</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -28491,10 +29216,22 @@
       <folder path="0/src/core/contrib">
         <ccTool>
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>../../src/core/contrib</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -28558,76 +29295,22 @@
       <folder path="0/src/core/files">
         <ccTool>
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>../../src/core/files</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__PIC__=2</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-            <Elem>__pic__=2</Elem>
-          </preprocessorList>
-        </ccTool>
-      </folder>
-      <folder path="0/src/core/midi">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/core/midi</pElem>
-          </incDir>
-          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -28691,9 +29374,21 @@
       <folder path="0/src/core/settings">
         <ccTool>
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>../../src/core/settings</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -28757,10 +29452,22 @@
       <folder path="0/src/core/temperaments">
         <ccTool>
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -28818,6 +29525,26 @@
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
             <Elem>__pic__=2</Elem>
+          </preprocessorList>
+        </ccTool>
+      </folder>
+      <folder path="0/src/core/threading">
+        <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT=1</Elem>
           </preprocessorList>
         </ccTool>
       </folder>

--- a/ide-projects/NetBeans12/nbproject/configurations.xml
+++ b/ide-projects/NetBeans12/nbproject/configurations.xml
@@ -579,18 +579,25 @@
               <in>GOSoundRtPort.cpp</in>
             </df>
             <df name="scheduler">
+              <in>GOSoundGroupTask.cpp</in>
               <in>GOSoundGroupWorkItem.cpp</in>
+              <in>GOSoundOutputTask.cpp</in>
               <in>GOSoundOutputWorkItem.cpp</in>
+              <in>GOSoundReleaseTask.cpp</in>
               <in>GOSoundReleaseWorkItem.cpp</in>
               <in>GOSoundScheduler.cpp</in>
               <in>GOSoundThread.cpp</in>
+              <in>GOSoundTouchTask.cpp</in>
               <in>GOSoundTouchWorkItem.cpp</in>
+              <in>GOSoundTremulantTask.cpp</in>
               <in>GOSoundTremulantWorkItem.cpp</in>
+              <in>GOSoundWindchestTask.cpp</in>
               <in>GOSoundWindchestWorkItem.cpp</in>
             </df>
             <in>GOSound.cpp</in>
             <in>GOSoundAudioSection.cpp</in>
             <in>GOSoundEngine.cpp</in>
+            <in>GOSoundFader.cpp</in>
             <in>GOSoundProvider.cpp</in>
             <in>GOSoundProviderSynthedTrem.cpp</in>
             <in>GOSoundProviderWave.cpp</in>
@@ -762,7 +769,15 @@
           <buildCommand>${MAKE} -f Makefile -j 16 -k</buildCommand>
           <cleanCommand>${MAKE} -f Makefile clean</cleanCommand>
           <executablePath>../../build/current/bin/GrandOrgue</executablePath>
-          <ccTool flags="-std=c++11 -msse3">
+          <ccTool flags="1">
+            <incDir>
+              <pElem>../../build/current/src/core/go_defs.h</pElem>
+            </incDir>
+            <preprocessorList>
+              <Elem>WXUSINGDLL</Elem>
+              <Elem>_FILE_OFFSET_BITS=64</Elem>
+              <Elem>__WXGTK__</Elem>
+            </preprocessorList>
           </ccTool>
         </makeTool>
         <preBuild>
@@ -6133,11 +6148,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -6351,11 +6362,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -6569,11 +6576,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -6787,11 +6790,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -7005,11 +7004,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -7223,11 +7218,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -7441,11 +7432,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -7659,11 +7646,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -7877,11 +7860,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -8095,11 +8074,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -8313,11 +8288,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -8531,11 +8502,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -8749,11 +8716,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -8967,11 +8930,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -9185,11 +9144,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -9403,11 +9358,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -9621,11 +9572,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -9839,11 +9786,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -10057,11 +10000,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -10275,11 +10214,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -10493,11 +10428,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -10711,11 +10642,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -10929,11 +10856,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -11147,11 +11070,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -11365,11 +11284,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -11583,11 +11498,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -11801,11 +11712,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -12019,11 +11926,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -12237,11 +12140,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -12455,11 +12354,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -12673,11 +12568,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -12891,11 +12782,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -13109,11 +12996,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -13327,11 +13210,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -13545,11 +13424,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -13763,11 +13638,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -13981,11 +13852,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -14199,11 +14066,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -17090,11 +16953,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17108,11 +16967,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17126,11 +16981,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17144,11 +16995,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17162,11 +17009,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17180,11 +17023,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17198,11 +17037,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17216,11 +17051,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17234,11 +17065,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -17252,11 +17079,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -19781,11 +19604,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -19799,11 +19618,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -19898,11 +19713,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -19916,11 +19727,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -20987,11 +20794,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -21005,11 +20808,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -21185,11 +20984,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -21203,11 +20998,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -21464,11 +21255,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -21482,11 +21269,7 @@
             tool="1"
             flavor2="8">
         <ccTool flags="4">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>GrandOrgueImages_EXPORTS</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -21826,7 +21609,6 @@
       <item path="../../src/core/GOCompress.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -21839,9 +21621,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -21908,7 +21688,6 @@
       <item path="../../src/core/GOHash.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -21922,9 +21701,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -21991,7 +21768,6 @@
       <item path="../../src/core/GOKeyConvert.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -22003,9 +21779,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22072,7 +21846,6 @@
       <item path="../../src/core/GOLogicalColour.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22139,7 +21912,6 @@
       <item path="../../src/core/GOMemoryPool.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -22154,9 +21926,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22223,7 +21993,6 @@
       <item path="../../src/core/GOOrgan.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/core/midi</pElem>
@@ -22241,9 +22010,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22310,7 +22077,6 @@
       <item path="../../src/core/GOOrganList.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -22326,9 +22092,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22395,7 +22159,6 @@
       <item path="../../src/core/GOPath.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -22409,9 +22172,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22478,7 +22239,6 @@
       <item path="../../src/core/GORodgers.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -22556,7 +22316,6 @@
             flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -22629,7 +22388,6 @@
       <item path="../../src/core/GOStdPath.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -22642,9 +22400,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22711,7 +22467,6 @@
       <item path="../../src/core/GOTimer.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>../../src/core/threading</pElem>
@@ -22726,8 +22481,6 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22794,7 +22547,6 @@
       <item path="../../src/core/GOUtil.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -22806,9 +22558,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -22875,7 +22625,6 @@
       <item path="../../src/core/GOWavPack.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -22951,7 +22700,6 @@
       <item path="../../src/core/GOWavPackWriter.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -23027,7 +22775,6 @@
       <item path="../../src/core/GOWave.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="4">
           <incDir>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -23043,9 +22790,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -23124,16 +22869,13 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>../../src/core/threading</pElem>
             <pElem>../../src/core/files</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23148,7 +22890,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/files</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -23162,9 +22903,7 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
             <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23189,10 +22928,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23211,7 +22947,6 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>../../src/core/contrib</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
@@ -23219,9 +22954,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23240,7 +22973,6 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/contrib</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
@@ -23248,9 +22980,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23265,7 +22995,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -23279,9 +23008,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23295,7 +23022,6 @@
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -23307,9 +23033,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23324,7 +23048,6 @@
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
@@ -23334,8 +23057,6 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23350,7 +23071,6 @@
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/files</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -23362,9 +23082,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23379,7 +23097,6 @@
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -23389,9 +23106,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23405,7 +23120,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -23416,9 +23130,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23440,12 +23152,9 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23463,16 +23172,13 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23497,9 +23203,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23521,9 +23225,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23545,9 +23247,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23565,14 +23265,11 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23604,7 +23301,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -23614,9 +23310,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23636,8 +23330,6 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23656,14 +23348,11 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23701,15 +23390,12 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23731,10 +23417,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23753,14 +23436,11 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23778,15 +23458,12 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23809,10 +23486,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23835,10 +23509,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23856,15 +23527,12 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23886,10 +23554,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23907,15 +23572,12 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23936,9 +23598,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23959,9 +23619,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -23974,7 +23632,6 @@
           <incDir>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -23984,9 +23641,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -24003,15 +23658,12 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
         </ccTool>
@@ -24037,8 +23689,6 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -24123,8 +23773,6 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -24349,24 +23997,12 @@
             flavor2="8">
         <ccTool flags="5">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_STD_MUTEX</Elem>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>NDEBUG</Elem>
             <Elem>WXUSINGDLL</Elem>
@@ -24395,9 +24031,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
           </incDir>
           <preprocessorList>
@@ -24463,26 +24097,6 @@
       </item>
       <item path="../../src/grandorgue/GOApp.cpp" ex="false" tool="1" flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOAudioRecorder.cpp"
@@ -24490,75 +24104,13 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOBitmapCache.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GODocument.cpp"
@@ -24566,32 +24118,11 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOEvent.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -24605,15 +24136,11 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
@@ -24677,32 +24204,11 @@
       </item>
       <item path="../../src/grandorgue/GOFrame.cpp" ex="false" tool="1" flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOLog.cpp" ex="false" tool="1" flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -24716,15 +24222,11 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
@@ -24792,7 +24294,6 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -24806,15 +24307,11 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
@@ -24879,95 +24376,15 @@
       <item path="../../src/grandorgue/GOMainWindowData.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOMetronome.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOOrganController.cpp"
@@ -24975,411 +24392,34 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOProperties.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/GOVirtualCouplerController.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/GODivisionalSetter.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/GOSetter.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/control/GOCombinationButtonSet.cpp"
@@ -25388,6 +24428,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -25402,13 +24443,8 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -25418,12 +24454,11 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../src/grandorgue/combinations/control</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
@@ -25488,281 +24523,43 @@
       <item path="../../src/grandorgue/combinations/control/GODivisionalButtonControl.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/control/GOGeneralButtonControl.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOCombination.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOCombinationDefinition.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GODivisionalCombination.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/combinations/model/GOGeneralCombination.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/config/GOConfig.cpp"
@@ -25778,7 +24575,6 @@
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -25796,11 +24592,7 @@
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
             <pElem>../../src/core/archive</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -25821,10 +24613,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -25838,7 +24627,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -25847,10 +24635,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -25871,10 +24656,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -25896,121 +24678,14 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOButtonControl.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
-            <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
-            <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
-            <Elem>__BFLT16_DIG__=2</Elem>
-            <Elem>__BFLT16_EPSILON__=7.81250000000000000000000000000000000e-3BF16</Elem>
-            <Elem>__BFLT16_HAS_DENORM__=1</Elem>
-            <Elem>__BFLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__BFLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__BFLT16_IS_IEC_60559__=0</Elem>
-            <Elem>__BFLT16_MANT_DIG__=8</Elem>
-            <Elem>__BFLT16_MAX_10_EXP__=38</Elem>
-            <Elem>__BFLT16_MAX_EXP__=128</Elem>
-            <Elem>__BFLT16_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__BFLT16_MIN_10_EXP__=(-37)</Elem>
-            <Elem>__BFLT16_MIN_EXP__=(-125)</Elem>
-            <Elem>__BFLT16_MIN__=1.17549435082228750796873653722224568e-38BF16</Elem>
-            <Elem>__BFLT16_NORM_MAX__=3.38953138925153547590470800371487867e+38BF16</Elem>
-            <Elem>__DBL_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT128_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
-            <Elem>__FLT16_DENORM_MIN__=5.96046447753906250000000000000000000e-8F16</Elem>
-            <Elem>__FLT16_DIG__=3</Elem>
-            <Elem>__FLT16_EPSILON__=9.76562500000000000000000000000000000e-4F16</Elem>
-            <Elem>__FLT16_HAS_DENORM__=1</Elem>
-            <Elem>__FLT16_HAS_INFINITY__=1</Elem>
-            <Elem>__FLT16_HAS_QUIET_NAN__=1</Elem>
-            <Elem>__FLT16_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT16_MANT_DIG__=11</Elem>
-            <Elem>__FLT16_MAX_10_EXP__=4</Elem>
-            <Elem>__FLT16_MAX_EXP__=16</Elem>
-            <Elem>__FLT16_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT16_MIN_10_EXP__=(-4)</Elem>
-            <Elem>__FLT16_MIN_EXP__=(-13)</Elem>
-            <Elem>__FLT16_MIN__=6.10351562500000000000000000000000000e-5F16</Elem>
-            <Elem>__FLT16_NORM_MAX__=6.55040000000000000000000000000000000e+4F16</Elem>
-            <Elem>__FLT32X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT32_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64X_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT64_IS_IEC_60559__=1</Elem>
-            <Elem>__FLT_IS_IEC_60559__=1</Elem>
-            <Elem>__GCC_CONSTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GCC_DESTRUCTIVE_SIZE=64</Elem>
-            <Elem>__GNUC_EXECUTION_CHARSET_NAME="UTF-8"</Elem>
-            <Elem>__GNUC_RH_RELEASE__=6</Elem>
-            <Elem>__GNUC_WIDE_EXECUTION_CHARSET_NAME="UTF-32LE"</Elem>
-            <Elem>__GNUC__=13</Elem>
-            <Elem>__GNUG__=13</Elem>
-            <Elem>__GXX_ABI_VERSION=1018</Elem>
-            <Elem>__LDBL_IS_IEC_60559__=1</Elem>
-            <Elem>__REGISTER_PREFIX__=</Elem>
-            <Elem>__SSE3__=1</Elem>
-            <Elem>__STDCPP_THREADS__=1</Elem>
-            <Elem>__STRICT_ANSI__=1</Elem>
-            <Elem>__USER_LABEL_PREFIX__=</Elem>
-            <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
-            <Elem>__cplusplus=201103L</Elem>
-            <Elem>__cpp_constexpr=200704L</Elem>
-          </preprocessorList>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOCallbackButtonControl.cpp"
@@ -26024,7 +24699,6 @@
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -26035,11 +24709,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26053,7 +24723,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -26066,10 +24735,6 @@
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26090,110 +24755,26 @@
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOLabelControl.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPistonControl.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/control/GOPushbuttonControl.cpp"
@@ -26202,18 +24783,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/core</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/12/include</pElem>
@@ -26237,8 +24807,6 @@
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
             <Elem>__FLT16_DECIMAL_DIG__=5</Elem>
@@ -26301,73 +24869,24 @@
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/help</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOOrganSettingsDialog.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/help</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/GOProgressDialog.cpp"
@@ -26391,12 +24910,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26412,7 +24926,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -26423,10 +24936,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26435,26 +24945,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/common/GODialogCloser.cpp"
@@ -26476,10 +24966,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26492,7 +24979,6 @@
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -26505,15 +24991,10 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
@@ -26595,15 +25076,10 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/help</pElem>
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26623,7 +25099,6 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/help</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/size</pElem>
@@ -26631,11 +25106,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26656,18 +25127,13 @@
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/help</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26677,6 +25143,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -26689,7 +25156,6 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/help</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/size</pElem>
@@ -26703,11 +25169,7 @@
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/settings</pElem>
             <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26717,6 +25179,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -26729,64 +25192,18 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp"
@@ -26795,6 +25212,7 @@
             flavor2="8">
         <ccTool flags="0">
           <incDir>
+            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
@@ -26804,7 +25222,6 @@
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -26820,11 +25237,7 @@
             <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>../../src/grandorgue/help</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26833,26 +25246,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsDialog.cpp"
@@ -26873,7 +25266,6 @@
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/help</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/size</pElem>
@@ -26888,11 +25280,7 @@
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/sound/ports</pElem>
             <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26910,7 +25298,6 @@
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
             <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -26919,11 +25306,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26941,7 +25324,6 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -26957,11 +25339,7 @@
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -26987,11 +25365,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27015,7 +25389,6 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/grandorgue/config</pElem>
@@ -27028,103 +25401,22 @@
             <pElem>../../src/core/settings</pElem>
             <pElem>../../src/core/temperaments</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsOptions.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsOrgans.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/settings</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/archive</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/help</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/dialogs/settings/GOSettingsPaths.cpp"
@@ -27152,15 +25444,10 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/grandorgue/dialogs/common</pElem>
             <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27185,11 +25472,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27212,7 +25495,6 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/core/files</pElem>
@@ -27223,11 +25505,7 @@
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27243,7 +25521,6 @@
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -27259,11 +25536,7 @@
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27285,9 +25558,6 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27309,59 +25579,15 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
             <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIBankedGeneralsPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIButton.cpp"
@@ -27374,7 +25600,6 @@
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -27391,153 +25616,29 @@
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/size</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIControl.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUICouplerPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUICrescendoPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIDisplayMetrics.cpp"
@@ -27560,63 +25661,15 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIDivisionalsPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIEnclosure.cpp"
@@ -27630,7 +25683,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -27647,64 +25699,15 @@
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIFloatingPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIHW1Background.cpp"
@@ -27717,7 +25720,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -27731,10 +25733,6 @@
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27754,16 +25752,12 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27776,7 +25770,6 @@
             <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -27791,59 +25784,15 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/size</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUILabel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUILayoutEngine.cpp"
@@ -27867,12 +25816,7 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27887,7 +25831,6 @@
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -27907,11 +25850,7 @@
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/size</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -27923,7 +25862,6 @@
           <incDir>
             <pElem>../../src/grandorgue/gui</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/gui/primitives</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -27945,160 +25883,29 @@
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIMasterPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIMetronomePanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIPanelView.cpp"
@@ -28124,12 +25931,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28151,164 +25953,34 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/grandorgue/size</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUIRecorderPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUISequencerPanel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/combinations</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/GOGUISetterDisplayMetrics.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/gui/primitives/GOBitmap.cpp"
@@ -28329,10 +26001,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28354,10 +26023,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28378,10 +26044,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28399,16 +26062,11 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28429,10 +26087,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28446,7 +26101,6 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/html</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
@@ -28454,10 +26108,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28472,7 +26123,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -28490,11 +26140,7 @@
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/settings</pElem>
             <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28518,12 +26164,7 @@
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28541,18 +26182,13 @@
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/model</pElem>
             <pElem>../../src/core/threading</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28565,7 +26201,6 @@
             <pElem>../../src/grandorgue/loader</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -28581,11 +26216,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28594,26 +26225,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/loader/cache/GOCacheCleaner.cpp"
@@ -28626,7 +26237,6 @@
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/core/archive</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -28645,11 +26255,7 @@
             <pElem>../../src/grandorgue/dialogs/common</pElem>
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28658,26 +26264,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidi.cpp"
@@ -28693,7 +26279,6 @@
             <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue/midi/ports</pElem>
             <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -28705,14 +26290,10 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>../../src/grandorgue/dialogs/common</pElem>
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/temperaments</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28735,10 +26316,7 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28757,15 +26335,11 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28783,7 +26357,6 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
@@ -28792,11 +26365,7 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -28815,63 +26384,19 @@
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiPlayer.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiPlayerContent.cpp"
@@ -28889,107 +26414,26 @@
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiReceiver.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiRecorder.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/GOMidiSendProxy.cpp"
@@ -29013,15 +26457,10 @@
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>../../src/grandorgue/config</pElem>
             <pElem>../../src/grandorgue/midi/ports</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -29041,15 +26480,11 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -29060,7 +26495,6 @@
         <ccTool flags="0">
           <incDir>
             <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -29078,16 +26512,12 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -29113,19 +26543,20 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiOutPort.cpp"
@@ -29143,19 +26574,20 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiPort.cpp"
@@ -29178,14 +26610,15 @@
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/midi/ports/GOMidiPortFactory.cpp"
@@ -29202,23 +26635,13 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -29273,7 +26696,6 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
@@ -29287,7 +26709,6 @@
           <incDir>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13</pElem>
@@ -29299,20 +26720,11 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -29367,7 +26779,6 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
@@ -29381,7 +26792,6 @@
           <incDir>
             <pElem>/usr/include/wx-3.2/wx</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -29394,20 +26804,11 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -29462,7 +26863,6 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
@@ -29478,12 +26878,10 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
@@ -29492,17 +26890,9 @@
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -29557,7 +26947,6 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
@@ -29578,188 +26967,40 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOCoupler.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GODivisionalCoupler.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GODrawStop.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOEnclosure.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOEventHandlerList.cpp"
@@ -29777,233 +27018,43 @@
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOManual.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/document-base</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOOrganModel.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/yaml-cpp</pElem>
-            <pElem>/usr/include/yaml-cpp/node/detail</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/yaml</pElem>
-            <pElem>/usr/include/yaml-cpp/node</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOPipe.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GORank.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOReferencePipe.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOSoundingPipe.cpp"
@@ -30011,69 +27062,13 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOStop.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOSwitch.cpp"
@@ -30088,7 +27083,6 @@
             <pElem>../../src/grandorgue/combinations/model</pElem>
             <pElem>../../src/grandorgue/midi</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/grandorgue/control</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -30100,11 +27094,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -30113,173 +27103,34 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/GOWindchest.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>../../src/grandorgue/control</pElem>
-            <pElem>../../src/grandorgue/gui</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue/gui/primitives</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/pipe-config/GOPipeConfig.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigNode.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-            <pElem>../../src/grandorgue/midi</pElem>
-            <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/model/pipe-config/GOPipeConfigTreeNode.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/config</pElem>
-            <pElem>../../src/grandorgue/config</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue/dialogs/common</pElem>
-            <pElem>../../src/grandorgue/size</pElem>
-            <pElem>../../src/core/midi</pElem>
-            <pElem>../../src/core/settings</pElem>
-            <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/modification/GOModificationProxy.cpp"
@@ -30301,59 +27152,13 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundAudioSection.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/grandorgue/model</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/grandorgue/loader/cache</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundEngine.cpp"
@@ -30361,115 +27166,34 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/sound/GOSoundFader.cpp"
+            ex="false"
+            tool="1"
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundProvider.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/contrib</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/grandorgue/loader/cache</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundProviderSynthedTrem.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundProviderWave.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/grandorgue/loader</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/core/files</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundRecorder.cpp"
@@ -30477,54 +27201,13 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundReleaseAlignTable.cpp"
             ex="false"
             tool="1"
-            flavor2="8">
-        <ccTool flags="0">
-          <incDir>
-            <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue/loader/cache</pElem>
-            <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>/usr/include/c++/13</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
-            <pElem>/usr/include/c++/13/debug</pElem>
-            <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
-            <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
-            <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
-            <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundResample.cpp"
@@ -30540,7 +27223,6 @@
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -30554,8 +27236,6 @@
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/settings</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
@@ -30574,11 +27254,7 @@
             <pElem>../../src/grandorgue/size</pElem>
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/temperaments</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -30591,14 +27267,12 @@
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -30611,14 +27285,12 @@
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -30627,26 +27299,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/GOSoundStateHandler.cpp"
@@ -30656,7 +27308,6 @@
         <ccTool flags="0">
           <incDir>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -30683,12 +27334,14 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>WXUSINGDLL</Elem>
+            <Elem>_REENTRANT</Elem>
+            <Elem>__WXGTK__</Elem>
+          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/ports/GOSoundPort.cpp"
@@ -30696,23 +27349,9 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK</Elem>
             <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__WXGTK__</Elem>
           </preprocessorList>
@@ -30734,24 +27373,14 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/jack</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -30806,7 +27435,6 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
@@ -30828,22 +27456,13 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -30898,7 +27517,6 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
@@ -30915,7 +27533,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>../../src/grandorgue/config</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -30927,17 +27544,9 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK=1</Elem>
-            <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -30992,7 +27601,6 @@
             <Elem>__STRICT_ANSI__=1</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="13.2.1 20231205 (Red Hat 13.2.1-6)"</Elem>
-            <Elem>__WXGTK__=1</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
           </preprocessorList>
@@ -31003,26 +27611,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundGroupWorkItem.cpp"
@@ -31041,16 +27629,11 @@
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31059,26 +27642,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundOutputWorkItem.cpp"
@@ -31097,10 +27660,7 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31109,26 +27669,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundReleaseWorkItem.cpp"
@@ -31142,7 +27682,6 @@
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>../../src/grandorgue/sound</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -31152,11 +27691,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31165,26 +27700,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundThread.cpp"
@@ -31192,26 +27707,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundTouchTask.cpp"
@@ -31219,26 +27714,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundTouchWorkItem.cpp"
@@ -31255,10 +27730,8 @@
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>../../src/core/threading</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31267,26 +27740,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundTremulantWorkItem.cpp"
@@ -31304,17 +27757,12 @@
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/threading</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31323,26 +27771,6 @@
             tool="1"
             flavor2="11">
         <ccTool flags="1">
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
-          <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </item>
       <item path="../../src/grandorgue/sound/scheduler/GOSoundWindchestWorkItem.cpp"
@@ -31355,7 +27783,6 @@
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
@@ -31376,12 +27803,15 @@
             <pElem>../../src/core/midi</pElem>
             <pElem>../../src/core/settings</pElem>
             <pElem>../../src/core/temperaments</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
+        </ccTool>
+      </item>
+      <item path="../../src/grandorgue/updater/GOUpdateChecker.cpp"
+            ex="false"
+            tool="1"
+            flavor2="11">
+        <ccTool flags="1">
         </ccTool>
       </item>
       <item path="../../src/grandorgue/wxcontrols/GOAudioGauge.cpp"
@@ -31398,14 +27828,10 @@
             <pElem>/usr/include/c++/13/debug</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
-            <pElem>../../src/grandorgue</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2/wx</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31426,10 +27852,7 @@
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31454,9 +27877,6 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31480,10 +27900,7 @@
             <pElem>/usr/include/wx-3.2/wx/gtk</pElem>
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/c++/13/backward</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </item>
@@ -31717,13 +28134,6 @@
         <ccTool flags="0">
         </ccTool>
       </item>
-      <item path="/home/oleg/my-projects/grandorgue/GrandOrgue/src/grandorgue/updater/GOUpdateChecker.cpp"
-            ex="false"
-            tool="1"
-            flavor2="11">
-        <ccTool flags="1">
-        </ccTool>
-      </item>
       <item path="/usr/share/cmake/Modules/CMakeCCompilerABI.c"
             ex="false"
             tool="0"
@@ -31739,17 +28149,17 @@
       <folder path="0/build">
         <ccTool>
           <incDir>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/core</pElem>
             <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>../../submodules/RtMidi</pElem>
             <pElem>../../submodules/RtAudio</pElem>
             <pElem>../../submodules/PortAudio/include</pElem>
             <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../build/current/src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/include/wx-3.0/wx</pElem>
@@ -31768,9 +28178,9 @@
             <pElem>/usr/include/c++/11/x86_64-redhat-linux</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueImages_EXPORTS=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__WXGTK__=1</Elem>
           </preprocessorList>
@@ -31779,12 +28189,10 @@
       <folder path="0/build/current/CMakeFiles">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/grandorgue/contrib</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_STD_MUTEX=1</Elem>
-            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>NDEBUG</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
@@ -31850,11 +28258,23 @@
       <folder path="0/src/build">
         <ccTool>
           <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
             <pElem>../../src/build</pElem>
             <pElem>/usr/lib/gcc/x86_64-redhat-linux/13/include</pElem>
             <pElem>../../build/current/src/build</pElem>
           </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -31915,10 +28335,22 @@
       </folder>
       <folder path="0/src/core">
         <ccTool>
+          <incDir>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
+          </incDir>
           <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__WXGTK__=1</Elem>
           </preprocessorList>
@@ -32389,18 +28821,24 @@
           </preprocessorList>
         </ccTool>
       </folder>
-      <folder path="0/src/grandorgue/combinations/control">
+      <folder path="0/src/grandorgue">
         <ccTool>
           <incDir>
-            <pElem>../../src/grandorgue/combinations/control</pElem>
+            <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
+            <pElem>../../submodules/RtMidi</pElem>
+            <pElem>../../submodules/RtAudio</pElem>
+            <pElem>../../submodules/PortAudio/include</pElem>
+            <pElem>../../submodules/ZitaConvolver/source</pElem>
+            <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
+            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/combinations/model">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/combinations/model</pElem>
-          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK</Elem>
+            <Elem>_REENTRANT</Elem>
+          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/config">
@@ -32411,7 +28849,6 @@
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
@@ -32480,13 +28917,6 @@
           </incDir>
         </ccTool>
       </folder>
-      <folder path="0/src/grandorgue/dialogs/midi-event">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/dialogs/midi-event</pElem>
-          </incDir>
-        </ccTool>
-      </folder>
       <folder path="0/src/grandorgue/document-base">
         <ccTool>
           <incDir>
@@ -32518,7 +28948,6 @@
         <ccTool>
           <incDir>
             <pElem>../../src/grandorgue/midi/dialog-creator</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </folder>
@@ -32527,20 +28956,18 @@
           <incDir>
             <pElem>../../src/grandorgue/midi/ports</pElem>
           </incDir>
-        </ccTool>
-      </folder>
-      <folder path="0/src/grandorgue/model/pipe-config">
-        <ccTool>
-          <incDir>
-            <pElem>../../src/grandorgue/model/pipe-config</pElem>
-          </incDir>
+          <preprocessorList>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
+          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/src/grandorgue/modification">
         <ccTool>
           <incDir>
             <pElem>../../src/grandorgue/modification</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
         </ccTool>
       </folder>
@@ -32551,7 +28978,6 @@
             <pElem>/usr/include/c++/13</pElem>
             <pElem>/usr/include/c++/13/bits</pElem>
             <pElem>/usr/include/wx-3.2/wx</pElem>
-            <pElem>../../src/core</pElem>
             <pElem>../../src/core/config</pElem>
             <pElem>/usr/include/c++/13/ext</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux/bits</pElem>
@@ -32563,15 +28989,11 @@
             <pElem>/usr/include/wx-3.2/wx/unix</pElem>
             <pElem>/usr/include/wx-3.2/wx/meta</pElem>
             <pElem>/usr/include/wx-3.2/wx/generic</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>/usr/include/c++/13/x86_64-redhat-linux</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
           </incDir>
           <preprocessorList>
             <Elem>GO_USE_JACK=1</Elem>
             <Elem>WXUSINGDLL=1</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT=1</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
@@ -32633,27 +29055,13 @@
           </preprocessorList>
         </ccTool>
       </folder>
-      <folder path="0/src/grandorgue/updater">
+      <folder path="0/src/grandorgue/sound/ports">
         <ccTool>
-          <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/grandorgue/resource</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>../../submodules/RtMidi</pElem>
-            <pElem>../../submodules/RtAudio</pElem>
-            <pElem>../../submodules/PortAudio/include</pElem>
-            <pElem>../../submodules/ZitaConvolver/source</pElem>
-            <pElem>../../src/grandorgue</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/grandorgue</pElem>
-          </incDir>
           <preprocessorList>
-            <Elem>GO_USE_JACK</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
+            <Elem>GO_USE_JACK=1</Elem>
+            <Elem>WXUSINGDLL=1</Elem>
+            <Elem>_REENTRANT=1</Elem>
+            <Elem>__WXGTK__=1</Elem>
           </preprocessorList>
         </ccTool>
       </folder>
@@ -32676,18 +29084,17 @@
       <folder path="0/src/rt">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/core</pElem>
             <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>../../submodules/RtMidi</pElem>
             <pElem>../../submodules/RtAudio</pElem>
             <pElem>../../submodules/PortAudio/include</pElem>
             <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../build/current/src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../src/grandorgue/contrib</pElem>
@@ -32718,8 +29125,6 @@
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS=1</Elem>
             <Elem>NDEBUG</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT</Elem>
             <Elem>__DBL_IS_IEC_60559__=2</Elem>
             <Elem>__FLT128_IS_IEC_60559__=2</Elem>
@@ -32744,7 +29149,6 @@
             <Elem>__UNIX_JACK__</Elem>
             <Elem>__USER_LABEL_PREFIX__=</Elem>
             <Elem>__VERSION__="11.1.1 20210428 (Red Hat 11.1.1-1)"</Elem>
-            <Elem>__WXGTK__</Elem>
             <Elem>__cplusplus=201103L</Elem>
             <Elem>__cpp_constexpr=200704L</Elem>
             <Elem>__pic__=2</Elem>
@@ -32754,14 +29158,8 @@
       <folder path="0/src/tools">
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
             <pElem>../../src/core</pElem>
           </incDir>
-          <preprocessorList>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
-            <Elem>__WXGTK__</Elem>
-          </preprocessorList>
         </ccTool>
       </folder>
       <folder path="0/submodules">
@@ -32781,17 +29179,17 @@
         </cTool>
         <ccTool>
           <incDir>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/core</pElem>
             <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>../../submodules/RtMidi</pElem>
             <pElem>../../submodules/RtAudio</pElem>
             <pElem>../../submodules/PortAudio/include</pElem>
             <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../build/current/src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
             <pElem>/usr/include/c++/11/bits</pElem>
@@ -32800,6 +29198,7 @@
           <preprocessorList>
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
+            <Elem>_REENTRANT</Elem>
             <Elem>__BFLT16_DECIMAL_DIG__=4</Elem>
             <Elem>__BFLT16_DENORM_MIN__=9.18354961579912115600575419704879436e-41BF16</Elem>
             <Elem>__BFLT16_DIG__=2</Elem>
@@ -33054,18 +29453,17 @@
         </cTool>
         <ccTool>
           <incDir>
-            <pElem>../../build/current/src/core/go_defs.h</pElem>
-            <pElem>../../src/core</pElem>
-            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
-            <pElem>/usr/include/wx-3.2</pElem>
-            <pElem>../../build/current/src/core</pElem>
             <pElem>../../src/grandorgue/resource</pElem>
+            <pElem>../../src/core</pElem>
             <pElem>../../submodules/RtMidi</pElem>
             <pElem>../../submodules/RtAudio</pElem>
             <pElem>../../submodules/PortAudio/include</pElem>
             <pElem>../../submodules/ZitaConvolver/source</pElem>
             <pElem>../../src/grandorgue</pElem>
+            <pElem>/usr/lib64/wx/include/gtk3-unicode-3.2</pElem>
+            <pElem>/usr/include/wx-3.2</pElem>
             <pElem>../../build/current/src/grandorgue</pElem>
+            <pElem>../../build/current/src/core</pElem>
             <pElem>/usr/lib64/wx/include/gtk3-unicode-3.0</pElem>
             <pElem>/usr/include/wx-3.0</pElem>
             <pElem>../../src/grandorgue/contrib</pElem>
@@ -33076,10 +29474,7 @@
             <Elem>GO_USE_JACK</Elem>
             <Elem>GrandOrgueCore_EXPORTS</Elem>
             <Elem>NDEBUG</Elem>
-            <Elem>WXUSINGDLL</Elem>
-            <Elem>_FILE_OFFSET_BITS=64</Elem>
             <Elem>_REENTRANT</Elem>
-            <Elem>__WXGTK__</Elem>
           </preprocessorList>
         </ccTool>
       </folder>

--- a/src/core/GOInt.h
+++ b/src/core/GOInt.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -109,7 +109,7 @@ private:
 public:
   GOInt24(int val = 0) { assign(val); }
 
-  operator int() { return ((hi << 16) | lo); }
+  operator int() const { return ((hi << 16) | lo); }
 
   int operator=(const int val) {
     assign(val);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -188,8 +188,8 @@ GOHashType GOOrganController::GenerateCacheHash() {
   hash.Update(MAX_READAHEAD);
   hash.Update(SHORT_LOOP_LENGTH);
   GOSoundProvider::UpdateCacheHash(hash);
-  hash.Update(sizeof(GOSoundAudioSection::audio_start_data_segment));
-  hash.Update(sizeof(GOSoundAudioSection::audio_end_data_segment));
+  hash.Update(sizeof(GOSoundAudioSection::StartSegment));
+  hash.Update(sizeof(GOSoundAudioSection::EndSegment));
   return hash.getHash();
 }
 

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -188,8 +188,8 @@ GOHashType GOOrganController::GenerateCacheHash() {
   hash.Update(MAX_READAHEAD);
   hash.Update(SHORT_LOOP_LENGTH);
   GOSoundProvider::UpdateCacheHash(hash);
-  hash.Update(sizeof(audio_start_data_segment));
-  hash.Update(sizeof(audio_end_data_segment));
+  hash.Update(sizeof(GOSoundAudioSection::audio_start_data_segment));
+  hash.Update(sizeof(GOSoundAudioSection::audio_end_data_segment));
   return hash.getHash();
 }
 

--- a/src/grandorgue/dialogs/settings/GOSettingsOptions.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOptions.cpp
@@ -9,9 +9,9 @@
 
 #include <wx/checkbox.h>
 #include <wx/choice.h>
-#include <wx/filepicker.h>
 #include <wx/log.h>
 #include <wx/msgdlg.h>
+#include <wx/sizer.h>
 #include <wx/spinctrl.h>
 #include <wx/stattext.h>
 

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -410,12 +410,13 @@ inline void GOSoundAudioSection::StereoCompressedLinear(
   stream->position_fraction = stream->position_fraction & (UPSAMPLE_FACTOR - 1);
 }
 
-inline DecodeBlockFunction GOSoundAudioSection::GetDecodeBlockFunction(
-  unsigned channels,
-  unsigned bits_per_sample,
-  bool compressed,
-  interpolation_type interpolation,
-  bool is_end) {
+inline GOSoundAudioSection::DecodeBlockFunction GOSoundAudioSection::
+  GetDecodeBlockFunction(
+    unsigned channels,
+    unsigned bits_per_sample,
+    bool compressed,
+    interpolation_type interpolation,
+    bool is_end) {
   if (compressed && !is_end) {
     /* TODO: Add support for polyphase compressed decoders. Fallback to
      * linear interpolation for now. */

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -35,7 +35,7 @@ static unsigned limited_diff(unsigned a, unsigned b) {
 }
 
 GOSoundAudioSection::GOSoundAudioSection(GOMemoryPool &pool)
-  : m_Data(NULL),
+  : m_data(NULL),
     m_ReleaseAligner(NULL),
     m_ReleaseStartSegment(0),
     m_Pool(pool) {
@@ -50,10 +50,10 @@ void GOSoundAudioSection::ClearData() {
   m_BytesPerSample = 0;
   m_WaveTremulantStateFor = BOOL3_DEFAULT;
   m_IsCompressed = false;
-  m_Channels = 0;
-  if (m_Data) {
-    m_Pool.Free(m_Data);
-    m_Data = NULL;
+  m_channels = 0;
+  if (m_data) {
+    m_Pool.Free(m_data);
+    m_data = NULL;
   }
   if (m_ReleaseAligner) {
     delete m_ReleaseAligner;
@@ -84,7 +84,7 @@ bool GOSoundAudioSection::LoadCache(GOCache &cache) {
     return false;
   if (!cache.Read(&m_IsCompressed, sizeof(m_IsCompressed)))
     return false;
-  if (!cache.Read(&m_Channels, sizeof(m_Channels)))
+  if (!cache.Read(&m_channels, sizeof(m_channels)))
     return false;
   if (!cache.Read(&m_SampleFracBits, sizeof(m_SampleFracBits)))
     return false;
@@ -94,8 +94,8 @@ bool GOSoundAudioSection::LoadCache(GOCache &cache) {
     return false;
   if (!cache.Read(&m_ReleaseCrossfadeLength, sizeof(m_ReleaseCrossfadeLength)))
     return false;
-  m_Data = (unsigned char *)cache.ReadBlock(m_AllocSize);
-  if (!m_Data)
+  m_data = (unsigned char *)cache.ReadBlock(m_AllocSize);
+  if (!m_data)
     return false;
 
   unsigned temp;
@@ -163,7 +163,7 @@ bool GOSoundAudioSection::SaveCache(GOCacheWriter &cache) const {
     return false;
   if (!cache.Write(&m_IsCompressed, sizeof(m_IsCompressed)))
     return false;
-  if (!cache.Write(&m_Channels, sizeof(m_Channels)))
+  if (!cache.Write(&m_channels, sizeof(m_channels)))
     return false;
   if (!cache.Write(&m_SampleFracBits, sizeof(m_SampleFracBits)))
     return false;
@@ -173,7 +173,7 @@ bool GOSoundAudioSection::SaveCache(GOCacheWriter &cache) const {
     return false;
   if (!cache.Write(&m_ReleaseCrossfadeLength, sizeof(m_ReleaseCrossfadeLength)))
     return false;
-  if (!cache.WriteBlock(m_Data, m_AllocSize))
+  if (!cache.WriteBlock(m_data, m_AllocSize))
     return false;
 
   unsigned temp;
@@ -528,10 +528,10 @@ bool GOSoundAudioSection::ReadBlock(
           = &stream->audio_section->m_EndSegments[next_end_segment_index];
 
         stream->position_index += next->start_offset;
-        stream->ptr = stream->audio_section->m_Data;
+        stream->ptr = stream->audio_section->m_data;
         stream->cache = next->cache;
         stream->cache.ptr
-          = stream->audio_section->m_Data + (intptr_t)stream->cache.ptr;
+          = stream->audio_section->m_data + (intptr_t)stream->cache.ptr;
         assert(next_end->end_offset >= next->start_offset);
         stream->transition_position = next_end->transition_offset;
         stream->end_ptr = next_end->end_ptr;
@@ -605,7 +605,7 @@ void GOSoundAudioSection::GetMaxAmplitudeAndDerivative() {
   for (unsigned int i = 0; i < m_SampleCount; i++) {
     /* Get sum of amplitudes in channels */
     int f = 0;
-    for (unsigned int j = 0; j < m_Channels; j++) {
+    for (unsigned int j = 0; j < m_channels; j++) {
       int val = GetSample(i, j, &cache);
       f += val;
       if (abs(val) > m_MaxAmplitude)
@@ -630,23 +630,21 @@ void GOSoundAudioSection::DoCrossfade(
   unsigned dest_offset,
   const unsigned char *src,
   unsigned src_offset,
-  unsigned channels,
-  unsigned bits_per_sample,
   unsigned fade_length,
   unsigned loop_length,
   unsigned length) {
   for (; dest_offset < length; dest_offset += loop_length)
-    for (unsigned pos = 0; pos < fade_length; pos++)
-      for (unsigned j = 0; j < channels; j++) {
-        float val1 = GetSampleData(
-          pos + dest_offset, j, bits_per_sample, channels, dest);
-        float val2
-          = GetSampleData(pos + src_offset, j, bits_per_sample, channels, src);
-        float factor = (cos(M_PI * (pos + 0.5) / fade_length) + 1.0) * 0.5;
+    for (unsigned pos = 0; pos < fade_length; pos++) {
+      float factor = (cos(M_PI * (pos + 0.5) / fade_length) + 1.0) * 0.5;
+
+      for (uint8_t j = 0; j < m_channels; j++) {
+        float val1 = GetSampleData(dest, pos + dest_offset, j);
+        float val2 = GetSampleData(src, pos + src_offset, j);
         float result = val1 * factor + val2 * (1 - factor);
-        SetSampleData(
-          pos + dest_offset, j, bits_per_sample, channels, result, dest);
+
+        SetSampleData(dest, pos + dest_offset, j, (int)result);
       }
+    }
 }
 
 void GOSoundAudioSection::Setup(
@@ -665,6 +663,7 @@ void GOSoundAudioSection::Setup(
   if (pcm_data_channels < 1 || pcm_data_channels > 2)
     throw(wxString) _("< More than 2 channels in");
 
+  m_channels = pcm_data_channels;
   m_BitsPerSample = wave_bits_per_sample(pcm_data_format);
   compress = (compress) && (m_BitsPerSample > 8);
 
@@ -768,8 +767,6 @@ void GOSoundAudioSection::Setup(
             MAX_READAHEAD,
             (const unsigned char *)pcm_data,
             start_seg.start_offset - fade_len,
-            pcm_data_channels,
-            m_BitsPerSample,
             fade_len,
             loop_length,
             end_length);
@@ -827,18 +824,17 @@ void GOSoundAudioSection::Setup(
   }
 
   m_AllocSize = total_alloc_samples * m_BytesPerSample;
-  m_Data = (unsigned char *)m_Pool.Alloc(m_AllocSize, !compress);
-  if (m_Data == NULL)
+  m_data = (unsigned char *)m_Pool.Alloc(m_AllocSize, !compress);
+  if (m_data == NULL)
     throw GOOutOfMemory();
   m_SampleRate = pcm_data_sample_rate;
   m_SampleCount = total_alloc_samples;
   m_SampleFracBits = m_BitsPerSample - 1;
-  m_Channels = pcm_data_channels;
   m_IsCompressed = false;
   m_WaveTremulantStateFor = waveTremulantStateFor;
 
   /* Store the main data blob. */
-  memcpy(m_Data, pcm_data, m_AllocSize);
+  memcpy(m_data, pcm_data, m_AllocSize);
 
   GetMaxAmplitudeAndDerivative();
 
@@ -870,10 +866,10 @@ void GOSoundAudioSection::Compress(bool format16) {
     state.prev[1] = state.value[1];
 
     state.value[0] = GetSample(i, 0);
-    if (m_Channels > 1)
+    if (m_channels > 1)
       state.value[1] = GetSample(i, 1);
 
-    for (unsigned j = 0; j < m_Channels; j++) {
+    for (unsigned j = 0; j < m_channels; j++) {
       int val = state.value[j];
       int encode = val - (state.prev[j] + (state.prev[j] - state.last[j]) / 2);
 
@@ -886,21 +882,21 @@ void GOSoundAudioSection::Compress(bool format16) {
        * uncompressed data. */
       if (output_len + 10 >= m_AllocSize) {
         m_Pool.Free(data);
-        m_Data = (unsigned char *)m_Pool.MoveToPool(m_Data, m_AllocSize);
-        if (m_Data == NULL)
+        m_data = (unsigned char *)m_Pool.MoveToPool(m_data, m_AllocSize);
+        if (m_data == NULL)
           throw GOOutOfMemory();
         return;
       }
     }
   }
 
-  m_Pool.Free(m_Data);
-  m_Data = data;
+  m_Pool.Free(m_data);
+  m_data = data;
   m_AllocSize = output_len;
   m_IsCompressed = true;
 
-  m_Data = (unsigned char *)m_Pool.MoveToPool(m_Data, m_AllocSize);
-  if (m_Data == NULL)
+  m_data = (unsigned char *)m_Pool.MoveToPool(m_data, m_AllocSize);
+  if (m_data == NULL)
     throw GOOutOfMemory();
 }
 
@@ -957,7 +953,7 @@ void GOSoundAudioSection::InitStream(
   const EndSegment &end = m_EndSegments[PickEndSegment(0)];
   assert(end.transition_offset >= start.start_offset);
   stream->resample_coefs = resampler_coefs;
-  stream->ptr = stream->audio_section->m_Data;
+  stream->ptr = stream->audio_section->m_data;
   stream->transition_position = end.transition_offset;
   stream->end_seg = &end;
   stream->end_ptr = end.end_ptr;
@@ -966,13 +962,13 @@ void GOSoundAudioSection::InitStream(
   stream->position_index = start.start_offset;
   stream->position_fraction = 0;
   stream->decode_call = GetDecodeBlockFunction(
-    m_Channels,
+    m_channels,
     m_BitsPerSample,
     m_IsCompressed,
     stream->resample_coefs->interpolation,
     false);
   stream->end_decode_call = GetDecodeBlockFunction(
-    m_Channels,
+    m_channels,
     m_BitsPerSample,
     m_IsCompressed,
     stream->resample_coefs->interpolation,
@@ -984,7 +980,7 @@ void GOSoundAudioSection::InitStream(
   stream->end_pos = end.end_pos - stream->margin;
   stream->cache = start.cache;
   stream->cache.ptr
-    = stream->audio_section->m_Data + (intptr_t)stream->cache.ptr;
+    = stream->audio_section->m_data + (intptr_t)stream->cache.ptr;
 }
 
 void GOSoundAudioSection::InitAlignedStream(
@@ -995,7 +991,7 @@ void GOSoundAudioSection::InitAlignedStream(
   const EndSegment &end = m_EndSegments[PickEndSegment(m_ReleaseStartSegment)];
   assert(end.transition_offset >= start.start_offset);
 
-  stream->ptr = stream->audio_section->m_Data;
+  stream->ptr = stream->audio_section->m_data;
   stream->transition_position = end.transition_offset;
   stream->end_seg = &end;
   stream->end_ptr = end.end_ptr;
@@ -1008,13 +1004,13 @@ void GOSoundAudioSection::InitAlignedStream(
   stream->position_index = start.start_offset;
   stream->position_fraction = existing_stream->position_fraction;
   stream->decode_call = GetDecodeBlockFunction(
-    m_Channels,
+    m_channels,
     m_BitsPerSample,
     m_IsCompressed,
     stream->resample_coefs->interpolation,
     false);
   stream->end_decode_call = GetDecodeBlockFunction(
-    m_Channels,
+    m_channels,
     m_BitsPerSample,
     m_IsCompressed,
     stream->resample_coefs->interpolation,
@@ -1026,7 +1022,7 @@ void GOSoundAudioSection::InitAlignedStream(
   stream->end_pos = end.end_pos - stream->margin;
   stream->cache = start.cache;
   stream->cache.ptr
-    = stream->audio_section->m_Data + (intptr_t)stream->cache.ptr;
+    = stream->audio_section->m_data + (intptr_t)stream->cache.ptr;
   if (!m_ReleaseAligner) {
     return;
   }
@@ -1037,35 +1033,34 @@ void GOSoundAudioSection::GetHistory(
   const Stream *stream, int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]) {
   memset(
     history, 0, sizeof(history[0][0]) * BLOCK_HISTORY * MAX_OUTPUT_CHANNELS);
-  if (stream->position_index >= stream->transition_position) {
+  if (stream->position_index >= stream->transition_position)
     for (unsigned i = 0; i < BLOCK_HISTORY; i++)
-      for (unsigned j = 0; j < stream->audio_section->m_Channels; j++)
-        history[i][j] = GetSampleData(
+      for (uint8_t j = 0; j < stream->audio_section->m_channels; j++)
+        history[i][j] = getSampleData(
+          stream->end_ptr,
           stream->position_index - stream->transition_position + i,
+          stream->audio_section->m_channels,
           j,
-          stream->audio_section->m_BitsPerSample,
-          stream->audio_section->m_Channels,
-          stream->end_ptr);
-  } else {
-    if (!stream->audio_section->m_IsCompressed) {
-      for (unsigned i = 0; i < BLOCK_HISTORY; i++)
-        for (unsigned j = 0; j < stream->audio_section->m_Channels; j++)
-          history[i][j] = GetSampleData(
-            stream->position_index + i,
-            j,
-            stream->audio_section->m_BitsPerSample,
-            stream->audio_section->m_Channels,
-            stream->ptr);
-    } else {
-      DecompressionCache cache = stream->cache;
-      for (unsigned i = 0; i < BLOCK_HISTORY; i++) {
-        for (unsigned j = 0; j < stream->audio_section->m_Channels; j++)
-          history[i][j] = cache.value[j];
-        DecompressionStep(
-          cache,
-          stream->audio_section->m_Channels,
-          stream->audio_section->m_BitsPerSample >= 20);
-      }
+          stream->audio_section->m_BitsPerSample);
+  else if (!stream->audio_section->m_IsCompressed)
+    for (unsigned i = 0; i < BLOCK_HISTORY; i++)
+      for (uint8_t j = 0; j < stream->audio_section->m_channels; j++)
+        history[i][j] = getSampleData(
+          stream->ptr,
+          stream->position_index + i,
+          stream->audio_section->m_channels,
+          j,
+          stream->audio_section->m_BitsPerSample);
+  else {
+    DecompressionCache cache = stream->cache;
+
+    for (unsigned i = 0; i < BLOCK_HISTORY; i++) {
+      for (uint8_t j = 0; j < stream->audio_section->m_channels; j++)
+        history[i][j] = cache.value[j];
+      DecompressionStep(
+        cache,
+        stream->audio_section->m_channels,
+        stream->audio_section->m_BitsPerSample >= 20);
     }
   }
 }

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -230,7 +230,7 @@ bool GOSoundAudioSection::SaveCache(GOCacheWriter &cache) const {
  * into the correct range. */
 
 template <class T>
-inline void GOSoundAudioSection::MonoUncompressedLinear(
+void GOSoundAudioSection::MonoUncompressedLinear(
   Stream *stream, float *output, unsigned int n_blocks) {
   // copy the sample buffer
   T *input = (T *)(stream->ptr);
@@ -253,7 +253,7 @@ inline void GOSoundAudioSection::MonoUncompressedLinear(
 }
 
 template <class T>
-inline void GOSoundAudioSection::StereoUncompressedLinear(
+void GOSoundAudioSection::StereoUncompressedLinear(
   Stream *stream, float *output, unsigned int n_blocks) {
   typedef T stereoSample[][2];
 
@@ -284,7 +284,7 @@ inline void GOSoundAudioSection::StereoUncompressedLinear(
 }
 
 template <class T>
-inline void GOSoundAudioSection::MonoUncompressedPolyphase(
+void GOSoundAudioSection::MonoUncompressedPolyphase(
   Stream *stream, float *output, unsigned int n_blocks) {
   // copy the sample buffer
   T *input = ((T *)stream->ptr);
@@ -316,7 +316,7 @@ inline void GOSoundAudioSection::MonoUncompressedPolyphase(
 }
 
 template <class T>
-inline void GOSoundAudioSection::StereoUncompressedPolyphase(
+void GOSoundAudioSection::StereoUncompressedPolyphase(
   Stream *stream, float *output, unsigned int n_blocks) {
   typedef T stereoSample[][2];
 
@@ -354,7 +354,7 @@ inline void GOSoundAudioSection::StereoUncompressedPolyphase(
 }
 
 template <bool format16>
-inline void GOSoundAudioSection::MonoCompressedLinear(
+void GOSoundAudioSection::MonoCompressedLinear(
   Stream *stream, float *output, unsigned int n_blocks) {
   for (unsigned int i = 0; i < n_blocks; i++,
                     stream->position_fraction += stream->increment_fraction,
@@ -379,7 +379,7 @@ inline void GOSoundAudioSection::MonoCompressedLinear(
 }
 
 template <bool format16>
-inline void GOSoundAudioSection::StereoCompressedLinear(
+void GOSoundAudioSection::StereoCompressedLinear(
   Stream *stream, float *output, unsigned int n_blocks) {
   // copy the sample buffer
   for (unsigned int i = 0; i < n_blocks;
@@ -408,7 +408,7 @@ inline void GOSoundAudioSection::StereoCompressedLinear(
   stream->position_fraction = stream->position_fraction & (UPSAMPLE_FACTOR - 1);
 }
 
-inline GOSoundAudioSection::DecodeBlockFunction GOSoundAudioSection::
+GOSoundAudioSection::DecodeBlockFunction GOSoundAudioSection::
   GetDecodeBlockFunction(
     unsigned channels,
     unsigned bits_per_sample,
@@ -471,7 +471,7 @@ inline GOSoundAudioSection::DecodeBlockFunction GOSoundAudioSection::
   return NULL;
 }
 
-inline unsigned GOSoundAudioSection::PickEndSegment(
+unsigned GOSoundAudioSection::PickEndSegment(
   unsigned start_segment_index) const {
   const unsigned x = abs(rand());
   for (unsigned i = 0; i < m_EndSegments.size(); i++) {

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -42,8 +42,6 @@ GOSoundAudioSection::GOSoundAudioSection(GOMemoryPool &pool)
   ClearData();
 }
 
-GOSoundAudioSection::~GOSoundAudioSection() { ClearData(); }
-
 void GOSoundAudioSection::ClearData() {
   m_AllocSize = 0;
   m_SampleCount = 0;
@@ -1035,8 +1033,6 @@ void GOSoundAudioSection::InitAlignedStream(
   m_ReleaseAligner->SetupRelease(*stream, *existing_stream);
 }
 
-unsigned GOSoundAudioSection::GetSampleRate() const { return m_SampleRate; }
-
 void GOSoundAudioSection::GetHistory(
   const Stream *stream, int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]) {
   memset(
@@ -1076,8 +1072,8 @@ void GOSoundAudioSection::GetHistory(
 
 GOSampleStatistic GOSoundAudioSection::GetStatistic() {
   GOSampleStatistic stat;
-
   size_t size = 0;
+
   for (unsigned i = 0; i < m_EndSegments.size(); i++)
     size += m_EndSegments[i].end_size;
   stat.SetEndSegmentSize(size);

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -208,7 +208,7 @@ private:
   inline int GetSampleData(
     const unsigned char *sampleData, unsigned position, uint8_t channel) const {
     return getSampleData(
-      m_data, position, m_channels, channel, m_BitsPerSample);
+      sampleData, position, m_channels, channel, m_BitsPerSample);
   }
 
   template <typename T>
@@ -218,7 +218,7 @@ private:
   }
 
   inline static void setSampleData(
-    void *sampleData,
+    unsigned char *sampleData,
     unsigned position,
     uint8_t channels,
     uint8_t channel,

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -27,74 +27,76 @@ class GOMemoryPool;
 class GOSoundReleaseAlignTable;
 class GOSampleStatistic;
 
-struct audio_section_stream_s;
-
-typedef void (*DecodeBlockFunction)(
-  audio_section_stream_s *stream, float *output, unsigned int n_blocks);
-
-typedef struct audio_start_data_segment_s {
-  /* Sample offset into entire audio section where data begins. */
-  unsigned start_offset;
-
-  DecompressionCache cache;
-
-} audio_start_data_segment;
-
-typedef struct audio_end_data_segment_s {
-  /* Sample offset where the loop ends and needs to jump into the next
-   * start segment. */
-  unsigned end_offset;
-
-  /* Sample offset where the uncompressed end data blob begins (must be less
-   * than end_offset). */
-  unsigned transition_offset;
-
-  /* Uncompressed ending data blob. This data must start before sample_offset*/
-  unsigned char *end_data;
-  unsigned char *end_ptr;
-  unsigned read_end;
-  unsigned end_pos;
-  unsigned end_size;
-  unsigned end_loop_length;
-
-  /* Index of the next section segment to be played (-1 indicates the
-   * end of the blob. */
-  int next_start_segment_index;
-
-} audio_end_data_segment;
-
-typedef struct audio_section_stream_s {
-  const GOSoundAudioSection *audio_section;
-  const struct resampler_coefs_s *resample_coefs;
-
-  /* Method used to decode stream */
-  DecodeBlockFunction decode_call;
-
-  /* Cached method used to decode the data in end_ptr. This is just the
-   * uncompressed version of decode_call */
-  DecodeBlockFunction end_decode_call;
-
-  /* Used for both compressed and uncompressed decoding */
-  const unsigned char *ptr;
-
-  /* Derived from the start and end audio segments which were used to setup
-   * this stream. */
-  const audio_end_data_segment *end_seg;
-  const unsigned char *end_ptr;
-  unsigned margin;
-  unsigned transition_position;
-  unsigned read_end;
-  unsigned end_pos;
-
-  unsigned position_index;
-  unsigned position_fraction;
-  unsigned increment_fraction;
-
-  /* for decoding compressed format */
-  DecompressionCache cache;
-} audio_section_stream;
-
 class GOSoundAudioSection {
+public:
+  struct audio_start_data_segment {
+    /* Sample offset into entire audio section where data begins. */
+    unsigned start_offset;
+
+    DecompressionCache cache;
+  };
+
+  struct audio_end_data_segment {
+    /* Sample offset where the loop ends and needs to jump into the next
+     * start segment. */
+    unsigned end_offset;
+
+    /* Sample offset where the uncompressed end data blob begins (must be less
+     * than end_offset). */
+    unsigned transition_offset;
+
+    /* Uncompressed ending data blob. This data must start before
+     * sample_offset*/
+    unsigned char *end_data;
+    unsigned char *end_ptr;
+    unsigned read_end;
+    unsigned end_pos;
+    unsigned end_size;
+    unsigned end_loop_length;
+
+    /* Index of the next section segment to be played (-1 indicates the
+     * end of the blob. */
+    int next_start_segment_index;
+  };
+
+  struct audio_section_stream;
+
+private:
+  typedef void (*DecodeBlockFunction)(
+    audio_section_stream *stream, float *output, unsigned int n_blocks);
+
+public:
+  struct audio_section_stream {
+    const GOSoundAudioSection *audio_section;
+    const struct resampler_coefs_s *resample_coefs;
+
+    /* Method used to decode stream */
+    DecodeBlockFunction decode_call;
+
+    /* Cached method used to decode the data in end_ptr. This is just the
+     * uncompressed version of decode_call */
+    DecodeBlockFunction end_decode_call;
+
+    /* Used for both compressed and uncompressed decoding */
+    const unsigned char *ptr;
+
+    /* Derived from the start and end audio segments which were used to setup
+     * this stream. */
+    const audio_end_data_segment *end_seg;
+    const unsigned char *end_ptr;
+    unsigned margin;
+    unsigned transition_position;
+    unsigned read_end;
+    unsigned end_pos;
+
+    unsigned position_index;
+    unsigned position_fraction;
+    unsigned increment_fraction;
+
+    /* for decoding compressed format */
+    DecompressionCache cache;
+  };
+
 private:
   template <class T>
   static void MonoUncompressedLinear(

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -29,14 +29,14 @@ class GOSampleStatistic;
 
 class GOSoundAudioSection {
 public:
-  struct audio_start_data_segment {
+  struct StartSegment {
     /* Sample offset into entire audio section where data begins. */
     unsigned start_offset;
 
     DecompressionCache cache;
   };
 
-  struct audio_end_data_segment {
+  struct EndSegment {
     /* Sample offset where the loop ends and needs to jump into the next
      * start segment. */
     unsigned end_offset;
@@ -59,14 +59,14 @@ public:
     int next_start_segment_index;
   };
 
-  struct audio_section_stream;
+  struct Stream;
 
 private:
   typedef void (*DecodeBlockFunction)(
-    audio_section_stream *stream, float *output, unsigned int n_blocks);
+    Stream *stream, float *output, unsigned int n_blocks);
 
 public:
-  struct audio_section_stream {
+  struct Stream {
     const GOSoundAudioSection *audio_section;
     const struct resampler_coefs_s *resample_coefs;
 
@@ -82,7 +82,7 @@ public:
 
     /* Derived from the start and end audio segments which were used to setup
      * this stream. */
-    const audio_end_data_segment *end_seg;
+    const EndSegment *end_seg;
     const unsigned char *end_ptr;
     unsigned margin;
     unsigned transition_position;
@@ -100,22 +100,22 @@ public:
 private:
   template <class T>
   static void MonoUncompressedLinear(
-    audio_section_stream *stream, float *output, unsigned int n_blocks);
+    Stream *stream, float *output, unsigned int n_blocks);
   template <class T>
   static void StereoUncompressedLinear(
-    audio_section_stream *stream, float *output, unsigned int n_blocks);
+    Stream *stream, float *output, unsigned int n_blocks);
   template <class T>
   static void MonoUncompressedPolyphase(
-    audio_section_stream *stream, float *output, unsigned int n_blocks);
+    Stream *stream, float *output, unsigned int n_blocks);
   template <class T>
   static void StereoUncompressedPolyphase(
-    audio_section_stream *stream, float *output, unsigned int n_blocks);
+    Stream *stream, float *output, unsigned int n_blocks);
   template <bool format16>
   static void MonoCompressedLinear(
-    audio_section_stream *stream, float *output, unsigned int n_blocks);
+    Stream *stream, float *output, unsigned int n_blocks);
   template <bool format16>
   static void StereoCompressedLinear(
-    audio_section_stream *stream, float *output, unsigned int n_blocks);
+    Stream *stream, float *output, unsigned int n_blocks);
 
   static DecodeBlockFunction GetDecodeBlockFunction(
     unsigned channels,
@@ -142,8 +142,8 @@ private:
     unsigned loop_length,
     unsigned length);
 
-  std::vector<audio_start_data_segment> m_StartSegments;
-  std::vector<audio_end_data_segment> m_EndSegments;
+  std::vector<StartSegment> m_StartSegments;
+  std::vector<EndSegment> m_EndSegments;
 
   /* Pointer to (size) bytes of data encoded in the format (type) */
   unsigned char *m_Data;
@@ -195,22 +195,18 @@ public:
 
   /* Initialize a stream to play this audio section and seek into it using
    * release alignment if available. */
-  void InitAlignedStream(
-    audio_section_stream *stream,
-    const audio_section_stream *existing_stream) const;
+  void InitAlignedStream(Stream *stream, const Stream *existing_stream) const;
 
   /* Initialize a stream to play this audio section */
   void InitStream(
     const struct resampler_coefs_s *resampler_coefs,
-    audio_section_stream *stream,
+    Stream *stream,
     float sample_rate_adjustment) const;
 
   /* Read an audio buffer from an audio section stream */
-  static bool ReadBlock(
-    audio_section_stream *stream, float *buffer, unsigned int n_blocks);
+  static bool ReadBlock(Stream *stream, float *buffer, unsigned int n_blocks);
   static void GetHistory(
-    const audio_section_stream *stream,
-    int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]);
+    const Stream *stream, int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]);
 
   void Setup(
     const GOCacheObject *pObjectFor,

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
@@ -173,8 +173,8 @@ void GOSoundReleaseAlignTable::ComputeTable(
 }
 
 void GOSoundReleaseAlignTable::SetupRelease(
-  GOSoundAudioSection::audio_section_stream &release_sampler,
-  const GOSoundAudioSection::audio_section_stream &old_sampler) const {
+  GOSoundAudioSection::Stream &release_sampler,
+  const GOSoundAudioSection::Stream &old_sampler) const {
   int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS];
   GOSoundAudioSection::GetHistory(&old_sampler, history);
 

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
@@ -173,8 +173,8 @@ void GOSoundReleaseAlignTable::ComputeTable(
 }
 
 void GOSoundReleaseAlignTable::SetupRelease(
-  audio_section_stream &release_sampler,
-  const audio_section_stream &old_sampler) const {
+  GOSoundAudioSection::audio_section_stream &release_sampler,
+  const GOSoundAudioSection::audio_section_stream &old_sampler) const {
   int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS];
   GOSoundAudioSection::GetHistory(&old_sampler, history);
 

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.h
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.h
@@ -8,10 +8,10 @@
 #ifndef GOSOUNDRELEASEALIGNTABLE_H
 #define GOSOUNDRELEASEALIGNTABLE_H
 
-class GOSoundAudioSection;
+#include "GOSoundAudioSection.h"
+
 class GOCache;
 class GOCacheWriter;
-typedef struct audio_section_stream_s audio_section_stream;
 
 #define PHASE_ALIGN_DERIVATIVES 2
 #define PHASE_ALIGN_AMPLITUDES 32
@@ -38,8 +38,8 @@ public:
     unsigned start_position);
 
   void SetupRelease(
-    audio_section_stream &release_sampler,
-    const audio_section_stream &old_sampler) const;
+    GOSoundAudioSection::audio_section_stream &release_sampler,
+    const GOSoundAudioSection::audio_section_stream &old_sampler) const;
 };
 
 #endif /* GOSOUNDRELEASEALIGNTABLE_H */

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.h
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.h
@@ -38,8 +38,8 @@ public:
     unsigned start_position);
 
   void SetupRelease(
-    GOSoundAudioSection::audio_section_stream &release_sampler,
-    const GOSoundAudioSection::audio_section_stream &old_sampler) const;
+    GOSoundAudioSection::Stream &release_sampler,
+    const GOSoundAudioSection::Stream &old_sampler) const;
 };
 
 #endif /* GOSOUNDRELEASEALIGNTABLE_H */

--- a/src/grandorgue/sound/GOSoundSampler.h
+++ b/src/grandorgue/sound/GOSoundSampler.h
@@ -21,7 +21,7 @@ struct GOSoundSampler {
   int m_SamplerTaskId;
   GOSoundWindchestTask *p_WindchestTask;
   unsigned m_AudioGroupId;
-  GOSoundAudioSection::audio_section_stream stream;
+  GOSoundAudioSection::Stream stream;
   GOSoundFader fader;
   GOSoundFilter::FilterState toneBalanceFilterState;
   uint64_t time;

--- a/src/grandorgue/sound/GOSoundSampler.h
+++ b/src/grandorgue/sound/GOSoundSampler.h
@@ -21,7 +21,7 @@ struct GOSoundSampler {
   int m_SamplerTaskId;
   GOSoundWindchestTask *p_WindchestTask;
   unsigned m_AudioGroupId;
-  audio_section_stream stream;
+  GOSoundAudioSection::audio_section_stream stream;
   GOSoundFader fader;
   GOSoundFilter::FilterState toneBalanceFilterState;
   uint64_t time;


### PR DESCRIPTION
This is the first PR related to  #710

- Moved the structs defined in `GOSoundAudioSection.h` inside the `GOSoundAudioSection` cla ss
- Renamed the structs according to the GO naming conventions
- Moved inline functions implementations to their definitions
- Rewrote GetSampleData and SetSampleData implementation with template functions
- Some static functions made as not-static for accessing to members of  `GOSoundAudioSection`

This is only refactoring. No GO behaviour should be changed.