### PR TITLE
Removed GODrawStop::IsActive

### DIFF
--- a/src/grandorgue/model/GOCoupler.cpp
+++ b/src/grandorgue/model/GOCoupler.cpp
@@ -64,7 +64,7 @@ void GOCoupler::PreparePlayback() {
     m_Keyshift = m_DestinationKeyshift + src->GetFirstLogicalKeyMIDINoteNumber()
       - dest->GetFirstLogicalKeyMIDINoteNumber();
   }
-  if (m_UnisonOff && IsActive())
+  if (m_UnisonOff && IsEngaged())
     src->SetUnisonOff(true);
 }
 
@@ -266,7 +266,7 @@ void GOCoupler::SetOut(int noteNumber, unsigned velocity) {
     return;
   m_InternalVelocity[note] = velocity;
 
-  if (!IsActive())
+  if (!IsEngaged())
     return;
   unsigned newstate = m_InternalVelocity[note];
   if (newstate)
@@ -378,7 +378,7 @@ void GOCoupler::OnDrawstopStateChanged(bool on) {
 }
 
 void GOCoupler::RefreshState() {
-  bool on = IsActive();
+  bool on = IsEngaged();
 
   if (m_UnisonOff)
     r_OrganModel.GetManual(m_SourceManual)->SetUnisonOff(on);

--- a/src/grandorgue/model/GODrawStop.cpp
+++ b/src/grandorgue/model/GODrawStop.cpp
@@ -29,7 +29,6 @@ GODrawstop::GODrawstop(GOOrganModel &organModel)
   : GOButtonControl(organModel, MIDI_RECV_DRAWSTOP, false),
     m_Type(FUNCTION_INPUT),
     m_GCState(0),
-    m_ActiveState(false),
     m_ControlledDrawstops(),
     m_ControllingDrawstops(),
     m_IsToStoreInDivisional(false),
@@ -150,10 +149,9 @@ void GODrawstop::SetInternalState(bool on, const wxString &stateName) {
 
     for (const auto &intState : m_InternalStates)
       resState = resState || intState.second;
-    if (m_ActiveState != resState) {
+    if (IsEngaged() != resState) {
       Display(resState);
       // must be before calling m_ControlledDrawstops[i]->Update();
-      m_ActiveState = resState;
       OnDrawstopStateChanged(resState);
       for (auto *pDrawstop : m_ControlledDrawstops)
         pDrawstop->Update(); // reads m_ActiveState
@@ -187,7 +185,7 @@ void GODrawstop::Update() {
   case FUNCTION_NAND:
     state = true;
     for (unsigned i = 0; i < m_ControllingDrawstops.size(); i++)
-      state = state && m_ControllingDrawstops[i]->IsActive();
+      state = state && m_ControllingDrawstops[i]->IsEngaged();
     if (m_Type == FUNCTION_NAND)
       SetDrawStopState(!state);
     else
@@ -198,7 +196,7 @@ void GODrawstop::Update() {
   case FUNCTION_NOR:
     state = false;
     for (unsigned i = 0; i < m_ControllingDrawstops.size(); i++)
-      state = state || m_ControllingDrawstops[i]->IsActive();
+      state = state || m_ControllingDrawstops[i]->IsEngaged();
     if (m_Type == FUNCTION_NOR)
       SetDrawStopState(!state);
     else
@@ -208,12 +206,12 @@ void GODrawstop::Update() {
   case FUNCTION_XOR:
     state = false;
     for (unsigned i = 0; i < m_ControllingDrawstops.size(); i++)
-      state = state != m_ControllingDrawstops[i]->IsActive();
+      state = state != m_ControllingDrawstops[i]->IsEngaged();
     SetDrawStopState(state);
     break;
 
   case FUNCTION_NOT:
-    state = m_ControllingDrawstops[0]->IsActive();
+    state = m_ControllingDrawstops[0]->IsEngaged();
     SetDrawStopState(!state);
     break;
   }

--- a/src/grandorgue/model/GODrawStop.h
+++ b/src/grandorgue/model/GODrawStop.h
@@ -34,7 +34,6 @@ private:
   int m_GCState;
   std::unordered_map<wxString, bool, wxStringHash, wxStringEqual>
     m_InternalStates;
-  bool m_ActiveState;
   std::vector<GODrawstop *> m_ControlledDrawstops;
   std::vector<GODrawstop *> m_ControllingDrawstops;
 
@@ -68,7 +67,6 @@ public:
 
   bool IsToStoreInDivisional() const { return m_IsToStoreInDivisional; }
   bool IsToStoreInGeneral() const { return m_IsToStoreInGeneral; }
-  bool IsActive() const { return m_ActiveState; }
   bool GetCombinationState() const override { return IsEngaged(); }
 
   void Init(GOConfigReader &cfg, wxString group, wxString name);

--- a/src/grandorgue/model/GOStop.cpp
+++ b/src/grandorgue/model/GOStop.cpp
@@ -126,7 +126,7 @@ void GOStop::SetKey(unsigned note, unsigned velocity) {
   if (m_KeyVelocity[note] == velocity)
     return;
   m_KeyVelocity[note] = velocity;
-  if (IsActive())
+  if (IsEngaged())
     SetRankKey(note, m_KeyVelocity[note]);
 }
 
@@ -157,7 +157,7 @@ void GOStop::PreparePlayback() {
 void GOStop::StartPlayback() {
   GODrawstop::StartPlayback();
 
-  if (IsAuto() && IsActive())
+  if (IsAuto() && IsEngaged())
     SetRankKey(0, 0x7f);
 }
 

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -123,7 +123,7 @@ void GOTremulant::AbortPlayback() {
 void GOTremulant::StartPlayback() {
   GODrawstop::StartPlayback();
 
-  if (IsActive() && m_TremulantType == GOSynthTrem) {
+  if (IsEngaged() && m_TremulantType == GOSynthTrem) {
     GOSoundEngine *pSoundEngine = GetSoundEngine();
 
     assert(m_TremulantN > 0);

--- a/src/grandorgue/model/GOWindchest.cpp
+++ b/src/grandorgue/model/GOWindchest.cpp
@@ -117,7 +117,9 @@ void GOWindchest::UpdateTremulant(GOTremulant *tremulant) {
       GOTremulant *t = r_OrganModel.GetTremulant(m_tremulant[i]);
       if (t->GetTremulantType() != GOWavTrem)
         continue;
-      bool on = t->IsActive();
+
+      bool on = t->IsEngaged();
+
       for (unsigned j = 0; j < m_pipes.size(); j++)
         m_pipes[j]->SetWaveTremulant(on);
       return;


### PR DESCRIPTION
I mentioned that ``GODrawStop::IsActive()`` duplicated ``GOButtonControl::IsEngaged()``

So this PR removes ``GODrawStop::IsActive()`` and replaces all it's usages with ``GOButtonControl::IsEngaged()``

It is just refactoring. No GO behavior should be changed.

