### PR TITLE
Elimenated clang compilation warnings "argument unused during compilation" https://github.com/GrandOrgue/grandorgue/issues/2001

### DIFF
--- a/cmake/AddCpuOptions.cmake
+++ b/cmake/AddCpuOptions.cmake
@@ -1,0 +1,13 @@
+# Copyright 2006 Milan Digital Audio LLC
+# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# License GPL-2.0 or later
+# (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+
+include(${CMAKE_SOURCE_DIR}/cmake/AddCXXOption.cmake)
+
+add_cxx_option(-mmmx)
+add_cxx_option(-msse)
+add_cxx_option(-msse2)
+add_cxx_option(-msse3)
+add_cxx_option(-mstackrealign)
+

--- a/cmake/AddCpuOptions.cmake
+++ b/cmake/AddCpuOptions.cmake
@@ -5,9 +5,12 @@
 
 include(${CMAKE_SOURCE_DIR}/cmake/AddCXXOption.cmake)
 
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86")
 add_cxx_option(-mmmx)
 add_cxx_option(-msse)
 add_cxx_option(-msse2)
 add_cxx_option(-msse3)
+endif()
+
 add_cxx_option(-mstackrealign)
 

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -5,13 +5,7 @@
 include(${CMAKE_SOURCE_DIR}/cmake/AddLinkerOption.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/CopyWxTranslations.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/CopyDependencies.cmake)
-
-add_option(-mmmx)
-add_option(-msse)
-add_option(-msse2)
-add_option(-msse3)
-
-add_option(-mstackrealign)
+include(${CMAKE_SOURCE_DIR}/cmake/AddCpuOptions.cmake)
 
 find_package(wxWidgets REQUIRED html net adv core base)
 include(${wxWidgets_USE_FILE})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,10 +1,4 @@
-add_option(-mmmx)
-add_option(-msse)
-add_option(-msse2)
-add_option(-msse3)
-
-add_option(-mstackrealign)
-
+include(${CMAKE_SOURCE_DIR}/cmake/AddCpuOptions.cmake)
 include(UsewxWidgets)
 include_directories(${CMAKE_BINARY_DIR}/src/core/go_defs.h ${CMAKE_SOURCE_DIR}/src/core)
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,14 +1,8 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
-add_option(-mmmx)
-add_option(-msse)
-add_option(-msse2)
-add_option(-msse3)
-
-add_option(-mstackrealign)
-
+include(${CMAKE_SOURCE_DIR}/cmake/AddCpuOptions.cmake)
 include(UsewxWidgets)
 
 include_directories(${CMAKE_BINARY_DIR}/src/core/go_defs.h ${CMAKE_SOURCE_DIR}/src/core)


### PR DESCRIPTION
This is the first PR related to #2001

It moves adding the cpu-specific compilation options to a separate file ``cmake/AddCpuOptions.cmake`` and adds a checking if the target CPU supports them.

No GO behaviour should be changed.