### PR TITLE
Fixed a clang warning about braces in a complex initialisator https://github.com/GrandOrgue/grandorgue/issues/2001

### DIFF
--- a/src/grandorgue/sound/GOSoundRecorder.cpp
+++ b/src/grandorgue/sound/GOSoundRecorder.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -51,7 +51,7 @@ struct_WAVE GOSoundRecorder::generateHeader(unsigned datasize) {
     {WAVE_TYPE_RIFF, datasize + 36},
     WAVE_TYPE_WAVE,
     {WAVE_TYPE_FMT, 16},
-    {m_BytesPerSample == 4 ? 3 : 1,
+    {(m_BytesPerSample == 4 ? 3 : 1),
      m_Channels,
      m_SampleRate,
      m_SampleRate * m_BytesPerSample * m_Channels,


### PR DESCRIPTION
Relates to: #2001 

No GO behavior should be changed