### PR TITLE
Fixed installing dependencies for macos-14

### DIFF
--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -e
+
+brew install pkgconf || true
+brew link --overwrite pkgconf
 brew install \
   cmake \
   docbook-xsl \
@@ -8,7 +11,6 @@ brew install \
   gettext \
   imagemagick \
   jack \
-  pkg-config \
   wxwidgets \
   yaml-cpp
 brew link gettext --force

--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-brew install pkgconf || true
-brew link --overwrite pkgconf
+brew install pkg-config || true
+brew link --overwrite pkg-config
 brew install \
   cmake \
   docbook-xsl \


### PR DESCRIPTION
This PR adds a workaround of unability to install pkg-config on a  github runner

@larspalo @rousseldenis could you approve this PR because the GO release 3.15.3 failed without this change: https://github.com/GrandOrgue/grandorgue/actions/runs/11994050654/job/33437785531#step:3:384 ?