### PR TITLE
Fixed crash of reference pipes with the "--gui-only" option https://github.com/GrandOrgue/grandorgue/issues/2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash of reference pipes with the "--justgui" option https://github.com/GrandOrgue/grandorgue/issues/2019
 - Fixed crash on attempt of loading an organ if it's files did not exist https://github.com/GrandOrgue/grandorgue/issues/1990
 - Fixed the sequencer "Save file" button not lightening after inserting or deleting a combination https://github.com/GrandOrgue/grandorgue/issues/2024
 - Fixed appearence, sizing and the scrollbar issues with the Stops window https://github.com/GrandOrgue/grandorgue/issues/1961

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -179,6 +179,7 @@ model/GOOrganModel.cpp
 model/GOPipe.cpp
 model/GORank.cpp
 model/GOReferencePipe.cpp
+model/GOReferencingObject.cpp
 model/GOSoundingPipe.cpp
 model/GOStop.cpp
 model/GOSwitch.cpp

--- a/src/grandorgue/model/GOEventHandlerList.h
+++ b/src/grandorgue/model/GOEventHandlerList.h
@@ -18,6 +18,7 @@ class GOControl;
 class GOControlChangedHandler;
 class GOEventHandler;
 class GOMidiConfigurator;
+class GOReferencingObject;
 class GOSoundStateHandler;
 class GOSaveableObject;
 
@@ -57,6 +58,7 @@ private:
   };
 
   UPVector<GOCacheObject> m_CacheObjects;
+  UPVector<GOReferencingObject> m_ReferencingObjects;
   UPVector<GOCombinationButtonSet> m_CombinationButtonSets;
   UPVector<GOControlChangedHandler> m_ControlChangedHandlers;
   UPVector<GOMidiConfigurator> m_MidiConfigurators;
@@ -67,6 +69,9 @@ private:
 public:
   const std::vector<GOCacheObject *> &GetCacheObjects() const {
     return m_CacheObjects.AsVector();
+  }
+  const std::vector<GOReferencingObject *> &GetReferencingObjects() const {
+    return m_ReferencingObjects.AsVector();
   }
   const std::vector<GOCombinationButtonSet *> &GetCombinationButtonSets()
     const {
@@ -86,6 +91,14 @@ public:
   }
 
   void RegisterCacheObject(GOCacheObject *obj) { m_CacheObjects.Add(obj); }
