### PR TITLE
Extracted class GOAudioDeviceConfig into a separate file

### DIFF
--- a/src/grandorgue/config/GOAudioDeviceConfig.h
+++ b/src/grandorgue/config/GOAudioDeviceConfig.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOAUDIODEVICECONFIG_H
+#define GOAUDIODEVICECONFIG_H
+
+class GOAudioDeviceConfig {
+public:
+  struct GroupOutput {
+    wxString name;
+    float left;
+    float right;
+  };
+
+  wxString name;
+  unsigned channels;
+  unsigned desired_latency;
+  std::vector<std::vector<GroupOutput>> scale_factors;
+};
+
+#endif /* GOAUDIODEVICECONFIG_H */

--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -343,7 +343,7 @@ void GOConfig::Load() {
         unsigned group_count = cfg.ReadInteger(
           CMBSetting, wxT("AudioDevices"), prefix + wxT("GroupCount"), 0, 200);
         for (unsigned k = 0; k < group_count; k++) {
-          GOAudioGroupOutputConfig group;
+          GOAudioDeviceConfig::GroupOutput group;
           wxString p = prefix + wxString::Format(wxT("Group%03d"), k + 1);
 
           group.name
@@ -405,7 +405,7 @@ void GOConfig::Load() {
     conf.scale_factors.resize(conf.channels);
     conf.desired_latency = GetDefaultLatency();
     for (unsigned k = 0; k < m_AudioGroups.size(); k++) {
-      GOAudioGroupOutputConfig group;
+      GOAudioDeviceConfig::GroupOutput group;
       group.name = m_AudioGroups[k];
 
       group.left = 0.0f;

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -28,23 +28,11 @@
 #include "size/GOLogicalRect.h"
 #include "temperaments/GOTemperamentList.h"
 
+#include "GOAudioDeviceConfig.h"
 #include "GOMidiDeviceConfigList.h"
 #include "GOOrganList.h"
 #include "GOPortsConfig.h"
 #include "ptrvector.h"
-
-typedef struct {
-  wxString name;
-  float left;
-  float right;
-} GOAudioGroupOutputConfig;
-
-typedef struct {
-  wxString name;
-  unsigned channels;
-  unsigned desired_latency;
-  std::vector<std::vector<GOAudioGroupOutputConfig>> scale_factors;
-} GOAudioDeviceConfig;
 
 typedef struct {
   GOMidiReceiverType type;

--- a/src/grandorgue/dialogs/settings/GOSettingsAudio.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsAudio.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -767,7 +767,8 @@ bool GOSettingsAudio::TransferDataFromWindow() {
               conf.scale_factors[channel_id][l].right = data->volume;
           }
         if (!found) {
-          GOAudioGroupOutputConfig gconf;
+          GOAudioDeviceConfig::GroupOutput gconf;
+
           gconf.name = data->name;
           gconf.left = -121;
           gconf.right = -121;


### PR DESCRIPTION
This is a second PR related to #1265

It only reorganises thesource code files. No GO behavior should be changed.