### PR TITLE
Simplified adding a device output node in the Settings/Audio panel

### DIFF
--- a/src/grandorgue/dialogs/settings/GOSettingsAudio.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsAudio.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -224,18 +224,18 @@ bool GOSettingsAudio::TransferDataToWindow() {
       if (j >= audio_config[i].scale_factors.size())
         continue;
       for (unsigned k = 0; k < audio_config[i].scale_factors[j].size(); k++) {
-        if (audio_config[i].scale_factors[j][k].left >= -120) {
-          wxTreeItemId group;
-          group = AddGroupNode(
-            channel, audio_config[i].scale_factors[j][k].name, true);
-          UpdateVolume(group, audio_config[i].scale_factors[j][k].left);
-        }
-        if (audio_config[i].scale_factors[j][k].right >= -120) {
-          wxTreeItemId group;
-          group = AddGroupNode(
-            channel, audio_config[i].scale_factors[j][k].name, false);
-          UpdateVolume(group, audio_config[i].scale_factors[j][k].right);
-        }
+        if (audio_config[i].scale_factors[j][k].left >= -120)
+          AddGroupNode(
+            channel,
+            audio_config[i].scale_factors[j][k].name,
+            true,
+            audio_config[i].scale_factors[j][k].left);
+        if (audio_config[i].scale_factors[j][k].right >= -120)
+          AddGroupNode(
+            channel,
+            audio_config[i].scale_factors[j][k].name,
+            false,
+            audio_config[i].scale_factors[j][k].right);
       }
     }
   }

--- a/src/grandorgue/dialogs/settings/GOSettingsAudio.cpp
+++ b/src/grandorgue/dialogs/settings/GOSettingsAudio.cpp
@@ -338,7 +338,7 @@ wxTreeItemId GOSettingsAudio::AddChannelNode(
 }
 
 wxTreeItemId GOSettingsAudio::AddGroupNode(
-  const wxTreeItemId &channel, const wxString &name, bool left) {
+  const wxTreeItemId &channel, const wxString &name, bool left, float volume) {
   wxTreeItemId current;
   current = GetGroupNode(channel, name, left);
   if (current.IsOk())
@@ -347,7 +347,7 @@ wxTreeItemId GOSettingsAudio::AddGroupNode(
     channel, name, -1, -1, new AudioItemData(name, left, -121));
   m_AudioOutput->Expand(current);
   m_AudioOutput->Expand(channel);
-  UpdateVolume(current, -121);
+  UpdateVolume(current, volume);
   return current;
 }
 
@@ -535,9 +535,7 @@ void GOSettingsAudio::OnOutputAdd(wxCommandEvent &event) {
       _("Add new audio group"), _("New audio group"), names, this);
     if (index == -1)
       return;
-    wxTreeItemId id
-      = AddGroupNode(selection, groups[index].first, groups[index].second);
-    UpdateVolume(id, 0);
+    AddGroupNode(selection, groups[index].first, groups[index].second, 0);
   } else if (data && data->type == AudioItemData::ROOT_NODE) {
     int index;
     wxArrayString devs;
@@ -688,7 +686,7 @@ void GOSettingsAudio::OnOutputDefault(wxCommandEvent &event) {
     == wxNO)
     return;
   wxTreeItemId root = m_AudioOutput->GetRootItem();
-  wxTreeItemId audio, channel, group;
+  wxTreeItemId audio, channel;
   wxTreeItemIdValue i;
   wxString dev_name = wxEmptyString;
   audio = m_AudioOutput->GetFirstChild(root, i);
@@ -702,17 +700,13 @@ void GOSettingsAudio::OnOutputDefault(wxCommandEvent &event) {
   audio = AddDeviceNode(dev_name);
   channel = AddChannelNode(audio, 0);
 
-  for (unsigned l = m_AudioGroups->GetCount(), i = 0; i < l; i++) {
-    group = AddGroupNode(channel, m_AudioGroups->GetString(i), true);
-    UpdateVolume(group, 0);
-  }
+  for (unsigned l = m_AudioGroups->GetCount(), i = 0; i < l; i++)
+    AddGroupNode(channel, m_AudioGroups->GetString(i), true, 0);
 
   channel = AddChannelNode(audio, 1);
 
-  for (unsigned l = m_AudioGroups->GetCount(), i = 0; i < l; i++) {
-    group = AddGroupNode(channel, m_AudioGroups->GetString(i), false);
-    UpdateVolume(group, 0);
-  }
+  for (unsigned l = m_AudioGroups->GetCount(), i = 0; i < l; i++)
+    AddGroupNode(channel, m_AudioGroups->GetString(i), false, 0);
 
   m_AudioOutput->ExpandAll();
   UpdateButtons();

--- a/src/grandorgue/dialogs/settings/GOSettingsAudio.h
+++ b/src/grandorgue/dialogs/settings/GOSettingsAudio.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -77,7 +77,7 @@ private:
   wxTreeItemId AddDeviceNode(wxString name, unsigned latency);
   wxTreeItemId AddChannelNode(const wxTreeItemId &audio, unsigned channel);
   wxTreeItemId AddGroupNode(
-    const wxTreeItemId &channel, const wxString &name, bool left);
+    const wxTreeItemId &channel, const wxString &name, bool left, float volume);
   void UpdateDevice(const wxTreeItemId &dev);
   void UpdateVolume(const wxTreeItemId &group, float volume);
   void UpdateButtons();


### PR DESCRIPTION
This is a next PR related to #1265 

This is a small code enchancement in GOSettingsAudio: earlier AddGroupNode set output level to mute and the caller had to call UpdateVolume after AddGroupNode.

Now AddGroupNode accepts the volume as a parameter.

This is just refactoring. No GO behavior should be changed.