### PR TITLE
Fixed not releasing a pipe after fast switching between vave-based tremulant samples and regular pipe samples https://github.com/GrandOrgue/grandorgue/issues/2004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed not releasing a pipe after fast switching between vave-based tremulant samples and regular pipe samples https://github.com/GrandOrgue/grandorgue/issues/2004
 - Removed support of MacOs 12
 - Fixed hang if there were lots of unused ODF entries https://github.com/GrandOrgue/grandorgue/issues/1918
 # 3.15.3 (2024-11-23)

--- a/src/grandorgue/sound/GOSoundFader.cpp
+++ b/src/grandorgue/sound/GOSoundFader.cpp
@@ -32,9 +32,6 @@ void GOSoundFader::Process(
   unsigned nFrames, float *buffer, float externalVolume) {
   // setup process
 
-  // Consider the velocity volume as part of the external volume
-  externalVolume *= m_VelocityVolume;
-
   float startTargetVolumePoint = m_LastTargetVolumePoint;
 
   // Calculate new m_LastTargetVolumePoint
@@ -82,12 +79,19 @@ void GOSoundFader::Process(
     }
   }
 
+  // Calculate the external volume
+  float newExternalVolume = m_VelocityVolume * externalVolume;
+
+  if (m_LastExternalVolumePoint < 0.0f)
+    m_LastExternalVolumePoint = newExternalVolume;
+
   float startExternalVolumePoint = m_LastExternalVolumePoint;
+
   // Calculate new m_LastExternalVolumePoint
   // the target volume will be changed from startExternalVolumePoint to
   // m_LastExternalVolumePoint during the nFrames period
-  if (externalVolume != startExternalVolumePoint)
-    m_LastExternalVolumePoint += (externalVolume - startExternalVolumePoint)
+  if (newExternalVolume != startExternalVolumePoint)
+    m_LastExternalVolumePoint += (newExternalVolume - startExternalVolumePoint)
       // Assume that external volume is to be reached in MAX_FRAME_SIZE frames
       * std::max(nFrames, EXTERNAL_VOLUME_CHANGE_FRAMES)
       / EXTERNAL_VOLUME_CHANGE_FRAMES;

--- a/src/grandorgue/sound/GOSoundFader.cpp
+++ b/src/grandorgue/sound/GOSoundFader.cpp
@@ -80,18 +80,19 @@ void GOSoundFader::Process(
   }
 
   // Calculate the external volume
-  float newExternalVolume = m_VelocityVolume * externalVolume;
+  float targetExternalVolume = m_VelocityVolume * externalVolume;
 
   if (m_LastExternalVolumePoint < 0.0f)
-    m_LastExternalVolumePoint = newExternalVolume;
+    m_LastExternalVolumePoint = targetExternalVolume;
 
   float startExternalVolumePoint = m_LastExternalVolumePoint;
 
   // Calculate new m_LastExternalVolumePoint
   // the target volume will be changed from startExternalVolumePoint to
   // m_LastExternalVolumePoint during the nFrames period
-  if (newExternalVolume != startExternalVolumePoint)
-    m_LastExternalVolumePoint += (newExternalVolume - startExternalVolumePoint)
+  if (targetExternalVolume != startExternalVolumePoint)
+    m_LastExternalVolumePoint
+      += (targetExternalVolume - startExternalVolumePoint)
       // Assume that external volume is to be reached in MAX_FRAME_SIZE frames
       * std::max(nFrames, EXTERNAL_VOLUME_CHANGE_FRAMES)
       / EXTERNAL_VOLUME_CHANGE_FRAMES;

