### PR TITLE
Fixed non bringing a dialog windows on top when it had been already open https://github.com/GrandOrgue/grandorgue/issues/1961

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed non bringing a dialog windows on top when it had been already open https://github.com/GrandOrgue/grandorgue/issues/1961
 - Fixed combination button lighting when a crescendo was in the Override=Off mode https://github.com/GrandOrgue/grandorgue/issues/1935
 # 3.15.1 (2024-09-03)
 - Fixed saving of Settings->Paths https://github.com/GrandOrgue/grandorgue/issues/1907

--- a/src/grandorgue/dialogs/common/GODialogCloser.cpp
+++ b/src/grandorgue/dialogs/common/GODialogCloser.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,7 +14,11 @@ GODialogCloser::GODialogCloser(wxDialog *pDlg) : p_dialog(pDlg) {
 
 bool GODialogCloser::ShowAdvanced(bool isAutoDestroyable) {
   m_AutoDestroyable = isAutoDestroyable;
-  return p_dialog->Show(true);
+
+  bool res = p_dialog->Show(true);
+
+  p_dialog->Raise();
+  return res;
 }
 
 int GODialogCloser::ShowModalAdvanced(bool isAutoDestroyable) {


### PR DESCRIPTION
This PR solves the first problem mentioned at #1961: when a modeless dialog is open but is not overlapped by other windows, selecting this dialog with the menu earlier left this dialog overlapped, but now this dialog is brought on top.
