### PR TITLE
Implemented Load/Save in GODeviceNamePattern

### DIFF
--- a/src/grandorgue/config/GODeviceNamePattern.cpp
+++ b/src/grandorgue/config/GODeviceNamePattern.cpp
@@ -9,6 +9,9 @@
 
 #include <wx/regex.h>
 
+#include "config/GOConfigReader.h"
+#include "config/GOConfigWriter.h"
+
 GODeviceNamePattern::GODeviceNamePattern(
   const wxString &logicalName,
   const wxString &regEx,
@@ -42,6 +45,32 @@ void GODeviceNamePattern::SetRegEx(const wxString &regEx) {
     m_RegEx = regEx;
     m_CompiledRegEx = regEx.IsEmpty() ? nullptr : new wxRegEx(regEx);
   }
+}
+
+static const wxString WX_REGEX = wxT("RegEx");
+static const wxString WX_PORT_NAME = wxT("PortName");
+static const wxString WX_API_NAME = wxT("ApiName");
+
+void GODeviceNamePattern::LoadNamePattern(
+  GOConfigReader &cfg,
+  const wxString &group,
+  const wxString &prefix,
+  const wxString &nameKey) {
+  m_LogicalName = cfg.ReadString(CMBSetting, group, prefix + nameKey),
+  SetRegEx(cfg.ReadString(CMBSetting, group, prefix + WX_REGEX, false));
+  m_PortName = cfg.ReadString(CMBSetting, group, prefix + WX_PORT_NAME, false);
+  m_ApiName = cfg.ReadString(CMBSetting, group, prefix + WX_API_NAME, false);
+}
+
+void GODeviceNamePattern::SaveNamePattern(
+  GOConfigWriter &cfg,
+  const wxString &group,
+  const wxString &prefix,
+  const wxString &nameKey) const {
+  cfg.WriteString(group, prefix + nameKey, m_LogicalName);
+  cfg.WriteString(group, prefix + WX_REGEX, m_RegEx);
+  cfg.WriteString(group, prefix + WX_PORT_NAME, m_PortName);
+  cfg.WriteString(group, prefix + WX_API_NAME, m_ApiName);
 }
 
 bool GODeviceNamePattern::DoesMatch(const wxString &physicalName) {

--- a/src/grandorgue/config/GODeviceNamePattern.h
+++ b/src/grandorgue/config/GODeviceNamePattern.h
@@ -12,6 +12,9 @@
 
 class wxRegEx;
 
+class GOConfigReader;
+class GOConfigWriter;
+
 class GODeviceNamePattern {
 private:
   wxRegEx *m_CompiledRegEx = nullptr;
@@ -25,6 +28,8 @@ private:
   wxString m_PhysicalName;
 
 public:
+  GODeviceNamePattern() {}
+
   GODeviceNamePattern(
     const wxString &logicalName,
     const wxString &regEx = wxEmptyString,
@@ -52,6 +57,18 @@ public:
 
   const wxString &GetPhysicalName() const { return m_PhysicalName; }
   void SetPhysicalName(const wxString &name) { m_PhysicalName = name; }
+
+  void LoadNamePattern(
+    GOConfigReader &cfg,
+    const wxString &group,
+    const wxString &prefix,
+    const wxString &nameKey = wxEmptyString);
+
+  void SaveNamePattern(
+    GOConfigWriter &cfg,
+    const wxString &group,
+    const wxString &prefix,
+    const wxString &nameKey = wxEmptyString) const;
 
   void AssignNamePattern(const GODeviceNamePattern &src);
 

--- a/src/grandorgue/config/GOMidiDeviceConfig.cpp
+++ b/src/grandorgue/config/GOMidiDeviceConfig.cpp
@@ -7,6 +7,9 @@
 
 #include "GOMidiDeviceConfig.h"
 
+#include "config/GOConfigReader.h"
+#include "config/GOConfigWriter.h"
+
 GOMidiDeviceConfig::GOMidiDeviceConfig(
   const wxString &logicalName,
   const wxString &regEx,
@@ -26,4 +29,41 @@ void GOMidiDeviceConfig::AssignMidiDeviceConfig(const GOMidiDeviceConfig &src) {
 void GOMidiDeviceConfig::Assign(const GOMidiDeviceConfig &src) {
   AssignNamePattern(src);
   AssignMidiDeviceConfig(src);
+}
+
+static const wxString WX_ENABLED = wxT("Enabled");
+static const wxString WX_SHIFT = wxT("Shift");
+static const wxString WX_OUTPUT_DEVICE = wxT("OutputDevice");
+
+void GOMidiDeviceConfig::LoadDeviceConfig(
+  GOConfigReader &cfg,
+  const wxString &group,
+  const wxString &prefix,
+  const bool isInput) {
+  LoadNamePattern(cfg, group, prefix, wxEmptyString);
+  m_IsEnabled = cfg.ReadBoolean(CMBSetting, group, prefix + WX_ENABLED);
+  if (isInput) {
+    m_ChannelShift
+      = cfg.ReadInteger(CMBSetting, group, prefix + WX_SHIFT, 0, 15);
+    m_OutputDeviceName
+      = cfg.ReadString(CMBSetting, group, prefix + WX_OUTPUT_DEVICE, false);
+  } else {
+    m_ChannelShift = 0;
+    m_OutputDeviceName = wxEmptyString;
+  }
+}
+
+void GOMidiDeviceConfig::SaveDeviceConfig(
+  GOConfigWriter &cfg,
+  const wxString &group,
+  const wxString &prefix,
+  const bool isInput) const {
+  SaveNamePattern(cfg, group, prefix, wxEmptyString);
+  cfg.WriteBoolean(group, prefix + WX_ENABLED, m_IsEnabled);
+  if (isInput) {
+    cfg.WriteInteger(group, prefix + WX_SHIFT, m_ChannelShift);
+    if (p_OutputDevice)
+      cfg.WriteString(
+        group, prefix + WX_OUTPUT_DEVICE, p_OutputDevice->GetLogicalName());
+  }
 }

--- a/src/grandorgue/config/GOMidiDeviceConfig.h
+++ b/src/grandorgue/config/GOMidiDeviceConfig.h
@@ -21,11 +21,13 @@ private:
 public:
   typedef std::vector<GOMidiDeviceConfig *> RefVector;
 
-  bool m_IsEnabled;
-
+  bool m_IsEnabled = true;
   // Midi-in only
   int m_ChannelShift = 0;
+  wxString m_OutputDeviceName;
   GOMidiDeviceConfig *p_OutputDevice = NULL;
+
+  GOMidiDeviceConfig() {}
 
   GOMidiDeviceConfig(
     const wxString &logicalName,
@@ -40,6 +42,18 @@ public:
   GOMidiDeviceConfig(const GOMidiDeviceConfig &src) : GODeviceNamePattern(src) {
     AssignMidiDeviceConfig(src);
   }
+
+  void LoadDeviceConfig(
+    GOConfigReader &cfg,
+    const wxString &group,
+    const wxString &prefix,
+    const bool isInput);
+
+  void SaveDeviceConfig(
+    GOConfigWriter &cfg,
+    const wxString &group,
+    const wxString &prefix,
+    const bool isInput) const;
 };
 
 #endif /* GOMIDIDEVICECONFIG_H */

--- a/src/grandorgue/config/GOMidiDeviceConfigList.cpp
+++ b/src/grandorgue/config/GOMidiDeviceConfigList.cpp
@@ -121,12 +121,6 @@ GOMidiDeviceConfig *GOMidiDeviceConfigList::Append(
 
 static const wxString COUNT = wxT("Count");
 static const wxString DEVICE03D = wxT("Device%03d");
-static const wxString DEVICE03D_ENABLED = wxT("Device%03dEnabled");
-static const wxString DEVICE03D_REGEX = wxT("Device%03dRegEx");
-static const wxString DEVICE03D_PORT_NAME = wxT("Device%03dPortName");
-static const wxString DEVICE03D_API_NAME = wxT("Device%03dApiName");
-static const wxString DEVICE03D_SHIFT = wxT("Device%03dShift");
-static const wxString DEVICE03D_OUTPUT_DEVICE = wxT("Device%03dOutputDevice");
 
 void GOMidiDeviceConfigList::Load(
   GOConfigReader &cfg, const GOMidiDeviceConfigList *outputMidiDevices) {
@@ -134,81 +128,26 @@ void GOMidiDeviceConfigList::Load(
     CMBSetting, m_GroupName, COUNT, 0, MAX_MIDI_DEVICES, false, 0);
 
   for (unsigned i = 1; i <= count; i++) {
-    GOMidiDeviceConfig *const devConf = Append(
-      cfg.ReadString(CMBSetting, m_GroupName, wxString::Format(DEVICE03D, i)),
-      // logicalName
-      cfg.ReadString(
-        CMBSetting,
-        m_GroupName,
-        wxString::Format(DEVICE03D_REGEX, i),
-        false), // regEx
-      cfg.ReadString(
-        CMBSetting,
-        m_GroupName,
-        wxString::Format(DEVICE03D_PORT_NAME, i),
-        false), // portName
-      cfg.ReadString(
-        CMBSetting,
-        m_GroupName,
-        wxString::Format(DEVICE03D_API_NAME, i),
-        false), // apiName
-      cfg.ReadBoolean(
-        CMBSetting,
-        m_GroupName,
-        wxString::Format(DEVICE03D_ENABLED, i)) // isEnabled
-    );
+    GOMidiDeviceConfig devConf;
 
-    if (outputMidiDevices) // load an input device
-    {
-      devConf->m_ChannelShift = cfg.ReadInteger(
-        CMBSetting, m_GroupName, wxString::Format(DEVICE03D_SHIFT, i), 0, 15);
+    devConf.LoadDeviceConfig(
+      cfg, m_GroupName, wxString::Format(DEVICE03D, i), outputMidiDevices);
 
-      const wxString outDevName = cfg.ReadString(
-        CMBSetting,
-        m_GroupName,
-        wxString::Format(DEVICE03D_OUTPUT_DEVICE, i),
-        false);
-
-      if (!outDevName.IsEmpty())
-        devConf->p_OutputDevice
-          = outputMidiDevices->FindByLogicalName(outDevName);
+    if (outputMidiDevices && !devConf.m_OutputDeviceName.IsEmpty()) {
+      // load an input device
+      devConf.p_OutputDevice
+        = outputMidiDevices->FindByLogicalName(devConf.m_OutputDeviceName);
     }
+    Append(devConf);
   }
 }
 
 void GOMidiDeviceConfigList::Save(GOConfigWriter &cfg, const bool isInput) {
   unsigned i = 0;
 
-  for (GOMidiDeviceConfig *devConf : m_list) {
-    i++;
-    cfg.WriteString(
-      m_GroupName, wxString::Format(DEVICE03D, i), devConf->GetLogicalName());
-    cfg.WriteString(
-      m_GroupName, wxString::Format(DEVICE03D_REGEX, i), devConf->GetRegEx());
-    cfg.WriteString(
-      m_GroupName,
-      wxString::Format(DEVICE03D_PORT_NAME, i),
-      devConf->GetPortName());
-    cfg.WriteString(
-      m_GroupName,
-      wxString::Format(DEVICE03D_API_NAME, i),
-      devConf->GetApiName());
-    cfg.WriteBoolean(
-      m_GroupName,
-      wxString::Format(DEVICE03D_ENABLED, i),
-      devConf->m_IsEnabled);
-    if (isInput) {
-      cfg.WriteInteger(
-        m_GroupName,
-        wxString::Format(DEVICE03D_SHIFT, i),
-        devConf->m_ChannelShift);
-      if (devConf->p_OutputDevice)
-        cfg.WriteString(
-          m_GroupName,
-          wxString::Format(DEVICE03D_OUTPUT_DEVICE, i),
-          devConf->p_OutputDevice->GetLogicalName());
-    }
-  }
+  for (GOMidiDeviceConfig *devConf : m_list)
+    devConf->SaveDeviceConfig(
+      cfg, m_GroupName, wxString::Format(DEVICE03D, ++i), isInput);
   if (i > MAX_MIDI_DEVICES)
     i = MAX_MIDI_DEVICES;
   cfg.WriteInteger(m_GroupName, COUNT, i);


### PR DESCRIPTION
This is a next PR retated to #1265

It moves the loading/saving config code from GOMidiDeviceConfigList to GOMidiDeviceConfig and GODeviceNameConfig.

It will be reused for audio devices later.

It is just refactoring. No GO behavior should be changed.