### PR TITLE
Extracted class GODeviceNamePattern from GOMidiDeviceConfig

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -56,6 +56,7 @@ combinations/model/GOGeneralCombination.cpp
 combinations/GODivisionalSetter.cpp
 combinations/GOSetter.cpp
 config/GOConfig.cpp
+config/GODeviceNamePattern.cpp
 config/GOMidiDeviceConfig.cpp
 config/GOMidiDeviceConfigList.cpp
 config/GOPortsConfig.cpp

--- a/src/grandorgue/config/GODeviceNamePattern.cpp
+++ b/src/grandorgue/config/GODeviceNamePattern.cpp
@@ -12,8 +12,8 @@
 GODeviceNamePattern::GODeviceNamePattern(
   const wxString &logicalName,
   const wxString &regEx,
-  const wxString portName,
-  const wxString apiName,
+  const wxString &portName,
+  const wxString &apiName,
   const wxString &physicalName)
   : m_LogicalName(logicalName),
     m_PortName(portName),

--- a/src/grandorgue/config/GODeviceNamePattern.cpp
+++ b/src/grandorgue/config/GODeviceNamePattern.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GODeviceNamePattern.h"
+
+#include <wx/regex.h>
+
+GODeviceNamePattern::GODeviceNamePattern(
+  const wxString &logicalName,
+  const wxString &regEx,
+  const wxString portName,
+  const wxString apiName,
+  const wxString &physicalName)
+  : m_LogicalName(logicalName),
+    m_PortName(portName),
+    m_ApiName(apiName),
+    m_PhysicalName(physicalName) {
+  SetRegEx(regEx);
+}
+
+GODeviceNamePattern::~GODeviceNamePattern() {
+  if (m_CompiledRegEx)
+    delete m_CompiledRegEx;
+}
+
+void GODeviceNamePattern::AssignNamePattern(const GODeviceNamePattern &src) {
+  m_LogicalName = src.m_LogicalName;
+  m_PortName = src.m_PortName;
+  m_ApiName = src.m_ApiName;
+  SetRegEx(src.m_RegEx);
+  m_PhysicalName = src.m_PhysicalName;
+}
+
+void GODeviceNamePattern::SetRegEx(const wxString &regEx) {
+  if (regEx != m_RegEx) {
+    if (m_CompiledRegEx)
+      delete m_CompiledRegEx;
+    m_RegEx = regEx;
+    m_CompiledRegEx = regEx.IsEmpty() ? nullptr : new wxRegEx(regEx);
+  }
+}
+
+bool GODeviceNamePattern::DoesMatch(const wxString &physicalName) {
+  return (m_CompiledRegEx && m_CompiledRegEx->IsValid()
+          && m_CompiledRegEx->Matches(physicalName))
+    || m_LogicalName == physicalName;
+}

--- a/src/grandorgue/config/GODeviceNamePattern.h
+++ b/src/grandorgue/config/GODeviceNamePattern.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GODEVICENAMEPATTERN_H
+#define GODEVICENAMEPATTERN_H
+
+#include <wx/string.h>
+
+class wxRegEx;
+
+class GODeviceNamePattern {
+private:
+  wxRegEx *m_CompiledRegEx = nullptr;
+
+  wxString m_LogicalName;
+  wxString m_RegEx;
+  wxString m_PortName;
+  wxString m_ApiName;
+
+  // matchingResult. Not saved, only in memory
+  wxString m_PhysicalName;
+
+public:
+  GODeviceNamePattern(
+    const wxString &logicalName,
+    const wxString &regEx = wxEmptyString,
+    const wxString portName = wxEmptyString,
+    const wxString apiName = wxEmptyString,
+    const wxString &physicalName = wxEmptyString);
+
+  GODeviceNamePattern(const GODeviceNamePattern &src) {
+    AssignNamePattern(src);
+  }
+
+  ~GODeviceNamePattern();
+
+  const wxString &GetLogicalName() const { return m_LogicalName; }
+  void SetLogicalName(const wxString &name) { m_LogicalName = name; }
+
+  const wxString &GetRegEx() const { return m_RegEx; }
+  void SetRegEx(const wxString &regEx);
+
+  const wxString &GetPortName() const { return m_PortName; }
+  void SetPortName(const wxString &name) { m_PortName = name; }
+
+  const wxString &GetApiName() const { return m_ApiName; }
+  void SetApiName(const wxString &name) { m_ApiName = name; }
+
+  const wxString &GetPhysicalName() const { return m_PhysicalName; }
+  void SetPhysicalName(const wxString &name) { m_PhysicalName = name; }
+
+  void AssignNamePattern(const GODeviceNamePattern &src);
+
+  bool DoesMatch(const wxString &physicalName);
+};
+
+#endif /* GODEVICENAMEPATTERN_H */

