### PR TITLE
Removed support of MacOs 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
             build_on: linux
             pkg_suffix: wx32
 
-          - run_on: macos-12 # x86_64
+          - run_on: macos-13 # x86_64
             for: osx
             prepare: osx
             build_on: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed support of MacOs 12
 - Fixed hang if there were lots of unused ODF entries https://github.com/GrandOrgue/grandorgue/issues/1918
 # 3.15.3 (2024-11-23)
 - Fixed crash of reference pipes with the "--justgui" option https://github.com/GrandOrgue/grandorgue/issues/2019


### PR DESCRIPTION
Since GitHub dropped support of macos-12 runners https://github.com/actions/runner-images/issues/10721 we are unable to build GrandOrgue for that version of macos. So this PR switches building to macos-13.