### PR TITLE
Fixed clang warnings about unused variables https://github.com/GrandOrgue/grandorgue/issues/2001

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -821,7 +821,7 @@ bool GOOrganController::UpdateCache(GOProgressDialog *dlg, bool compress) {
   if (!writer.Write(&hash, sizeof(hash)))
     cache_save_ok = false;
 
-  for (unsigned i = 0; cache_save_ok; i++) {
+  while (cache_save_ok) {
     GOCacheObject *obj = objectDistributor.FetchNext();
 
     if (!obj)

--- a/src/grandorgue/combinations/GODivisionalSetter.cpp
+++ b/src/grandorgue/combinations/GODivisionalSetter.cpp
@@ -236,7 +236,6 @@ void GODivisionalSetter::LoadCombination(GOConfigReader &cfg) {
 
 const char *const DIVISIONALS = "divisionals";
 const char *const BANKED_DIVISIONALS = "banked-divisionals";
-const char *const NAME = "name";
 const char *const COMBINATIONS = "combinations";
 const wxString WX_MANUALP03U = wxT("Manual%03u");
 const wxString WX_PU = wxT("%u");

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -580,7 +580,6 @@ void GOSetter::Save(GOConfigWriter &cfg) {
   // another objects are saveble themself so they are saved separatelly
 }
 
-const char *const CURRENT = "current";
 const char *const SIMPLE_GENERALS = "generals";
 const char *const BANKED_GENERALS = "banked-generals";
 const char *const CRESCENDOS = "crescendos";

--- a/src/grandorgue/gui/frames/GOStopsWindow.cpp
+++ b/src/grandorgue/gui/frames/GOStopsWindow.cpp
@@ -23,8 +23,6 @@
 #include "model/GOSwitch.h"
 #include "model/GOTremulant.h"
 
-constexpr unsigned MAX_ELEMENTS = 2000;
-
 enum {
   ID_CHECKBOX = 200,
 };

--- a/src/grandorgue/loader/GOLoadWorker.h
+++ b/src/grandorgue/loader/GOLoadWorker.h
@@ -5,15 +5,15 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
+#ifndef GOLOADWORKER_H
+#define GOLOADWORKER_H
+
 #include "GOCacheObjectDistributor.h"
 
 #include <wx/string.h>
 
 class GOFileStore;
 class GOMemoryPool;
-
-#ifndef GOLOADWORKER_H
-#define GOLOADWORKER_H
 
 /**
  * A class for loading objects taken from GOCacheObjectDistributor

--- a/src/grandorgue/loader/GOLoadWorker.h
+++ b/src/grandorgue/loader/GOLoadWorker.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -27,7 +27,6 @@ private:
   GOMemoryPool &m_pool;
   GOCacheObjectDistributor &m_distributor;
 
-  GOCacheObject *m_LastObject;
   bool m_WereExceptions; // any exception included GOOutOfMemory
   bool m_OutOfMemory;
 

--- a/src/grandorgue/midi/GOMidiShortcutReceiver.h
+++ b/src/grandorgue/midi/GOMidiShortcutReceiver.h
@@ -14,7 +14,6 @@
 
 class GOConfigReader;
 class GOConfigWriter;
-class GOOrganController;
 
 class GOMidiShortcutReceiver : public GOMidiShortcutPattern {
 public:

--- a/src/grandorgue/midi/GOMidiShortcutReceiver.h
+++ b/src/grandorgue/midi/GOMidiShortcutReceiver.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -17,9 +17,6 @@ class GOConfigWriter;
 class GOOrganController;
 
 class GOMidiShortcutReceiver : public GOMidiShortcutPattern {
-private:
-  GOOrganController *m_OrganController;
-
 public:
   GOMidiShortcutReceiver(KEY_RECEIVER_TYPE type)
     : GOMidiShortcutPattern(type) {}

--- a/src/grandorgue/sound/GOSoundEngine.cpp
+++ b/src/grandorgue/sound/GOSoundEngine.cpp
@@ -38,7 +38,6 @@ GOSoundEngine::GOSoundEngine()
     m_SamplerPool(),
     m_AudioGroupCount(1),
     m_UsedPolyphony(0),
-    m_WorkerSlots(0),
     m_MeterInfo(1),
     m_TremulantTasks(),
     m_WindchestTasks(),

--- a/src/grandorgue/sound/GOSoundEngine.h
+++ b/src/grandorgue/sound/GOSoundEngine.h
@@ -54,7 +54,6 @@ private:
   GOSoundSamplerPool m_SamplerPool;
   unsigned m_AudioGroupCount;
   std::atomic_uint m_UsedPolyphony;
-  unsigned m_WorkerSlots;
   std::vector<double> m_MeterInfo;
   ptr_vector<GOSoundTremulantTask> m_TremulantTasks;
   ptr_vector<GOSoundWindchestTask> m_WindchestTasks;


### PR DESCRIPTION
This PR removes some unused const declarations. No GO behavior should be changed