### PR TITLE
Update grandorgue.xml about DefaultToEngaged entry.

### DIFF
--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -9749,7 +9749,7 @@ settings depends on the function.
           <term>DefaultToEngaged</term>
           <listitem>
             <para>
-(boolean, required) State of the button after loading.
+(boolean, required if Function is Input or not defined, else ignored) State of the button after loading.
      </para>
           </listitem>
         </varlistentry>


### PR DESCRIPTION
As per the source code in GODrawStop.cpp and function GODrawstop::Load, DefaultToEngaged entry is actually required only if Function is Input (or not defined), else it is ignored.
This change in the help would permit to solve the issue https://github.com/GrandOrgue/grandorgue/issues/1874.