### PR TITLE
Changed the parameter passing style of GOSettingFile

### DIFF
--- a/src/core/settings/GOSettingDirectory.cpp
+++ b/src/core/settings/GOSettingDirectory.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,15 +12,22 @@
 #include "GOPath.h"
 
 GOSettingDirectory::GOSettingDirectory(
-  GOSettingStore *store, wxString group, wxString name, wxString default_value)
-  : GOSettingString(store, group, name, default_value) {}
+  GOSettingStore *store,
+  const wxString &group,
+  const wxString &name,
+  const wxString &defaultValue)
+  : GOSettingString(store, group, name, defaultValue) {}
 
-wxString GOSettingDirectory::validate(wxString value) {
-  if (value == wxEmptyString || !wxFileName::DirExists(value))
-    value = getDefaultValue();
-  wxFileName file(value);
+wxString GOSettingDirectory::Validate(const wxString &value) const {
+  wxString newValue = value;
+
+  if (newValue == wxEmptyString || !wxFileName::DirExists(newValue))
+    newValue = GetDefaultValue();
+
+  wxFileName file(newValue);
+
   file.MakeAbsolute();
-  value = file.GetFullPath();
-  GOCreateDirectory(value);
-  return value;
+  newValue = file.GetFullPath();
+  GOCreateDirectory(newValue);
+  return newValue;
 }

--- a/src/core/settings/GOSettingDirectory.h
+++ b/src/core/settings/GOSettingDirectory.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,14 +12,14 @@
 
 class GOSettingDirectory : public GOSettingString {
 protected:
-  wxString validate(wxString value);
+  wxString Validate(const wxString &value) const override;
 
 public:
   GOSettingDirectory(
     GOSettingStore *store,
-    wxString group,
-    wxString name,
-    wxString default_value);
+    const wxString &group,
+    const wxString &name,
+    const wxString &defaultValue);
 };
 
 #endif

--- a/src/core/settings/GOSettingFile.cpp
+++ b/src/core/settings/GOSettingFile.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,18 +10,23 @@
 #include <wx/filename.h>
 
 GOSettingFile::GOSettingFile(
-  GOSettingStore *store, wxString group, wxString name, wxString default_value)
-  : GOSettingString(store, group, name, default_value) {}
+  GOSettingStore *store,
+  const wxString &group,
+  const wxString &name,
+  const wxString &defaultValue)
+  : GOSettingString(store, group, name, defaultValue) {}
 
-wxString GOSettingFile::validate(wxString value) {
-  if (value == wxEmptyString || !wxFileExists(value))
-    value = getDefaultValue();
-  if (!value.IsEmpty()) {
+wxString GOSettingFile::Validate(const wxString &value) const {
+  wxString newValue = value;
+
+  if (newValue == wxEmptyString || !wxFileExists(newValue))
+    newValue = GetDefaultValue();
+  if (!newValue.IsEmpty()) {
     // convert value to an absolute path
-    wxFileName file(value);
+    wxFileName file(newValue);
 
     file.MakeAbsolute();
-    value = file.GetFullPath();
+    newValue = file.GetFullPath();
   }
-  return value;
+  return newValue;
 }

--- a/src/core/settings/GOSettingFile.h
+++ b/src/core/settings/GOSettingFile.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,14 +12,14 @@
 
 class GOSettingFile : public GOSettingString {
 protected:
-  wxString validate(wxString value);
+  wxString Validate(const wxString &value) const override;
 
 public:
   GOSettingFile(
     GOSettingStore *store,
-    wxString group,
-    wxString name,
-    wxString default_value);
+    const wxString &group,
+    const wxString &name,
+    const wxString &defaultValue);
 };
 
 #endif

--- a/src/core/settings/GOSettingString.cpp
+++ b/src/core/settings/GOSettingString.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,10 +11,13 @@
 #include "config/GOConfigWriter.h"
 
 GOSettingString::GOSettingString(
-  GOSettingStore *store, wxString group, wxString name, wxString default_value)
+  GOSettingStore *store,
+  const wxString &group,
+  const wxString &name,
+  const wxString &defaultValue)
   : GOSetting(store, group, name),
