### PR TITLE
Enchanced code style of GOEventHandlerList

### DIFF
--- a/src/grandorgue/model/GOEventHandlerList.cpp
+++ b/src/grandorgue/model/GOEventHandlerList.cpp
@@ -7,75 +7,19 @@
 
 #include "GOEventHandlerList.h"
 
-#include <algorithm>
-
 #include "control/GOControlChangedHandler.h"
 
-void GOEventHandlerList::RegisterCacheObject(GOCacheObject *obj) {
-  m_CacheObjects.push_back(obj);
-}
-
-void GOEventHandlerList::RegisterCombinationButtonSet(
-  GOCombinationButtonSet *obj) {
-  m_CombinationButtonSets.push_back(obj);
-}
-
-void GOEventHandlerList::RegisterControlChangedHandler(
-  GOControlChangedHandler *handler) {
-  m_ControlChangedHandlers.push_back(handler);
-}
-
-void GOEventHandlerList::RegisterEventHandler(GOEventHandler *handler) {
-  m_MidiEventHandlers.push_back(handler);
-}
-
-void GOEventHandlerList::RegisterMidiConfigurator(GOMidiConfigurator *obj) {
-  m_MidiConfigurators.push_back(obj);
-}
-
-void GOEventHandlerList::RegisterSoundStateHandler(
-  GOSoundStateHandler *handler) {
-  m_SoundStateHandlers.push_back(handler);
-}
-
-void GOEventHandlerList::UnRegisterSoundStateHandler(
-  GOSoundStateHandler *handler) {
-  auto it = std::find(
-    m_SoundStateHandlers.begin(), m_SoundStateHandlers.end(), handler);
-
-  if (it != m_SoundStateHandlers.end()) {
-    *it = nullptr;
-    m_SoundStateHandlers.erase(it);
-  }
-}
-
-void GOEventHandlerList::RegisterSaveableObject(GOSaveableObject *obj) {
-  if (
-    std::find(m_SaveableObjects.begin(), m_SaveableObjects.end(), obj)
-    == m_SaveableObjects.end())
-    m_SaveableObjects.push_back(obj);
-}
-
-void GOEventHandlerList::UnregisterSaveableObject(GOSaveableObject *obj) {
-  auto it = std::find(m_SaveableObjects.begin(), m_SaveableObjects.end(), obj);
-
-  if (it != m_SaveableObjects.end()) {
-    *it = nullptr;
-    m_SaveableObjects.erase(it);
-  }
-}
-
 void GOEventHandlerList::SendControlChanged(void *pControl) {
-  for (auto handler : m_ControlChangedHandlers)
+  for (auto handler : m_ControlChangedHandlers.AsVector())
     handler->ControlChanged(pControl);
 }
 
 void GOEventHandlerList::Cleanup() {
-  m_CacheObjects.clear();
-  m_CombinationButtonSets.clear();
-  m_ControlChangedHandlers.clear();
-  m_MidiConfigurators.clear();
-  m_MidiEventHandlers.clear();
-  m_SoundStateHandlers.clear();
-  m_SaveableObjects.clear();
+  m_CacheObjects.Clear();
+  m_CombinationButtonSets.Clear();
+  m_ControlChangedHandlers.Clear();
+  m_MidiConfigurators.Clear();
+  m_MidiEventHandlers.Clear();
+  m_SoundStateHandlers.Clear();
+  m_SaveableObjects.Clear();
 }

--- a/src/grandorgue/model/GOEventHandlerList.h
+++ b/src/grandorgue/model/GOEventHandlerList.h
@@ -8,6 +8,8 @@
 #ifndef GOEVENTHANDLERLIST_H
 #define GOEVENTHANDLERLIST_H
 
+#include <algorithm>
+#include <unordered_set>
 #include <vector>
 
 class GOCacheObject;
