### PR TITLE
Refactored GOMidiPlayer for playing midi events though GOMidi instead of GOMOrganController

### DIFF
--- a/src/core/midi/GOMidiEvent.cpp
+++ b/src/core/midi/GOMidiEvent.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -20,7 +20,8 @@ GOMidiEvent::GOMidiEvent()
     m_time(0),
     m_string(),
     m_data(),
-    m_IsToUseNoteOff(true) {}
+    m_IsToUseNoteOff(true),
+    m_IsAllowedToReload(true) {}
 
 GOMidiEvent::GOMidiEvent(const GOMidiEvent &e)
   : m_MidiType(e.m_MidiType),
@@ -31,7 +32,8 @@ GOMidiEvent::GOMidiEvent(const GOMidiEvent &e)
     m_time(e.m_time),
     m_string(e.m_string.Clone()),
     m_data(e.m_data),
-    m_IsToUseNoteOff(e.m_IsToUseNoteOff) {}
+    m_IsToUseNoteOff(e.m_IsToUseNoteOff),
+    m_IsAllowedToReload(e.m_IsAllowedToReload) {}
 
 void GOMidiEvent::SetString(const wxString &str, unsigned length) {
   unsigned len = str.length();

--- a/src/core/midi/GOMidiEvent.h
+++ b/src/core/midi/GOMidiEvent.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -56,6 +56,11 @@ private:
   wxString m_string;
   std::vector<uint8_t> m_data;
   bool m_IsToUseNoteOff;
+  /**
+   * Is allowing to close the organ and to load another organ when playing this
+   * midi event
+   */
+  bool m_IsAllowedToReload;
 
 public:
   GOMidiEvent();
@@ -95,6 +100,9 @@ public:
 
   void SetUseNoteOff(bool useNoteOff) { m_IsToUseNoteOff = useNoteOff; }
   bool IsUsingNoteOff() const { return m_IsToUseNoteOff; }
+
+  bool IsAllowedToReload() const { return m_IsAllowedToReload; }
+  void SetAllowedToReload(bool value) { m_IsAllowedToReload = value; }
 };
 
 #endif

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -1027,7 +1027,7 @@ void GOOrganController::Abort() {
 
   GOEventDistributor::AbortPlayback();
 
-  m_MidiPlayer->StopPlaying();
+  m_MidiPlayer->Cleanup();
   m_MidiRecorder->StopRecording();
   m_AudioRecorder->StopRecording();
   m_AudioRecorder->SetAudioRecorder(NULL);
@@ -1064,6 +1064,7 @@ void GOOrganController::PreparePlayback(
 
   GOEventDistributor::StartPlayback();
   GOEventDistributor::PrepareRecording();
+  m_MidiPlayer->Setup(midi);
 
   // Light the OnState button
   if (p_OnStateButton) {

--- a/src/grandorgue/gui/frames/GOFrame.cpp
+++ b/src/grandorgue/gui/frames/GOFrame.cpp
@@ -1345,12 +1345,14 @@ void GOFrame::OnMidiEvent(const GOMidiEvent &event) {
       _("MIDI event: ") + event.ToString(m_Sound.GetMidi().GetMidiMap()));
   }
 
-  ptr_vector<GOOrgan> &organs = m_config.GetOrganList();
-  for (unsigned i = 0; i < organs.size(); i++)
-    if (organs[i]->Match(event) && organs[i]->IsUsable(m_config)) {
-      SendLoadOrgan(*organs[i]);
-      return;
-    }
+  if (event.IsAllowedToReload()) {
+    ptr_vector<GOOrgan> &organs = m_config.GetOrganList();
+    for (auto pOrgan : organs)
+      if (pOrgan->Match(event) && pOrgan->IsUsable(m_config)) {
+        SendLoadOrgan(*pOrgan);
+        break;
+      }
+  }
 }
 
 void GOFrame::OnSetTitle(wxCommandEvent &event) {

--- a/src/grandorgue/midi/GOMidi.cpp
+++ b/src/grandorgue/midi/GOMidi.cpp
@@ -95,12 +95,13 @@ void GOMidi::Recv(const GOMidiEvent &e) {
   AddPendingEvent(event);
 }
 
-void GOMidi::OnMidiEvent(wxMidiEvent &event) {
-  GOMidiEvent e = event.GetMidiEvent();
+void GOMidi::PlayEvent(const GOMidiEvent &e) {
   for (unsigned i = 0; i < m_Listeners.size(); i++)
     if (m_Listeners[i])
       m_Listeners[i]->Send(e);
 }
+
+void GOMidi::OnMidiEvent(wxMidiEvent &e) { PlayEvent(e.GetMidiEvent()); }
 
 void GOMidi::Send(const GOMidiEvent &e) {
   for (unsigned j = 0; j < m_midi_out_devices.size(); j++)

--- a/src/grandorgue/midi/GOMidi.h
+++ b/src/grandorgue/midi/GOMidi.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -33,7 +33,6 @@ private:
   int m_transpose;
   std::vector<GOMidiListener *> m_Listeners;
   GOMidiPortFactory m_MidiFactory;
-  void OnMidiEvent(wxMidiEvent &event);
 
 public:
   GOMidi(GOConfig &settings);
@@ -43,6 +42,8 @@ public:
   void UpdateDevices(const GOPortsConfig &portsConfig);
 
   void Recv(const GOMidiEvent &e);
+  void PlayEvent(const GOMidiEvent &e);
+  void OnMidiEvent(wxMidiEvent &e);
   void Send(const GOMidiEvent &e);
 
   const ptr_vector<GOMidiPort> &GetInDevices() const {

--- a/src/grandorgue/midi/GOMidiPlayer.h
+++ b/src/grandorgue/midi/GOMidiPlayer.h
@@ -20,13 +20,18 @@
 #include "GOTime.h"
 #include "GOTimerCallback.h"
 
+class GOMidi;
+class GOMidiMap;
 class GOMidiEvent;
 class GOMidiFileReader;
 class GOOrganController;
+class GOTimer;
 
 class GOMidiPlayer : public GOElementCreator, private GOTimerCallback {
 private:
-  GOOrganController *m_OrganController;
+  GOMidiMap &r_MidiMap;
+  GOTimer &r_timer;
+  GOMidi *p_midi;
   GOMidiPlayerContent m_content;
   GOLabelControl m_PlayingTime;
   GOTime m_Start;
@@ -43,13 +48,28 @@ private:
   void ButtonStateChanged(int id, bool newState) override;
 
   void UpdateDisplay();
+
+  /**
+   * Set the buttons and the display to the initial state
+   */
+  void ResetUI();
+  /**
+   * Send midi event to the organ
+   * @param event the event to process
+   */
+  void PlayMidiEvent(const GOMidiEvent &e);
   void HandleTimer() override;
 
 public:
   GOMidiPlayer(GOOrganController *organController);
   ~GOMidiPlayer();
 
-  void Clear();
+  /**
+   * Set up for playing any midi
+   * @param pMidi - a pointer to the midi engine
+   */
+  void Setup(GOMidi *pMidi) { p_midi = pMidi; }
+
   void LoadFile(const wxString &filename, unsigned manuals, bool pedal);
   bool IsLoaded();
 
@@ -61,6 +81,11 @@ public:
   void Load(GOConfigReader &cfg) override;
   GOEnclosure *GetEnclosure(const wxString &name, bool is_panel) override;
   GOLabelControl *GetLabelControl(const wxString &name, bool is_panel) override;
+
+  /**
+   * Clean up. Playing will be impossible until Setup is called
+   */
+  void Cleanup();
 };
 
 #endif


### PR DESCRIPTION
Earlier GOMidiPlayer used GOOrganController::ProcessMidi for playing midi events. It caused that the ``Log Midi Events`` did not log events from a midi file.

This PR
- Introduces the new method GOMidi::PlayMidiEvent for the signge entry point for all events either from a midi devices or fom a midi file
- Now GOMidiPlayer uses GOMidi::PlayMidiEvent instead of GOOrganController::ProcessMidi
- Eliminates most of usages of GOOrganController in GOMidiPlayer
- Starts logging midi events when they are played from a midi file