+
+  void RegisterReferencingObject(GOReferencingObject *pObj) {
+    m_ReferencingObjects.Add(pObj);
+  }
+
+  void UnRegisterReferencingObject(GOReferencingObject *pObj) {
+    m_ReferencingObjects.Remove(pObj);
+  }
 
   void RegisterCombinationButtonSet(GOCombinationButtonSet *obj) {
     m_CombinationButtonSets.Add(obj);

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -17,6 +17,7 @@
 #include "GOEnclosure.h"
 #include "GOManual.h"
 #include "GORank.h"
+#include "GOReferencingObject.h"
 #include "GOSwitch.h"
 #include "GOTremulant.h"
 #include "GOWindchest.h"
@@ -169,6 +170,9 @@ void GOOrganModel::Load(GOConfigReader &cfg) {
   for (unsigned i = 0; i < m_tremulants.size(); i++)
     m_tremulants[i]->SetElementID(
       GetRecorderElementID(wxString::Format(wxT("T%d"), i)));
+
+  for (GOReferencingObject *pObj : GetReferencingObjects())
+    pObj->ResolveReferences();
 }
 
 void GOOrganModel::LoadCmbButtons(GOConfigReader &cfg) {

--- a/src/grandorgue/model/GOReferencePipe.cpp
+++ b/src/grandorgue/model/GOReferencePipe.cpp
@@ -20,6 +20,7 @@
 GOReferencePipe::GOReferencePipe(
   GOOrganModel *model, GORank *rank, unsigned midi_key_number)
   : GOPipe(model, rank, midi_key_number),
+    GOReferencingObject(*model),
     m_model(model),
     m_Reference(NULL),
     m_ReferenceID(0),
@@ -34,7 +35,7 @@ void GOReferencePipe::Load(
     throw(wxString) _("ReferencePipe without Reference");
 }
 
-void GOReferencePipe::Initialize() {
+void GOReferencePipe::OnResolvingReferences() {
   if (!m_Filename.StartsWith(wxT("REF:")))
     throw(wxString) _("ReferencePipe without Reference");
 

--- a/src/grandorgue/model/GOReferencePipe.cpp
+++ b/src/grandorgue/model/GOReferencePipe.cpp
@@ -10,8 +10,6 @@
 #include <wx/intl.h>
 #include <wx/tokenzr.h>
 
-#include "config/GOConfigReader.h"
-
 #include "GOManual.h"
 #include "GOOrganModel.h"
 #include "GORank.h"
@@ -28,8 +26,6 @@ GOReferencePipe::GOReferencePipe(
 
 void GOReferencePipe::Load(
   GOConfigReader &cfg, const wxString &group, const wxString &prefix) {
-  SetGroupAndPrefix(group, prefix);
-  m_model->RegisterCacheObject(this);
   m_Filename = cfg.ReadStringTrim(ODFSetting, group, prefix);
   if (!m_Filename.StartsWith(wxT("REF:")))
     throw(wxString) _("ReferencePipe without Reference");

--- a/src/grandorgue/model/GOReferencePipe.h
+++ b/src/grandorgue/model/GOReferencePipe.h
@@ -14,9 +14,7 @@
 
 class GOOrganModel;
 
-class GOReferencePipe : public GOPipe,
-                        private GOCacheObject,
-                        public GOReferencingObject {
+class GOReferencePipe : public GOPipe, public GOReferencingObject {
 private:
   GOOrganModel *m_model;
   GOPipe *m_Reference;
@@ -24,12 +22,6 @@ private:
   wxString m_Filename;
 
   void OnResolvingReferences() override;
-  void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) override {}
-  bool LoadCache(GOMemoryPool &pool, GOCache &cache) override { return true; }
-  void Initialize() override {}
-  bool SaveCache(GOCacheWriter &cache) const override { return true; }
-  void UpdateHash(GOHash &hash) const override {}
-  const wxString &GetLoadTitle() const override { return m_Filename; }
 
   void VelocityChanged(unsigned velocity, unsigned old_velocity) override;
 

--- a/src/grandorgue/model/GOReferencePipe.h
+++ b/src/grandorgue/model/GOReferencePipe.h
@@ -10,19 +10,23 @@
 
 #include "GOCacheObject.h"
 #include "GOPipe.h"
+#include "GOReferencingObject.h"
 
 class GOOrganModel;
 
-class GOReferencePipe : public GOPipe, private GOCacheObject {
+class GOReferencePipe : public GOPipe,
+                        private GOCacheObject,
+                        public GOReferencingObject {
 private:
   GOOrganModel *m_model;
   GOPipe *m_Reference;
   unsigned m_ReferenceID;
   wxString m_Filename;
 
-  void Initialize() override;
+  void OnResolvingReferences() override;
   void LoadData(const GOFileStore &fileStore, GOMemoryPool &pool) override {}
   bool LoadCache(GOMemoryPool &pool, GOCache &cache) override { return true; }
+  void Initialize() override {}
   bool SaveCache(GOCacheWriter &cache) const override { return true; }
   void UpdateHash(GOHash &hash) const override {}
   const wxString &GetLoadTitle() const override { return m_Filename; }

--- a/src/grandorgue/model/GOReferencingObject.cpp
+++ b/src/grandorgue/model/GOReferencingObject.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOReferencingObject.h"
+
+#include "GOEventHandlerList.h"
+
+GOReferencingObject::GOReferencingObject(GOEventHandlerList &handlerList)
+  : r_HandlerList(handlerList) {
+  r_HandlerList.RegisterReferencingObject(this);
+}
+
+GOReferencingObject::~GOReferencingObject() {
+  r_HandlerList.UnRegisterReferencingObject(this);
+}
+
+void GOReferencingObject::ResolveReferences() {
+  if (!m_HasBeenResolved) {
+    OnResolvingReferences();
+    m_HasBeenResolved = true;
+  }
+}

--- a/src/grandorgue/model/GOReferencingObject.h
+++ b/src/grandorgue/model/GOReferencingObject.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOREFERENCINGOBJECT_H
+#define GOREFERENCINGOBJECT_H
+
+class GOEventHandlerList;
+
+class GOReferencingObject {
+private:
+  GOEventHandlerList &r_HandlerList;
+  bool m_HasBeenResolved = false;
+
+protected:
+  virtual void OnResolvingReferences() {}
+
+public:
+  GOReferencingObject(GOEventHandlerList &handlerList);
+  virtual ~GOReferencingObject();
+
+  void ResolveReferences();
+};
+
+#endif /* GOREFERENCINGOBJECT_H */

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -100,9 +100,7 @@ void GOTremulant::OnDrawstopStateChanged(bool on) {
       m_PlaybackHandle = pSoundEngine ? pSoundEngine->StartTremulantSample(
                            m_TremProvider, m_TremulantN, m_LastStop)
                                       : nullptr;
-      on = (m_PlaybackHandle != nullptr);
-    } else {
-      assert(m_PlaybackHandle);
+    } else if (m_PlaybackHandle) {
       m_LastStop = pSoundEngine
         ? pSoundEngine->StopSample(m_TremProvider, m_PlaybackHandle)
         : 0;


### PR DESCRIPTION
Resolves: #2019

The reason of the crash was that GOReferencePipe internal structures were set up during the ``Initialise()`` call that was skipped with `--gui-only`.

This PR
- Introduces the new class GOReferencingObject that may refer to another objects that might be loaded from the ODF in any order.
- It's subclass should implement the `OnResolvingReferences` method where it should actually finds another objects from the model because they all have already loaded from the ODF.
- GOOrganModel::Load calls ResolveReferences of all GOReferencingObject instances as the last step of ODF loading
- GOReferencePipe is now a subclass of GOReferencingObject. GOReferencePipe::OnResolvingReferences now sets up it's internal structures instead of GOReferencePipe::Initialize().
- GOReferencePipe is not more a subclass of GOCachedObject because it needs to read neither any files nor the cache