@@ -20,44 +22,105 @@ class GOSaveableObject;
 
 class GOEventHandlerList {
 private:
-  std::vector<GOCacheObject *> m_CacheObjects;
-  std::vector<GOCombinationButtonSet *> m_CombinationButtonSets;
-  std::vector<GOControlChangedHandler *> m_ControlChangedHandlers;
-  std::vector<GOMidiConfigurator *> m_MidiConfigurators;
-  std::vector<GOEventHandler *> m_MidiEventHandlers;
-  std::vector<GOSoundStateHandler *> m_SoundStateHandlers;
-  std::vector<GOSaveableObject *> m_SaveableObjects;
+  template <class T> class UPVector {
+  private:
+    std::vector<T *> objVector;
+    std::unordered_set<T *> objSet;
+
+  public:
+    void Add(T *pObj) {
+      if (objSet.find(pObj) == objSet.end()) {
+        objSet.insert(pObj);
+        objVector.push_back(pObj);
+      }
+    }
+
+    void Remove(T *pObj) {
+      auto sIt = objSet.find(pObj);
+
+      if (sIt != objSet.end()) {
+        auto vIt = std::find(objVector.begin(), objVector.end(), pObj);
+
+        if (vIt != objVector.end())
+          objVector.erase(vIt);
+        objSet.erase(sIt);
+      }
+    }
+
+    const std::vector<T *> &AsVector() const { return objVector; }
+
+    void Clear() {
+      objVector.clear();
+      objSet.clear();
+    }
+  };
+
+  UPVector<GOCacheObject> m_CacheObjects;
+  UPVector<GOCombinationButtonSet> m_CombinationButtonSets;
+  UPVector<GOControlChangedHandler> m_ControlChangedHandlers;
+  UPVector<GOMidiConfigurator> m_MidiConfigurators;
+  UPVector<GOEventHandler> m_MidiEventHandlers;
+  UPVector<GOSoundStateHandler> m_SoundStateHandlers;
+  UPVector<GOSaveableObject> m_SaveableObjects;
 
 public:
   const std::vector<GOCacheObject *> &GetCacheObjects() const {
-    return m_CacheObjects;
+    return m_CacheObjects.AsVector();
   }
   const std::vector<GOCombinationButtonSet *> &GetCombinationButtonSets()
     const {
-    return m_CombinationButtonSets;
+    return m_CombinationButtonSets.AsVector();
   }
   const std::vector<GOMidiConfigurator *> &GetMidiConfigurators() const {
-    return m_MidiConfigurators;
+    return m_MidiConfigurators.AsVector();
   }
   const std::vector<GOEventHandler *> &GetMidiEventHandlers() const {
-    return m_MidiEventHandlers;
+    return m_MidiEventHandlers.AsVector();
   }
   const std::vector<GOSoundStateHandler *> &GetSoundStateHandlers() const {
-    return m_SoundStateHandlers;
+    return m_SoundStateHandlers.AsVector();
   }
   const std::vector<GOSaveableObject *> &GetSaveableObjects() const {
-    return m_SaveableObjects;
+    return m_SaveableObjects.AsVector();
   }
 
-  void RegisterCacheObject(GOCacheObject *obj);
-  void RegisterCombinationButtonSet(GOCombinationButtonSet *obj);
-  void RegisterControlChangedHandler(GOControlChangedHandler *handler);
-  void RegisterMidiConfigurator(GOMidiConfigurator *obj);
-  void RegisterEventHandler(GOEventHandler *handler);
-  void RegisterSoundStateHandler(GOSoundStateHandler *handler);
-  void UnRegisterSoundStateHandler(GOSoundStateHandler *handler);
-  void RegisterSaveableObject(GOSaveableObject *obj);
-  void UnregisterSaveableObject(GOSaveableObject *obj);
+  void RegisterCacheObject(GOCacheObject *obj) { m_CacheObjects.Add(obj); }
+
+  void RegisterCombinationButtonSet(GOCombinationButtonSet *obj) {
+    m_CombinationButtonSets.Add(obj);
+  }
+
+  void RegisterControlChangedHandler(GOControlChangedHandler *handler) {
+    m_ControlChangedHandlers.Add(handler);
+  }
+
+  void UnRegisterControlChangedHandler(GOControlChangedHandler *handler) {
+    m_ControlChangedHandlers.Remove(handler);
+  }
+
+  void RegisterMidiConfigurator(GOMidiConfigurator *obj) {
+    m_MidiConfigurators.Add(obj);
+  }
+
+  void RegisterEventHandler(GOEventHandler *handler) {
+    m_MidiEventHandlers.Add(handler);
+  }
+
+  void RegisterSoundStateHandler(GOSoundStateHandler *handler) {
+    m_SoundStateHandlers.Add(handler);
+  }
+
+  void UnRegisterSoundStateHandler(GOSoundStateHandler *handler) {
+    m_SoundStateHandlers.Remove(handler);
+  }
+
+  void RegisterSaveableObject(GOSaveableObject *obj) {
+    m_SaveableObjects.Add(obj);
+  }
+
+  void UnregisterSaveableObject(GOSaveableObject *obj) {
+    m_SaveableObjects.Remove(obj);
+  }
 
   /**
    * Calls ControlChanged for all ControlChanged handlers


### PR DESCRIPTION
This is the first PR related to #1816

Earlier `GOEventHandlerList.cpp` contained a lot of copy-pasted code, so adding a new method requires to copy-paste more.

This PR reorganises this class so all the reusable code is in the methods of the new inner class UPVector. Now most of methods only forward to a corresponding method of UPVector.

It is just refactoring. No GO behavior should be changed.