### PR TITLE
Fixed combination button lighting when a crescendo was in the Override=Off mode https://github.com/GrandOrgue/grandorgue/issues/1935

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed combination button lighting when a crescendo was in the Override=Off mode https://github.com/GrandOrgue/grandorgue/issues/1935
 # 3.15.1 (2024-09-03)
 - Fixed saving of Settings->Paths https://github.com/GrandOrgue/grandorgue/issues/1907
 - Fixed crash on releasing a key of any Binauralpipes organ https://github.com/GrandOrgue/grandorgue/issues/1986

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -1025,8 +1025,8 @@ void GOSetter::PushGeneral(
     = GetCrescendoAddSet(elementSet);
 
   NotifyCmbPushed(cmb.Push(m_state, pExtraSet));
-  if (!pExtraSet) { // Otherwise the crescendo in add mode:
-                    // not to switch off combination buttons
+  if (pButtonToLight || !pExtraSet) { // Otherwise the crescendo in add mode:
+                                      // not to switch off combination buttons
     UpdateAllSetsButtonsLight(pButtonToLight, -1);
   }
 }
@@ -1042,7 +1042,7 @@ void GOSetter::PushDivisional(
       = GetCrescendoAddSet(elementSet);
 
     NotifyCmbPushed(cmb.Push(m_state, pExtraSet));
-    if (!pExtraSet)
+    if (pButtonToLight || !pExtraSet)
       UpdateAllSetsButtonsLight(pButtonToLight, cmbManual);
   }
 }


### PR DESCRIPTION
This PR solves the first part of #1935: lighing combination buttons when a crescendo in the Add mode