### PR TITLE
Incapsulated GODeviceConfig code

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -55,6 +55,7 @@ combinations/model/GODivisionalCombination.cpp
 combinations/model/GOGeneralCombination.cpp
 combinations/GODivisionalSetter.cpp
 combinations/GOSetter.cpp
+config/GOAudioDeviceConfig.cpp
 config/GOConfig.cpp
 config/GODeviceNamePattern.cpp
 config/GOMidiDeviceConfig.cpp

--- a/src/grandorgue/config/GOAudioDeviceConfig.cpp
+++ b/src/grandorgue/config/GOAudioDeviceConfig.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOAudioDeviceConfig.h"
+
+#include <algorithm>
+
+#include "config/GOConfigReader.h"
+#include "config/GOConfigWriter.h"
+
+static constexpr unsigned DEFAULT_LATENCY = 50;
+const wxString GOAudioDeviceConfig::WX_AUDIO_DEVICES = wxT("AudioDevices");
+
+GOAudioDeviceConfig::GOAudioDeviceConfig(
+  const wxString &name, unsigned desiredLatency, uint8_t channels)
+  : m_name(name), m_DesiredLatency(desiredLatency), m_channels(channels) {
+  m_ChannelOutputs.resize(channels);
+}
+
+GOAudioDeviceConfig::GOAudioDeviceConfig()
+  : GOAudioDeviceConfig(wxEmptyString, DEFAULT_LATENCY, 0) {}
+
+GOAudioDeviceConfig::GOAudioDeviceConfig(
+  const std::vector<wxString> &audioGroups)
+  : GOAudioDeviceConfig(wxEmptyString, DEFAULT_LATENCY, 2) {
+  std::vector<GroupOutput> &leftOutput = m_ChannelOutputs[0];
+  std::vector<GroupOutput> &rightOutput = m_ChannelOutputs[1];
+  for (const auto &groupName : audioGroups) {
+    leftOutput.emplace_back(groupName, true, DEFAULT_VOLUME);
+    rightOutput.emplace_back(groupName, false, DEFAULT_VOLUME);
+  }
+}
+
+static const wxString WX_DVICE_03D_FMT = wxT("Device%03d");
+static const wxString WX_NAME = wxT("Name");
+static const wxString WX_CHANNEL_COUNT = wxT("ChannelCount");
+static const wxString WX_LATENCY = wxT("Latency");
+static const wxString WX_CHANNEL_03D_FMT = wxT("Channel%03d");
+static const wxString WX_GROUP_COUNT = wxT("GroupCount");
+static const wxString WX_GROUP_03D_FMT = wxT("Group%03d");
+static const wxString WX_LEFT = wxT("Left");
+static const wxString WX_RIGHT = wxT("Right");
+
+void GOAudioDeviceConfig::Load(GOConfigReader &cfg, unsigned deviceN) {
+  const wxString p0 = wxString::Format(WX_DVICE_03D_FMT, deviceN);
+
+  m_name = cfg.ReadString(CMBSetting, WX_AUDIO_DEVICES, p0 + WX_NAME);
+  m_DesiredLatency = cfg.ReadInteger(
+    CMBSetting,
+    WX_AUDIO_DEVICES,
+    p0 + WX_LATENCY,
+    0,
+    999,
+    false,
+    DEFAULT_LATENCY);
+  m_channels = (uint8_t)cfg.ReadInteger(
+    CMBSetting, WX_AUDIO_DEVICES, p0 + WX_CHANNEL_COUNT, 0, 200);
+  m_ChannelOutputs.resize(m_channels);
+  for (uint8_t j = 0; j < m_channels; j++) {
+    const wxString p1 = p0 + wxString::Format(WX_CHANNEL_03D_FMT, j + 1);
+    std::vector<GroupOutput> &groups = m_ChannelOutputs[j];
+    const unsigned groupCount = cfg.ReadInteger(
+      CMBSetting, WX_AUDIO_DEVICES, p1 + WX_GROUP_COUNT, 0, 200);
+
+    for (unsigned k = 0; k < groupCount; k++) {
+      const wxString p2 = p1 + wxString::Format(WX_GROUP_03D_FMT, k + 1);
+
+      groups.emplace_back(
+        cfg.ReadString(CMBSetting, WX_AUDIO_DEVICES, p2 + WX_NAME),
+        (float)cfg.ReadFloat(
+          CMBSetting, WX_AUDIO_DEVICES, p2 + WX_LEFT, MUTE_VOLUME, MAX_VOLUME),
+        (float)cfg.ReadFloat(
+          CMBSetting,
+          WX_AUDIO_DEVICES,
+          p2 + WX_RIGHT,
+          MUTE_VOLUME,
+          MAX_VOLUME));
+    }
+  }
+}
+
+void GOAudioDeviceConfig::Save(GOConfigWriter &cfg, unsigned deviceN) const {
+  const wxString p0 = wxString::Format(WX_DVICE_03D_FMT, deviceN);
+
+  cfg.WriteString(WX_AUDIO_DEVICES, p0 + WX_NAME, m_name);
+  cfg.WriteInteger(WX_AUDIO_DEVICES, p0 + WX_CHANNEL_COUNT, m_channels);
+  cfg.WriteInteger(WX_AUDIO_DEVICES, p0 + WX_LATENCY, m_DesiredLatency);
+  for (uint8_t j = 0; j < m_channels; j++) {
+    const wxString p1 = p0 + wxString::Format(WX_CHANNEL_03D_FMT, j + 1);
+    const std::vector<GroupOutput> &groups = m_ChannelOutputs[j];
+    const unsigned groupCount = groups.size();
+
+    cfg.WriteInteger(WX_AUDIO_DEVICES, p1 + WX_GROUP_COUNT, groupCount);
+    for (unsigned k = 0; k < groupCount; k++) {
+      const GroupOutput &group = groups[k];
+      const wxString p2 = p1 + wxString::Format(WX_GROUP_03D_FMT, k + 1);
+
+      cfg.WriteString(WX_AUDIO_DEVICES, p2 + WX_NAME, group.GetName());
+      cfg.WriteFloat(WX_AUDIO_DEVICES, p2 + WX_LEFT, group.GetLeft());
+      cfg.WriteFloat(WX_AUDIO_DEVICES, p2 + WX_RIGHT, group.GetRight());
+    }
+  }
+}
+
+void GOAudioDeviceConfig::SetOutputVolume(
+  uint8_t channel, const wxString &groupName, bool isLeft, float vol) {
+  auto &groups = m_ChannelOutputs[channel];
+  auto groupsEnd = groups.end();
+  auto iExistingGroup
+    = std::find_if(groups.begin(), groups.end(), [&groupName](const auto &g) {
+        return g.GetName() == groupName;
+      });
+
+  if (iExistingGroup == groupsEnd)
+    groups.emplace_back(
+      groupName, volumeFor(true, isLeft, vol), volumeFor(false, isLeft, vol));
+  else
+    iExistingGroup->SetVolume(isLeft, vol);
+}

