### PR TITLE
Disabled breaking the whole github build if som of build is failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
     needs: [calc_ver]
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - run_on: ubuntu-20.04


### PR DESCRIPTION
Earlier if a build for some OS failed in GitHub (usually on installing dependencies), the builds for other OSes were broken immediatelly.

After this PR the builds for other OSes will continue. So the future `Rerun failed jobs` will rerun only one job.