### PR TITLE
GetAudioDeviceConfig became non-constant

### DIFF
--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -575,10 +575,6 @@ int GOConfig::GetStrictAudioGroupId(const wxString &str) {
   return -1;
 }
 
-const std::vector<GOAudioDeviceConfig> &GOConfig::GetAudioDeviceConfig() {
-  return m_AudioDeviceConfig;
-}
-
 void GOConfig::SetAudioDeviceConfig(
   const std::vector<GOAudioDeviceConfig> &config) {
   if (!config.size())

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -184,7 +184,9 @@ public:
     m_SoundPortsConfig = portsConfig;
   }
 
-  const std::vector<GOAudioDeviceConfig> &GetAudioDeviceConfig();
+  std::vector<GOAudioDeviceConfig> &GetAudioDeviceConfig() {
+    return m_AudioDeviceConfig;
+  }
   const unsigned GetTotalAudioChannels() const;
   void SetAudioDeviceConfig(const std::vector<GOAudioDeviceConfig> &config);
   unsigned GetDefaultLatency();


### PR DESCRIPTION
This is a small refactoring related to #1265.

In the future regex matching will fill m_PhysicalName in GOAudioDeviceConfig.  So GetAudioDeviceConfig() can not more be constant.

This PR also moves a simple implementation of this function to the GOConfig.h header.

It is just refactoring. No GO behavior should be changed.