### PR TITLE
Fixed saving of Settings->Paths https://github.com/GrandOrgue/grandorgue/issues/1907

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
+- Fixed saving of Settings->Paths https://github.com/GrandOrgue/grandorgue/issues/1907
 - Fixed crash on releasing a key of any Binauralpipes organ https://github.com/GrandOrgue/grandorgue/issues/1986
-- Fixed absance of warnings of unused Pipe999ReleaseCrossfadeLength https://github.com/GrandOrgue/grandorgue/issues/1904
+- Fixed absence of warnings of unused Pipe999ReleaseCrossfadeLength https://github.com/GrandOrgue/grandorgue/issues/1904
 - Fixed loading organ to not abort if reading InfoFilename failed and also fixed showing link in properties dialog if InfoFilename exists
 # 3.15.0 (2024-08-06)
 - Added capability of regex matching audio device names https://github.com/GrandOrgue/grandorgue/issues/1265

--- a/src/core/GOPath.cpp
+++ b/src/core/GOPath.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,12 +11,16 @@
 #include <wx/filename.h>
 #include <wx/log.h>
 
-void GOCreateDirectory(const wxString &path) {
-  if (wxFileName::DirExists(path))
-    return;
-  if (!wxFileName::Mkdir(path, 0777, wxPATH_MKDIR_FULL)) {
-    wxLogError(_("Failed to create directory '%s'"), path.c_str());
+bool go_create_directory(const wxString &path) {
+  bool res = true;
+
+  if (
+    !wxFileName::DirExists(path)
+    && !wxFileName::Mkdir(path, 0777, wxPATH_MKDIR_FULL)) {
+    wxLogError(_("Failed to create directory '%s'"), path);
+    res = false;
   }
+  return res;
 }
 
 wxString GONormalizePath(const wxString &path) {

--- a/src/core/GOPath.cpp
+++ b/src/core/GOPath.cpp
@@ -11,7 +11,7 @@
 #include <wx/filename.h>
 #include <wx/log.h>
 
-bool go_create_directory(const wxString &path) {
+bool GOCreateDirectory(const wxString &path) {
   bool res = true;
 
   if (

--- a/src/core/GOPath.h
+++ b/src/core/GOPath.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,7 +10,7 @@
 
 #include <wx/string.h>
 
-void GOCreateDirectory(const wxString &path);
+bool go_create_directory(const wxString &path);
 wxString GONormalizePath(const wxString &path);
 wxString GOGetPath(const wxString &path);
 

--- a/src/core/GOPath.h
+++ b/src/core/GOPath.h
@@ -10,7 +10,7 @@
 
 #include <wx/string.h>
 
-bool go_create_directory(const wxString &path);
+bool GOCreateDirectory(const wxString &path);
 wxString GONormalizePath(const wxString &path);
 wxString GOGetPath(const wxString &path);
 

--- a/src/core/settings/GOSettingDirectory.cpp
+++ b/src/core/settings/GOSettingDirectory.cpp
@@ -21,13 +21,14 @@ GOSettingDirectory::GOSettingDirectory(
 wxString GOSettingDirectory::Validate(const wxString &value) const {
   wxString newValue = value;
 
-  if (newValue == wxEmptyString || !wxFileName::DirExists(newValue))
+  if (newValue == wxEmptyString)
     newValue = GetDefaultValue();
 
   wxFileName file(newValue);
 
   file.MakeAbsolute();
   newValue = file.GetFullPath();
-  GOCreateDirectory(newValue);
+  if (!wxFileName::DirExists(newValue))
+    go_create_directory(newValue);
   return newValue;
 }

--- a/src/core/settings/GOSettingDirectory.cpp
+++ b/src/core/settings/GOSettingDirectory.cpp
@@ -26,6 +26,6 @@ wxString GOSettingDirectory::Validate(const wxString &value) const {
   const wxString newValue = file.GetFullPath();
 
   if (!wxFileName::DirExists(newValue))
-    go_create_directory(newValue);
+    GOCreateDirectory(newValue);
   return newValue;
 }

--- a/src/core/settings/GOSettingDirectory.cpp
+++ b/src/core/settings/GOSettingDirectory.cpp
@@ -19,15 +19,12 @@ GOSettingDirectory::GOSettingDirectory(
   : GOSettingString(store, group, name, defaultValue) {}
 
 wxString GOSettingDirectory::Validate(const wxString &value) const {
-  wxString newValue = value;
-
-  if (newValue == wxEmptyString)
-    newValue = GetDefaultValue();
-
-  wxFileName file(newValue);
+  wxFileName file(!value.IsEmpty() ? value : GetDefaultValue());
 
   file.MakeAbsolute();
-  newValue = file.GetFullPath();
+
+  const wxString newValue = file.GetFullPath();
+
   if (!wxFileName::DirExists(newValue))
     go_create_directory(newValue);
   return newValue;


### PR DESCRIPTION
Resolves: #1907

The reason why the path settings may not be saved was that the directory did not exist.

This PR adds making the directory.