### PR TITLE
Changed passing parameters to GODrawStop::Init, GODrawStop::Load and to the same methods in the subclasses

### DIFF
--- a/src/grandorgue/model/GOCoupler.cpp
+++ b/src/grandorgue/model/GOCoupler.cpp
@@ -106,7 +106,7 @@ void GOCoupler::Init(
       = r_OrganModel.GetManual(m_DestinationManual)->RegisterCoupler(this);
 }
 
-void GOCoupler::Load(GOConfigReader &cfg, wxString group) {
+void GOCoupler::Load(GOConfigReader &cfg, const wxString &group) {
   m_UnisonOff
     = cfg.ReadBoolean(ODFSetting, group, wxT("UnisonOff"), true, false);
   m_DestinationManual = cfg.ReadInteger(

--- a/src/grandorgue/model/GOCoupler.h
+++ b/src/grandorgue/model/GOCoupler.h
@@ -75,7 +75,7 @@ public:
     int keyshift,
     int dest_manual,
     GOCouplerType coupler_type);
-  void Load(GOConfigReader &cfg, wxString group);
+  void Load(GOConfigReader &cfg, const wxString &group);
 
   // send key states for all chained couplers
   void RefreshState();

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -77,7 +77,8 @@ void GODrawstop::SetFunctionType(GOFunctionType newFunctionType) {
   }
 }
 
-void GODrawstop::Init(GOConfigReader &cfg, wxString group, wxString name) {
+void GODrawstop::Init(
+  GOConfigReader &cfg, const wxString &group, const wxString &name) {
   m_Type = FUNCTION_INPUT;
   m_Engaged = cfg.ReadBoolean(CMBSetting, group, wxT("DefaultToEngaged"));
   m_GCState = 0;
@@ -96,7 +97,7 @@ void GODrawstop::SetupIsToStoreInCmb() {
     || isControlledByUser;
 }
 
-void GODrawstop::Load(GOConfigReader &cfg, wxString group) {
+void GODrawstop::Load(GOConfigReader &cfg, const wxString &group) {
   m_Type = (GOFunctionType)cfg.ReadEnum(
     ODFSetting,
     group,

--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -78,8 +78,8 @@ public:
   bool IsToStoreInGeneral() const { return m_IsToStoreInGeneral; }
   bool GetCombinationState() const override { return IsEngaged(); }
 
-  void Init(GOConfigReader &cfg, wxString group, wxString name);
-  void Load(GOConfigReader &cfg, wxString group);
+  void Init(GOConfigReader &cfg, const wxString &group, const wxString &name);
+  void Load(GOConfigReader &cfg, const wxString &group);
   void RegisterControlled(GODrawstop *sw);
   void UnRegisterControlled(GODrawstop *sw);
   virtual void SetButtonState(bool on) override;

--- a/src/grandorgue/model/GOStop.cpp
+++ b/src/grandorgue/model/GOStop.cpp
@@ -29,7 +29,7 @@ unsigned GOStop::IsAuto() const {
   return (m_RankInfo.size() == 1 && m_RankInfo[0].Rank->GetPipeCount() == 1);
 }
 
-void GOStop::Load(GOConfigReader &cfg, wxString group) {
+void GOStop::Load(GOConfigReader &cfg, const wxString &group) {
   unsigned number_of_ranks = cfg.ReadInteger(
     ODFSetting, group, wxT("NumberOfRanks"), 0, 999, false, 0);
 

--- a/src/grandorgue/model/GOStop.h
+++ b/src/grandorgue/model/GOStop.h
@@ -41,7 +41,7 @@ private:
 public:
   GOStop(GOOrganModel &organModel, unsigned first_midi_note_number);
   GORank *GetRank(unsigned index);
-  void Load(GOConfigReader &cfg, wxString group);
+  void Load(GOConfigReader &cfg, const wxString &group);
   void SetKey(unsigned note, unsigned velocity);
   ~GOStop(void);
 


### PR DESCRIPTION
This PR adds some optimizations to passing parameters to Load and Init methods.

No GO behavior should be changed.