### PR TITLE
Renamed GOCombinationElement::SetCombination to SetCombinationState

### DIFF
--- a/src/grandorgue/GOVirtualCouplerController.cpp
+++ b/src/grandorgue/GOVirtualCouplerController.cpp
@@ -149,7 +149,7 @@ void GOVirtualCouplerController::Load(
     bool isCoupleThrough = cfg.ReadBoolean(
       CMBSetting, pCoupleThrough->GetGroup(), WX_COUPLE_THROUGH, false, false);
 
-    pCoupleThrough->Set(isCoupleThrough);
+    pCoupleThrough->SetButtonState(isCoupleThrough);
   }
 }
 

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -996,7 +996,9 @@ void GOSetter::OnCombinationsSaved(const wxString &yamlFile) {
 
 void GOSetter::Update() {}
 
-void GOSetter::SetterActive(bool on) { m_buttons[ID_SETTER_SET]->Set(on); }
+void GOSetter::SetterActive(bool on) {
+  m_buttons[ID_SETTER_SET]->SetButtonState(on);
+}
 
 void GOSetter::ToggleSetter() { m_buttons[ID_SETTER_SET]->Push(); }
 

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -454,7 +454,7 @@ bool GOCombination::Push(
       if (
         m_ElementStates[i] != BOOL3_DEFAULT
         && (!extraSet || extraSet->find(i) == extraSet->end())) {
-        r_ElementDefinitions[i].control->SetCombination(
+        r_ElementDefinitions[i].control->SetCombinationState(
           to_bool(m_ElementStates[i]));
         used |= to_bool(m_ElementStates[i]);
       }

--- a/src/grandorgue/combinations/model/GOCombinationElement.h
+++ b/src/grandorgue/combinations/model/GOCombinationElement.h
@@ -11,7 +11,7 @@
 class GOCombinationElement {
 public:
   virtual bool GetCombinationState() const = 0;
-  virtual void SetCombination(bool on) = 0;
+  virtual void SetCombinationState(bool on) = 0;
   virtual bool IsControlledByUser() const = 0;
 };
 

--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -92,10 +92,10 @@ void GOButtonControl::HandleKey(int key) {
 void GOButtonControl::Push() {
   if (m_ReadOnly)
     return;
-  Set(m_Engaged ^ true);
+  SetButtonState(m_Engaged ^ true);
 }
 
-void GOButtonControl::Set(bool on) {}
+void GOButtonControl::SetButtonState(bool on) {}
 
 void GOButtonControl::AbortPlayback() {
   m_sender.SetDisplay(false);
@@ -121,12 +121,12 @@ void GOButtonControl::ProcessMidi(const GOMidiEvent &event) {
     if (m_Pushbutton)
       Push();
     else
-      Set(true);
+      SetButtonState(true);
     break;
 
   case MIDI_MATCH_OFF:
     if (!m_Pushbutton)
-      Set(false);
+      SetButtonState(false);
     break;
 
   default:

--- a/src/grandorgue/control/GOButtonControl.h
+++ b/src/grandorgue/control/GOButtonControl.h
@@ -81,7 +81,7 @@ public:
   bool IsPiston() const { return m_IsPiston; }
 
   virtual void Push();
-  virtual void Set(bool on);
+  virtual void SetButtonState(bool on);
   virtual void Display(bool onoff);
   bool IsEngaged() const;
   bool DisplayInverted() const;

--- a/src/grandorgue/control/GOCallbackButtonControl.cpp
+++ b/src/grandorgue/control/GOCallbackButtonControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -26,7 +26,7 @@ void GOCallbackButtonControl::Push() {
     GOButtonControl::Push();
 }
 
-void GOCallbackButtonControl::Set(bool on) {
+void GOCallbackButtonControl::SetButtonState(bool on) {
   if (IsEngaged() == on)
     return;
   m_callback->ButtonStateChanged(this, on);

--- a/src/grandorgue/control/GOCallbackButtonControl.h
+++ b/src/grandorgue/control/GOCallbackButtonControl.h
@@ -23,7 +23,7 @@ public:
     bool isPushbutton,
     bool isPiston = false);
   void Push(void) override;
-  void Set(bool on) override;
+  void SetButtonState(bool on) override;
 
   const wxString &GetMidiTypeCode() const override;
   const wxString &GetMidiType() const override;

--- a/src/grandorgue/dialogs/GOStopsDialog.cpp
+++ b/src/grandorgue/dialogs/GOStopsDialog.cpp
@@ -139,7 +139,7 @@ void GOStopsDialog::OnElementChanging(wxCommandEvent &event) {
     = static_cast<GOCombinationElement *>(pCheck->GetClientData());
 
   if (pE)
-    pE->SetCombination(event.IsChecked());
+    pE->SetCombinationState(event.IsChecked());
 }
 
 void GOStopsDialog::ControlChanged(GOControl *pControl) {

--- a/src/grandorgue/model/GOCoupler.cpp
+++ b/src/grandorgue/model/GOCoupler.cpp
@@ -359,7 +359,7 @@ void GOCoupler::SetKey(
   ChangeKey(note, velocity);
 }
 
-void GOCoupler::ChangeState(bool on) {
+void GOCoupler::OnDrawstopStateChanged(bool on) {
   if (m_UnisonOff)
     r_OrganModel.GetManual(m_SourceManual)->SetUnisonOff(on);
   else {

--- a/src/grandorgue/model/GOCoupler.h
+++ b/src/grandorgue/model/GOCoupler.h
@@ -51,7 +51,7 @@ private:
   void ChangeKey(int note, unsigned velocity);
   void SetOut(int note, unsigned velocity);
   unsigned GetInternalState(int note);
-  void ChangeState(bool on) override;
+  void OnDrawstopStateChanged(bool on) override;
   void SetupIsToStoreInCmb() override;
 
   void PreparePlayback() override;

--- a/src/grandorgue/model/GODivisionalCoupler.h
+++ b/src/grandorgue/model/GODivisionalCoupler.h
@@ -23,7 +23,7 @@ private:
   bool m_BiDirectionalCoupling;
   std::vector<unsigned> m_manuals;
 
-  void ChangeState(bool on) override {}
+  void OnDrawstopStateChanged(bool on) override {}
   void SetupIsToStoreInCmb() override;
 
 public:

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -136,7 +136,7 @@ void GODrawstop::SetButtonState(bool on) {
   if (IsEngaged() == on)
     return;
   Display(on);
-  SetState(on);
+  SetDrawStopState(on);
 }
 
 void GODrawstop::Reset() {
@@ -147,7 +147,7 @@ void GODrawstop::Reset() {
   SetButtonState(m_GCState > 0 ? true : false);
 }
 
-void GODrawstop::SetState(bool on) {
+void GODrawstop::SetDrawStopState(bool on) {
   if (IsActive() == on)
     return;
   if (IsReadOnly()) {
@@ -173,7 +173,7 @@ void GODrawstop::Update() {
   bool state;
   switch (m_Type) {
   case FUNCTION_INPUT:
-    SetState(IsEngaged());
+    SetDrawStopState(IsEngaged());
     break;
 
   case FUNCTION_AND:
@@ -182,9 +182,9 @@ void GODrawstop::Update() {
     for (unsigned i = 0; i < m_ControllingDrawstops.size(); i++)
       state = state && m_ControllingDrawstops[i]->IsActive();
     if (m_Type == FUNCTION_NAND)
-      SetState(!state);
+      SetDrawStopState(!state);
     else
-      SetState(state);
+      SetDrawStopState(state);
     break;
 
   case FUNCTION_OR:
@@ -193,21 +193,21 @@ void GODrawstop::Update() {
     for (unsigned i = 0; i < m_ControllingDrawstops.size(); i++)
       state = state || m_ControllingDrawstops[i]->IsActive();
     if (m_Type == FUNCTION_NOR)
-      SetState(!state);
+      SetDrawStopState(!state);
     else
-      SetState(state);
+      SetDrawStopState(state);
     break;
 
   case FUNCTION_XOR:
     state = false;
     for (unsigned i = 0; i < m_ControllingDrawstops.size(); i++)
       state = state != m_ControllingDrawstops[i]->IsActive();
-    SetState(state);
+    SetDrawStopState(state);
     break;
 
   case FUNCTION_NOT:
     state = m_ControllingDrawstops[0]->IsActive();
-    SetState(!state);
+    SetDrawStopState(!state);
     break;
   }
 }

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -132,7 +132,7 @@ void GODrawstop::Save(GOConfigWriter &cfg) {
   GOButtonControl::Save(cfg);
 }
 
-void GODrawstop::Set(bool on) {
+void GODrawstop::SetButtonState(bool on) {
   if (IsEngaged() == on)
     return;
   Display(on);
@@ -144,7 +144,7 @@ void GODrawstop::Reset() {
     return;
   if (m_GCState < 0)
     return;
-  Set(m_GCState > 0 ? true : false);
+  SetButtonState(m_GCState > 0 ? true : false);
 }
 
 void GODrawstop::SetState(bool on) {
@@ -161,7 +161,7 @@ void GODrawstop::SetState(bool on) {
 
 void GODrawstop::SetCombinationState(bool on) {
   if (!IsReadOnly())
-    Set(on);
+    SetButtonState(on);
 }
 
 void GODrawstop::StartPlayback() {

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -29,8 +29,6 @@ GODrawstop::GODrawstop(GOOrganModel &organModel)
   : GOButtonControl(organModel, MIDI_RECV_DRAWSTOP, false),
     m_Type(FUNCTION_INPUT),
     m_GCState(0),
-    m_ActiveState(false),
-    m_CombinationState(false),
     m_ControlledDrawstops(),
     m_ControllingDrawstops(),
     m_IsToStoreInDivisional(false),
@@ -160,11 +158,9 @@ void GODrawstop::SetState(bool on) {
     m_ControlledDrawstops[i]->Update();
 }
 
-void GODrawstop::SetCombination(bool on) {
-  if (IsReadOnly())
-    return;
-  m_CombinationState = on;
-  Set(on);
+void GODrawstop::SetCombinationState(bool on) {
+  if (!IsReadOnly())
+    Set(on);
 }
 
 void GODrawstop::StartPlayback() {

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -154,7 +154,7 @@ void GODrawstop::SetState(bool on) {
     Display(on);
   }
   m_ActiveState = on;
-  ChangeState(on);
+  OnDrawstopStateChanged(on);
   for (unsigned i = 0; i < m_ControlledDrawstops.size(); i++)
     m_ControlledDrawstops[i]->Update();
 }

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -29,6 +29,7 @@ GODrawstop::GODrawstop(GOOrganModel &organModel)
   : GOButtonControl(organModel, MIDI_RECV_DRAWSTOP, false),
     m_Type(FUNCTION_INPUT),
     m_GCState(0),
+    m_ActiveState(false),
     m_ControlledDrawstops(),
     m_ControllingDrawstops(),
     m_IsToStoreInDivisional(false),

--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -50,7 +50,7 @@ protected:
   virtual void SetupIsToStoreInCmb();
 
   void SetState(bool on);
-  virtual void ChangeState(bool on) = 0;
+  virtual void OnDrawstopStateChanged(bool on) = 0;
 
   void Save(GOConfigWriter &cfg) override;
 

--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -30,7 +30,6 @@ private:
   GOFunctionType m_Type;
   int m_GCState;
   bool m_ActiveState;
-  bool m_CombinationState;
   std::vector<GODrawstop *> m_ControlledDrawstops;
   std::vector<GODrawstop *> m_ControllingDrawstops;
 
@@ -71,7 +70,7 @@ public:
   virtual void Set(bool on) override;
   virtual void Update();
   void Reset();
-  void SetCombination(bool on) override;
+  void SetCombinationState(bool on) override;
 };
 
 #endif

--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -67,7 +67,7 @@ public:
   void Init(GOConfigReader &cfg, wxString group, wxString name);
   void Load(GOConfigReader &cfg, wxString group);
   void RegisterControlled(GODrawstop *sw);
-  virtual void Set(bool on) override;
+  virtual void SetButtonState(bool on) override;
   virtual void Update();
   void Reset();
   void SetCombinationState(bool on) override;

--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -35,6 +35,8 @@ private:
 
   bool IsControlledByUser() const override { return !IsReadOnly(); }
 
+  void SetDrawStopState(bool on);
+
 protected:
   /*
    * m_IsToStoreInDivisional and m_IsToStoreInGeneral control whether the
@@ -49,7 +51,6 @@ protected:
 
   virtual void SetupIsToStoreInCmb();
 
-  void SetState(bool on);
   virtual void OnDrawstopStateChanged(bool on) = 0;
 
   void Save(GOConfigWriter &cfg) override;

--- a/src/grandorgue/model/GOStop.cpp
+++ b/src/grandorgue/model/GOStop.cpp
@@ -130,7 +130,7 @@ void GOStop::SetKey(unsigned note, unsigned velocity) {
     SetRankKey(note, m_KeyVelocity[note]);
 }
 
-void GOStop::ChangeState(bool on) {
+void GOStop::OnDrawstopStateChanged(bool on) {
   if (IsAuto()) {
     SetRankKey(0, on ? 0x7f : 0x00);
   } else {

--- a/src/grandorgue/model/GOStop.cpp
+++ b/src/grandorgue/model/GOStop.cpp
@@ -143,7 +143,7 @@ GOStop::~GOStop(void) {}
 
 void GOStop::AbortPlayback() {
   if (IsAuto())
-    Set(false);
+    SetButtonState(false);
   GOButtonControl::AbortPlayback();
 }
 

--- a/src/grandorgue/model/GOStop.h
+++ b/src/grandorgue/model/GOStop.h
@@ -32,7 +32,7 @@ private:
   unsigned m_NumberOfAccessiblePipes;
 
   void SetRankKey(unsigned key, unsigned velocity);
-  void ChangeState(bool on) override;
+  void OnDrawstopStateChanged(bool on) override;
 
   void AbortPlayback() override;
   void PreparePlayback() override;

--- a/src/grandorgue/model/GOSwitch.h
+++ b/src/grandorgue/model/GOSwitch.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -19,7 +19,7 @@ class GOSwitch : public GODrawstop {
   unsigned m_IndexInManual = 0;
 
 protected:
-  void ChangeState(bool) override {}
+  void OnDrawstopStateChanged(bool) override {}
 
 public:
   GOSwitch(GOOrganModel &organModel) : GODrawstop(organModel) {}

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -91,7 +91,7 @@ void GOTremulant::InitSoundProvider(GOMemoryPool &pool) {
   }
 }
 
-void GOTremulant::ChangeState(bool on) {
+void GOTremulant::OnDrawstopStateChanged(bool on) {
   if (m_TremulantType == GOSynthTrem) {
     GOSoundEngine *pSoundEngine = GetSoundEngine();
 

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -37,7 +37,7 @@ private:
   unsigned m_TremulantN;
 
   void InitSoundProvider(GOMemoryPool &pool);
-  void ChangeState(bool on) override;
+  void OnDrawstopStateChanged(bool on) override;
   void SetupIsToStoreInCmb() override;
 
   void Initialize() override;


### PR DESCRIPTION
This PR 
- Renames GOCombinationElement::SetCombination to SetCombinationState
- Deletes the unused member GODrawstop::m_CombinationState
- Renames GOButtonControl::Set to SetButtonState
- Renames GODrawStop::ChangeState to OnDrawsStopChanged
- Renames GODrawStop::SetState to SetDrawstopChanged and made it private

It is just renaming. No GO behavior should be changed.