### PR TITLE
Got rid of the clang warning of overriding CurrentSelection

### DIFF
--- a/src/core/GOChoice.h
+++ b/src/core/GOChoice.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -23,11 +23,11 @@ public:
     return wxChoice::Append(item, (void *)value);
   }
 
-  T GetCurrentSelection() {
+  T GetCurrentValue() {
     return (T)(intptr_t)GetClientData(wxChoice::GetCurrentSelection());
   }
 
-  void SetCurrentSelection(const T value) {
+  void SetCurrentValue(const T value) {
     SetSelection(0);
     for (unsigned i = 0; i < GetCount(); i++)
       if ((void *)value == GetClientData(i))

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventRecvTab.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventRecvTab.cpp
@@ -328,7 +328,7 @@ bool GOMidiEventRecvTab::TransferDataFromWindow() {
 }
 
 void GOMidiEventRecvTab::OnTypeChange(wxCommandEvent &event) {
-  GOMidiReceiverMessageType type = m_eventtype->GetCurrentSelection();
+  GOMidiReceiverMessageType type = m_eventtype->GetCurrentValue();
   if (m_original->HasChannel(type))
     m_channel->Enable();
   else
@@ -467,7 +467,7 @@ void GOMidiEventRecvTab::LoadEvent() {
 
   GOMidiReceiverEventPattern &e = m_midi.GetEvent(m_current);
 
-  m_eventtype->SetCurrentSelection(e.type);
+  m_eventtype->SetCurrentValue(e.type);
 
   wxCommandEvent event;
   OnTypeChange(event);
@@ -508,7 +508,7 @@ GOMidiReceiverEventPattern GOMidiEventRecvTab::GetCurrentEvent() {
     e.deviceId
       = m_MidiMap.GetDeviceIdByLogicalName(m_device->GetStringSelection());
 
-  e.type = m_eventtype->GetCurrentSelection();
+  e.type = m_eventtype->GetCurrentValue();
   if (m_channel->GetSelection() == 0)
     e.channel = -1;
   else

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventSendTab.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventSendTab.cpp
@@ -289,7 +289,7 @@ bool GOMidiEventSendTab::TransferDataFromWindow() {
 }
 
 void GOMidiEventSendTab::OnTypeChange(wxCommandEvent &event) {
-  GOMidiSenderMessageType type = m_eventtype->GetCurrentSelection();
+  GOMidiSenderMessageType type = m_eventtype->GetCurrentValue();
   if (m_original->HasChannel(type))
     m_channel->Enable();
   else
@@ -409,7 +409,7 @@ void GOMidiEventSendTab::LoadEvent() {
 
   GOMidiSenderEventPattern &e = m_midi.GetEvent(m_current);
 
-  m_eventtype->SetCurrentSelection(e.type);
+  m_eventtype->SetCurrentValue(e.type);
 
   wxCommandEvent event;
   OnTypeChange(event);
@@ -437,7 +437,7 @@ void GOMidiEventSendTab::StoreEvent() {
     e.deviceId
       = m_MidiMap.GetDeviceIdByLogicalName(m_device->GetStringSelection());
 
-  e.type = m_eventtype->GetCurrentSelection();
+  e.type = m_eventtype->GetCurrentValue();
   e.channel = m_channel->GetSelection() + 1;
   e.key = m_key->GetValue();
   e.low_value = m_LowValue->GetValue();

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsOptions.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsOptions.cpp
@@ -131,7 +131,7 @@ GOSettingsOptions::GOSettingsOptions(GOConfig &settings, wxWindow *parent)
   m_LoadLastFile->Append(
     _("Start without any organ"), GOInitialLoadType::LOAD_NONE);
   m_Limit->SetValue(m_config.ManagePolyphony());
-  m_LoadLastFile->SetCurrentSelection(m_config.LoadLastFile());
+  m_LoadLastFile->SetCurrentValue(m_config.LoadLastFile());
   m_Scale->SetValue(m_config.ScaleRelease());
   m_Random->SetValue(m_config.RandomizeSpeaking());
 
@@ -430,7 +430,7 @@ bool GOSettingsOptions::TransferDataFromWindow() {
   m_config.ManagePolyphony(m_Limit->IsChecked());
   m_config.CompressCache(m_CompressCache->IsChecked());
   m_config.ManageCache(m_ManageCache->IsChecked());
-  m_config.LoadLastFile(m_LoadLastFile->GetCurrentSelection());
+  m_config.LoadLastFile(m_LoadLastFile->GetCurrentValue());
   m_config.ODFCheck(m_ODFCheck->IsChecked());
   m_config.ODFHw1Check(m_ODFHw1Check->IsChecked());
   m_config.RecordDownmix(m_RecordDownmix->IsChecked());


### PR DESCRIPTION
This is a next PR related to #2001

It is just renaming. No GO behavior should be changed.