### PR TITLE
Fixed crash on releasing a key of any Binauralpipes organ https://github.com/GrandOrgue/grandorgue/issues/1986

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on releasing a key of any Binauralpipes organ https://github.com/GrandOrgue/grandorgue/issues/1986
 - Fixed absance of warnings of unused Pipe999ReleaseCrossfadeLength https://github.com/GrandOrgue/grandorgue/issues/1904
 - Fixed loading organ to not abort if reading InfoFilename failed and also fixed showing link in properties dialog if InfoFilename exists
 # 3.15.0 (2024-08-06)

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -319,7 +319,8 @@ void GOSoundStream::InitAlignedStream(
   /* Translate increment in case of differing sample rates */
   resample = existing_stream->resample;
   m_ResamplingPos.Init(
-    pSection->GetSampleRate() / existing_stream->audio_section->GetSampleRate(),
+    (float)pSection->GetSampleRate()
+      / existing_stream->audio_section->GetSampleRate(),
     startIndex,
     &existing_stream->m_ResamplingPos);
   decode_call = getDecodeBlockFunction(


### PR DESCRIPTION
Resolves: #1986

The reason was initiaising GOSoundResample::ResamplingPosition::m_FractionIncrement with 0 that caused dividing by zero.