--- a/src/grandorgue/sound/GOSoundFader.cpp
+++ b/src/grandorgue/sound/GOSoundFader.cpp
@@ -36,28 +36,51 @@ void GOSoundFader::Process(
   externalVolume *= m_VelocityVolume;
 
   float startTargetVolumePoint = m_LastTargetVolumePoint;
+
   // Calculate new m_LastTargetVolumePoint
   // the target volume will be changed from startTargetVolumePoint to
   // m_LastTargetVolumePoint during the nFrames
-  float targetVolumeDeltaPerFrame
-    = m_IncreasingDeltaPerFrame + m_DecreasingDeltaPerFrame;
 
-  if (targetVolumeDeltaPerFrame != 0.0f) {
-    m_LastTargetVolumePoint = std::clamp(
-      startTargetVolumePoint + targetVolumeDeltaPerFrame * nFrames,
-      0.0f,
-      m_TargetVolume);
+  unsigned framesLeftAfterIncreasing = nFrames;
 
-    if (m_LastTargetVolumePoint >= m_TargetVolume)
-      // target volume is reached. Stop increasing
+  // increasing section
+  if (m_IncreasingDeltaPerFrame > 0.0f) {
+    // we are increasing now
+    float newTargetVolumePoint
+      = m_LastTargetVolumePoint + m_IncreasingDeltaPerFrame * nFrames;
+
+    if (newTargetVolumePoint < m_TargetVolume) {
+      framesLeftAfterIncreasing = 0; // we are increase during the whole period
+      m_LastTargetVolumePoint = newTargetVolumePoint;
+    } else {
+      // we reach m_TargetVolume inside this nFrames period
+
+      // stop increasing
       m_IncreasingDeltaPerFrame = 0.0f;
-    else if (m_LastTargetVolumePoint <= 0.0f)
-      // Decreasing is finished. Stop it.
-      m_DecreasingDeltaPerFrame = 0.0f;
+
+      // calculate how many frames left after increasing
+      framesLeftAfterIncreasing = nFrames
+        - unsigned((m_TargetVolume - m_LastTargetVolumePoint)
+                   / m_IncreasingDeltaPerFrame);
+
+      m_LastTargetVolumePoint = m_TargetVolume;
+    }
   }
 
-  if (m_LastExternalVolumePoint < 0.0f) // The first Process() call
-    m_LastExternalVolumePoint = externalVolume;
+  // decreasing section
+  if (framesLeftAfterIncreasing && m_DecreasingDeltaPerFrame > 0.0f) {
+    // decrease the volume
+    float newTargetVolumePoint = m_LastTargetVolumePoint
+      - m_DecreasingDeltaPerFrame * framesLeftAfterIncreasing;
+
+    if (newTargetVolumePoint > 0.0f) {
+      m_LastTargetVolumePoint = newTargetVolumePoint;
+    } else {
+      // stop decreasing
+      m_DecreasingDeltaPerFrame = 0.0f;
+      m_LastTargetVolumePoint = 0.0f;
+    }
+  }
 
   float startExternalVolumePoint = m_LastExternalVolumePoint;
   // Calculate new m_LastExternalVolumePoint

--- a/src/grandorgue/sound/GOSoundFader.h
+++ b/src/grandorgue/sound/GOSoundFader.h
@@ -8,6 +8,8 @@
 #ifndef GOSOUNDFADER_H_
 #define GOSOUNDFADER_H_
 
+#include <assert.h>
+
 /**
  * This class is responsible for smoothly changing a volume of samples.
  *
@@ -69,11 +71,22 @@ public:
    * @param nFrames number of frames for full decay
    */
   inline void StartDecreasingVolume(unsigned nFrames) {
-    // stop increasing the volume if it has not yet finished
-    m_IncreasingDeltaPerFrame = 0.0f;
     // maybe m_TargetVolume has not yet been reached, but the velocity of
     // decreasing should be the same as it has reached
-    m_DecreasingDeltaPerFrame = -(m_TargetVolume / nFrames);
+    m_DecreasingDeltaPerFrame = m_TargetVolume / nFrames;
+    if (m_IncreasingDeltaPerFrame > 0.0f) {
+      /*
+        The increasing has not yet finished. We are starting a "virtual"
+        decreasing from m_TargetVolume to 0.
+        The increasing processus will continue until it meet the "virtual"
+        decreasing one at the new m_TargetVolume. Let's calculate it
+       */
+      assert(m_LastTargetVolumePoint < m_TargetVolume);
+      m_TargetVolume = (m_TargetVolume - m_LastTargetVolumePoint)
+          * m_IncreasingDeltaPerFrame
+          / (m_IncreasingDeltaPerFrame + m_DecreasingDeltaPerFrame)
+        + m_LastTargetVolumePoint;
+    }
   }
 
   inline float GetVelocityVolume() const { return m_VelocityVolume; }

--- a/src/grandorgue/sound/GOSoundFader.h
+++ b/src/grandorgue/sound/GOSoundFader.h
@@ -69,6 +69,8 @@ public:
    * @param nFrames number of frames for full decay
    */
   inline void StartDecreasingVolume(unsigned nFrames) {
+    // stop increasing the volume if it has not yet finished
+    m_IncreasingDeltaPerFrame = 0.0f;
     // maybe m_TargetVolume has not yet been reached, but the velocity of
     // decreasing should be the same as it has reached
     m_DecreasingDeltaPerFrame = -(m_TargetVolume / nFrames);


### PR DESCRIPTION
Resolves: #2004 

It resolves the issue with the midi file from https://github.com/GrandOrgue/grandorgue/issues/2004#issuecomment-2424900664

The reason was GOSoundFader: when a sampler was in "increasing" crossfade state and then it was switched to another attack (with the wave-based tremulants on/off), the old attack sample was never released and sounded infinitelly.