### PR TITLE
Added GODrawStop tests

### DIFF
--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -15,7 +15,7 @@
 
 class GODrawstop : public GOButtonControl, virtual public GOCombinationElement {
 public:
-  typedef enum {
+  enum GOFunctionType {
     FUNCTION_INPUT,
     FUNCTION_AND,
     FUNCTION_OR,
@@ -23,7 +23,7 @@ public:
     FUNCTION_XOR,
     FUNCTION_NAND,
     FUNCTION_NOR
-  } GOFunctionType;
+  };
 
 private:
   static const struct IniFileEnumEntry m_function_types[];
@@ -60,6 +60,15 @@ protected:
 public:
   GODrawstop(GOOrganModel &organModel);
 
+  /* + For tests only */
+  GOFunctionType GetFunctionType() const { return m_Type; }
+  void SetFunctionType(GOFunctionType newFunctionType);
+
+  void ClearControllingDrawstops();
+  void AddControllingDrawstop(
+    GODrawstop *pDrawStop, unsigned switchN, const wxString &group);
+  /* - For tests only */
+
   bool IsToStoreInDivisional() const { return m_IsToStoreInDivisional; }
   bool IsToStoreInGeneral() const { return m_IsToStoreInGeneral; }
   bool IsActive() const { return m_ActiveState; }
@@ -68,6 +77,7 @@ public:
   void Init(GOConfigReader &cfg, wxString group, wxString name);
   void Load(GOConfigReader &cfg, wxString group);
   void RegisterControlled(GODrawstop *sw);
+  void UnRegisterControlled(GODrawstop *sw);
   virtual void SetButtonState(bool on) override;
   virtual void Update();
   void Reset();

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -4,12 +4,14 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
+#include <cstdio>
+#include <iostream>
+
 #include "GOTestCollection.h"
+#include "GOTestDrawStop.h"
 #include "GOTestOrganModel.h"
 #include "GOTestSwitch.h"
 #include "GOTestWindchest.h"
-#include <cstdio>
-#include <iostream>
 
 int main() {
   /*
@@ -20,9 +22,10 @@ int main() {
   */
 
   /* Instantiate all the test classes here */
-  new GOTestWindchest;
+  new GOTestDrawStop;
   new GOTestOrganModel;
   new GOTestSwitch;
+  new GOTestWindchest;
   /* end of instanciation */
   GOTestResultCollection test_result_collection;
   test_result_collection = GOTestCollection::Instance()->run();

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -22,10 +22,10 @@ int main() {
   */
 
   /* Instantiate all the test classes here */
-  new GOTestDrawStop;
-  new GOTestOrganModel;
-  new GOTestSwitch;
-  new GOTestWindchest;
+  GOTestDrawStop::TestFunctions testDrawStopFunctions;
+  GOTestOrganModel testOrganModel;
+  GOTestSwitch testSwitch;
+  GOTestWindchest testWindchest;
   /* end of instanciation */
   GOTestResultCollection test_result_collection;
   test_result_collection = GOTestCollection::Instance()->run();

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(go_tests
     # Add here your tests files
+    model/GOTestDrawStop.cpp
     model/GOTestOrganModel.cpp
     model/GOTestSwitch.cpp
     model/GOTestWindchest.cpp

--- a/src/tests/testing/model/GOTestDrawStop.cpp
+++ b/src/tests/testing/model/GOTestDrawStop.cpp
@@ -2,73 +2,77 @@
 
 #include "model/GOSwitch.h"
 
-void GOTestDrawStop::run() {
+std::string GOTestDrawStop::CLASS_NAME = "GOTestDrawStop";
+std::string GOTestDrawStop::TestFunctions::TEST_NAME
+  = CLASS_NAME + "::Functions";
+
+void GOTestDrawStop::TestFunctions::run() {
   // test grouping functionality
-  GOSwitch *sw1 = new GOSwitch(*this->controller);
-  GOSwitch *sw2 = new GOSwitch(*this->controller);
-  GOSwitch *sw3 = new GOSwitch(*this->controller);
-  GOSwitch *sw12 = new GOSwitch(*this->controller);
-  GOSwitch *sw13 = new GOSwitch(*this->controller);
-  GOSwitch *sw23 = new GOSwitch(*this->controller);
+  GOSwitch sw1(*controller);
+  GOSwitch sw2(*controller);
+  GOSwitch sw3(*controller);
+  GOSwitch sw12(*controller);
+  GOSwitch sw13(*controller);
+  GOSwitch sw23(*controller);
 
-  sw12->SetFunctionType(GODrawstop::FUNCTION_AND);
-  sw13->SetFunctionType(GODrawstop::FUNCTION_OR);
-  sw23->SetFunctionType(GODrawstop::FUNCTION_XOR);
-  sw12->AddControllingDrawstop(sw1, 1, "sw1");
-  sw12->AddControllingDrawstop(sw2, 2, "sw1");
-  sw13->AddControllingDrawstop(sw1, 1, "sw2");
-  sw13->AddControllingDrawstop(sw3, 2, "sw2");
-  sw23->AddControllingDrawstop(sw2, 1, "sw3");
-  sw23->AddControllingDrawstop(sw3, 2, "sw3");
+  sw12.SetFunctionType(GODrawstop::FUNCTION_AND);
+  sw13.SetFunctionType(GODrawstop::FUNCTION_OR);
+  sw23.SetFunctionType(GODrawstop::FUNCTION_XOR);
+  sw12.AddControllingDrawstop(&sw1, 1, "sw1");
+  sw12.AddControllingDrawstop(&sw2, 2, "sw1");
+  sw13.AddControllingDrawstop(&sw1, 1, "sw2");
+  sw13.AddControllingDrawstop(&sw3, 2, "sw2");
+  sw23.AddControllingDrawstop(&sw2, 1, "sw3");
+  sw23.AddControllingDrawstop(&sw3, 2, "sw3");
 
-  GOAssert(!sw12->IsActive(), "false AND false");
-  GOAssert(!sw13->IsActive(), "false OR false");
-  GOAssert(!sw23->IsActive(), "false XOR false");
+  GOAssert(!sw12.IsActive(), "false AND false");
+  GOAssert(!sw13.IsActive(), "false OR false");
+  GOAssert(!sw23.IsActive(), "false XOR false");
 
-  sw1->SetButtonState(true);
-  GOAssert(!sw12->IsActive(), "true AND false");
-  GOAssert(sw13->IsActive(), "true OR false");
-  GOAssert(!sw23->IsActive(), "false XOR false");
+  sw1.SetButtonState(true);
+  GOAssert(!sw12.IsActive(), "true AND false");
+  GOAssert(sw13.IsActive(), "true OR false");
+  GOAssert(!sw23.IsActive(), "false XOR false");
 
-  sw1->SetButtonState(false);
-  sw2->SetButtonState(true);
-  GOAssert(!sw12->IsActive(), "false AND true");
-  GOAssert(!sw13->IsActive(), "false OR false");
-  GOAssert(sw23->IsActive(), "true XOR false");
+  sw1.SetButtonState(false);
+  sw2.SetButtonState(true);
+  GOAssert(!sw12.IsActive(), "false AND true");
+  GOAssert(!sw13.IsActive(), "false OR false");
+  GOAssert(sw23.IsActive(), "true XOR false");
 
-  sw1->SetButtonState(true);
-  GOAssert(sw12->IsActive(), "true AND true");
-  GOAssert(sw13->IsActive(), "true OR false");
-  GOAssert(sw23->IsActive(), "true XOR false");
+  sw1.SetButtonState(true);
+  GOAssert(sw12.IsActive(), "true AND true");
+  GOAssert(sw13.IsActive(), "true OR false");
+  GOAssert(sw23.IsActive(), "true XOR false");
 
-  sw1->SetButtonState(false);
-  sw2->SetButtonState(false);
-  sw3->SetButtonState(true);
-  GOAssert(!sw12->IsActive(), "false AND false");
-  GOAssert(sw13->IsActive(), "false OR true");
-  GOAssert(sw23->IsActive(), "false XOR true");
+  sw1.SetButtonState(false);
+  sw2.SetButtonState(false);
+  sw3.SetButtonState(true);
+  GOAssert(!sw12.IsActive(), "false AND false");
+  GOAssert(sw13.IsActive(), "false OR true");
+  GOAssert(sw23.IsActive(), "false XOR true");
 
-  sw1->SetButtonState(true);
-  GOAssert(!sw12->IsActive(), "true AND false");
-  GOAssert(sw13->IsActive(), "true OR true");
-  GOAssert(sw23->IsActive(), "false XOR true");
+  sw1.SetButtonState(true);
+  GOAssert(!sw12.IsActive(), "true AND false");
+  GOAssert(sw13.IsActive(), "true OR true");
+  GOAssert(sw23.IsActive(), "false XOR true");
 
-  sw1->SetButtonState(false);
-  sw2->SetButtonState(true);
-  GOAssert(!sw12->IsActive(), "false AND true");
-  GOAssert(sw13->IsActive(), "false OR true");
-  GOAssert(!sw23->IsActive(), "true XOR true");
+  sw1.SetButtonState(false);
+  sw2.SetButtonState(true);
+  GOAssert(!sw12.IsActive(), "false AND true");
+  GOAssert(sw13.IsActive(), "false OR true");
+  GOAssert(!sw23.IsActive(), "true XOR true");
 
-  sw1->SetButtonState(true);
-  GOAssert(sw12->IsActive(), "true AND true");
-  GOAssert(sw13->IsActive(), "true OR true");
-  GOAssert(!sw23->IsActive(), "true XOR true");
+  sw1.SetButtonState(true);
+  GOAssert(sw12.IsActive(), "true AND true");
+  GOAssert(sw13.IsActive(), "true OR true");
+  GOAssert(!sw23.IsActive(), "true XOR true");
 
   /*
   std::string message;
 
   // Check global Switch
-  GOSwitch *go_switch = new GOSwitch(*this->controller);
+  GOSwitch *go_switch(*this->controller);
   message = "The associated manual should be -1 as it is a global switch!";
   this->GOAssert(go_switch->GetAssociatedManualN() == -1, message);
 
@@ -77,4 +81,8 @@ void GOTestDrawStop::run() {
   */
 
   // Test AND function of switches
+
+  sw23.ClearControllingDrawstops();
+  sw13.ClearControllingDrawstops();
+  sw12.ClearControllingDrawstops();
 }

--- a/src/tests/testing/model/GOTestDrawStop.cpp
+++ b/src/tests/testing/model/GOTestDrawStop.cpp
@@ -7,7 +7,6 @@ std::string GOTestDrawStop::TestFunctions::TEST_NAME
   = CLASS_NAME + "::Functions";
 
 void GOTestDrawStop::TestFunctions::run() {
-  // test grouping functionality
   GOSwitch sw1(*controller);
   GOSwitch sw2(*controller);
   GOSwitch sw3(*controller);
@@ -67,20 +66,6 @@ void GOTestDrawStop::TestFunctions::run() {
   GOAssert(sw12.IsActive(), "true AND true");
   GOAssert(sw13.IsActive(), "true OR true");
   GOAssert(!sw23.IsActive(), "true XOR true");
-
-  /*
-  std::string message;
-
-  // Check global Switch
-  GOSwitch *go_switch(*this->controller);
-  message = "The associated manual should be -1 as it is a global switch!";
-  this->GOAssert(go_switch->GetAssociatedManualN() == -1, message);
-
-  message = "The switch index in manual should be 0!";
-  this->GOAssert(go_switch->GetIndexInManual() == 0, message);
-  */
-
-  // Test AND function of switches
 
   sw23.ClearControllingDrawstops();
   sw13.ClearControllingDrawstops();

--- a/src/tests/testing/model/GOTestDrawStop.cpp
+++ b/src/tests/testing/model/GOTestDrawStop.cpp
@@ -1,0 +1,80 @@
+#include "GOTestDrawStop.h"
+
+#include "model/GOSwitch.h"
+
+void GOTestDrawStop::run() {
+  // test grouping functionality
+  GOSwitch *sw1 = new GOSwitch(*this->controller);
+  GOSwitch *sw2 = new GOSwitch(*this->controller);
+  GOSwitch *sw3 = new GOSwitch(*this->controller);
+  GOSwitch *sw12 = new GOSwitch(*this->controller);
+  GOSwitch *sw13 = new GOSwitch(*this->controller);
+  GOSwitch *sw23 = new GOSwitch(*this->controller);
+
+  sw12->SetFunctionType(GODrawstop::FUNCTION_AND);
+  sw13->SetFunctionType(GODrawstop::FUNCTION_OR);
+  sw23->SetFunctionType(GODrawstop::FUNCTION_XOR);
+  sw12->AddControllingDrawstop(sw1, 1, "sw1");
+  sw12->AddControllingDrawstop(sw2, 2, "sw1");
+  sw13->AddControllingDrawstop(sw1, 1, "sw2");
+  sw13->AddControllingDrawstop(sw3, 2, "sw2");
+  sw23->AddControllingDrawstop(sw2, 1, "sw3");
+  sw23->AddControllingDrawstop(sw3, 2, "sw3");
+
+  GOAssert(!sw12->IsActive(), "false AND false");
+  GOAssert(!sw13->IsActive(), "false OR false");
+  GOAssert(!sw23->IsActive(), "false XOR false");
+
+  sw1->SetButtonState(true);
+  GOAssert(!sw12->IsActive(), "true AND false");
+  GOAssert(sw13->IsActive(), "true OR false");
+  GOAssert(!sw23->IsActive(), "false XOR false");
+
+  sw1->SetButtonState(false);
+  sw2->SetButtonState(true);
+  GOAssert(!sw12->IsActive(), "false AND true");
+  GOAssert(!sw13->IsActive(), "false OR false");
+  GOAssert(sw23->IsActive(), "true XOR false");
+
+  sw1->SetButtonState(true);
+  GOAssert(sw12->IsActive(), "true AND true");
+  GOAssert(sw13->IsActive(), "true OR false");
+  GOAssert(sw23->IsActive(), "true XOR false");
+
+  sw1->SetButtonState(false);
+  sw2->SetButtonState(false);
+  sw3->SetButtonState(true);
+  GOAssert(!sw12->IsActive(), "false AND false");
+  GOAssert(sw13->IsActive(), "false OR true");
+  GOAssert(sw23->IsActive(), "false XOR true");
+
+  sw1->SetButtonState(true);
+  GOAssert(!sw12->IsActive(), "true AND false");
+  GOAssert(sw13->IsActive(), "true OR true");
+  GOAssert(sw23->IsActive(), "false XOR true");
+
+  sw1->SetButtonState(false);
+  sw2->SetButtonState(true);
+  GOAssert(!sw12->IsActive(), "false AND true");
+  GOAssert(sw13->IsActive(), "false OR true");
+  GOAssert(!sw23->IsActive(), "true XOR true");
+
+  sw1->SetButtonState(true);
+  GOAssert(sw12->IsActive(), "true AND true");
+  GOAssert(sw13->IsActive(), "true OR true");
+  GOAssert(!sw23->IsActive(), "true XOR true");
+
+  /*
+  std::string message;
+
+  // Check global Switch
+  GOSwitch *go_switch = new GOSwitch(*this->controller);
+  message = "The associated manual should be -1 as it is a global switch!";
+  this->GOAssert(go_switch->GetAssociatedManualN() == -1, message);
+
+  message = "The switch index in manual should be 0!";
+  this->GOAssert(go_switch->GetIndexInManual() == 0, message);
+  */
+
+  // Test AND function of switches
+}

--- a/src/tests/testing/model/GOTestDrawStop.h
+++ b/src/tests/testing/model/GOTestDrawStop.h
@@ -3,16 +3,19 @@
 
 #include "GOTest.h"
 
-class GOTestDrawStop : public GOCommonControllerTest {
-
+class GOTestDrawStop {
 private:
-  std::string name = "GOTestDrawStop";
+  static std::string CLASS_NAME;
 
 public:
-  GOTestDrawStop() {}
-  virtual ~GOTestDrawStop() {}
-  virtual void run();
-  std::string GetName() { return name; }
+  class TestFunctions : public GOCommonControllerTest {
+  private:
+    static std::string TEST_NAME;
+
+  public:
+    virtual void run() override;
+    std::string GetName() override { return TEST_NAME; }
+  };
 };
 
 #endif /* GOTESTDRAWSTOP_H */

--- a/src/tests/testing/model/GOTestDrawStop.h
+++ b/src/tests/testing/model/GOTestDrawStop.h
@@ -1,0 +1,18 @@
+#ifndef GOTESTDRAWSTOP_H
+#define GOTESTDRAWSTOP_H
+
+#include "GOTest.h"
+
+class GOTestDrawStop : public GOCommonControllerTest {
+
+private:
+  std::string name = "GOTestDrawStop";
+
+public:
+  GOTestDrawStop() {}
+  virtual ~GOTestDrawStop() {}
+  virtual void run();
+  std::string GetName() { return name; }
+};
+
+#endif /* GOTESTDRAWSTOP_H */


### PR DESCRIPTION
The first unsuccessful attempt of #2012 motivated me to write a test of GODrawStop.

This PR also adds some GODrawStop methods for constructing a switch network in tests.

No GO behavior should be changed.