-    m_Value(default_value),
-    m_DefaultValue(default_value) {}
+    m_Value(defaultValue),
+    m_DefaultValue(defaultValue) {}
 
 void GOSettingString::Load(GOConfigReader &cfg) {
   (*this)(cfg.ReadString(CMBSetting, m_Group, m_Name, false, m_DefaultValue));
@@ -23,15 +26,3 @@ void GOSettingString::Load(GOConfigReader &cfg) {
 void GOSettingString::Save(GOConfigWriter &cfg) {
   cfg.WriteString(m_Group, m_Name, m_Value);
 }
-
-void GOSettingString::setDefaultValue(wxString default_value) {
-  m_DefaultValue = default_value;
-}
-
-wxString GOSettingString::getDefaultValue() { return m_DefaultValue; }
-
-wxString GOSettingString::operator()() const { return m_Value; }
-
-void GOSettingString::operator()(wxString value) { m_Value = validate(value); }
-
-wxString GOSettingString::validate(wxString value) { return value; }

--- a/src/core/settings/GOSettingString.h
+++ b/src/core/settings/GOSettingString.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -19,20 +19,22 @@ private:
   void Save(GOConfigWriter &cfg);
 
 protected:
-  wxString getDefaultValue();
-  virtual wxString validate(wxString value);
+  const wxString &GetDefaultValue() const { return m_DefaultValue; }
+  virtual wxString Validate(const wxString &value) const { return value; }
 
 public:
   GOSettingString(
     GOSettingStore *store,
-    wxString group,
-    wxString name,
-    wxString default_value);
+    const wxString &group,
+    const wxString &name,
+    const wxString &defaultValue);
 
-  void setDefaultValue(wxString default_value);
+  void SetDefaultValue(const wxString &defaultValue) {
+    m_DefaultValue = defaultValue;
+  }
 
-  wxString operator()() const;
-  void operator()(wxString value);
+  const wxString &operator()() const { return m_Value; }
+  void operator()(const wxString &value) { m_Value = Validate(value); }
 };
 
 #endif

--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -386,22 +386,22 @@ void GOConfig::LoadDefaults() {
     m_MIDIEvents.push_back(new GOMidiReceiverBase(m_MIDISettings[i].type));
   m_ResourceDir = GOStdPath::GetResourceDir();
 
-  OrganPath.setDefaultValue(GOStdPath::GetGrandOrgueSubDir(_("Organs")));
-  OrganPackagePath.setDefaultValue(
+  OrganPath.SetDefaultValue(GOStdPath::GetGrandOrgueSubDir(_("Organs")));
+  OrganPackagePath.SetDefaultValue(
     GOStdPath::GetGrandOrgueSubDir(_("Organ packages")));
-  OrganCachePath.setDefaultValue(
+  OrganCachePath.SetDefaultValue(
     GOStdPath::GetGrandOrgueSubDir(wxT("Cache") + m_InstanceName));
-  OrganSettingsPath.setDefaultValue(
+  OrganSettingsPath.SetDefaultValue(
     GOStdPath::GetGrandOrgueSubDir(wxT("Data") + m_InstanceName));
-  OrganCombinationsPath.setDefaultValue(
+  OrganCombinationsPath.SetDefaultValue(
     GOStdPath::GetGrandOrgueSubDir(_("Combinations")));
-  ExportImportPath.setDefaultValue(
+  ExportImportPath.SetDefaultValue(
     GOStdPath::GetGrandOrgueSubDir(_("Settings")));
-  AudioRecorderPath.setDefaultValue(
+  AudioRecorderPath.SetDefaultValue(
     GOStdPath::GetGrandOrgueSubDir(_("Audio recordings")));
-  MidiRecorderPath.setDefaultValue(
+  MidiRecorderPath.SetDefaultValue(
     GOStdPath::GetGrandOrgueSubDir(_("MIDI recordings")));
-  MidiPlayerPath.setDefaultValue(
+  MidiPlayerPath.SetDefaultValue(
     GOStdPath::GetGrandOrgueSubDir(_("MIDI recordings")));
 }
 


### PR DESCRIPTION
This PR

- Changed passing wxString parameters of `GOSettingString`, `GOSettingDirectory`, `GOSettingFile` constructors in favor of `const wxString &`
- renamed methods of these classes according to the GO naming conventions
- moved simple implementations of  the methods from `.cpp` to `.h` files

This is just refactoring. No GO behavior should be changed.