### PR TITLE
Fix InfoFilename handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed loading organ to not abort if reading InfoFilename failed and also fixed showing link in properties dialog if InfoFilename exists
 # 3.15.0 (2024-08-06)
 - Added capability of regex matching audio device names https://github.com/GrandOrgue/grandorgue/issues/1265
 - Added a checkbox-based Stops dialog (Audio/Midi -> Stops) https://github.com/GrandOrgue/grandorgue/issues/1816

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -219,19 +219,16 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
       m_InfoFilename = fn.GetFullPath();
   } else {
     if (!m_FileStore.AreArchivesUsed()) {
-      GOLoaderFilename::GenerateFullPath(
+      fn = GOLoaderFilename::generateFullPath(
         info_filename, wxFileName(GetODFFilename()).GetPath());
-      fn = info_filename;
       if (
         fn.FileExists()
-        && (fn.GetExt() == wxT("html") || fn.GetExt() == wxT("htm"))) {
+        && (fn.GetExt() == wxT("html") || fn.GetExt() == wxT("htm")))
         m_InfoFilename = fn.GetFullPath();
-      } else {
-        if (m_config.ODFCheck())
-          wxLogWarning(
-            _("InfoFilename %s either does not exist or is not a html file"),
-            fn.GetFullPath());
-      }
+      else if (m_config.ODFCheck())
+        wxLogWarning(
+          _("InfoFilename %s either does not exist or is not a html file"),
+          fn.GetFullPath());
     }
   }
 

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -219,22 +219,24 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
     else
       m_InfoFilename = wxEmptyString;
   } else {
-    GOLoaderFilename fname;
-
-    fname.Assign(info_filename);
-    std::unique_ptr<GOOpenedFile> file = fname.Open(m_FileStore);
-    fn = info_filename;
-    if (
-      file->isValid()
-      && (fn.GetExt() == wxT("html") || fn.GetExt() == wxT("htm"))) {
-      if (fn.FileExists() && !m_FileStore.AreArchivesUsed())
+    if (!m_FileStore.AreArchivesUsed()) {
+      info_filename.Replace(
+        wxT("\\"), wxString(wxFileName::GetPathSeparator()));
+      wxString infoFilePath
+        = wxFileName(GetODFFilename()).GetPath(wxPATH_GET_SEPARATOR)
+        + info_filename;
+      fn = infoFilePath;
+      if (
+        fn.FileExists()
+        && (fn.GetExt() == wxT("html") || fn.GetExt() == wxT("htm"))) {
         m_InfoFilename = fn.GetFullPath();
-      else
+      } else {
         m_InfoFilename = wxEmptyString;
-    } else {
-      m_InfoFilename = wxEmptyString;
-      if (m_config.ODFCheck())
-        wxLogWarning(_("InfoFilename does not point to a html file"));
+        if (m_config.ODFCheck())
+          wxLogWarning(
+            _("InfoFilename %s either does not exist or is not a html file"),
+            fn.GetFullPath());
+      }
     }
   }
 

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -210,28 +210,23 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   wxString info_filename
     = cfg.ReadFileName(ODFSetting, WX_ORGAN, wxT("InfoFilename"), false);
   wxFileName fn;
+  m_InfoFilename = wxEmptyString;
   if (info_filename.IsEmpty()) {
     /* Resolve organ file path */
     fn = GetODFFilename();
     fn.SetExt(wxT("html"));
     if (fn.FileExists() && !m_FileStore.AreArchivesUsed())
       m_InfoFilename = fn.GetFullPath();
-    else
-      m_InfoFilename = wxEmptyString;
   } else {
     if (!m_FileStore.AreArchivesUsed()) {
-      info_filename.Replace(
-        wxT("\\"), wxString(wxFileName::GetPathSeparator()));
-      wxString infoFilePath
-        = wxFileName(GetODFFilename()).GetPath(wxPATH_GET_SEPARATOR)
-        + info_filename;
-      fn = infoFilePath;
+      GOLoaderFilename::GenerateFullPath(
+        info_filename, wxFileName(GetODFFilename()).GetPath());
+      fn = info_filename;
       if (
         fn.FileExists()
         && (fn.GetExt() == wxT("html") || fn.GetExt() == wxT("htm"))) {
         m_InfoFilename = fn.GetFullPath();
       } else {
-        m_InfoFilename = wxEmptyString;
         if (m_config.ODFCheck())
           wxLogWarning(
             _("InfoFilename %s either does not exist or is not a html file"),

--- a/src/grandorgue/loader/GOLoaderFilename.cpp
+++ b/src/grandorgue/loader/GOLoaderFilename.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */

--- a/src/grandorgue/loader/GOLoaderFilename.cpp
+++ b/src/grandorgue/loader/GOLoaderFilename.cpp
@@ -7,7 +7,6 @@
 
 #include "GOLoaderFilename.h"
 
-#include <wx/filename.h>
 #include <wx/log.h>
 
 #include "archive/GOArchive.h"
@@ -54,9 +53,7 @@ std::unique_ptr<GOOpenedFile> GOLoaderFilename::Open(
 
     wxString fullPath = m_path;
 
-    fullPath.Replace(wxT("\\"), wxString(wxFileName::GetPathSeparator()));
-    if (!baseDir.IsEmpty())
-      fullPath = baseDir + wxFileName::GetPathSeparator() + fullPath;
+    GenerateFullPath(fullPath, baseDir);
 
     if (fullPath.IsEmpty())
       throw _("File name is empty");

--- a/src/grandorgue/loader/GOLoaderFilename.cpp
+++ b/src/grandorgue/loader/GOLoaderFilename.cpp
@@ -7,6 +7,7 @@
 
 #include "GOLoaderFilename.h"
 
+#include <wx/filename.h>
 #include <wx/log.h>
 
 #include "archive/GOArchive.h"
@@ -51,9 +52,7 @@ std::unique_ptr<GOOpenedFile> GOLoaderFilename::Open(
     else if (m_RootKind == ROOT_RESOURCE)
       baseDir = fileStore.GetResourceDirectory();
 
-    wxString fullPath = m_path;
-
-    GenerateFullPath(fullPath, baseDir);
+    wxString fullPath = generateFullPath(m_path, baseDir);
 
     if (fullPath.IsEmpty())
       throw _("File name is empty");
@@ -62,4 +61,13 @@ std::unique_ptr<GOOpenedFile> GOLoaderFilename::Open(
     file = new GOStandardFile(fullPath, m_path);
   }
   return std::unique_ptr<GOOpenedFile>(file);
+}
+
+wxString GOLoaderFilename::generateFullPath(
+  const wxString &relPath, const wxString &baseDir) {
+  wxString res = relPath;
+  res.Replace(wxT("\\"), wxString(wxFileName::GetPathSeparator()));
+  if (!baseDir.IsEmpty())
+    res = baseDir + wxFileName::GetPathSeparator() + res;
+  return res;
 }

--- a/src/grandorgue/loader/GOLoaderFilename.h
+++ b/src/grandorgue/loader/GOLoaderFilename.h
@@ -10,7 +10,6 @@
 
 #include <memory>
 
-#include <wx/filename.h>
 #include <wx/string.h>
 
 class GOOpenedFile;
@@ -64,11 +63,8 @@ public:
     return pFileName ? pFileName->GenerateMessage(srcMsg) : srcMsg;
   }
 
-  static void GenerateFullPath(wxString &relPath, wxString baseDir) {
-    relPath.Replace(wxT("\\"), wxString(wxFileName::GetPathSeparator()));
-    if (!baseDir.IsEmpty())
-      relPath = baseDir + wxFileName::GetPathSeparator() + relPath;
-  }
+  static wxString generateFullPath(
+    const wxString &relPath, const wxString &baseDir);
 };
 
 #endif

--- a/src/grandorgue/loader/GOLoaderFilename.h
+++ b/src/grandorgue/loader/GOLoaderFilename.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include <wx/filename.h>
 #include <wx/string.h>
 
 class GOOpenedFile;
@@ -61,6 +62,12 @@ public:
   static wxString generateMessage(
     const GOLoaderFilename *pFileName, const wxString &srcMsg) {
     return pFileName ? pFileName->GenerateMessage(srcMsg) : srcMsg;
+  }
+
+  static void GenerateFullPath(wxString &relPath, wxString baseDir) {
+    relPath.Replace(wxT("\\"), wxString(wxFileName::GetPathSeparator()));
+    if (!baseDir.IsEmpty())
+      relPath = baseDir + wxFileName::GetPathSeparator() + relPath;
   }
 };
 


### PR DESCRIPTION
This PR attempts to fix two issues with the InfoFilename which has a value that is not mandatory to include in the odf at all. The issues are:

1. If value is present but can not be opened/handled by GO for any reason (typo etc.) the whole organ loading would abort.
2. If value is present and possible to handle by GO, wxFileName::FileExists() would still fail (at least under Linux) if path supplied isn't absolute. Thus, even if a valid relative path exists, the more info link wouldn't be shown in the info dialog.

With this PR, and as the value is not mandatory in the odf, a log warning for an invalid file will be supplied only if strict checking is enabled, but the organ will continue to load. Also the correct more info link to the InfoFilename will be shown if the file is valid/existing.