--- a/src/grandorgue/config/GODeviceNamePattern.h
+++ b/src/grandorgue/config/GODeviceNamePattern.h
@@ -28,8 +28,8 @@ public:
   GODeviceNamePattern(
     const wxString &logicalName,
     const wxString &regEx = wxEmptyString,
-    const wxString portName = wxEmptyString,
-    const wxString apiName = wxEmptyString,
+    const wxString &portName = wxEmptyString,
+    const wxString &apiName = wxEmptyString,
     const wxString &physicalName = wxEmptyString);
 
   GODeviceNamePattern(const GODeviceNamePattern &src) {

--- a/src/grandorgue/config/GOMidiDeviceConfig.cpp
+++ b/src/grandorgue/config/GOMidiDeviceConfig.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,36 +14,16 @@ GOMidiDeviceConfig::GOMidiDeviceConfig(
   const wxString apiName,
   bool isEnabled,
   const wxString &physicalName)
-  : m_LogicalName(logicalName),
-    m_PortName(portName),
-    m_ApiName(apiName),
-    m_IsEnabled(isEnabled),
-    m_PhysicalName(physicalName) {
-  SetRegEx(regEx);
-}
+  : GODeviceNamePattern(logicalName, regEx, portName, apiName, physicalName),
+    m_IsEnabled(isEnabled) {}
 
-void GOMidiDeviceConfig::SetRegEx(const wxString &regEx) {
-  if (regEx != m_RegEx) {
-    if (p_CompiledRegEx)
-      delete p_CompiledRegEx;
-    m_RegEx = regEx;
-    p_CompiledRegEx = regEx.IsEmpty() ? NULL : new wxRegEx(regEx);
-  }
-}
-
-void GOMidiDeviceConfig::Assign(const GOMidiDeviceConfig &src) {
-  m_LogicalName = src.m_LogicalName;
-  m_PortName = src.m_PortName;
-  m_ApiName = src.m_ApiName;
-  SetRegEx(src.m_RegEx);
+void GOMidiDeviceConfig::AssignMidiDeviceConfig(const GOMidiDeviceConfig &src) {
   m_IsEnabled = src.m_IsEnabled;
   m_ChannelShift = src.m_ChannelShift;
-  m_PhysicalName = src.m_PhysicalName;
   p_OutputDevice = NULL;
 }
 
-bool GOMidiDeviceConfig::DoesMatch(const wxString &physicalName) {
-  return (p_CompiledRegEx && p_CompiledRegEx->IsValid()
-          && p_CompiledRegEx->Matches(physicalName))
-    || m_LogicalName == physicalName;
+void GOMidiDeviceConfig::Assign(const GOMidiDeviceConfig &src) {
+  AssignNamePattern(src);
+  AssignMidiDeviceConfig(src);
 }

--- a/src/grandorgue/config/GOMidiDeviceConfig.cpp
+++ b/src/grandorgue/config/GOMidiDeviceConfig.cpp
@@ -10,8 +10,8 @@
 GOMidiDeviceConfig::GOMidiDeviceConfig(
   const wxString &logicalName,
   const wxString &regEx,
-  const wxString portName,
-  const wxString apiName,
+  const wxString &portName,
+  const wxString &apiName,
   bool isEnabled,
   const wxString &physicalName)
   : GODeviceNamePattern(logicalName, regEx, portName, apiName, physicalName),

--- a/src/grandorgue/config/GOMidiDeviceConfig.h
+++ b/src/grandorgue/config/GOMidiDeviceConfig.h
@@ -30,8 +30,8 @@ public:
   GOMidiDeviceConfig(
     const wxString &logicalName,
     const wxString &regEx = wxEmptyString,
-    const wxString portName = wxEmptyString,
-    const wxString apiName = wxEmptyString,
+    const wxString &portName = wxEmptyString,
+    const wxString &apiName = wxEmptyString,
     bool isEnabled = true,
     const wxString &physicalName = wxEmptyString);
 

--- a/src/grandorgue/config/GOMidiDeviceConfig.h
+++ b/src/grandorgue/config/GOMidiDeviceConfig.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,30 +8,24 @@
 #ifndef GOMIDIDEVICECONFIG_H
 #define GOMIDIDEVICECONFIG_H
 
-#include <wx/regex.h>
 #include <wx/string.h>
 
 #include <vector>
 
-class GOMidiDeviceConfig {
+#include "GODeviceNamePattern.h"
+
+class GOMidiDeviceConfig : public GODeviceNamePattern {
 private:
-  wxRegEx *p_CompiledRegEx = NULL;
+  void AssignMidiDeviceConfig(const GOMidiDeviceConfig &src);
 
 public:
   typedef std::vector<GOMidiDeviceConfig *> RefVector;
 
-  wxString m_LogicalName;
-  wxString m_RegEx;
-  wxString m_PortName;
-  wxString m_ApiName;
   bool m_IsEnabled;
 
   // Midi-in only
   int m_ChannelShift = 0;
   GOMidiDeviceConfig *p_OutputDevice = NULL;
-
-  // matchingResult. Not saved, only in memory
-  wxString m_PhysicalName;
 
   GOMidiDeviceConfig(
     const wxString &logicalName,
@@ -43,11 +37,9 @@ public:
 
   void Assign(const GOMidiDeviceConfig &src);
 
-  GOMidiDeviceConfig(const GOMidiDeviceConfig &src) { Assign(src); }
-
-  void SetRegEx(const wxString &regEx);
-
-  bool DoesMatch(const wxString &physicalName);
+  GOMidiDeviceConfig(const GOMidiDeviceConfig &src) : GODeviceNamePattern(src) {
+    AssignMidiDeviceConfig(src);
+  }
 };
 
 #endif /* GOMIDIDEVICECONFIG_H */

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventRecvTab.cpp
@@ -207,9 +207,9 @@ GOMidiEventRecvTab::GOMidiEventRecvTab(
   m_device->Append(_("Any device"));
   for (GOMidiDeviceConfig *pDevConf : m_MidiIn)
     if (
-      portsConfig.IsEnabled(pDevConf->m_PortName, pDevConf->m_ApiName)
+      portsConfig.IsEnabled(pDevConf->GetPortName(), pDevConf->GetApiName())
       && pDevConf->m_IsEnabled)
-      m_device->Append(pDevConf->m_LogicalName);
+      m_device->Append(pDevConf->GetLogicalName());
 
   m_channel->Append(_("Any channel"));
   for (unsigned int i = 1; i <= 16; i++)

--- a/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
+++ b/src/grandorgue/dialogs/midi-event/GOMidiEventSendTab.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -194,9 +194,9 @@ GOMidiEventSendTab::GOMidiEventSendTab(
   m_device->Append(_("Any device"));
   for (const GOMidiDeviceConfig *pDevConf : m_MidiOut)
     if (
-      portsConfig.IsEnabled(pDevConf->m_PortName, pDevConf->m_ApiName)
+      portsConfig.IsEnabled(pDevConf->GetPortName(), pDevConf->GetApiName())
       && pDevConf->m_IsEnabled)
-      m_device->Append(pDevConf->m_LogicalName);
+      m_device->Append(pDevConf->GetLogicalName());
 
   for (unsigned int i = 1; i <= 16; i++)
     m_channel->Append(wxString::Format(wxT("%d"), i));
@@ -482,8 +482,9 @@ GOMidiSenderEventPattern GOMidiEventSendTab::CopyEvent() {
     : NULL;
   const GOMidiDeviceConfig *pOutDev = pInDev ? pInDev->p_OutputDevice : NULL;
 
-  e.deviceId
-    = pOutDev ? m_MidiMap.GetDeviceIdByLogicalName(pOutDev->m_LogicalName) : 0;
+  e.deviceId = pOutDev
+    ? m_MidiMap.GetDeviceIdByLogicalName(pOutDev->GetLogicalName())
+    : 0;
 
   e.type = MIDI_S_NONE;
   e.channel = 1;

--- a/src/grandorgue/dialogs/settings/GOSettingsMidiDeviceList.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsMidiDeviceList.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -101,7 +101,7 @@ void GOSettingsMidiDeviceList::OnMatchingClick(wxCommandEvent &event) {
   if (dlg.ShowModal() == wxID_OK) {
     dlg.SaveTo(devConf);
     m_ConfListTmp.RemoveByLogicalNameOutOf(
-      devConf.m_LogicalName, m_ListedConfs);
+      devConf.GetLogicalName(), m_ListedConfs);
   }
 }
 
@@ -109,9 +109,9 @@ void GOSettingsMidiDeviceList::Save(
   const GOSettingsMidiDeviceList *pOutDevList) {
   for (GOMidiDeviceConfig *pDevConfTmp : m_ListedConfs) {
     GOMidiDeviceConfig *pDevConf = m_ConfList.FindByPhysicalName(
-      pDevConfTmp->m_PhysicalName,
-      pDevConfTmp->m_PortName,
-      pDevConfTmp->m_ApiName);
+      pDevConfTmp->GetPhysicalName(),
+      pDevConfTmp->GetPortName(),
+      pDevConfTmp->GetApiName());
     const GOMidiDeviceConfigList *pOutConfList
       = pOutDevList ? &pOutDevList->m_ConfList : NULL;
 
@@ -124,6 +124,6 @@ void GOSettingsMidiDeviceList::Save(
 
     // remove unlisted devices with the same logical name
     m_ConfList.RemoveByLogicalNameOutOf(
-      pDevConfTmp->m_LogicalName, m_ListedConfs);
+      pDevConfTmp->GetLogicalName(), m_ListedConfs);
   }
 }

--- a/src/grandorgue/dialogs/settings/GOSettingsMidiDevices.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsMidiDevices.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -137,8 +137,8 @@ void SettingsMidiDevices::RenewDevices(
   for (unsigned l = m_OutDevices.GetDeviceCount(), i = 0; i < l; i++) {
     const GOMidiDeviceConfig &c = m_OutDevices.GetDeviceConf(i);
 
-    m_RecorderDevice->Append(c.m_PhysicalName);
-    if (m_config.MidiRecorderOutputDevice() == c.m_LogicalName)
+    m_RecorderDevice->Append(c.GetPhysicalName());
+    if (m_config.MidiRecorderOutputDevice() == c.GetLogicalName())
       m_RecorderDevice->SetSelection(i + 1);
   }
 }
@@ -166,7 +166,7 @@ void SettingsMidiDevices::OnInOutDeviceClick(wxCommandEvent &event) {
 
   if (devConf.p_OutputDevice)
     for (unsigned i = 1; i < choices.GetCount(); i++)
-      if (choices[i] == devConf.p_OutputDevice->m_PhysicalName)
+      if (choices[i] == devConf.p_OutputDevice->GetPhysicalName())
         selection = i;
 
   int result = wxGetSingleChoiceIndex(
@@ -192,7 +192,7 @@ void SettingsMidiDevices::OnInChannelShiftClick(wxCommandEvent &event) {
       "interface's channel 1 to appear as channel 9,\n"
       "channel 2 to appear as channel 10, and so on."),
     _("Channel offset:"),
-    devConf.m_PhysicalName,
+    devConf.GetPhysicalName(),
     devConf.m_ChannelShift,
     0,
     15,
@@ -219,6 +219,6 @@ bool SettingsMidiDevices::TransferDataFromWindow() {
     m_config.MidiRecorderOutputDevice(wxEmptyString);
   else
     m_config.MidiRecorderOutputDevice(
-      m_OutDevices.GetDeviceConf(iRec - 1).m_LogicalName);
+      m_OutDevices.GetDeviceConf(iRec - 1).GetLogicalName());
   return true;
 }

--- a/src/grandorgue/dialogs/settings/GOSettingsMidiMatchDialog.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsMidiMatchDialog.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -9,6 +9,7 @@
 
 #include <wx/app.h>
 #include <wx/msgdlg.h>
+#include <wx/regex.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/statusbr.h>
@@ -76,10 +77,10 @@ GOSettingsMidiMatchDialog::GOSettingsMidiMatchDialog(
 }
 
 void GOSettingsMidiMatchDialog::FillWith(const GOMidiDeviceConfig &devConf) {
-  m_PhysicalName = devConf.m_PhysicalName;
-  t_PhysicalName->ChangeValue(devConf.m_PhysicalName);
-  t_LogicalName->ChangeValue(devConf.m_LogicalName);
-  t_regex->ChangeValue(devConf.m_RegEx);
+  m_PhysicalName = devConf.GetPhysicalName();
+  t_PhysicalName->ChangeValue(devConf.GetPhysicalName());
+  t_LogicalName->ChangeValue(devConf.GetLogicalName());
+  t_regex->ChangeValue(devConf.GetRegEx());
 }
 
 bool GOSettingsMidiMatchDialog::ValidateLogicalName(wxString &errMsg) {
@@ -94,10 +95,10 @@ bool GOSettingsMidiMatchDialog::ValidateLogicalName(wxString &errMsg) {
     // Check logicalName for uniqueness
     for (const GOMidiDeviceConfig *pDev : *p_OtherDevices)
       if (
-        pDev->m_PhysicalName != m_PhysicalName
-        && pDev->m_LogicalName == newLogicalName) {
-        errMsg
-          = _("Logical device name is already used by ") + pDev->m_PhysicalName;
+        pDev->GetPhysicalName() != m_PhysicalName
+        && pDev->GetLogicalName() == newLogicalName) {
+        errMsg = _("Logical device name is already used by ")
+          + pDev->GetPhysicalName();
         isValid = false;
         break;
       }
@@ -167,6 +168,6 @@ bool GOSettingsMidiMatchDialog::Validate() {
 }
 
 void GOSettingsMidiMatchDialog::SaveTo(GOMidiDeviceConfig &devConf) {
-  devConf.m_LogicalName = t_LogicalName->GetValue();
+  devConf.SetLogicalName(t_LogicalName->GetValue());
   devConf.SetRegEx(t_regex->GetValue());
 }

--- a/src/grandorgue/midi/GOMidi.cpp
+++ b/src/grandorgue/midi/GOMidi.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -60,7 +60,7 @@ void GOMidi::Open() {
     if (pDevConf && pDevConf->m_IsEnabled)
       ((GOMidiInPort *)pPort)
         ->Open(
-          m_MidiMap.GetDeviceIdByLogicalName(pDevConf->m_LogicalName),
+          m_MidiMap.GetDeviceIdByLogicalName(pDevConf->GetLogicalName()),
           pDevConf->m_ChannelShift);
     else
       pPort->Close();
@@ -75,7 +75,8 @@ void GOMidi::Open() {
       pPort->IsToUse() && portsConfig.IsEnabled(portName, apiName)
       && (devConf = m_config.m_MidiOut.FindByPhysicalName(pPort->GetName(), portName, apiName))
       && devConf->m_IsEnabled)
-      pPort->Open(m_MidiMap.GetDeviceIdByLogicalName(devConf->m_LogicalName));
+      pPort->Open(
+        m_MidiMap.GetDeviceIdByLogicalName(devConf->GetLogicalName()));
     else
       pPort->Close();
   }


### PR DESCRIPTION
This is the first PR related to #1265

It extracts the matching device name code from `GOMidiDeviceConfig` to a new class `GODeviceNamePattern`.

It is just refactoring. No GO behavior should be changed.
