### PR TITLE
Introduced a class GOControl as a universal base for other controls

### DIFF
--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -1158,7 +1158,7 @@ void GOSetter::Crescendo(int newpos, bool force) {
   m_CrescendoDisplay.SetContent(buffer);
 }
 
-void GOSetter::ControlChanged(void *control) {
+void GOSetter::ControlChanged(GOControl *control) {
   if (control == &m_swell)
     Crescendo(m_swell.GetValue() * CRESCENDO_STEPS / 128);
 }

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -88,7 +88,7 @@ private:
 
   void ButtonStateChanged(int id, bool newState) override;
 
-  void ControlChanged(GOControl *control);
+  void ControlChanged(GOControl *control) override;
 
   void PreparePlayback();
 

--- a/src/grandorgue/combinations/GOSetter.h
+++ b/src/grandorgue/combinations/GOSetter.h
@@ -88,7 +88,7 @@ private:
 
   void ButtonStateChanged(int id, bool newState) override;
 
-  void ControlChanged(void *control);
+  void ControlChanged(GOControl *control);
 
   void PreparePlayback();
 

--- a/src/grandorgue/control/GOButtonControl.h
+++ b/src/grandorgue/control/GOButtonControl.h
@@ -16,6 +16,7 @@
 #include "midi/GOMidiShortcutReceiver.h"
 #include "sound/GOSoundStateHandler.h"
 
+#include "GOControl.h"
 #include "GOEventHandler.h"
 #include "GOSaveableObject.h"
 
@@ -25,7 +26,8 @@ class GOMidiEvent;
 class GOMidiMap;
 class GOOrganModel;
 
-class GOButtonControl : private GOEventHandler,
+class GOButtonControl : public GOControl,
+                        private GOEventHandler,
                         public GOSaveableObject,
                         public GOSoundStateHandler,
                         public GOMidiConfigurator {

--- a/src/grandorgue/control/GOControl.h
+++ b/src/grandorgue/control/GOControl.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOCONTROL_H
+#define GOCONTROL_H
+
+/* The base class of other controls */
+
+class GOControl {
+public:
+  virtual ~GOControl() {}
+};
+
+#endif /* GOCONTROL_H */

--- a/src/grandorgue/control/GOControlChangedHandler.h
+++ b/src/grandorgue/control/GOControlChangedHandler.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,11 +8,13 @@
 #ifndef GOCONTROLCHANGEDHANDLER_H
 #define GOCONTROLCHANGEDHANDLER_H
 
+class GOControl;
+
 class GOControlChangedHandler {
 public:
   virtual ~GOControlChangedHandler() {}
 
-  virtual void ControlChanged(void *control) = 0;
+  virtual void ControlChanged(GOControl *control) = 0;
 };
 
 #endif

--- a/src/grandorgue/control/GOLabelControl.h
+++ b/src/grandorgue/control/GOLabelControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,13 +14,15 @@
 #include "midi/GOMidiSender.h"
 #include "sound/GOSoundStateHandler.h"
 
+#include "GOControl.h"
 #include "GOSaveableObject.h"
 
 class GOConfigReader;
 class GOConfigWriter;
 class GOOrganController;
 
-class GOLabelControl : private GOSaveableObject,
+class GOLabelControl : public GOControl,
+                       private GOSaveableObject,
                        private GOSoundStateHandler,
                        public GOMidiConfigurator {
 protected:

--- a/src/grandorgue/control/GOPistonControl.cpp
+++ b/src/grandorgue/control/GOPistonControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -88,7 +88,7 @@ void GOPistonControl::Load(GOConfigReader &cfg, wxString group) {
   ControlChanged(drawstop);
 }
 
-void GOPistonControl::ControlChanged(void *control) {
+void GOPistonControl::ControlChanged(GOControl *control) {
   if (control == drawstop)
     Display(drawstop->IsEngaged() ^ drawstop->DisplayInverted());
 }

--- a/src/grandorgue/control/GOPistonControl.h
+++ b/src/grandorgue/control/GOPistonControl.h
@@ -20,7 +20,7 @@ class GOPistonControl : public GOPushbuttonControl,
 private:
   GOButtonControl *drawstop;
 
-  void ControlChanged(GOControl *control);
+  void ControlChanged(GOControl *control) override;
 
 public:
   GOPistonControl(GOOrganModel &organModel);

--- a/src/grandorgue/control/GOPistonControl.h
+++ b/src/grandorgue/control/GOPistonControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -20,7 +20,7 @@ class GOPistonControl : public GOPushbuttonControl,
 private:
   GOButtonControl *drawstop;
 
-  void ControlChanged(void *control);
+  void ControlChanged(GOControl *control);
 
 public:
   GOPistonControl(GOOrganModel &organModel);

--- a/src/grandorgue/gui/GOGUIControl.cpp
+++ b/src/grandorgue/gui/GOGUIControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -37,7 +37,7 @@ void GOGUIControl::Layout() {}
 
 void GOGUIControl::Save(GOConfigWriter &cfg) {}
 
-void GOGUIControl::ControlChanged(void *control) {
+void GOGUIControl::ControlChanged(GOControl *control) {
   if (control == m_control)
     if (!m_DrawPending) {
       m_DrawPending = true;

--- a/src/grandorgue/gui/GOGUIControl.h
+++ b/src/grandorgue/gui/GOGUIControl.h
@@ -36,7 +36,7 @@ protected:
   void Init(GOConfigReader &cfg, wxString group);
   void Save(GOConfigWriter &cfg);
 
-  void ControlChanged(GOControl *control);
+  void ControlChanged(GOControl *control) override;
 
 public:
   GOGUIControl(GOGUIPanel *panel, void *control);

--- a/src/grandorgue/gui/GOGUIControl.h
+++ b/src/grandorgue/gui/GOGUIControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -36,7 +36,7 @@ protected:
   void Init(GOConfigReader &cfg, wxString group);
   void Save(GOConfigWriter &cfg);
 
-  void ControlChanged(void *control);
+  void ControlChanged(GOControl *control);
 
 public:
   GOGUIControl(GOGUIPanel *panel, void *control);

--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,7 +13,7 @@
 #include "combinations/model/GOCombinationElement.h"
 #include "control/GOButtonControl.h"
 
-class GODrawstop : public GOButtonControl, public GOCombinationElement {
+class GODrawstop : public GOButtonControl, virtual public GOCombinationElement {
 public:
   typedef enum {
     FUNCTION_INPUT,

--- a/src/grandorgue/model/GOEnclosure.h
+++ b/src/grandorgue/model/GOEnclosure.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,6 +10,7 @@
 
 #include <wx/string.h>
 
+#include "control/GOControl.h"
 #include "midi/GOMidiConfigurator.h"
 #include "midi/GOMidiReceiver.h"
 #include "midi/GOMidiSender.h"
@@ -25,7 +26,8 @@ class GOMidiEvent;
 class GOMidiMap;
 class GOOrganModel;
 
-class GOEnclosure : private GOEventHandler,
+class GOEnclosure : public GOControl,
+                    private GOEventHandler,
                     private GOSaveableObject,
                     private GOSoundStateHandler,
                     public GOMidiConfigurator {

--- a/src/grandorgue/model/GOEventHandlerList.cpp
+++ b/src/grandorgue/model/GOEventHandlerList.cpp
@@ -9,7 +9,7 @@
 
 #include "control/GOControlChangedHandler.h"
 
-void GOEventHandlerList::SendControlChanged(void *pControl) {
+void GOEventHandlerList::SendControlChanged(GOControl *pControl) {
   for (auto handler : m_ControlChangedHandlers.AsVector())
     handler->ControlChanged(pControl);
 }

--- a/src/grandorgue/model/GOEventHandlerList.h
+++ b/src/grandorgue/model/GOEventHandlerList.h
@@ -14,6 +14,7 @@
 
 class GOCacheObject;
 class GOCombinationButtonSet;
+class GOControl;
 class GOControlChangedHandler;
 class GOEventHandler;
 class GOMidiConfigurator;
@@ -126,7 +127,7 @@ public:
    * Calls ControlChanged for all ControlChanged handlers
    * @param pControl - the control that state is changed
    */
-  void SendControlChanged(void *pControl);
+  void SendControlChanged(GOControl *pControl);
 
   void Cleanup();
 };

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -14,6 +14,7 @@
 
 #include "combinations/control/GOCombinationButtonSet.h"
 #include "combinations/model/GOCombinationDefinition.h"
+#include "control/GOControl.h"
 #include "midi/GOMidiConfigurator.h"
 #include "midi/GOMidiReceiver.h"
 #include "midi/GOMidiSender.h"
@@ -32,7 +33,8 @@ class GOSwitch;
 class GOTremulant;
 class GOOrganModel;
 
-class GOManual : private GOEventHandler,
+class GOManual : public GOControl,
+                 private GOEventHandler,
                  private GOCombinationButtonSet,
                  private GOSaveableObject,
                  private GOSoundStateHandler,


### PR DESCRIPTION
This is a second PR related to #1816

It 
- introduces a new class GOControl as a universal base for other controls 
- changed the parameter type of `ControlChanged` from `void *` to `GOControl *`

It added a capability of making a dynamic_cast from `GOControl` to other classes in the future.

It is just refactoring. No GO behavior should be changed.