### PR TITLE
Fixed not compatibilyty between polyphase interpolation and loseless compression https://github.com/GrandOrgue/grandorgue/issues/710

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed not compatibilyty between polyphase interpolation and loseless compression https://github.com/GrandOrgue/grandorgue/issues/710
 - Fixed not sounding of pipe after an enclosure has closed to zero and then opened https://github.com/GrandOrgue/grandorgue/issues/1813
 - Added Midi listener for Panic button and Exit GO function. https://github.com/GrandOrgue/grandorgue/issues/1905
 - Added a tone balance (bass/treble harmonics balance) voicing option

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -185,7 +185,7 @@ GOHashType GOOrganController::GenerateCacheHash() {
   hash.Update(sizeof(GOSoundingPipe));
   hash.Update(sizeof(GOSoundReleaseAlignTable));
   hash.Update(BLOCK_HISTORY);
-  hash.Update(MAX_READAHEAD);
+  hash.Update(GOSoundAudioSection::getMaxReadAhead());
   hash.Update(SHORT_LOOP_LENGTH);
   GOSoundProvider::UpdateCacheHash(hash);
   hash.Update(sizeof(GOSoundAudioSection::StartSegment));

--- a/src/grandorgue/dialogs/settings/GOSettingsOptions.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsOptions.cpp
@@ -426,15 +426,6 @@ GOSettingsOptions::GOSettingsOptions(GOConfig &settings, wxWindow *parent)
 }
 
 bool GOSettingsOptions::TransferDataFromWindow() {
-  if (
-    m_Interpolation->GetSelection() == 1 && m_LosslessCompression->IsChecked())
-    wxMessageBox(
-      _("Polyphase is not supported with lossless compression - "
-        "falling back to linear."),
-      _("Warning"),
-      wxOK | wxICON_WARNING,
-      this);
-
   m_config.LosslessCompression(m_LosslessCompression->IsChecked());
   m_config.ManagePolyphony(m_Limit->IsChecked());
   m_config.CompressCache(m_CompressCache->IsChecked());

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -27,7 +27,11 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+// maximal readahead is necessary for polyphase resampling
+static constexpr unsigned MAX_READAHEAD = GOSoundResample::POLYPHASE_POINTS;
 static constexpr unsigned DEFAULT_END_SEG_LENGTH = MAX_READAHEAD * 2;
+
+const unsigned GOSoundAudioSection::getMaxReadAhead() { return MAX_READAHEAD; }
 
 GOSoundAudioSection::GOSoundAudioSection(GOMemoryPool &pool)
   : m_data(NULL),

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -14,7 +14,6 @@
 #include "GOBool3.h"
 #include "GOInt.h"
 #include "GOSoundCompress.h"
-#include "GOSoundDefs.h"
 #include "GOSoundResample.h"
 #include "GOWave.h"
 
@@ -29,6 +28,8 @@ class GOSampleStatistic;
 
 class GOSoundAudioSection {
 public:
+  static const unsigned getMaxReadAhead();
+
   struct StartSegment {
     /* Sample offset into entire audio section where data begins. */
     unsigned start_offset;

--- a/src/grandorgue/sound/GOSoundDefs.h
+++ b/src/grandorgue/sound/GOSoundDefs.h
@@ -11,8 +11,6 @@
 /* Number of samples to match for release alignment. */
 #define BLOCK_HISTORY (2)
 
-/* Maximum of the above values */
-#define MAX_READAHEAD (8)
 /* Minimum remaining loop length after a crossfade */
 #define REMAINING_AFTER_CROSSFADE 256
 

--- a/src/grandorgue/sound/GOSoundResample.cpp
+++ b/src/grandorgue/sound/GOSoundResample.cpp
@@ -107,10 +107,10 @@ unsigned GOSoundResample::getVectorLength(
 
   switch (interpolation) {
   case GO_LINEAR_INTERPOLATION:
-    res = LinearResampler::getVectorLength();
+    res = LinearResampler::VECTOR_LENGTH;
     break;
   case GO_POLYPHASE_INTERPOLATION:
-    res = PolyphaseResampler::getVectorLength();
+    res = PolyphaseResampler::VECTOR_LENGTH;
   }
   return res;
 }

--- a/src/grandorgue/sound/GOSoundResample.h
+++ b/src/grandorgue/sound/GOSoundResample.h
@@ -249,7 +249,7 @@ public:
      * @return Necessary number of continous input samples for calculating one
      * output sample
      */
-    static constexpr unsigned getVectorLength() { return nPoints; }
+    static constexpr unsigned VECTOR_LENGTH = nPoints;
 
     /**
      * Do actual resampling of an input sample block to the output block of the


### PR DESCRIPTION
Resolves: #710

This PR adds an implementation of polyphase interpolation for compressed samples. 
- It adds the `OSoundStream::StreamCacheReadAheadWindow` class for providing a vector of 8 continous samples necessary for polyphase interpolation from a compressed stream. 
- Now GOSoundStream::getDecodeBlockFunction supports a combination of compressed + polyphase
- Removes warning from GOSettingsOptions::TransferDataFromWindow when compressed + polyphase are both selected

It also makes a few of cosmetic changes:
- Moves the MAX_READAHEAD constant from GOSoundDefs.h to GOSoundAudioSection.cpp
- Replaces the getVectorLength() function with the VECTOR_LENGTH constant
- Moves StreamPtrWindow and StreamCacheWindow classes inside the GOSoundStream class
- Removes the check margin code