### PR TITLE
Fixed clang warnings on collisions between the class and the struct declarations https://github.com/GrandOrgue/grandorgue/issues/2001

### DIFF
--- a/src/grandorgue/combinations/GODivisionalSetter.h
+++ b/src/grandorgue/combinations/GODivisionalSetter.h
@@ -25,7 +25,7 @@
 class GOOrganController;
 class GODivisionalCombination;
 class GOLabelControl;
-class GOSetterState;
+struct GOSetterState;
 
 class GODivisionalSetter : public GOElementCreator,
                            private GOCombinationButtonSet,

--- a/src/grandorgue/combinations/model/GODivisionalCombination.h
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.h
@@ -15,7 +15,7 @@
 class GOConfigReader;
 class GOConfigWriter;
 class GOOrganController;
-class GOSetterState;
+struct GOSetterState;
 
 class GODivisionalCombination : public GOCombination {
 protected:

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -18,7 +18,7 @@ class GOSoundProvider;
 class GOConfigReader;
 class GOConfigWriter;
 class GOMemoryPool;
-class GOSoundSampler;
+struct GOSoundSampler;
 struct IniFileEnumEntry;
 
 typedef enum { GOSynthTrem, GOWavTrem } GOTremulantType;

--- a/src/grandorgue/sound/GOSoundSamplerPool.h
+++ b/src/grandorgue/sound/GOSoundSamplerPool.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,7 +12,7 @@
 #include "ptrvector.h"
 #include "threading/GOMutex.h"
 
-class GOSoundSampler;
+struct GOSoundSampler;
 
 class GOSoundSamplerPool {
 private:


### PR DESCRIPTION
This is a next PR related to #2001

It replace the `class` with the `struct` declaration when it accords the definition. It gets rid some clang compilation warnings.

No GO behavior should be changed.