### PR TITLE
Made inner types GOMidiShortcutPattern

### DIFF
--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -24,7 +24,7 @@ GOButtonControl::GOButtonControl(
     r_OrganModel(organModel),
     m_midi(organModel, midi_type),
     m_sender(organModel, MIDI_SEND_BUTTON),
-    m_shortcut(KEY_RECV_BUTTON),
+    m_shortcut(GOMidiShortcutReceiver::KEY_RECV_BUTTON),
     m_Pushbutton(pushbutton),
     m_Displayed(false),
     m_Name(),
@@ -80,7 +80,7 @@ void GOButtonControl::HandleKey(int key) {
   if (m_ReadOnly)
     return;
   switch (m_shortcut.Match(key)) {
-  case KEY_MATCH:
+  case GOMidiShortcutReceiver::KEY_MATCH:
     Push();
     break;
 

--- a/src/grandorgue/control/GOLabelControl.cpp
+++ b/src/grandorgue/control/GOLabelControl.cpp
@@ -15,7 +15,8 @@
 #include "GODocument.h"
 
 GOLabelControl::GOLabelControl(GOOrganModel &organModel)
-  : GOMidiConfigurator(organModel),
+  : GOMidiObject(organModel),
+    r_OrganModel(organModel),
     m_Name(),
     m_Content(),
     m_sender(organModel, MIDI_SEND_LABEL) {

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventKeyTab.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventKeyTab.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -32,8 +32,9 @@ GOMidiEventKeyTab::GOMidiEventKeyTab(
   wxBoxSizer *sizer = new wxStaticBoxSizer(
     wxVERTICAL,
     this,
-    m_key.GetType() == KEY_RECV_ENCLOSURE ? _("&Plus-Shortcut:")
-                                          : _("&Shortcut:"));
+    m_key.GetType() == GOMidiShortcutPattern::KEY_RECV_ENCLOSURE
+      ? _("&Plus-Shortcut:")
+      : _("&Shortcut:"));
   m_keyselect = new wxChoice(this, ID_KEY_SELECT);
   sizer->Add(m_keyselect, 1, wxEXPAND);
 
@@ -43,7 +44,7 @@ GOMidiEventKeyTab::GOMidiEventKeyTab(
 
   topSizer->Add(sizer, 0, wxALL | wxEXPAND, 6);
 
-  if (m_key.GetType() == KEY_RECV_ENCLOSURE) {
+  if (m_key.GetType() == GOMidiShortcutPattern::KEY_RECV_ENCLOSURE) {
     sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("&Minus-Shortcut:"));
     m_keyminusselect = new wxChoice(this, ID_MINUS_KEY_SELECT);
     sizer->Add(m_keyminusselect, 1, wxEXPAND);

--- a/src/grandorgue/midi/GOMidiShortcutPattern.h
+++ b/src/grandorgue/midi/GOMidiShortcutPattern.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,28 +8,28 @@
 #ifndef GOMIDISHORTCUTPATTERN_H
 #define GOMIDISHORTCUTPATTERN_H
 
-typedef enum {
-  KEY_RECV_BUTTON,
-  KEY_RECV_ENCLOSURE,
-} KEY_RECEIVER_TYPE;
-
-typedef enum {
-  KEY_MATCH_NONE,
-  KEY_MATCH,
-  KEY_MATCH_MINUS,
-} KEY_MATCH_TYPE;
-
 class GOMidiShortcutPattern {
+public:
+  enum ReceiverType {
+    KEY_RECV_BUTTON,
+    KEY_RECV_ENCLOSURE,
+  };
+  enum MatchType {
+    KEY_MATCH_NONE,
+    KEY_MATCH,
+    KEY_MATCH_MINUS,
+  };
+
 protected:
-  KEY_RECEIVER_TYPE m_type;
+  ReceiverType m_type;
   unsigned m_ShortcutKey = 0;
   unsigned m_MinusKey = 0;
 
 public:
-  GOMidiShortcutPattern(KEY_RECEIVER_TYPE type) : m_type(type) {}
+  GOMidiShortcutPattern(ReceiverType type) : m_type(type) {}
   virtual ~GOMidiShortcutPattern() {}
 
-  KEY_RECEIVER_TYPE GetType() const { return m_type; }
+  ReceiverType GetType() const { return m_type; }
 
   unsigned GetShortcut() const { return m_ShortcutKey; }
   void SetShortcut(unsigned key) { m_ShortcutKey = key; }

--- a/src/grandorgue/midi/GOMidiShortcutReceiver.cpp
+++ b/src/grandorgue/midi/GOMidiShortcutReceiver.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -33,7 +33,7 @@ void GOMidiShortcutReceiver::Save(GOConfigWriter &cfg, wxString group) {
   }
 }
 
-KEY_MATCH_TYPE GOMidiShortcutReceiver::Match(unsigned key) {
+GOMidiShortcutReceiver::MatchType GOMidiShortcutReceiver::Match(unsigned key) {
   if (m_ShortcutKey == key)
     return KEY_MATCH;
   if (m_MinusKey == key)

--- a/src/grandorgue/midi/GOMidiShortcutReceiver.h
+++ b/src/grandorgue/midi/GOMidiShortcutReceiver.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -17,13 +17,12 @@ class GOConfigWriter;
 
 class GOMidiShortcutReceiver : public GOMidiShortcutPattern {
 public:
-  GOMidiShortcutReceiver(KEY_RECEIVER_TYPE type)
-    : GOMidiShortcutPattern(type) {}
+  GOMidiShortcutReceiver(ReceiverType type) : GOMidiShortcutPattern(type) {}
 
   void Load(GOConfigReader &cfg, wxString group);
   void Save(GOConfigWriter &cfg, wxString group);
 
-  KEY_MATCH_TYPE Match(unsigned key);
+  MatchType Match(unsigned key);
 
   bool RenewFrom(const GOMidiShortcutPattern &newPattern);
 };

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -21,7 +21,7 @@ GOEnclosure::GOEnclosure(GOOrganModel &organModel)
     r_MidiMap(organModel.GetConfig().GetMidiMap()),
     m_midi(organModel, MIDI_RECV_ENCLOSURE),
     m_sender(organModel, MIDI_SEND_ENCLOSURE),
-    m_shortcut(KEY_RECV_ENCLOSURE),
+    m_shortcut(GOMidiShortcutReceiver::KEY_RECV_ENCLOSURE),
     m_Name(),
     m_DefaultAmpMinimumLevel(0),
     m_MIDIInputNumber(0),
@@ -118,11 +118,11 @@ void GOEnclosure::ProcessMidi(const GOMidiEvent &event) {
 
 void GOEnclosure::HandleKey(int key) {
   switch (m_shortcut.Match(key)) {
-  case KEY_MATCH:
+  case GOMidiShortcutReceiver::KEY_MATCH:
     SetIntMidiValue(m_MIDIValue + 8);
     break;
 
-  case KEY_MATCH_MINUS:
+  case GOMidiShortcutReceiver::KEY_MATCH_MINUS:
     SetIntMidiValue(m_MIDIValue - 8);
     break;
   default:


### PR DESCRIPTION
This PR moves two enums `KEY_RECEIVER_TYPE` and `KEY_MATCH_TYPE` inside the class `GOMidiShortcutPattern` and renames to `ReceiverType` and `MatchType`

It is just refactoring. No GO behavior should be changed.