### PR TITLE
Added capability of overriding AmpMinimumLevel in the .cmb file https://github.com/GrandOrgue/grandorgue/issues/782

### DIFF
--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -1174,7 +1174,7 @@ void GOSetter::Crescendo(int newpos, bool force) {
 
 void GOSetter::ControlChanged(GOControl *control) {
   if (control == &m_CrescendoCtrl)
-    Crescendo(m_CrescendoCtrl.GetValue() * CRESCENDO_STEPS / 128);
+    Crescendo(m_CrescendoCtrl.GetMidiValue() * CRESCENDO_STEPS / 128);
 }
 
 void GOSetter::UpdateTranspose() {

--- a/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
+++ b/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -341,7 +341,7 @@ bool GOGUIEnclosure::HandleMousePress(
     state.SetControl(this);
     state.SetIndex(value);
 
-    m_enclosure->Set(value);
+    m_enclosure->SetValue(value);
     return true;
   }
 }

--- a/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
+++ b/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
@@ -305,8 +305,9 @@ void GOGUIEnclosure::PrepareDraw(double scale, GOBitmap *background) {
 }
 
 void GOGUIEnclosure::Draw(GODC &dc) {
-  GOBitmap &bmp
-    = m_Bitmaps[((m_Bitmaps.size() - 1) * m_enclosure->GetValue()) / 127];
+  GOBitmap &bmp = m_Bitmaps
+    [((m_Bitmaps.size() - 1) * m_enclosure->GetMidiValue())
+     / GOEnclosure::MAX_MIDI_VALUE];
   dc.DrawBitmap(bmp, m_BoundingRect);
 
   if (m_TextWidth)
@@ -341,7 +342,7 @@ bool GOGUIEnclosure::HandleMousePress(
     state.SetControl(this);
     state.SetIndex(value);
 
-    m_enclosure->SetValue(value);
+    m_enclosure->SetIntMidiValue(value);
     return true;
   }
 }

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -15,8 +15,6 @@
 
 #include "GOOrganModel.h"
 
-static constexpr uint8_t MAX_MIDI_VALUE = 127;
-
 GOEnclosure::GOEnclosure(GOOrganModel &organModel)
   : GOMidiConfigurator(organModel),
     r_OrganModel(organModel),
@@ -62,7 +60,7 @@ void GOEnclosure::LoadFromCmb(GOConfigReader &cfg, uint8_t defaultValue) {
     0,
     100,
     m_DefaultAmpMinimumLevel);
-  SetValue(cfg.ReadInteger(
+  SetMidiValue(cfg.ReadInteger(
     CMBSetting, m_group, WX_VALUE, 0, MAX_MIDI_VALUE, false, defaultValue));
 }
 
@@ -91,12 +89,10 @@ void GOEnclosure::Save(GOConfigWriter &cfg) {
   cfg.WriteInteger(m_group, WX_VALUE, m_MIDIValue);
 }
 
-void GOEnclosure::SetValue(uint8_t n) {
-  if (n > 127)
-    n = 127;
+void GOEnclosure::SetMidiValue(uint8_t n) {
   if (n != m_MIDIValue) {
     m_MIDIValue = n;
-    m_sender.SetValue(m_MIDIValue);
+    m_sender.SetValue(n);
   }
   r_OrganModel.UpdateVolume();
   r_OrganModel.SendControlChanged(this);
@@ -109,23 +105,24 @@ float GOEnclosure::GetAttenuation() {
 }
 
 void GOEnclosure::Scroll(bool scroll_up) {
-  SetValue(m_MIDIValue + (scroll_up ? 4 : -4));
+  SetIntMidiValue(m_MIDIValue + (scroll_up ? 4 : -4));
 }
 
 void GOEnclosure::ProcessMidi(const GOMidiEvent &event) {
   int value;
+
   if (m_midi.Match(event, value) == MIDI_MATCH_CHANGE)
-    SetValue(value);
+    SetIntMidiValue(value);
 }
 
 void GOEnclosure::HandleKey(int key) {
   switch (m_shortcut.Match(key)) {
   case KEY_MATCH:
-    SetValue(m_MIDIValue + 8);
+    SetIntMidiValue(m_MIDIValue + 8);
     break;
 
   case KEY_MATCH_MINUS:
-    SetValue(m_MIDIValue - 8);
+    SetIntMidiValue(m_MIDIValue - 8);
     break;
   default:
     break;

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -59,6 +59,7 @@ void GOEnclosure::LoadFromCmb(GOConfigReader &cfg, uint8_t defaultValue) {
     WX_AMP_MINIMUM_LEVEL,
     0,
     100,
+    false,
     m_DefaultAmpMinimumLevel);
   SetMidiValue(cfg.ReadInteger(
     CMBSetting, m_group, WX_VALUE, 0, MAX_MIDI_VALUE, false, defaultValue));

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -24,9 +24,9 @@ GOEnclosure::GOEnclosure(GOOrganModel &organModel)
     m_midi(organModel, MIDI_RECV_ENCLOSURE),
     m_sender(organModel, MIDI_SEND_ENCLOSURE),
     m_shortcut(KEY_RECV_ENCLOSURE),
+    m_Name(),
     m_DefaultAmpMinimumLevel(0),
     m_MIDIInputNumber(0),
-    m_Name(),
     m_Displayed1(false),
     m_Displayed2(false),
     m_AmpMinimumLevel(0),
@@ -62,7 +62,7 @@ void GOEnclosure::LoadFromCmb(GOConfigReader &cfg, uint8_t defaultValue) {
     0,
     100,
     m_DefaultAmpMinimumLevel);
-  Set(cfg.ReadInteger(
+  SetValue(cfg.ReadInteger(
     CMBSetting, m_group, WX_VALUE, 0, MAX_MIDI_VALUE, false, defaultValue));
 }
 
@@ -91,9 +91,7 @@ void GOEnclosure::Save(GOConfigWriter &cfg) {
   cfg.WriteInteger(m_group, WX_VALUE, m_MIDIValue);
 }
 
-void GOEnclosure::Set(int n) {
-  if (n < 0)
-    n = 0;
+void GOEnclosure::SetValue(uint8_t n) {
   if (n > 127)
     n = 127;
   if (n != m_MIDIValue) {
@@ -104,8 +102,6 @@ void GOEnclosure::Set(int n) {
   r_OrganModel.SendControlChanged(this);
 }
 
-int GOEnclosure::GetMIDIInputNumber() { return m_MIDIInputNumber; }
-
 float GOEnclosure::GetAttenuation() {
   static const float scale = 1.0 / 12700.0;
   return (float)(m_MIDIValue * (100 - m_AmpMinimumLevel) + 127 * m_AmpMinimumLevel)
@@ -113,30 +109,28 @@ float GOEnclosure::GetAttenuation() {
 }
 
 void GOEnclosure::Scroll(bool scroll_up) {
-  Set(m_MIDIValue + (scroll_up ? 4 : -4));
+  SetValue(m_MIDIValue + (scroll_up ? 4 : -4));
 }
 
 void GOEnclosure::ProcessMidi(const GOMidiEvent &event) {
   int value;
   if (m_midi.Match(event, value) == MIDI_MATCH_CHANGE)
-    Set(value);
+    SetValue(value);
 }
 
 void GOEnclosure::HandleKey(int key) {
   switch (m_shortcut.Match(key)) {
   case KEY_MATCH:
-    Set(m_MIDIValue + 8);
+    SetValue(m_MIDIValue + 8);
     break;
 
   case KEY_MATCH_MINUS:
-    Set(m_MIDIValue - 8);
+    SetValue(m_MIDIValue - 8);
     break;
   default:
     break;
   }
 }
-
-int GOEnclosure::GetValue() { return m_MIDIValue; }
 
 bool GOEnclosure::IsDisplayed(bool new_format) {
   if (new_format)

--- a/src/grandorgue/model/GOEnclosure.h
+++ b/src/grandorgue/model/GOEnclosure.h
@@ -1,12 +1,14 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
 #ifndef GOENCLOSURE_H_
 #define GOENCLOSURE_H_
+
+#include <cstdint>
 
 #include <wx/string.h>
 
@@ -38,16 +40,20 @@ private:
   GOMidiReceiver m_midi;
   GOMidiSender m_sender;
   GOMidiShortcutReceiver m_shortcut;
-  int m_AmpMinimumLevel;
+  uint8_t m_DefaultAmpMinimumLevel;
   int m_MIDIInputNumber;
-  int m_MIDIValue;
   wxString m_Name;
   bool m_Displayed1;
   bool m_Displayed2;
 
+  uint8_t m_AmpMinimumLevel;
+  uint8_t m_MIDIValue;
+
   void ProcessMidi(const GOMidiEvent &event) override;
   void HandleKey(int key) override;
 
+  // Load all customizable values from the .cmb file
+  void LoadFromCmb(GOConfigReader &cfg, uint8_t defaultValue);
   void Save(GOConfigWriter &cfg) override;
 
   void AbortPlayback() override;
@@ -63,8 +69,11 @@ private:
 public:
   GOEnclosure(GOOrganModel &organModel);
   void Init(
-    GOConfigReader &cfg, wxString group, wxString Name, unsigned def_value);
-  void Load(GOConfigReader &cfg, wxString group, int enclosure_nb);
+    GOConfigReader &cfg,
+    const wxString &group,
+    const wxString &name,
+    uint8_t defaultValue);
+  void Load(GOConfigReader &cfg, const wxString &group, int enclosure_nb);
   void Set(int n);
   const wxString &GetName() const { return m_Name; }
   int GetValue();

--- a/src/grandorgue/model/GOEnclosure.h
+++ b/src/grandorgue/model/GOEnclosure.h
@@ -40,9 +40,9 @@ private:
   GOMidiReceiver m_midi;
   GOMidiSender m_sender;
   GOMidiShortcutReceiver m_shortcut;
-  uint8_t m_DefaultAmpMinimumLevel;
-  int m_MIDIInputNumber;
   wxString m_Name;
+  uint8_t m_DefaultAmpMinimumLevel;
+  uint8_t m_MIDIInputNumber;
   bool m_Displayed1;
   bool m_Displayed2;
 
@@ -74,10 +74,12 @@ public:
     const wxString &name,
     uint8_t defaultValue);
   void Load(GOConfigReader &cfg, const wxString &group, int enclosure_nb);
-  void Set(int n);
   const wxString &GetName() const { return m_Name; }
-  int GetValue();
-  int GetMIDIInputNumber();
+  uint8_t GetAmpMinimumLevel() const { return m_AmpMinimumLevel; }
+  void SetAmpMinimumLevel(uint8_t v) { m_AmpMinimumLevel = v; }
+  uint8_t GetMIDIInputNumber() const { return m_MIDIInputNumber; }
+  uint8_t GetValue() const { return m_MIDIValue; }
+  void SetValue(uint8_t n);
   float GetAttenuation();
 
   void Scroll(bool scroll_up);

--- a/src/grandorgue/model/GOEnclosure.h
+++ b/src/grandorgue/model/GOEnclosure.h
@@ -8,6 +8,7 @@
 #ifndef GOENCLOSURE_H_
 #define GOENCLOSURE_H_
 
+#include <algorithm>
 #include <cstdint>
 
 #include <wx/string.h>
@@ -67,6 +68,8 @@ private:
   }
 
 public:
+  static constexpr uint8_t MAX_MIDI_VALUE = 127;
+
   GOEnclosure(GOOrganModel &organModel);
   void Init(
     GOConfigReader &cfg,
@@ -78,8 +81,11 @@ public:
   uint8_t GetAmpMinimumLevel() const { return m_AmpMinimumLevel; }
   void SetAmpMinimumLevel(uint8_t v) { m_AmpMinimumLevel = v; }
   uint8_t GetMIDIInputNumber() const { return m_MIDIInputNumber; }
-  uint8_t GetValue() const { return m_MIDIValue; }
-  void SetValue(uint8_t n);
+  uint8_t GetMidiValue() const { return m_MIDIValue; }
+  void SetMidiValue(uint8_t n);
+  void SetIntMidiValue(int n) {
+    SetMidiValue((uint8_t)std::clamp(n, 0, (int)MAX_MIDI_VALUE));
+  }
   float GetAttenuation();
 
   void Scroll(bool scroll_up);

--- a/src/tests/testing/model/GOTestWindchest.cpp
+++ b/src/tests/testing/model/GOTestWindchest.cpp
@@ -47,20 +47,20 @@ void GOTestWindchest::run() {
   GOEnclosure *enclosure = new GOEnclosure(*this->controller);
   windchest->AddEnclosure(enclosure);
 
-  enclosure->SetValue(127);
+  enclosure->SetMidiValue(127);
   float volume = windchest->GetVolume();
   message = "The Windchest volume is not 1 but ";
   message = message + std::to_string(volume);
   this->GOAssert(volume == 1, message);
 
-  enclosure->SetValue(0);
+  enclosure->SetMidiValue(0);
   volume = windchest->GetVolume();
   message = "The Windchest volume is not 0 but ";
   message = message + std::to_string(volume);
   this->GOAssert(volume == 0, message);
 
   // Check a MIDI value of 50 (50/127)
-  enclosure->SetValue(50);
+  enclosure->SetMidiValue(50);
   volume = windchest->GetVolume();
   message = "The Windchest volume is not 0.393701 but ";
   message = message + std::to_string(volume);

--- a/src/tests/testing/model/GOTestWindchest.cpp
+++ b/src/tests/testing/model/GOTestWindchest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2023-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -47,20 +47,20 @@ void GOTestWindchest::run() {
   GOEnclosure *enclosure = new GOEnclosure(*this->controller);
   windchest->AddEnclosure(enclosure);
 
-  enclosure->Set(127);
+  enclosure->SetValue(127);
   float volume = windchest->GetVolume();
   message = "The Windchest volume is not 1 but ";
   message = message + std::to_string(volume);
   this->GOAssert(volume == 1, message);
 
-  enclosure->Set(0);
+  enclosure->SetValue(0);
   volume = windchest->GetVolume();
   message = "The Windchest volume is not 0 but ";
   message = message + std::to_string(volume);
   this->GOAssert(volume == 0, message);
 
   // Check a MIDI value of 50 (50/127)
-  enclosure->Set(50);
+  enclosure->SetValue(50);
   volume = windchest->GetVolume();
   message = "The Windchest volume is not 0.393701 but ";
   message = message + std::to_string(volume);


### PR DESCRIPTION
This is the first PR related to #782

This PR
- Introduces GOEnclosure::m_DefaultAmpMinimumLevel loaded from the ODF
- Adds Load and Save m_AmpMinimumLevel from/to .cmb
- Adds the GetAmpMinimumLevel and SetAmpMinimumLevel methods for future use
- Changes the data type of m_AmpMinimumLevel and m_MIDIValue to uint8_t
- Renames GoEnclosure::Set to SetMidiValue, GoEnclosure::GetValue to GetMidiValue
- Extracted the common part of GOEnclosure::Init and GOEnclosure::Load tp GOEnclosure::LoadFromCmb
- Added an advanced version of GOEnclosure::SetIntMidiValue

This PR does not add any GUI for redefining AmpMinimumLevel. It will be added in a future PR after some discussion in #782 