--- a/src/grandorgue/config/GOAudioDeviceConfig.h
+++ b/src/grandorgue/config/GOAudioDeviceConfig.h
@@ -8,18 +8,80 @@
 #ifndef GOAUDIODEVICECONFIG_H
 #define GOAUDIODEVICECONFIG_H
 
+#include <cstdint>
+#include <vector>
+
+#include <wx/string.h>
+
+class GOConfigReader;
+class GOConfigWriter;
+
 class GOAudioDeviceConfig {
 public:
-  struct GroupOutput {
-    wxString name;
-    float left;
-    float right;
+  // volume values in dB
+  static constexpr float MUTE_VOLUME = -121.0f;
+  static constexpr float MIN_VOLUME = -120.0f;
+  static constexpr float DEFAULT_VOLUME = 0.0f;
+  static constexpr float MAX_VOLUME = 40.0f;
+
+  static const wxString WX_AUDIO_DEVICES;
+
+  static bool isEnabled(float vol) { return vol >= MIN_VOLUME; }
+
+  class GroupOutput {
+  private:
+    wxString m_name;
+    float m_left;
+    float m_right;
+
+  public:
+    GroupOutput(const wxString &name, float left, float right)
+      : m_name(name), m_left(left), m_right(right) {}
+
+    const wxString &GetName() const { return m_name; }
+    const bool IsLeftEnabled() const { return isEnabled(m_left); }
+    const bool IsRightEnabled() const { return isEnabled(m_right); }
+    const float GetLeft() const { return m_left; }
+    const float GetRight() const { return m_right; }
+
+    void SetVolume(bool isLeft, float vol) {
+      (isLeft ? m_left : m_right) = vol;
+    }
   };
 
-  wxString name;
-  unsigned channels;
-  unsigned desired_latency;
-  std::vector<std::vector<GroupOutput>> scale_factors;
+private:
+  std::vector<std::vector<GroupOutput>> m_ChannelOutputs;
+  wxString m_name;
+  unsigned m_DesiredLatency;
+  uint8_t m_channels;
+
+  static float volumeFor(bool isForLeft, bool isLeft, float vol) {
+    return isLeft == isForLeft ? vol : MUTE_VOLUME;
+  }
+
+public:
+  GOAudioDeviceConfig(
+    const wxString &name, unsigned desiredLatency, uint8_t channels);
+
+  // Creates en ampty config for future Load()
+  GOAudioDeviceConfig();
+
+  // Creates the config with default settings
+  GOAudioDeviceConfig(const std::vector<wxString> &audioGroups);
+
+  const wxString &GetName() const { return m_name; }
+  unsigned GetDesiredLatency() const { return m_DesiredLatency; }
+  uint8_t GetChannels() const { return m_channels; }
+  const std::vector<std::vector<GroupOutput>> &GetChannelOututs() const {
+    return m_ChannelOutputs;
+  }
+
+  void Load(GOConfigReader &cfg, unsigned deviceN);
+  void Save(GOConfigWriter &cfg, unsigned deviceN) const;
+
+  // sets the volume for the group. If the group is not on file then create it
+  void SetOutputVolume(
+    uint8_t channel, const wxString &groupName, bool isLeft, float vol);
 };
 
 #endif /* GOAUDIODEVICECONFIG_H */

--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -315,49 +315,21 @@ void GOConfig::Load() {
 
     m_AudioDeviceConfig.clear();
     count = cfg.ReadInteger(
-      CMBSetting, wxT("AudioDevices"), COUNT, 0, 200, false, 0);
-    for (unsigned i = 0; i < count; i++) {
-      GOAudioDeviceConfig conf;
-      conf.name = cfg.ReadString(
-        CMBSetting,
-        wxT("AudioDevices"),
-        wxString::Format(wxT("Device%03dName"), i + 1));
-      conf.channels = cfg.ReadInteger(
-        CMBSetting,
-        wxT("AudioDevices"),
-        wxString::Format(wxT("Device%03dChannelCount"), i + 1),
-        0,
-        200);
-      conf.desired_latency = cfg.ReadInteger(
-        CMBSetting,
-        wxT("AudioDevices"),
-        wxString::Format(wxT("Device%03dLatency"), i + 1),
-        0,
-        999,
-        false,
-        GetDefaultLatency());
-      conf.scale_factors.resize(conf.channels);
-      for (unsigned j = 0; j < conf.channels; j++) {
-        wxString prefix
-          = wxString::Format(wxT("Device%03dChannel%03d"), i + 1, j + 1);
-        unsigned group_count = cfg.ReadInteger(
-          CMBSetting, wxT("AudioDevices"), prefix + wxT("GroupCount"), 0, 200);
-        for (unsigned k = 0; k < group_count; k++) {
-          GOAudioDeviceConfig::GroupOutput group;
-          wxString p = prefix + wxString::Format(wxT("Group%03d"), k + 1);
+      CMBSetting,
+      GOAudioDeviceConfig::WX_AUDIO_DEVICES,
+      COUNT,
+      0,
+      200,
+      false,
+      0);
 
-          group.name
-            = cfg.ReadString(CMBSetting, wxT("AudioDevices"), p + wxT("Name"));
-          group.left = cfg.ReadFloat(
-            CMBSetting, wxT("AudioDevices"), p + wxT("Left"), -121.0, 40);
-          group.right = cfg.ReadFloat(
-            CMBSetting, wxT("AudioDevices"), p + wxT("Right"), -121.0, 40);
-
-          conf.scale_factors[j].push_back(group);
-        }
+    if (count > 0)
+      for (unsigned i = 0; i < count; i++) {
+        m_AudioDeviceConfig.emplace_back();
+        m_AudioDeviceConfig[i].Load(cfg, i + 1);
       }
-      m_AudioDeviceConfig.push_back(conf);
-    }
+    else // default device config
+      m_AudioDeviceConfig.emplace_back(m_AudioGroups);
 
     load_ports_config(
       cfg, MIDI_PORTS, GOMidiPortFactory::getInstance(), m_MidiPortsConfig);
@@ -396,27 +368,6 @@ void GOConfig::Load() {
       wxCopyFile(m_ConfigFileName, m_ConfigFileName + wxT(".last"));
   } catch (wxString error) {
     wxLogError(wxT("%s\n"), error.c_str());
-  }
-
-  if (!m_AudioDeviceConfig.size()) {
-    GOAudioDeviceConfig conf;
-    conf.name = wxEmptyString;
-    conf.channels = 2;
-    conf.scale_factors.resize(conf.channels);
-    conf.desired_latency = GetDefaultLatency();
-    for (unsigned k = 0; k < m_AudioGroups.size(); k++) {
-      GOAudioDeviceConfig::GroupOutput group;
-      group.name = m_AudioGroups[k];
-
-      group.left = 0.0f;
-      group.right = -121.0f;
-      conf.scale_factors[0].push_back(group);
-
-      group.left = -121.0f;
-      group.right = 0.0f;
-      conf.scale_factors[1].push_back(group);
-    }
-    m_AudioDeviceConfig.push_back(conf);
   }
 }
 
@@ -639,7 +590,7 @@ const unsigned GOConfig::GetTotalAudioChannels() const {
   unsigned channels = 0;
 
   for (const GOAudioDeviceConfig &deviceConfig : m_AudioDeviceConfig)
-    channels += deviceConfig.channels;
+    channels += deviceConfig.GetChannels();
   return channels;
 }
 
@@ -677,45 +628,12 @@ void GOConfig::Flush() {
   save_ports_config(
     cfg, SOUND_PORTS, GOSoundPortFactory::getInstance(), m_SoundPortsConfig);
 
-  for (unsigned i = 0; i < m_AudioDeviceConfig.size(); i++) {
-    cfg.WriteString(
-      wxT("AudioDevices"),
-      wxString::Format(wxT("Device%03dName"), i + 1),
-      m_AudioDeviceConfig[i].name);
-    cfg.WriteInteger(
-      wxT("AudioDevices"),
-      wxString::Format(wxT("Device%03dChannelCount"), i + 1),
-      m_AudioDeviceConfig[i].channels);
-    cfg.WriteInteger(
-      wxT("AudioDevices"),
-      wxString::Format(wxT("Device%03dLatency"), i + 1),
-      m_AudioDeviceConfig[i].desired_latency);
-    for (unsigned j = 0; j < m_AudioDeviceConfig[i].channels; j++) {
-      wxString prefix
-        = wxString::Format(wxT("Device%03dChannel%03d"), i + 1, j + 1);
-      cfg.WriteInteger(
-        wxT("AudioDevices"),
-        prefix + wxT("GroupCount"),
-        m_AudioDeviceConfig[i].scale_factors[j].size());
-      for (unsigned k = 0; k < m_AudioDeviceConfig[i].scale_factors[j].size();
-           k++) {
-        wxString p = prefix + wxString::Format(wxT("Group%03d"), k + 1);
-        cfg.WriteString(
-          wxT("AudioDevices"),
-          p + wxT("Name"),
-          m_AudioDeviceConfig[i].scale_factors[j][k].name);
-        cfg.WriteFloat(
-          wxT("AudioDevices"),
-          p + wxT("Left"),
-          m_AudioDeviceConfig[i].scale_factors[j][k].left);
-        cfg.WriteFloat(
-          wxT("AudioDevices"),
-          p + wxT("Right"),
-          m_AudioDeviceConfig[i].scale_factors[j][k].right);
-      }
-    }
-  }
-  cfg.WriteInteger(wxT("AudioDevices"), COUNT, m_AudioDeviceConfig.size());
+  const unsigned audioDeviceCount = m_AudioDeviceConfig.size();
+
+  for (unsigned i = 0; i < audioDeviceCount; i++)
+    m_AudioDeviceConfig[i].Save(cfg, i + 1);
+  cfg.WriteInteger(
+    GOAudioDeviceConfig::WX_AUDIO_DEVICES, COUNT, audioDeviceCount);
 
   save_ports_config(
     cfg, MIDI_PORTS, GOMidiPortFactory::getInstance(), m_MidiPortsConfig);

--- a/src/grandorgue/sound/GOSound.cpp
+++ b/src/grandorgue/sound/GOSound.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -72,36 +72,45 @@ void GOSound::OpenSound() {
   assert(!m_open);
   assert(m_AudioOutputs.size() == 0);
 
-  unsigned audio_group_count = m_config.GetAudioGroups().size();
-  std::vector<GOAudioDeviceConfig> audio_config
+  const unsigned audio_group_count = m_config.GetAudioGroups().size();
+  const std::vector<GOAudioDeviceConfig> &audio_config
     = m_config.GetAudioDeviceConfig();
+  const unsigned audioDeviceCount = audio_config.size();
   std::vector<GOAudioOutputConfiguration> engine_config;
 
   m_AudioOutputs.resize(audio_config.size());
   for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
     m_AudioOutputs[i].port = NULL;
-  engine_config.resize(audio_config.size());
-  for (unsigned i = 0; i < engine_config.size(); i++) {
-    engine_config[i].channels = audio_config[i].channels;
-    engine_config[i].scale_factors.resize(engine_config[i].channels);
-    for (unsigned j = 0; j < engine_config[i].channels; j++) {
-      engine_config[i].scale_factors[j].resize(audio_group_count * 2);
-      for (unsigned k = 0; k < audio_group_count * 2; k++)
-        engine_config[i].scale_factors[j][k] = -121;
+  engine_config.resize(audioDeviceCount);
+  for (unsigned i = 0; i < audioDeviceCount; i++) {
+    const GOAudioDeviceConfig &deviceConfig = audio_config[i];
+    const auto &deviceOutputs = deviceConfig.GetChannelOututs();
+    GOAudioOutputConfiguration &engineConfig = engine_config[i];
 
-      if (j >= audio_config[i].scale_factors.size())
+    engineConfig.channels = deviceConfig.GetChannels();
+    engineConfig.scale_factors.resize(engineConfig.channels);
+    for (unsigned j = 0; j < engineConfig.channels; j++) {
+      std::vector<float> &scaleFactors = engineConfig.scale_factors[j];
+
+      scaleFactors.resize(audio_group_count * 2);
+      std::fill(
+        scaleFactors.begin(),
+        scaleFactors.end(),
+        GOAudioDeviceConfig::MUTE_VOLUME);
+
+      if (j >= deviceOutputs.size())
         continue;
-      for (unsigned k = 0; k < audio_config[i].scale_factors[j].size(); k++) {
-        int id = m_config.GetStrictAudioGroupId(
-          audio_config[i].scale_factors[j][k].name);
-        if (id == -1)
-          continue;
-        if (audio_config[i].scale_factors[j][k].left >= -120)
-          engine_config[i].scale_factors[j][id * 2]
-            = audio_config[i].scale_factors[j][k].left;
-        if (audio_config[i].scale_factors[j][k].right >= -120)
-          engine_config[i].scale_factors[j][id * 2 + 1]
-            = audio_config[i].scale_factors[j][k].right;
+
+      const auto &channelOutputs = deviceOutputs[j];
+
+      for (unsigned k = 0; k < channelOutputs.size(); k++) {
+        const auto &groupOutput = channelOutputs[k];
+        int id = m_config.GetStrictAudioGroupId(groupOutput.GetName());
+
+        if (id >= 0) {
+          scaleFactors[id * 2] = groupOutput.GetLeft();
+          scaleFactors[id * 2 + 1] = groupOutput.GetRight();
+        }
       }
     }
   }
@@ -128,11 +137,12 @@ void GOSound::OpenSound() {
 
   try {
     for (unsigned i = 0; i < m_AudioOutputs.size(); i++) {
-      wxString name = audio_config[i].name;
+      const GOAudioDeviceConfig &deviceConfig = audio_config[i];
+      wxString name = deviceConfig.GetName();
 
       const GOPortsConfig &portsConfig(m_config.GetSoundPortsConfig());
 
-      if (name == wxEmptyString)
+      if (name.IsEmpty())
         name = GetDefaultAudioDevice(portsConfig);
 
       m_AudioOutputs[i].port
@@ -143,10 +153,10 @@ void GOSound::OpenSound() {
           name.c_str());
 
       m_AudioOutputs[i].port->Init(
-        audio_config[i].channels,
+        deviceConfig.GetChannels(),
         GetEngine().GetSampleRate(),
         m_SamplesPerBuffer,
-        audio_config[i].desired_latency,
+        deviceConfig.GetDesiredLatency(),
         i);
     }
 


### PR DESCRIPTION
This is a next PR retated to #1265

It moves lots of code related to `GODeviceConfig` from `GOConfig` and `GOAudioSettings` to the `GODeviceConfig` class itself.

It is just refactoring. No GO behavior should be changed.