### PR TITLE
Reworked the resampler code https://github.com/GrandOrgue/grandorgue/issues/710

### DIFF
--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -27,6 +27,8 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+static constexpr unsigned DEFAULT_END_SEG_LENGTH = MAX_READAHEAD * 2;
+
 GOSoundAudioSection::GOSoundAudioSection(GOMemoryPool &pool)
   : m_data(NULL),
     m_ReleaseAligner(NULL),
@@ -105,18 +107,11 @@ bool GOSoundAudioSection::LoadCache(GOCache &cache) {
     return false;
   for (unsigned i = 0; i < temp; i++) {
     EndSegment s;
-    if (!cache.Read(&s.end_offset, sizeof(s.end_offset)))
-      return false;
+
     if (!cache.Read(
           &s.next_start_segment_index, sizeof(s.next_start_segment_index)))
       return false;
     if (!cache.Read(&s.transition_offset, sizeof(s.transition_offset)))
-      return false;
-    if (!cache.Read(&s.end_loop_length, sizeof(s.end_loop_length)))
-      return false;
-    if (!cache.Read(&s.read_end, sizeof(s.read_end)))
-      return false;
-    if (!cache.Read(&s.end_pos, sizeof(s.end_pos)))
       return false;
     if (!cache.Read(&s.end_size, sizeof(s.end_size)))
       return false;
@@ -185,18 +180,11 @@ bool GOSoundAudioSection::SaveCache(GOCacheWriter &cache) const {
     return false;
   for (unsigned i = 0; i < temp; i++) {
     const EndSegment *s = &m_EndSegments[i];
-    if (!cache.Write(&s->end_offset, sizeof(s->end_offset)))
-      return false;
+
     if (!cache.Write(
           &s->next_start_segment_index, sizeof(s->next_start_segment_index)))
       return false;
     if (!cache.Write(&s->transition_offset, sizeof(s->transition_offset)))
-      return false;
-    if (!cache.Write(&s->end_loop_length, sizeof(s->end_loop_length)))
-      return false;
-    if (!cache.Write(&s->read_end, sizeof(s->read_end)))
-      return false;
-    if (!cache.Write(&s->end_pos, sizeof(s->end_pos)))
       return false;
     if (!cache.Write(&s->end_size, sizeof(s->end_size)))
       return false;
@@ -373,10 +361,9 @@ void GOSoundAudioSection::Setup(
         min_reqd_samples = loop.m_EndPosition + 1;
 
       start_seg.start_offset = loop.m_StartPosition;
-      end_seg.end_offset = loop.m_EndPosition;
+      end_seg.end_pos = loop.m_EndPosition;
       end_seg.next_start_segment_index = i + 1;
-      const unsigned loop_length
-        = 1 + end_seg.end_offset - start_seg.start_offset;
+      const unsigned loop_length = end_seg.end_pos - start_seg.start_offset;
       wxString loopError;
 
       if (fade_len > loop_length - 1)
@@ -392,14 +379,12 @@ void GOSoundAudioSection::Setup(
         unsigned end_length;
 
         // calculate the fade segment size and offsets
-        if (end_seg.end_offset - start_seg.start_offset > SHORT_LOOP_LENGTH) {
+        if (loop_length >= SHORT_LOOP_LENGTH) {
           end_seg.transition_offset
-            = end_seg.end_offset - MAX_READAHEAD - fade_len + 1;
-          end_seg.read_end = end_seg.end_offset - fade_len;
-          end_length = 2 * MAX_READAHEAD + fade_len;
+            = end_seg.end_pos - MAX_READAHEAD - fade_len;
+          end_length = DEFAULT_END_SEG_LENGTH + fade_len;
         } else {
           end_seg.transition_offset = start_seg.start_offset;
-          end_seg.read_end = end_seg.end_offset;
           end_length = SHORT_LOOP_LENGTH + MAX_READAHEAD;
           if (
             end_length < MAX_READAHEAD
@@ -422,21 +407,21 @@ void GOSoundAudioSection::Setup(
         end_seg.end_ptr
           = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;
 
-        const unsigned copy_len
-          = 1 + end_seg.end_offset - end_seg.transition_offset;
+        const unsigned nBytesToCopy
+          = (end_seg.end_pos - end_seg.transition_offset) * m_BytesPerSample;
 
         // Fill the fade seg with transition data, then with the loop start data
         memcpy(
           end_seg.end_data,
           ((const unsigned char *)pcm_data)
             + end_seg.transition_offset * m_BytesPerSample,
-          copy_len * m_BytesPerSample);
+          nBytesToCopy);
         loop_memcpy(
-          ((unsigned char *)end_seg.end_data) + copy_len * m_BytesPerSample,
+          ((unsigned char *)end_seg.end_data) + nBytesToCopy,
           ((const unsigned char *)pcm_data)
             + loop.m_StartPosition * m_BytesPerSample,
           loop_length * m_BytesPerSample,
-          (end_length - copy_len) * m_BytesPerSample);
+          end_seg.end_size - nBytesToCopy);
         if (fade_len > 0)
           // TODO: reduce the number of parameters of DoCrossfade that the call
           // would be easy readable without additional comments
@@ -449,8 +434,6 @@ void GOSoundAudioSection::Setup(
             loop_length,
             end_length);
 
-        end_seg.end_loop_length = loop_length;
-        end_seg.end_pos = end_length + end_seg.transition_offset;
         assert(end_length >= MAX_READAHEAD);
 
         m_StartSegments.push_back(start_seg);
@@ -468,35 +451,31 @@ void GOSoundAudioSection::Setup(
   } else {
     /* Create a default end segment */
     EndSegment end_seg;
-    end_seg.end_offset = pcm_data_nb_samples - 1;
-    end_seg.read_end = end_seg.end_offset + 1;
-    end_seg.next_start_segment_index = -1;
-    unsigned end_length = 2 * MAX_READAHEAD;
-    end_seg.end_size = end_length * m_BytesPerSample;
-    end_seg.end_data = (unsigned char *)m_Pool.Alloc(end_seg.end_size, true);
-    end_seg.transition_offset = limitedDiff(end_seg.end_offset, MAX_READAHEAD);
-    end_seg.end_loop_length = end_length * 2;
-    end_seg.end_ptr
-      = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;
 
-    const unsigned copy_len
-      = 1 + end_seg.end_offset - end_seg.transition_offset;
+    end_seg.end_pos = pcm_data_nb_samples;
+    end_seg.next_start_segment_index = -1;
+    end_seg.end_size = m_BytesPerSample * DEFAULT_END_SEG_LENGTH;
+    end_seg.end_data = (unsigned char *)m_Pool.Alloc(end_seg.end_size, true);
 
     if (!end_seg.end_data)
       throw GOOutOfMemory();
 
+    end_seg.transition_offset = limitedDiff(end_seg.end_pos, MAX_READAHEAD);
+    end_seg.end_ptr
+      = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;
+
+    const unsigned nBytesToCopy
+      = (end_seg.end_pos - end_seg.transition_offset) * m_BytesPerSample;
+
     memcpy(
       end_seg.end_data,
       ((const unsigned char *)pcm_data)
-        + end_seg.transition_offset * m_BytesPerSample,
-      copy_len * m_BytesPerSample);
+        + m_BytesPerSample * end_seg.transition_offset,
+      nBytesToCopy);
     memset(
-      ((unsigned char *)end_seg.end_data) + copy_len * m_BytesPerSample,
+      ((unsigned char *)end_seg.end_data) + nBytesToCopy,
       0,
-      (end_length - copy_len) * m_BytesPerSample);
-
-    end_seg.end_pos = end_length + end_seg.transition_offset;
-    assert(end_length >= MAX_READAHEAD);
+      end_seg.end_size - nBytesToCopy);
 
     m_EndSegments.push_back(end_seg);
   }

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -416,6 +416,9 @@ void GOSoundAudioSection::Setup(
           = (unsigned char *)m_Pool.Alloc(end_seg.end_size, true);
         if (!end_seg.end_data)
           throw GOOutOfMemory();
+
+        // make the universal pointer for reading the end segment with the same
+        // offset as the main data
         end_seg.end_ptr
           = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;
 

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -417,7 +417,7 @@ void GOSoundAudioSection::Setup(
         if (!end_seg.end_data)
           throw GOOutOfMemory();
 
-        // make the universal pointer for reading the end segment with the same
+        // make a virtual pointer for reading the end segment with the same
         // offset as the main data
         end_seg.end_ptr
           = end_seg.end_data - m_BytesPerSample * end_seg.transition_offset;

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -36,6 +36,10 @@ public:
     DecompressionCache cache;
   };
 
+  /**
+   * This segment contains copysamples from a loop end and then from the loop
+   * start. It is necessary for read-ahead when resampling
+   */
   struct EndSegment {
     /* Sample offset where the loop ends and needs to jump into the next
      * start segment. */

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -41,9 +41,12 @@ public:
    * loop start. It is necessary for read-ahead when resampling
    */
   struct EndSegment {
-    /* Sample offset where the loop ends and needs to jump into the next
-     * start segment. */
-    unsigned end_offset;
+    /* A position after the last copied sample in the end segment.
+     * An end segment has more MAX_READAHEAD samples after end_pos:
+     *     - A loop end segment contains a copy of samples from the loop start
+     *     - A release end segment contains zero samples
+     */
+    unsigned end_pos;
 
     /* Sample offset where the uncompressed end data blob begins (must be less
      * than end_offset). */
@@ -52,11 +55,12 @@ public:
     /* Uncompressed ending data blob. This data must start before
      * sample_offset*/
     unsigned char *end_data;
+
+    // A virtual pointer to end_data. end_data has transition_offset to end_ptr
     unsigned char *end_ptr;
-    unsigned read_end;
-    unsigned end_pos;
+
+    // The size of the end data in bytes
     unsigned end_size;
-    unsigned end_loop_length;
 
     /* Index of the next section segment to be played (-1 indicates the
      * end of the blob. */

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -37,8 +37,8 @@ public:
   };
 
   /**
-   * This segment contains copysamples from a loop end and then from the loop
-   * start. It is necessary for read-ahead when resampling
+   * This segment contains copy of samples from a loop end and then from the
+   * loop start. It is necessary for read-ahead when resampling
    */
   struct EndSegment {
     /* Sample offset where the loop ends and needs to jump into the next

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -49,7 +49,7 @@ public:
     unsigned end_pos;
 
     /* Sample offset where the uncompressed end data blob begins (must be less
-     * than end_offset). */
+     * than end_pos). */
     unsigned transition_offset;
 
     /* Uncompressed ending data blob. This data must start before

--- a/src/grandorgue/sound/GOSoundDefs.h
+++ b/src/grandorgue/sound/GOSoundDefs.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,10 +11,6 @@
 /* Number of samples to match for release alignment. */
 #define BLOCK_HISTORY (2)
 
-/* Read-Ahead of various playback modes */
-#define POLYPHASE_READAHEAD (8)
-#define LINEAR_COMPRESSED_READAHEAD (2)
-#define LINEAR_READAHEAD (1)
 /* Maximum of the above values */
 #define MAX_READAHEAD (8)
 /* Minimum remaining loop length after a crossfade */

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -106,7 +106,7 @@ void GOSoundEngine::SetSampleRate(unsigned sample_rate) {
 }
 
 void GOSoundEngine::SetInterpolationType(unsigned type) {
-  m_ResamplerCoefs.interpolation = (interpolation_type)type;
+  m_ResamplerCoefs.interpolation = (GOSoundResample::InterpolationType)type;
 }
 
 unsigned GOSoundEngine::GetSampleRate() { return m_SampleRate; }

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -101,12 +101,11 @@ void GOSoundEngine::SetSamplesPerBuffer(unsigned samples_per_buffer) {
 
 void GOSoundEngine::SetSampleRate(unsigned sample_rate) {
   m_SampleRate = sample_rate;
-  resampler_coefs_init(
-    &m_ResamplerCoefs, m_SampleRate, m_ResamplerCoefs.interpolation);
+  m_ResamplerCoefs.Init(m_SampleRate, m_ResamplerCoefs.m_interpolation);
 }
 
 void GOSoundEngine::SetInterpolationType(unsigned type) {
-  m_ResamplerCoefs.interpolation = (GOSoundResample::InterpolationType)type;
+  m_ResamplerCoefs.m_interpolation = (GOSoundResample::InterpolationType)type;
 }
 
 unsigned GOSoundEngine::GetSampleRate() { return m_SampleRate; }

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -47,7 +47,6 @@ GOSoundEngine::GOSoundEngine()
     m_AudioRecorder(NULL),
     m_TouchTask(),
     m_HasBeenSetup(false) {
-  memset(&m_ResamplerCoefs, 0, sizeof(m_ResamplerCoefs));
   m_SamplerPool.SetUsageLimit(2048);
   m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
   m_ReleaseProcessor = new GOSoundReleaseTask(*this, m_AudioGroupTasks);
@@ -101,11 +100,10 @@ void GOSoundEngine::SetSamplesPerBuffer(unsigned samples_per_buffer) {
 
 void GOSoundEngine::SetSampleRate(unsigned sample_rate) {
   m_SampleRate = sample_rate;
-  m_ResamplerCoefs.Init(m_SampleRate, m_ResamplerCoefs.m_interpolation);
 }
 
 void GOSoundEngine::SetInterpolationType(unsigned type) {
-  m_ResamplerCoefs.m_interpolation = (GOSoundResample::InterpolationType)type;
+  m_resample.m_interpolation = (GOSoundResample::InterpolationType)type;
 }
 
 unsigned GOSoundEngine::GetSampleRate() { return m_SampleRate; }
@@ -415,7 +413,7 @@ GOSoundSampler *GOSoundEngine::CreateTaskSample(
       sampler->velocity = velocity;
       sampler->stream.InitStream(
         section,
-        &m_ResamplerCoefs,
+        &m_resample,
         GetRandomFactor() * pSoundProvider->GetTuning() / (float)m_SampleRate);
 
       const float playback_gain
@@ -604,7 +602,7 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
       } else {
         new_sampler->stream.InitStream(
           release_section,
-          &m_ResamplerCoefs,
+          &m_resample,
           this_pipe->GetTuning() / (float)m_SampleRate);
       }
       new_sampler->is_release = true;

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -103,7 +103,7 @@ void GOSoundEngine::SetSampleRate(unsigned sample_rate) {
 }
 
 void GOSoundEngine::SetInterpolationType(unsigned type) {
-  m_resample.m_interpolation = (GOSoundResample::InterpolationType)type;
+  m_interpolation = (GOSoundResample::InterpolationType)type;
 }
 
 unsigned GOSoundEngine::GetSampleRate() { return m_SampleRate; }
@@ -412,8 +412,9 @@ GOSoundSampler *GOSoundEngine::CreateTaskSample(
       sampler->m_WaveTremulantStateFor = section->GetWaveTremulantStateFor();
       sampler->velocity = velocity;
       sampler->stream.InitStream(
-        section,
         &m_resample,
+        section,
+        m_interpolation,
         GetRandomFactor() * pSoundProvider->GetTuning() / (float)m_SampleRate);
 
       const float playback_gain
@@ -459,7 +460,8 @@ void GOSoundEngine::SwitchToAnotherAttack(GOSoundSampler *pSampler) {
 
         // start new section stream in the old sampler
         pSampler->m_WaveTremulantStateFor = section->GetWaveTremulantStateFor();
-        pSampler->stream.InitAlignedStream(section, &new_sampler->stream);
+        pSampler->stream.InitAlignedStream(
+          section, m_interpolation, &new_sampler->stream);
         pSampler->p_SoundProvider = pProvider;
         pSampler->time = m_CurrentTime + 1;
 
@@ -598,11 +600,13 @@ void GOSoundEngine::CreateReleaseSampler(GOSoundSampler *handle) {
       if (
         m_ReleaseAlignmentEnabled
         && release_section->SupportsStreamAlignment()) {
-        new_sampler->stream.InitAlignedStream(release_section, &handle->stream);
+        new_sampler->stream.InitAlignedStream(
+          release_section, m_interpolation, &handle->stream);
       } else {
         new_sampler->stream.InitStream(
-          release_section,
           &m_resample,
+          release_section,
+          m_interpolation,
           this_pipe->GetTuning() / (float)m_SampleRate);
       }
       new_sampler->is_release = true;

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -65,7 +65,7 @@ private:
   std::unique_ptr<GOSoundTouchTask> m_TouchTask;
   GOSoundScheduler m_Scheduler;
 
-  struct GOSoundResample m_ResamplerCoefs;
+  GOSoundResample m_resample;
 
   std::atomic_bool m_HasBeenSetup;
 

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -66,6 +66,7 @@ private:
   GOSoundScheduler m_Scheduler;
 
   GOSoundResample m_resample;
+  GOSoundResample::InterpolationType m_interpolation;
 
   std::atomic_bool m_HasBeenSetup;
 

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -65,7 +65,7 @@ private:
   std::unique_ptr<GOSoundTouchTask> m_TouchTask;
   GOSoundScheduler m_Scheduler;
 
-  struct resampler_coefs_s m_ResamplerCoefs;
+  struct GOSoundResample m_ResamplerCoefs;
 
   std::atomic_bool m_HasBeenSetup;
 

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -81,9 +81,7 @@ static void create_nyquist_filter(
   }
 }
 
-void GOSoundResample::Init(
-  const unsigned input_sample_rate,
-  GOSoundResample::InterpolationType interpolation) {
+GOSoundResample::GOSoundResample() {
   float temp[UPSAMPLE_FACTOR * POLYPHASE_POINTS];
 
   create_nyquist_filter(temp, POLYPHASE_POINTS, UPSAMPLE_FACTOR);
@@ -101,7 +99,6 @@ void GOSoundResample::Init(
     m_LinearCoeffs[i][0] = i / (float)UPSAMPLE_FACTOR;
     m_LinearCoeffs[i][1] = 1 - (i / (float)UPSAMPLE_FACTOR);
   }
-  m_interpolation = interpolation;
 }
 
 float *GOSoundResample::newResampledMono(
@@ -111,8 +108,6 @@ float *GOSoundResample::newResampledMono(
   unsigned to_samplerate) {
   struct GOSoundResample resample;
   float factor = ((float)from_samplerate) / to_samplerate;
-
-  resample.Init(to_samplerate, GO_POLYPHASE_INTERPOLATION);
 
   unsigned new_len = ceil(len / factor);
   unsigned position_index = 0;

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -120,9 +120,11 @@ float *GOSoundResample::NewResampledMono(
   unsigned &len,
   unsigned from_samplerate,
   unsigned to_samplerate) {
-  float factor = ((float)from_samplerate) / to_samplerate;
+  ResamplingPosition resamplingPos;
 
-  unsigned new_len = ceil(len / factor);
+  resamplingPos.Init((float)from_samplerate / to_samplerate);
+
+  unsigned new_len = resamplingPos.AvailableTargetSamples(len);
 
   if (!new_len)
     return NULL;
@@ -132,11 +134,9 @@ float *GOSoundResample::NewResampledMono(
   if (!out)
     return NULL;
 
-  ResamplingPosition resamplingPos;
   BoundedPtrSampleVector<float, float, 1> w(data, len);
   PolyphaseResampler resampler(*this);
 
-  resamplingPos.Init(factor);
   resampler.ResampleBlock<BoundedPtrSampleVector<float, float, 1>, 1>(
     resamplingPos, w, out, new_len);
   len = new_len;

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -96,8 +96,8 @@ GOSoundResample::GOSoundResample() {
     }
   }
   for (unsigned i = 0; i < UPSAMPLE_FACTOR; i++) {
-    m_LinearCoeffs[i][0] = i / (float)UPSAMPLE_FACTOR;
-    m_LinearCoeffs[i][1] = 1 - (i / (float)UPSAMPLE_FACTOR);
+    m_LinearCoefs[i][0] = 1 - (i / (float)UPSAMPLE_FACTOR);
+    m_LinearCoefs[i][1] = i / (float)UPSAMPLE_FACTOR;
   }
 }
 
@@ -119,11 +119,11 @@ float *GOSoundResample::NewResampledMono(
     return NULL;
 
   ResamplingPosition resamplingPos;
-  PointerWindow<float, 1> w(data, len);
+  BoundedPtrSampleVector<float, float, 1> w(data, len);
+  PolyphaseResampler resampler(*this);
 
   resamplingPos.Init(factor);
-
-  ResampleBlock<PolyphaseResampler, PointerWindow<float, 1>, 1>(
+  resampler.ResampleBlock<BoundedPtrSampleVector<float, float, 1>, 1>(
     resamplingPos, w, out, new_len);
   len = new_len;
   return out;

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -2,7 +2,7 @@
  * GrandOrgue - free pipe organ simulator based on MyOrgan
  *
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -76,9 +76,9 @@ static void create_nyquist_filter(
 #include <stdio.h>
 
 void resampler_coefs_init(
-  struct resampler_coefs_s *resampler_coefs,
+  struct GOSoundResample *resampler_coefs,
   const unsigned input_sample_rate,
-  interpolation_type interpolation) {
+  GOSoundResample::InterpolationType interpolation) {
   float temp[UPSAMPLE_FACTOR * SUBFILTER_TAPS];
 
 #if 1
@@ -119,9 +119,10 @@ float *resample_block(
   unsigned &len,
   unsigned from_samplerate,
   unsigned to_samplerate) {
-  struct resampler_coefs_s coefs;
+  struct GOSoundResample coefs;
   float factor = ((float)from_samplerate) / to_samplerate;
-  resampler_coefs_init(&coefs, to_samplerate, GO_POLYPHASE_INTERPOLATION);
+  resampler_coefs_init(
+    &coefs, to_samplerate, GOSoundResample::GO_POLYPHASE_INTERPOLATION);
   const float *coef = coefs.coefs;
   unsigned new_len = ceil(len / factor);
   unsigned position_index = 0;

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -101,6 +101,20 @@ GOSoundResample::GOSoundResample() {
   }
 }
 
+unsigned GOSoundResample::getVectorLength(
+  GOSoundResample::InterpolationType interpolation) {
+  unsigned res;
+
+  switch (interpolation) {
+  case GO_LINEAR_INTERPOLATION:
+    res = LinearResampler::getVectorLength();
+    break;
+  case GO_POLYPHASE_INTERPOLATION:
+    res = PolyphaseResampler::getVectorLength();
+  }
+  return res;
+}
+
 float *GOSoundResample::NewResampledMono(
   const float *data,
   unsigned &len,

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -30,6 +30,14 @@
 #define M_PI 3.14159265358979323846264338327950288
 #endif
 
+void GOSoundResample::ResamplingPosition::Init(
+  float factor, unsigned startIndex, const ResamplingPosition *pOld) {
+  m_index = startIndex;
+  m_fraction = pOld ? pOld->m_fraction : 0;
+  m_FractionIncrement
+    = roundf(factor * (pOld ? pOld->m_FractionIncrement : UPSAMPLE_FACTOR));
+}
+
 static double sinc(const double arg) {
   return (arg == 0) ? 1.0 : sin(M_PI * arg) / (M_PI * arg);
 }
@@ -72,8 +80,6 @@ static void create_nyquist_filter(
     output[i] = f;
   }
 }
-
-#include <stdio.h>
 
 void GOSoundResample::Init(
   const unsigned input_sample_rate,

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -270,6 +270,13 @@ public:
   };
 
   /**
+   * Returns the necessary sample vector length for the given interpolation type
+   * @param interpolation - the interpolation type
+   * @return the number of samples
+   */
+  static unsigned getVectorLength(InterpolationType interpolation);
+
+  /**
    * Allocate a new sample block and fill it with resampled data. Assume that
    *   the samples are mono
    * @param data a pointer to the source samples

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -2,7 +2,7 @@
  * GrandOrgue - free pipe organ simulator based on MyOrgan
  *
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -22,6 +22,8 @@
 #ifndef GOSOUNDRESAMPLE_H_
 #define GOSOUNDRESAMPLE_H_
 
+#include <cstdint>
+
 #define SUBFILTER_BITS (3U)
 #define SUBFILTER_TAPS (1U << SUBFILTER_BITS)
 #define UPSAMPLE_BITS (13U)
@@ -39,21 +41,21 @@
  * 48 kHz. */
 #define MAX_POSITIVE_FACTOR (2663U)
 
-typedef enum {
-  GO_LINEAR_INTERPOLATION = 0,
-  GO_POLYPHASE_INTERPOLATION = 1,
-} interpolation_type;
+struct GOSoundResample {
+  enum InterpolationType {
+    GO_LINEAR_INTERPOLATION = 0,
+    GO_POLYPHASE_INTERPOLATION = 1,
+  };
 
-struct resampler_coefs_s {
   float coefs[UPSAMPLE_FACTOR * SUBFILTER_TAPS];
   float linear[UPSAMPLE_FACTOR][2];
-  interpolation_type interpolation;
+  InterpolationType interpolation;
 };
 
 void resampler_coefs_init(
-  struct resampler_coefs_s *resampler_coefs,
+  struct GOSoundResample *resampler_coefs,
   const unsigned input_sample_rate,
-  interpolation_type interpolation);
+  GOSoundResample::InterpolationType interpolation);
 
 float *resample_block(
   float *data, unsigned &len, unsigned from_samplerate, unsigned to_samplerate);

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -96,10 +96,13 @@ public:
      *   position exceeds endIndex specified
      */
     inline unsigned AvailableTargetSamples(unsigned endIndex) {
-      return m_index < endIndex ? ((endIndex - m_index) * UPSAMPLE_FACTOR
-                                   + m_FractionIncrement - 1 // for rounding up
-                                   - m_fraction)
-          / m_FractionIncrement
+      return m_index < endIndex ? unsigned(
+               (
+                 // for preventing owerflowing if endIndex >= 2**19 ~ 550000
+                 uint64_t(endIndex - m_index) * UPSAMPLE_FACTOR
+                 + m_FractionIncrement - 1 // for rounding up
+                 - m_fraction)
+               / m_FractionIncrement)
                                 : 0;
     }
   };

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -49,15 +49,28 @@ struct GOSoundResample {
 
   float coefs[UPSAMPLE_FACTOR * SUBFILTER_TAPS];
   float linear[UPSAMPLE_FACTOR][2];
-  InterpolationType interpolation;
+  InterpolationType m_interpolation;
+
+  void Init(
+    const unsigned input_sample_rate,
+    GOSoundResample::InterpolationType interpolation);
+
+  /**
+   * Allocate a new sample block and fill it with resampled data. Assume that
+   *   the samples are mono
+   * @param data a pointer to the source samples
+   * @param before call - number of source samples. After call it is filled
+   *   with number of target samples
+   * @param from_samplerate source samplerate
+   * @param to_samplerate target samplerate
+   * @return a pointer to the new allocated data block. The caller is
+   *   responsible to free this block
+   */
+  static float *newResampledMono(
+    const float *data,
+    unsigned &len,
+    unsigned from_samplerate,
+    unsigned to_samplerate);
 };
-
-void resampler_coefs_init(
-  struct GOSoundResample *resampler_coefs,
-  const unsigned input_sample_rate,
-  GOSoundResample::InterpolationType interpolation);
-
-float *resample_block(
-  float *data, unsigned &len, unsigned from_samplerate, unsigned to_samplerate);
 
 #endif /* GOSOUNDRESAMPLE_H_ */

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -27,6 +27,7 @@
 struct GOSoundResample {
   static constexpr unsigned POLYPHASE_BITS = 3;
   static constexpr unsigned POLYPHASE_POINTS = 1 << POLYPHASE_BITS;
+  static constexpr unsigned LINEAR_POINTS = 2;
   static constexpr unsigned UPSAMPLE_BITS = 13;
   static constexpr unsigned UPSAMPLE_FACTOR = 1 << UPSAMPLE_BITS;
   static constexpr unsigned UPSAMPLE_MASK = UPSAMPLE_FACTOR - 1;
@@ -120,8 +121,8 @@ struct GOSoundResample {
     }
   };
 
-  float m_PolyphaseCoefs[UPSAMPLE_FACTOR * POLYPHASE_POINTS];
-  float m_LinearCoeffs[UPSAMPLE_FACTOR][2];
+  float m_PolyphaseCoefs[UPSAMPLE_FACTOR][POLYPHASE_POINTS];
+  float m_LinearCoeffs[UPSAMPLE_FACTOR][LINEAR_POINTS];
   InterpolationType m_interpolation;
 
   void Init(
@@ -130,14 +131,14 @@ struct GOSoundResample {
 
   template <class SourceT>
   inline float CalcLinear(unsigned fraction, SourceT &source) const {
-    const float(&coef)[2] = m_LinearCoeffs[fraction];
+    const float(&coef)[LINEAR_POINTS] = m_LinearCoeffs[fraction];
 
     return source.NextSample() * coef[1] + source.NextSample() * coef[0];
   }
 
   template <class SourceT>
   inline float CalcPolyphase(unsigned fraction, SourceT &source) const {
-    const float *pCoef = m_PolyphaseCoefs + (fraction << POLYPHASE_BITS);
+    const float *pCoef = m_PolyphaseCoefs[fraction];
     float out = 0.0f;
 
     for (unsigned j = 0; j < POLYPHASE_POINTS; j++)

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -207,8 +207,6 @@ public:
   // The coefficients for the polyphase interpolation
   float m_PolyphaseCoefs[UPSAMPLE_FACTOR][POLYPHASE_POINTS];
 
-  InterpolationType m_interpolation;
-
   GOSoundResample();
 
   template <unsigned nPoints> class ScalarProductionResampler {

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -89,12 +89,18 @@ public:
     }
 
     /**
-     * Calculates haw many target samples may be received from this position
-     * @param endIndex the index position after the last source sample
+     * Calculates the target samples length from given source position to the
+     * end index
+     * @param endIndex the first index position after the last source sample
+     * @result - the number of tatget samples can be received before the current
+     *   position exceeds endIndex specified
      */
     inline unsigned AvailableTargetSamples(unsigned endIndex) {
-      return ((endIndex - m_index) * UPSAMPLE_FACTOR - m_fraction)
-        / m_FractionIncrement;
+      return m_index < endIndex ? ((endIndex - m_index) * UPSAMPLE_FACTOR
+                                   + m_FractionIncrement - 1 // for rounding up
+                                   - m_fraction)
+          / m_FractionIncrement
+                                : 0;
     }
   };
 

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -25,8 +25,7 @@
 #include <cstdint>
 
 struct GOSoundResample {
-  static constexpr unsigned POLYPHASE_BITS = 3;
-  static constexpr unsigned POLYPHASE_POINTS = 1 << POLYPHASE_BITS;
+  static constexpr unsigned POLYPHASE_POINTS = 8;
   static constexpr unsigned LINEAR_POINTS = 2;
   static constexpr unsigned UPSAMPLE_BITS = 13;
   static constexpr unsigned UPSAMPLE_FACTOR = 1 << UPSAMPLE_BITS;
@@ -125,9 +124,7 @@ struct GOSoundResample {
   float m_LinearCoeffs[UPSAMPLE_FACTOR][LINEAR_POINTS];
   InterpolationType m_interpolation;
 
-  void Init(
-    const unsigned input_sample_rate,
-    GOSoundResample::InterpolationType interpolation);
+  GOSoundResample();
 
   template <class SourceT>
   inline float CalcLinear(unsigned fraction, SourceT &source) const {

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -24,27 +24,98 @@
 
 #include <cstdint>
 
-#define SUBFILTER_BITS (3U)
-#define SUBFILTER_TAPS (1U << SUBFILTER_BITS)
-#define UPSAMPLE_BITS (13U)
-#define UPSAMPLE_FACTOR (1U << UPSAMPLE_BITS)
-
-/* This factor must not be exceeded in the downsampler and it MUST be
- * greater than UPSAMPLE_FACTOR.
- *
- * The value of 2663 was tuned analytically and results in a filter power
- * ripple of less than 0.00002 dB when the sub filter taps is 8 and the
- * upsample factor is 2048.
- *
- * The roll off characteristic starts at:
- *  (UPSAMPLE_FACTOR * sample_rate) / (MAX_POSITIVE_FACTOR * 2) ~ 18kHz at
- * 48 kHz. */
-#define MAX_POSITIVE_FACTOR (2663U)
-
 struct GOSoundResample {
+  static constexpr unsigned SUBFILTER_BITS = 3;
+  static constexpr unsigned SUBFILTER_TAPS = 1 << SUBFILTER_BITS;
+  static constexpr unsigned UPSAMPLE_BITS = 13;
+  static constexpr unsigned UPSAMPLE_FACTOR = 1 << UPSAMPLE_BITS;
+  static constexpr unsigned UPSAMPLE_MASK = UPSAMPLE_FACTOR - 1;
+
+  /* This factor must not be exceeded in the downsampler and it MUST be
+   * greater than UPSAMPLE_FACTOR.
+   *
+   * The value of 2663 was tuned analytically and results in a filter power
+   * ripple of less than 0.00002 dB when the sub filter taps is 8 and the
+   * upsample factor is 2048.
+   *
+   * The roll off characteristic starts at:
+   *  (UPSAMPLE_FACTOR * sample_rate) / (MAX_POSITIVE_FACTOR * 2) ~ 18kHz at
+   * 48 kHz. */
+  static constexpr unsigned MAX_POSITIVE_FACTOR = 2663;
+
   enum InterpolationType {
     GO_LINEAR_INTERPOLATION = 0,
     GO_POLYPHASE_INTERPOLATION = 1,
+  };
+
+  /**
+   * A position in the source sample stream for the current position in the
+   * target stream. Because the numbers of source and target samples differ, the
+   * source position may be not integer and has a fractional part
+   */
+  class ResamplingPosition {
+  private:
+    // an integer part
+    unsigned m_index;
+    // a fractional part in 1/UPSAMPLE_FACTOR units
+    unsigned m_fraction;
+    // Increment of the source position for one target sample in
+    //   1/UPSAMPLE_FACTOR units
+    unsigned m_FractionIncrement;
+
+  public:
+    inline unsigned GetIndex() const { return m_index; }
+    inline void SetIndex(unsigned newIndex) { m_index = newIndex; }
+    inline unsigned GetFraction() const { return m_fraction; }
+    inline unsigned GetFractionIncrement() const { return m_FractionIncrement; }
+
+    /**
+     * A resampling factor equals to (source length / target length) or to
+     * (source sample rate / target sample rate)
+     * @return the resampling factor
+     */
+    inline float GetResamplingFactor() const {
+      return (float)m_FractionIncrement / UPSAMPLE_FACTOR;
+    }
+
+    void Init(
+      float factor,
+      unsigned startIndex = 0,
+      const ResamplingPosition *pOld = nullptr);
+
+    /**
+     * Advance the position for the next target sample
+     */
+    inline void Inc() {
+      m_fraction += m_FractionIncrement;
+      m_index += m_fraction >> UPSAMPLE_BITS;
+      m_fraction &= UPSAMPLE_MASK;
+    }
+  };
+
+  template <class SampleT, uint8_t nChannels> class PointerSource {
+  private:
+    static constexpr uint8_t m_NChannels = nChannels;
+
+    const SampleT *p_EndPtr;
+    const SampleT *p_CurrPtr;
+
+  public:
+    inline void Init(
+      const SampleT *ptr, uint8_t channel, unsigned from, unsigned to) {
+      p_EndPtr = ptr + m_NChannels * to;
+      p_CurrPtr = ptr + m_NChannels * from + channel;
+    }
+
+    inline float NextSample() {
+      float res = 0.0f;
+
+      if (p_CurrPtr < p_EndPtr) {
+        res = (float)*p_CurrPtr;
+        p_CurrPtr += m_NChannels;
+      }
+      return res;
+    }
   };
 
   float coefs[UPSAMPLE_FACTOR * SUBFILTER_TAPS];
@@ -54,6 +125,23 @@ struct GOSoundResample {
   void Init(
     const unsigned input_sample_rate,
     GOSoundResample::InterpolationType interpolation);
+
+  template <class SourceT>
+  inline float CalcLinear(unsigned fraction, SourceT &source) const {
+    const float(&coef)[2] = linear[fraction];
+
+    return source.NextSample() * coef[1] + source.NextSample() * coef[0];
+  }
+
+  template <class SourceT>
+  inline float CalcPolyphase(unsigned fraction, SourceT &source) const {
+    const float *pCoef = coefs + (fraction << SUBFILTER_BITS);
+    float out = 0.0f;
+
+    for (unsigned j = 0; j < SUBFILTER_TAPS; j++)
+      out += source.NextSample() * *(pCoef++);
+    return out;
+  }
 
   /**
    * Allocate a new sample block and fill it with resampled data. Assume that

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -87,6 +87,15 @@ public:
       m_index += m_fraction >> UPSAMPLE_BITS;
       m_fraction &= UPSAMPLE_MASK;
     }
+
+    /**
+     * Calculates haw many target samples may be received from this position
+     * @param endIndex the index position after the last source sample
+     */
+    inline unsigned AvailableTargetSamples(unsigned endIndex) {
+      return ((endIndex - m_index) * UPSAMPLE_FACTOR - m_fraction)
+        / m_FractionIncrement;
+    }
   };
 
   /**

--- a/src/grandorgue/sound/GOSoundReverb.cpp
+++ b/src/grandorgue/sound/GOSoundReverb.cpp
@@ -92,7 +92,9 @@ void GOSoundReverb::Setup(GOConfig &settings) {
       settings.SampleRate());
      */
     if (wav.GetSampleRate() != settings.SampleRate()) {
-      float *new_data = GOSoundResample::newResampledMono(
+      GOSoundResample resample;
+
+      float *new_data = resample.NewResampledMono(
         data, len, wav.GetSampleRate(), settings.SampleRate());
       if (!new_data)
         throw(wxString) _("Resampling failed");

--- a/src/grandorgue/sound/GOSoundReverb.cpp
+++ b/src/grandorgue/sound/GOSoundReverb.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -92,8 +92,8 @@ void GOSoundReverb::Setup(GOConfig &settings) {
       settings.SampleRate());
      */
     if (wav.GetSampleRate() != settings.SampleRate()) {
-      float *new_data
-        = resample_block(data, len, wav.GetSampleRate(), settings.SampleRate());
+      float *new_data = GOSoundResample::newResampledMono(
+        data, len, wav.GetSampleRate(), settings.SampleRate());
       if (!new_data)
         throw(wxString) _("Resampling failed");
       free(data);

--- a/src/grandorgue/sound/GOSoundSampler.h
+++ b/src/grandorgue/sound/GOSoundSampler.h
@@ -8,6 +8,7 @@
 #ifndef GOSOUNDSAMPLER_H_
 #define GOSOUNDSAMPLER_H_
 
+#include "GOBool3.h"
 #include "GOSoundFader.h"
 #include "GOSoundFilter.h"
 #include "GOSoundStream.h"

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -41,7 +41,7 @@ public:
     m_curr = PREV;
   }
 
-  inline float NextSample() {
+  inline int NextSample() {
     int res;
 
     if (m_curr == PREV) {
@@ -52,7 +52,7 @@ public:
       m_curr = ZERO;
     } else
       res = 0;
-    return (float)res;
+    return res;
   }
 };
 

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -314,10 +314,11 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
       end_seg = next_end;
     } else { // no loop available
       // fill the buffer with zeros
-      do {
-        *(buffer++) = 0.0f;
-        *(buffer++) = 0.0f;
-      } while (--n_blocks > 0);
+      float *p = buffer;
+
+      for (unsigned i = n_blocks * 2; i > 0; i--)
+        *(p++) = 0.0f;
+      n_blocks = 0;
       res = false;
     }
   }

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -304,7 +304,7 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
       const GOSoundAudioSection::EndSegment *next_end
         = &audio_section->GetEndSegment(next_end_segment_index);
 
-      assert(next_end->end_offset >= next->start_offset);
+      assert(next_end->end_pos >= next->start_offset);
       cache = next->cache;
       cache.ptr = audio_section->GetData() + (intptr_t)cache.ptr;
       transition_position = next_end->transition_offset;

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -12,21 +12,65 @@
 
 /* Block reading functions */
 
+template <class SampleT, uint8_t nChannels>
+class StreamPtrWindow
+  : public GOSoundResample::PtrSampleVector<SampleT, int, nChannels> {
+public:
+  inline StreamPtrWindow(GOSoundStream &stream)
+    : GOSoundResample::PtrSampleVector<SampleT, int, nChannels>(
+      (SampleT *)stream.GetPtr()) {}
+};
+
+template <bool format16, uint8_t nChannels>
+class StreamCacheWindow : public GOSoundResample::SampleVector<nChannels> {
+private:
+  DecompressionCache &r_cache;
+  uint8_t m_ChannelN;
+  enum { PREV, VALUE, ZERO } m_curr;
+
+public:
+  inline StreamCacheWindow(GOSoundStream &stream)
+    : r_cache(stream.GetDecompressionCache()) {}
+
+  inline void Seek(unsigned index, uint8_t channelN) {
+    while (r_cache.position <= index + 1) {
+      DecompressionStep(r_cache, nChannels, format16);
+    }
+    m_ChannelN = channelN;
+    m_curr = PREV;
+  }
+
+  inline float NextSample() {
+    int res;
+
+    if (m_curr == PREV) {
+      res = r_cache.prev[m_ChannelN];
+      m_curr = VALUE;
+    } else if (m_curr == VALUE) {
+      res = r_cache.value[m_ChannelN];
+      m_curr = ZERO;
+    } else
+      res = 0;
+    return (float)res;
+  }
+};
+
 /* The block decode functions should provide whatever the normal resolution of
  * the audio is. The fade engine should ensure that this data is always brought
  * into the correct range. */
 
 template <class ResamplerT, class WindowT>
-inline void GOSoundStream::DecodeBlock(float *pOut, unsigned nOutSamples) {
+void GOSoundStream::DecodeBlock(float *pOut, unsigned nOutSamples) {
+  ResamplerT resampler(*resample);
   WindowT w(*this);
 
-  resample->ResampleBlock<ResamplerT, WindowT, 2>(
+  resampler.template ResampleBlock<WindowT, 2>(
     resamplingPos, w, pOut, nOutSamples);
 }
 
 GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
-  unsigned channels,
-  unsigned bits_per_sample,
+  uint8_t channels,
+  uint8_t bits_per_sample,
   bool compressed,
   GOSoundResample::InterpolationType interpolation,
   bool is_end) {

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -205,8 +205,6 @@ void GOSoundStream::InitStream(
   m_ReadAheadMarginLength
     = calculate_margin(pSection->IsCompressed(), interpolation);
   assert(m_ReadAheadMarginLength <= MAX_READAHEAD);
-  read_end
-    = GOSoundAudioSection::limitedDiff(end.read_end, m_ReadAheadMarginLength);
   end_pos = end.end_pos - m_ReadAheadMarginLength;
   cache = start.cache;
   cache.ptr = audio_section->GetData() + (intptr_t)cache.ptr;
@@ -260,8 +258,6 @@ void GOSoundStream::InitAlignedStream(
   m_ReadAheadMarginLength
     = calculate_margin(pSection->IsCompressed(), interpolation);
   assert(m_ReadAheadMarginLength <= MAX_READAHEAD);
-  read_end
-    = GOSoundAudioSection::limitedDiff(end.read_end, m_ReadAheadMarginLength);
   end_pos = end.end_pos - m_ReadAheadMarginLength;
   cache = start.cache;
   cache.ptr = audio_section->GetData() + (intptr_t)cache.ptr;
@@ -269,40 +265,46 @@ void GOSoundStream::InitAlignedStream(
 
 bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
   while (n_blocks > 0) {
-    unsigned pos = m_ResamplingPos.GetIndex();
-    // Calculate target number of samples
-    unsigned len = m_ResamplingPos.AvailableTargetSamples(end_pos);
+    /*
+      Calculate target number of samples available from the current loop
+      min=1 - for infinite loop pervention we need to advance position after
+      end_pos. 1 target sample is always available due read-ahead
+     */
+    unsigned len = std::clamp(
+      m_ResamplingPos.AvailableTargetSamples(end_pos), 1U, n_blocks);
 
-    if (len == 0)
-      len = 1;
-    len = std::min(len, n_blocks);
-
-    if (pos >= transition_position) {
+    if (m_ResamplingPos.GetIndex() >= transition_position) {
+      // switch to or continue playing the end-segment
       assert(end_decode_call);
 
       /* Setup ptr and position required by the end-block */
       ptr = end_ptr;
-      // May be we also need to set the position to 0?
+      // we continue to use the same position as before because end_ptr is a
+      // "virtual" pointer: end_data - transition_offset
       (this->*end_decode_call)(buffer, len);
       buffer += 2 * len;
       n_blocks -= len;
 
-      if (pos >= end_pos) {
+      // A new position after playing the end segment
+      unsigned pos = m_ResamplingPos.GetIndex();
+
+      if (pos >= end_pos) { // the loop has been fully played. Move to the start
+                            // of the loop
         const GOSoundAudioSection::EndSegment *end = end_seg;
 
-        if (end->next_start_segment_index < 0) {
+        if (end->next_start_segment_index < 0) { // it is not a loop
           for (unsigned i = 0; i < n_blocks * 2; i++)
             buffer[i] = 0;
           return 0;
         }
 
-        pos -= end->end_offset + 1;
-        while (pos >= end->end_loop_length)
-          pos -= end->end_loop_length;
-
         const unsigned next_index = end->next_start_segment_index;
         const GOSoundAudioSection::StartSegment *next
           = &audio_section->GetStartSegment(next_index);
+
+        // switch to the start of the loop
+        ptr = audio_section->GetData();
+        m_ResamplingPos.SetIndex(next->start_offset + (pos - end_pos));
 
         /* Find a suitable end segment */
         const unsigned next_end_segment_index
@@ -310,15 +312,11 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
         const GOSoundAudioSection::EndSegment *next_end
           = &audio_section->GetEndSegment(next_end_segment_index);
 
-        ptr = audio_section->GetData();
-        m_ResamplingPos.SetIndex(next->start_offset + pos);
         cache = next->cache;
         cache.ptr = audio_section->GetData() + (intptr_t)cache.ptr;
         assert(next_end->end_offset >= next->start_offset);
         transition_position = next_end->transition_offset;
         end_ptr = next_end->end_ptr;
-        read_end = GOSoundAudioSection::limitedDiff(
-          next_end->read_end, m_ReadAheadMarginLength);
         end_pos = next_end->end_pos - m_ReadAheadMarginLength;
         end_seg = next_end;
       }

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -22,7 +22,8 @@ public:
 };
 
 template <bool format16, uint8_t nChannels>
-class StreamCacheWindow : public GOSoundResample::SampleVector<nChannels> {
+class StreamCacheWindow
+  : public GOSoundResample::FloatingSampleVector<nChannels> {
 private:
   DecompressionCache &r_cache;
   uint8_t m_ChannelN;

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -252,16 +252,16 @@ void GOSoundStream::InitStream(
     pSection->GetChannels(),
     pSection->GetBitsPerSample(),
     pSection->IsCompressed(),
-    resample_coefs->interpolation,
+    resample_coefs->m_interpolation,
     false);
   end_decode_call = getDecodeBlockFunction(
     pSection->GetChannels(),
     pSection->GetBitsPerSample(),
     pSection->IsCompressed(),
-    resample_coefs->interpolation,
+    resample_coefs->m_interpolation,
     true);
-  margin
-    = calculate_margin(pSection->IsCompressed(), resample_coefs->interpolation);
+  margin = calculate_margin(
+    pSection->IsCompressed(), resample_coefs->m_interpolation);
   assert(margin <= MAX_READAHEAD);
   read_end = GOSoundAudioSection::limitedDiff(end.read_end, margin);
   end_pos = end.end_pos - margin;
@@ -296,16 +296,16 @@ void GOSoundStream::InitAlignedStream(
     pSection->GetChannels(),
     pSection->GetBitsPerSample(),
     pSection->IsCompressed(),
-    resample_coefs->interpolation,
+    resample_coefs->m_interpolation,
     false);
   end_decode_call = getDecodeBlockFunction(
     pSection->GetChannels(),
     pSection->GetBitsPerSample(),
     pSection->IsCompressed(),
-    resample_coefs->interpolation,
+    resample_coefs->m_interpolation,
     true);
-  margin
-    = calculate_margin(pSection->IsCompressed(), resample_coefs->interpolation);
+  margin = calculate_margin(
+    pSection->IsCompressed(), resample_coefs->m_interpolation);
   assert(margin <= MAX_READAHEAD);
   read_end = GOSoundAudioSection::limitedDiff(end.read_end, margin);
   end_pos = end.end_pos - margin;

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -305,13 +305,13 @@ void GOSoundStream::GetHistory(
       for (uint8_t j = 0; j < nChannels; j++)
         history[i][j] = audio_section->GetSampleData(ptr, pos + i, j);
   else {
-    DecompressionCache cache = cache;
+    DecompressionCache tmpCache = cache;
 
     for (unsigned i = 0; i < BLOCK_HISTORY; i++) {
       for (uint8_t j = 0; j < nChannels; j++)
-        history[i][j] = cache.value[j];
+        history[i][j] = tmpCache.value[j];
       DecompressionStep(
-        cache, nChannels, audio_section->GetBitsPerSample() >= 20);
+        tmpCache, nChannels, audio_section->GetBitsPerSample() >= 20);
     }
   }
 }

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -157,7 +157,7 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
   unsigned channels,
   unsigned bits_per_sample,
   bool compressed,
-  interpolation_type interpolation,
+  GOSoundResample::InterpolationType interpolation,
   bool is_end) {
   if (compressed && !is_end) {
     /* TODO: Add support for polyphase compressed decoders. Fallback to
@@ -176,7 +176,9 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
       return &GOSoundStream::StereoCompressedLinear<false>;
     }
   } else {
-    if (interpolation == GO_POLYPHASE_INTERPOLATION && !compressed) {
+    if (
+      interpolation == GOSoundResample::GO_POLYPHASE_INTERPOLATION
+      && !compressed) {
       if (channels == 1) {
         if (bits_per_sample <= 8)
           return &GOSoundStream::MonoUncompressedPolyphase<GOInt8>;
@@ -216,8 +218,9 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
 }
 
 static unsigned calculate_margin(
-  bool compressed, interpolation_type interpolation) {
-  if (interpolation == GO_POLYPHASE_INTERPOLATION && !compressed)
+  bool compressed, GOSoundResample::InterpolationType interpolation) {
+  if (
+    interpolation == GOSoundResample::GO_POLYPHASE_INTERPOLATION && !compressed)
     return POLYPHASE_READAHEAD;
   else if (compressed)
     return LINEAR_COMPRESSED_READAHEAD;
@@ -227,7 +230,7 @@ static unsigned calculate_margin(
 
 void GOSoundStream::InitStream(
   const GOSoundAudioSection *pSection,
-  const struct resampler_coefs_s *resampler_coefs,
+  const struct GOSoundResample *resampler_coefs,
   float sample_rate_adjustment) {
   audio_section = pSection;
 

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -166,13 +166,8 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
 
 static unsigned calculate_margin(
   bool compressed, GOSoundResample::InterpolationType interpolation) {
-  if (
-    interpolation == GOSoundResample::GO_POLYPHASE_INTERPOLATION && !compressed)
-    return POLYPHASE_READAHEAD;
-  else if (compressed)
-    return LINEAR_COMPRESSED_READAHEAD;
-  else
-    return LINEAR_READAHEAD;
+  return GOSoundResample::getVectorLength(interpolation) - 1
+    + (unsigned)compressed;
 }
 
 void GOSoundStream::InitStream(

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -8,8 +8,10 @@
 #ifndef GOSOUNDSTREAM_H
 #define GOSOUNDSTREAM_H
 
-#include "GOSoundAudioSection.h"
+#include "GOSoundCompress.h"
 #include "GOSoundResample.h"
+
+class GOSoundAudioSection;
 
 class GOSoundStream {
 private:

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -26,16 +26,20 @@ private:
    * uncompressed version of decode_call */
   DecodeBlockFunction end_decode_call;
 
-  /* Used for both compressed and uncompressed decoding */
+  /* Current pointer. Used in the DecodeBlock functions. May be a real pointer
+   * to the audio section data or an end segment vir tual pointer */
   const unsigned char *ptr;
 
-  /* Derived from the start and end audio segments which were used to setup
-   * this stream. */
-  const GOSoundAudioSection::EndSegment *end_seg;
+  // A virtual pointer to the end segment. An real pointer has the
+  // transition_position offset from this
   const unsigned char *end_ptr;
 
+  // when to switch to the end segment
   unsigned transition_position;
+  // loop end pos, when to switch to the next start segment
   unsigned end_pos;
+  // -1 means it is not looped sample, otherwise the index of the start segment
+  int m_NextStartSegmentIndex;
 
   GOSoundResample::ResamplingPosition m_ResamplingPos;
 

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -34,13 +34,14 @@ private:
   const GOSoundAudioSection::EndSegment *end_seg;
   const unsigned char *end_ptr;
 
-  // How many last samples should be reserved for read-ahead
-  unsigned margin;
+  // How many last samples should not be resampled and should be only used for
+  // resampling previous samples
+  unsigned m_ReadAheadMarginLength;
   unsigned transition_position;
   unsigned read_end;
   unsigned end_pos;
 
-  GOSoundResample::ResamplingPosition resamplingPos;
+  GOSoundResample::ResamplingPosition m_ResamplingPos;
 
   /* for decoding compressed format */
   DecompressionCache cache;

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -64,14 +64,17 @@ public:
 
   /* Initialize a stream to play this audio section */
   void InitStream(
+    const GOSoundResample *pResample,
     const GOSoundAudioSection *pSection,
-    const struct GOSoundResample *resampler_coefs,
+    GOSoundResample::InterpolationType interpolation,
     float sample_rate_adjustment);
 
   /* Initialize a stream to play this audio section and seek into it using
    * release alignment if available. */
   void InitAlignedStream(
-    const GOSoundAudioSection *pSection, const GOSoundStream *existing_stream);
+    const GOSoundAudioSection *pSection,
+    GOSoundResample::InterpolationType interpolation,
+    const GOSoundStream *existing_stream);
 
   /* Read an audio buffer from an audio section stream */
   bool ReadBlock(float *buffer, unsigned int n_blocks);

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -33,6 +33,8 @@ private:
    * this stream. */
   const GOSoundAudioSection::EndSegment *end_seg;
   const unsigned char *end_ptr;
+
+  // How many last samples are reserved for resample vector
   unsigned margin;
   unsigned transition_position;
   unsigned read_end;

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -9,11 +9,12 @@
 #define GOSOUNDSTREAM_H
 
 #include "GOSoundAudioSection.h"
+#include "GOSoundResample.h"
 
 class GOSoundStream {
 private:
   const GOSoundAudioSection *audio_section;
-  const struct GOSoundResample *resample_coefs;
+  const GOSoundResample *resample;
 
   typedef void (GOSoundStream::*DecodeBlockFunction)(
     float *output, unsigned int n_blocks);
@@ -37,17 +38,10 @@ private:
   unsigned read_end;
   unsigned end_pos;
 
-  unsigned position_index;
-  unsigned position_fraction;
-  unsigned increment_fraction;
+  GOSoundResample::ResamplingPosition resamplingPos;
 
   /* for decoding compressed format */
   DecompressionCache cache;
-
-  inline void NormalisePosition() {
-    position_index += position_fraction >> UPSAMPLE_BITS;
-    position_fraction = position_fraction & (UPSAMPLE_FACTOR - 1);
-  }
 
   template <class T>
   void MonoUncompressedLinear(float *output, unsigned int n_blocks);

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -13,7 +13,7 @@
 class GOSoundStream {
 private:
   const GOSoundAudioSection *audio_section;
-  const struct resampler_coefs_s *resample_coefs;
+  const struct GOSoundResample *resample_coefs;
 
   typedef void (GOSoundStream::*DecodeBlockFunction)(
     float *output, unsigned int n_blocks);
@@ -66,7 +66,7 @@ private:
     unsigned channels,
     unsigned bits_per_sample,
     bool compressed,
-    interpolation_type interpolation,
+    GOSoundResample::InterpolationType interpolation,
     bool is_end);
 
   void GetHistory(int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]) const;
@@ -75,7 +75,7 @@ public:
   /* Initialize a stream to play this audio section */
   void InitStream(
     const GOSoundAudioSection *pSection,
-    const struct resampler_coefs_s *resampler_coefs,
+    const struct GOSoundResample *resampler_coefs,
     float sample_rate_adjustment);
 
   /* Initialize a stream to play this audio section and seek into it using

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -38,7 +38,6 @@ private:
   // resampling previous samples
   unsigned m_ReadAheadMarginLength;
   unsigned transition_position;
-  unsigned read_end;
   unsigned end_pos;
 
   GOSoundResample::ResamplingPosition m_ResamplingPos;

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -34,9 +34,6 @@ private:
   const GOSoundAudioSection::EndSegment *end_seg;
   const unsigned char *end_ptr;
 
-  // How many last samples should not be resampled and should be only used for
-  // resampling previous samples
-  unsigned m_ReadAheadMarginLength;
   unsigned transition_position;
   unsigned end_pos;
 

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -34,7 +34,7 @@ private:
   const GOSoundAudioSection::EndSegment *end_seg;
   const unsigned char *end_ptr;
 
-  // How many last samples are reserved for resample vector
+  // How many last samples should be reserved for read-ahead
   unsigned margin;
   unsigned transition_position;
   unsigned read_end;


### PR DESCRIPTION
This is a next PR related to #710 

Earlier there were a lot of similar code that did resampling with different conditions.

I implementing a single template class GOSoundResample::ScalarProductionResampler that does resampling in the function ResampleBlock. There are two subclasses LinearResampler and PolyphaseResampler that use the same algorithm of scalar production but has different coefficients and "points": the number of continous source samples required for calculating one target sample.

All conditions come as a template parameters to ResampleBlock: the source of the continous samples "FloatingSampleVector" with different implementations. For the performance reasons I don't use virtual functions but I use a compile-time linking with template parameters.

It allowed me to eliminate lot of duplicate code and use incarnations of GOSoundResample::ScalarProductionResampler::ResampleBlock in all cases. Most of them are in GOSoundStream:DecodeBlock and GOSoundStream:getDecodeBlockFunction.

There are several other minor changes:
- Moved the current interpolation algorithm from GOSoundResample to GOSoundEngine
- All coefficients are calculated in the GOSoundResample constructor. This class does not more contain any changing state
- Added lots of comments
- Small simplification of GOSoundStream logic (eliminated "margins" and extra members)

It is only a preparing refactoring. No GO behavior should be chanded.

But now implementing a polyphase-compressed is quite easy: we only need to create a proper FloatingSampleVector implementation and describe the new combinations in `GOSoundStream:getDecodeBlockFunction`