### PR TITLE
Fixed a compiler warning about the destructor of GOOrgancontroller https://github.com/GrandOrgue/grandorgue/issues/2001

### DIFF
--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -130,7 +130,7 @@ public:
     GOConfig &config,
     GOMidiDialogCreator *pMidiDialogCreator = nullptr,
     bool isAppInitialized = false);
-  ~GOOrganController();
+  virtual ~GOOrganController();
 
   GOSizeKeeper &GetStopWindowSizeKeeper() { return m_StopWindowSizeKeeper; }
 


### PR DESCRIPTION
This PR fixes a compilation warning. No GO behavior should be changed