### PR TITLE
[IMP] GOOrganController: allows to be loaded without an application

### DIFF
--- a/src/core/GOTimer.h
+++ b/src/core/GOTimer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -34,6 +34,7 @@ private:
 public:
   GOTimer();
   ~GOTimer();
+  void Cleanup() { m_Entries.clear(); };
 
   void SetTimer(GOTime time, GOTimerCallback *callback, unsigned interval = 0);
   void SetRelativeTimer(

--- a/src/grandorgue/GOAudioRecorder.cpp
+++ b/src/grandorgue/GOAudioRecorder.cpp
@@ -119,7 +119,7 @@ void GOAudioRecorder::UpdateDisplay() {
 void GOAudioRecorder::StopRecording() {
   m_buttons[ID_AUDIO_RECORDER_RECORD]->Display(false);
   m_buttons[ID_AUDIO_RECORDER_RECORD_RENAME]->Display(false);
-  m_OrganController->GetTimerManager()->DeleteTimer(this);
+  m_OrganController->GetTimer()->DeleteTimer(this);
   if (!IsRecording())
     return;
 
@@ -156,7 +156,7 @@ void GOAudioRecorder::StartRecording(bool rename) {
 
   m_RecordSeconds = 0;
   UpdateDisplay();
-  m_OrganController->GetTimerManager()->SetRelativeTimer(1000, this, 1000);
+  m_OrganController->GetTimer()->SetRelativeTimer(1000, this, 1000);
 }
 
 void GOAudioRecorder::HandleTimer() {

--- a/src/grandorgue/GOAudioRecorder.cpp
+++ b/src/grandorgue/GOAudioRecorder.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -119,7 +119,7 @@ void GOAudioRecorder::UpdateDisplay() {
 void GOAudioRecorder::StopRecording() {
   m_buttons[ID_AUDIO_RECORDER_RECORD]->Display(false);
   m_buttons[ID_AUDIO_RECORDER_RECORD_RENAME]->Display(false);
-  m_OrganController->DeleteTimer(this);
+  m_OrganController->GetTimerManager()->DeleteTimer(this);
   if (!IsRecording())
     return;
 
@@ -156,7 +156,7 @@ void GOAudioRecorder::StartRecording(bool rename) {
 
   m_RecordSeconds = 0;
   UpdateDisplay();
-  m_OrganController->SetRelativeTimer(1000, this, 1000);
+  m_OrganController->GetTimerManager()->SetRelativeTimer(1000, this, 1000);
 }
 
 void GOAudioRecorder::HandleTimer() {

--- a/src/grandorgue/GOBitmapCache.cpp
+++ b/src/grandorgue/GOBitmapCache.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -161,7 +161,9 @@ GOBitmapCache::GOBitmapCache(GOOrganController *organController)
     m_Bitmaps(),
     m_Filenames(),
     m_Masknames() {
-  BITMAP_LIST;
+  if (organController) {
+    BITMAP_LIST;
+  }
 }
 
 GOBitmapCache::~GOBitmapCache() {}

--- a/src/grandorgue/GOBitmapCache.h
+++ b/src/grandorgue/GOBitmapCache.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -28,6 +28,11 @@ private:
 public:
   GOBitmapCache(GOOrganController *organController);
   virtual ~GOBitmapCache();
+  void Cleanup() {
+    m_Bitmaps.clear();
+    m_Filenames.clear();
+    m_Masknames.clear();
+  };
 
   void RegisterBitmap(
     wxImage *bitmap, wxString filename, wxString maskname = wxEmptyString);

--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -55,7 +55,7 @@ bool GODocument::LoadOrgan(
   GOConfig &cfg = m_sound.GetSettings();
 
   CloseOrgan();
-  m_OrganController = new GOOrganController(cfg, this);
+  m_OrganController = new GOOrganController(cfg, this, true);
   wxString error = m_OrganController->Load(dlg, organ, cmb, isGuiOnly);
   if (!error.IsEmpty()) {
     if (error != wxT("!")) {

--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -176,7 +176,7 @@ void GOMetronome::UpdateBPM(int val) {
   if (m_BPM > 500)
     m_BPM = 500;
   if (m_Running)
-    m_OrganController->GetTimerManager()->UpdateInterval(this, 60000 / m_BPM);
+    m_OrganController->GetTimer()->UpdateInterval(this, 60000 / m_BPM);
   UpdateState();
 }
 
@@ -201,11 +201,11 @@ void GOMetronome::StartTimer() {
   m_Pos = 0;
   m_Running = true;
   UpdateState();
-  m_OrganController->GetTimerManager()->SetTimer(0, this, 60000 / m_BPM);
+  m_OrganController->GetTimer()->SetTimer(0, this, 60000 / m_BPM);
 }
 
 void GOMetronome::StopTimer() {
-  m_OrganController->GetTimerManager()->DeleteTimer(this);
+  m_OrganController->GetTimer()->DeleteTimer(this);
   m_Running = false;
   UpdateState();
 }

--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -176,7 +176,7 @@ void GOMetronome::UpdateBPM(int val) {
   if (m_BPM > 500)
     m_BPM = 500;
   if (m_Running)
-    m_OrganController->UpdateInterval(this, 60000 / m_BPM);
+    m_OrganController->GetTimerManager()->UpdateInterval(this, 60000 / m_BPM);
   UpdateState();
 }
 
@@ -201,11 +201,11 @@ void GOMetronome::StartTimer() {
   m_Pos = 0;
   m_Running = true;
   UpdateState();
-  m_OrganController->SetTimer(0, this, 60000 / m_BPM);
+  m_OrganController->GetTimerManager()->SetTimer(0, this, 60000 / m_BPM);
 }
 
 void GOMetronome::StopTimer() {
-  m_OrganController->DeleteTimer(this);
+  m_OrganController->GetTimerManager()->DeleteTimer(this);
   m_Running = false;
   UpdateState();
 }

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -100,7 +100,7 @@ GOOrganController::GOOrganController(
     m_AudioRecorder(NULL),
     m_MidiPlayer(NULL),
     m_MidiRecorder(NULL),
-    m_TimerManager(NULL),
+    m_timer(NULL),
     p_OnStateButton(nullptr),
     m_volume(0),
     m_b_customized(false),
@@ -127,7 +127,7 @@ GOOrganController::GOOrganController(
     m_MainWindowData(this, wxT("MainWindow")) {
   if (isAppInitialized) {
     // Load here objects that needs App (wx) to be loaded
-    m_TimerManager = new GOTimer();
+    m_timer = new GOTimer();
     m_bitmaps = new GOBitmapCache(this);
   }
   GOOrganModel::SetMidiDialogCreator(pMidiDialogCreator);
@@ -145,8 +145,10 @@ GOOrganController::~GOOrganController() {
   m_tremulants.clear();
   m_ranks.clear();
   m_VirtualCouplers.Cleanup();
-  m_TimerManager->Cleanup();
-  m_bitmaps->Cleanup();
+  if (m_timer)
+    delete m_timer;
+  if (m_bitmaps)
+    delete m_bitmaps;
   GOOrganModel::Cleanup();
   GOOrganModel::SetModelModificationListener(nullptr);
   GOOrganModel::SetMidiDialogCreator(nullptr);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -121,13 +121,14 @@ GOOrganController::GOOrganController(
     m_MidiSamplesetMatch(),
     m_SampleSetId1(0),
     m_SampleSetId2(0),
-    m_bitmaps(this),
+    m_bitmaps(nullptr),
     m_PitchLabel(this),
     m_TemperamentLabel(this),
     m_MainWindowData(this, wxT("MainWindow")) {
   if (isAppInitialized) {
     // Load here objects that needs App (wx) to be loaded
     m_TimerManager = new GOTimer();
+    m_bitmaps = new GOBitmapCache(this);
   }
   GOOrganModel::SetMidiDialogCreator(pMidiDialogCreator);
   GOOrganModel::SetModelModificationListener(this);
@@ -1006,8 +1007,6 @@ wxString GOOrganController::GetCombinationsDir() const {
 GOMemoryPool &GOOrganController::GetMemoryPool() { return m_pool; }
 
 GOConfig &GOOrganController::GetSettings() { return m_config; }
-
-GOBitmapCache &GOOrganController::GetBitmapCache() { return m_bitmaps; }
 
 GOMidi *GOOrganController::GetMidi() { return m_midi; }
 

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -145,6 +145,8 @@ GOOrganController::~GOOrganController() {
   m_tremulants.clear();
   m_ranks.clear();
   m_VirtualCouplers.Cleanup();
+  m_TimerManager->Cleanup();
+  m_bitmaps->Cleanup();
   GOOrganModel::Cleanup();
   GOOrganModel::SetModelModificationListener(nullptr);
   GOOrganModel::SetMidiDialogCreator(nullptr);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -82,7 +82,9 @@ static const wxString WX_ORGAN = wxT("Organ");
 static const wxString WX_GRANDORGUE_VERSION = wxT("GrandOrgueVersion");
 
 GOOrganController::GOOrganController(
-  GOConfig &config, GOMidiDialogCreator *pMidiDialogCreator)
+  GOConfig &config,
+  GOMidiDialogCreator *pMidiDialogCreator,
+  bool isAppInitialized)
   : GOEventDistributor(this),
     GOOrganModel(config),
     m_config(config),
@@ -98,6 +100,7 @@ GOOrganController::GOOrganController(
     m_AudioRecorder(NULL),
     m_MidiPlayer(NULL),
     m_MidiRecorder(NULL),
+    m_TimerManager(NULL),
     p_OnStateButton(nullptr),
     m_volume(0),
     m_b_customized(false),
@@ -122,6 +125,10 @@ GOOrganController::GOOrganController(
     m_PitchLabel(this),
     m_TemperamentLabel(this),
     m_MainWindowData(this, wxT("MainWindow")) {
+  if (isAppInitialized) {
+    // Load here objects that needs App (wx) to be loaded
+    m_TimerManager = new GOTimer();
+  }
   GOOrganModel::SetMidiDialogCreator(pMidiDialogCreator);
   GOOrganModel::SetModelModificationListener(this);
   m_setter = new GOSetter(this);

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -72,7 +72,7 @@ private:
   GOAudioRecorder *m_AudioRecorder;
   GOMidiPlayer *m_MidiPlayer;
   GOMidiRecorder *m_MidiRecorder;
-  GOTimer *m_TimerManager;
+  GOTimer *m_timer;
   GOButtonControl *p_OnStateButton;
   int m_volume;
   wxString m_Temperament;
@@ -238,7 +238,7 @@ public:
   /**
    * Return the Timer Manager for Metronome, Midi recorder, ...
    */
-  GOTimer *GetTimerManager() const { return m_TimerManager; }
+  GOTimer *GetTimer() const { return m_timer; }
 };
 
 #endif

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -54,7 +54,6 @@ class GOSoundRecorder;
 typedef struct _GOHashType GOHashType;
 
 class GOOrganController : public GOEventDistributor,
-                          public GOTimer,
                           public GOOrganModel,
                           public GOModificationProxy {
 private:
@@ -73,6 +72,7 @@ private:
   GOAudioRecorder *m_AudioRecorder;
   GOMidiPlayer *m_MidiPlayer;
   GOMidiRecorder *m_MidiRecorder;
+  GOTimer *m_TimerManager;
   GOButtonControl *p_OnStateButton;
   int m_volume;
   wxString m_Temperament;
@@ -126,7 +126,9 @@ private:
 
 public:
   GOOrganController(
-    GOConfig &config, GOMidiDialogCreator *pMidiDialogCreator = nullptr);
+    GOConfig &config,
+    GOMidiDialogCreator *pMidiDialogCreator = nullptr,
+    bool isAppInitialized = false);
   ~GOOrganController();
 
   // Returns organ modification flag
@@ -232,6 +234,11 @@ public:
   GOMidi *GetMidi();
 
   GOGUIMouseState &GetMouseState() { return m_MouseState; }
+
+  /**
+   * Return the Timer Manager for Metronome, Midi recorder, ...
+   */
+  GOTimer *GetTimerManager() { return m_TimerManager; }
 };
 
 #endif

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -102,7 +102,7 @@ private:
   GOGUIMouseState m_MouseState;
 
   GOMemoryPool m_pool;
-  GOBitmapCache m_bitmaps;
+  GOBitmapCache *m_bitmaps;
   GOLabelControl m_PitchLabel;
   GOLabelControl m_TemperamentLabel;
   GOMainWindowData m_MainWindowData;
@@ -186,7 +186,7 @@ public:
   void AddPanel(GOGUIPanel *panel);
   GOMemoryPool &GetMemoryPool();
   GOConfig &GetSettings();
-  GOBitmapCache &GetBitmapCache();
+  GOBitmapCache &GetBitmapCache() { return *m_bitmaps; }
   void SetTemperament(wxString name);
   wxString GetTemperament();
 

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -186,7 +186,7 @@ public:
   void AddPanel(GOGUIPanel *panel);
   GOMemoryPool &GetMemoryPool();
   GOConfig &GetSettings();
-  GOBitmapCache &GetBitmapCache() { return *m_bitmaps; }
+  GOBitmapCache &GetBitmapCache() const { return *m_bitmaps; }
   void SetTemperament(wxString name);
   wxString GetTemperament();
 
@@ -238,7 +238,7 @@ public:
   /**
    * Return the Timer Manager for Metronome, Midi recorder, ...
    */
-  GOTimer *GetTimerManager() { return m_TimerManager; }
+  GOTimer *GetTimerManager() const { return m_TimerManager; }
 };
 
 #endif

--- a/src/grandorgue/midi/GOMidiPlayer.cpp
+++ b/src/grandorgue/midi/GOMidiPlayer.cpp
@@ -150,7 +150,7 @@ void GOMidiPlayer::Pause() {
     m_Pause = true;
     m_buttons[ID_MIDI_PLAYER_PAUSE]->Display(m_Pause);
     m_Start = wxGetLocalTimeMillis() - m_Start;
-    m_OrganController->GetTimerManager()->DeleteTimer(this);
+    m_OrganController->GetTimer()->DeleteTimer(this);
   }
 }
 
@@ -172,7 +172,7 @@ void GOMidiPlayer::StopPlaying() {
   m_buttons[ID_MIDI_PLAYER_PLAY]->Display(false);
   m_buttons[ID_MIDI_PLAYER_PAUSE]->Display(false);
   UpdateDisplay();
-  m_OrganController->GetTimerManager()->DeleteTimer(this);
+  m_OrganController->GetTimer()->DeleteTimer(this);
 }
 
 bool GOMidiPlayer::IsPlaying() { return m_IsPlaying; }
@@ -212,7 +212,7 @@ void GOMidiPlayer::HandleTimer() {
       GOTime next = e.GetTime() * m_Speed + m_Start;
       if (next > m_Start + m_Speed * (m_PlayingSeconds + 1) * 1000)
         next = m_Start + m_Speed * (m_PlayingSeconds + 1) * 1000;
-      m_OrganController->GetTimerManager()->SetTimer(next, this);
+      m_OrganController->GetTimer()->SetTimer(next, this);
       return;
     }
   } while (true);

--- a/src/grandorgue/midi/GOMidiPlayer.cpp
+++ b/src/grandorgue/midi/GOMidiPlayer.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -150,7 +150,7 @@ void GOMidiPlayer::Pause() {
     m_Pause = true;
     m_buttons[ID_MIDI_PLAYER_PAUSE]->Display(m_Pause);
     m_Start = wxGetLocalTimeMillis() - m_Start;
-    m_OrganController->DeleteTimer(this);
+    m_OrganController->GetTimerManager()->DeleteTimer(this);
   }
 }
 
@@ -172,7 +172,7 @@ void GOMidiPlayer::StopPlaying() {
   m_buttons[ID_MIDI_PLAYER_PLAY]->Display(false);
   m_buttons[ID_MIDI_PLAYER_PAUSE]->Display(false);
   UpdateDisplay();
-  m_OrganController->DeleteTimer(this);
+  m_OrganController->GetTimerManager()->DeleteTimer(this);
 }
 
 bool GOMidiPlayer::IsPlaying() { return m_IsPlaying; }
@@ -212,7 +212,7 @@ void GOMidiPlayer::HandleTimer() {
       GOTime next = e.GetTime() * m_Speed + m_Start;
       if (next > m_Start + m_Speed * (m_PlayingSeconds + 1) * 1000)
         next = m_Start + m_Speed * (m_PlayingSeconds + 1) * 1000;
-      m_OrganController->SetTimer(next, this);
+      m_OrganController->GetTimerManager()->SetTimer(next, this);
       return;
     }
   } while (true);

--- a/src/grandorgue/midi/GOMidiRecorder.cpp
+++ b/src/grandorgue/midi/GOMidiRecorder.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -304,7 +304,7 @@ void GOMidiRecorder::UpdateDisplay() {
 void GOMidiRecorder::StopRecording() {
   m_buttons[ID_MIDI_RECORDER_RECORD]->Display(false);
   m_buttons[ID_MIDI_RECORDER_RECORD_RENAME]->Display(false);
-  m_OrganController->DeleteTimer(this);
+  m_OrganController->GetTimerManager()->DeleteTimer(this);
   if (!IsRecording())
     return;
   const unsigned char end[4] = {0x01, 0xFF, 0x2F, 0x00};
@@ -368,7 +368,7 @@ void GOMidiRecorder::StartRecording(bool rename) {
 
   m_RecordSeconds = 0;
   UpdateDisplay();
-  m_OrganController->SetRelativeTimer(1000, this, 1000);
+  m_OrganController->GetTimerManager()->SetRelativeTimer(1000, this, 1000);
 }
 
 GOEnclosure *GOMidiRecorder::GetEnclosure(const wxString &name, bool is_panel) {

--- a/src/grandorgue/midi/GOMidiRecorder.cpp
+++ b/src/grandorgue/midi/GOMidiRecorder.cpp
@@ -304,7 +304,7 @@ void GOMidiRecorder::UpdateDisplay() {
 void GOMidiRecorder::StopRecording() {
   m_buttons[ID_MIDI_RECORDER_RECORD]->Display(false);
   m_buttons[ID_MIDI_RECORDER_RECORD_RENAME]->Display(false);
-  m_OrganController->GetTimerManager()->DeleteTimer(this);
+  m_OrganController->GetTimer()->DeleteTimer(this);
   if (!IsRecording())
     return;
   const unsigned char end[4] = {0x01, 0xFF, 0x2F, 0x00};
@@ -368,7 +368,7 @@ void GOMidiRecorder::StartRecording(bool rename) {
 
   m_RecordSeconds = 0;
   UpdateDisplay();
-  m_OrganController->GetTimerManager()->SetRelativeTimer(1000, this, 1000);
+  m_OrganController->GetTimer()->SetRelativeTimer(1000, this, 1000);
 }
 
 GOEnclosure *GOMidiRecorder::GetEnclosure(const wxString &name, bool is_panel) {


### PR DESCRIPTION
This will improve the independence of GOOrganController from wx library:

- Remove the inheritance from GOTimer (that inherits from wxTimer). https://github.com/GrandOrgue/grandorgue/commit/3b4a332b1901d2d3164fdd60ae94e3e6eb86fab5
- Remove the loading of base images if wxApp is not initialized. https://github.com/GrandOrgue/grandorgue/pull/1971/commits/5717432d99d0c83cc6c14a37f0c2a80d3ba67f8b

Based on https://github.com/GrandOrgue/grandorgue/pull/1268 to check tests.

Review the last two commits.

No GO behavior should have been changed.


In tests, previous version was triggering warnings (by wx library):

![image](https://github.com/user-attachments/assets/204fe1a3-4f21-4ae5-a219-b5113a51e715)


In this version :

![image](https://github.com/user-attachments/assets/8906ccbf-0982-44ee-83c5-932bea370145)
