### PR TITLE
Increased maximum supporter config settings values and changed the defaults https://github.com/GrandOrgue/grandorgue/issues/2115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Changed default sample rate, samples per buffer and interpolation type to 48000, 512 and Polyphase https://github.com/GrandOrgue/grandorgue/issues/2115
+- Increased the maximum samples per buffer to 2048 https://github.com/GrandOrgue/grandorgue/issues/2115
+- Increased the maximum supported sample rate to 192000 https://github.com/GrandOrgue/grandorgue/issues/2115
 - Fixed nested scrolling in the MidiObject dialog on macOs https://github.com/GrandOrgue/grandorgue/issues/1972
 - Increased the maximum number of user-defined temperaments to 999 https://github.com/GrandOrgue/grandorgue/issues/1982
 # 3.15.4 (2024-12-20)

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -3806,7 +3806,7 @@ The detuning is small enough so that the ear can't appreciate the tuning differe
             <varlistentry>
               <term>Linear</term>
               <listitem>
-                <simpara>This method  lowers CPU load at he expense of audio quality.</simpara>
+                <simpara>This method lowers CPU load at he expense of audio quality.</simpara>
               </listitem>
             </varlistentry>
           </variablelist>

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -3806,7 +3806,7 @@ The detuning is small enough so that the ear can't appreciate the tuning differe
             <varlistentry>
               <term>Linear</term>
               <listitem>
-                <simpara>This method  lowers CPU load at he expense of audio quality. It is the only usable option when <link linkend="losslesscompression">lossless compression</link> is enabled, as polyphase interpolation is not yet implemented with lossless compression.</simpara>
+                <simpara>This method  lowers CPU load at he expense of audio quality.</simpara>
               </listitem>
             </varlistentry>
           </variablelist>
@@ -4489,7 +4489,10 @@ role="strong">STOP</emphasis> button is depressed.
           <indexterm>
             <primary>Sample rate</primary>
           </indexterm>
-          <para>Selects the output sample rate. Allowed values are 44100, 48000 and 96000 Hz.</para>
+          <para>
+	    Selects the output sample rate. Allowed values are 44100, 48000,
+	    96000 and 192000 Hz.
+	  </para>
           <para>The sample rate should match both the configured sample rate in the audio interface and the sample rate of the recorded samples  to avoid  resampling. If not, resampling can occur in all layers of the audio stack, and audio quality can suffer.</para>
         </sect3>
         <sect3 id="samplesperbuffer">
@@ -4497,7 +4500,7 @@ role="strong">STOP</emphasis> button is depressed.
           <indexterm>
             <primary>Samples per buffer</primary>
           </indexterm>
-          <para>Allowed values range from 16 to 1024 by increment of 16.</para>
+          <para>Allowed values range from 16 to 2048 by increment of 16.</para>
           <para>This parameter sets the output buffer size. Larger values usually reduce sound artifacts at the expense of latency.</para>
         </sect3>
       </sect2>
@@ -6671,7 +6674,7 @@ period.
       <para>
 The unit "samples" counts the number of samples from the start of the
 WAV file. On sample includes the values of all channels, eg: for a
-stereo WAV file at 44.1 kHz, 1 second is equivalent to 44100 samples.
+stereo WAV file at 48 kHz, 1 second is equivalent to 48000 samples.
       </para>
       <figure>
         <title>background bitmaps 1 to 30</title>
@@ -6709,7 +6712,7 @@ The samples are stored as WAV files according to the WAV file
 specification. The supported formats are: 8 bit, 16 bit and 24 bit PCM
 or 32 bit IEEE float, either mono or stereo. The preferred sample rates
 are 44100 or 48000 Hz - GO supports any sample rate between 22000 and
-96000 Hz. GO only supports a single data chunk. To play looped
+192000 Hz. GO only supports a single data chunk. To play looped
 samples, they must include cue points (cue chunk) and loops (smpl
 chunk). If there are multiple loops, each loop should overlap another
 loop. Attack samples include the attack phase and the loops - they may
@@ -10762,7 +10765,7 @@ Synthesized tremulants have the following attributes:
           <term>Period</term>
           <listitem>
             <para>
-(integer 32 - 44100, required) Period of the tremulant in ms
+(integer 32 - 441000, required) Period of the tremulant in ms
      </para>
           </listitem>
         </varlistentry>

--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -31,6 +31,11 @@
 #include "sound/GOSoundDefs.h"
 #include "sound/ports/GOSoundPort.h"
 #include "sound/ports/GOSoundPortFactory.h"
+
+static constexpr unsigned SAMPLE_RATE_DEFAULT = 48000;
+static constexpr unsigned SAMPLES_PER_BUFFER_DEFAULT = 512;
+static constexpr GOConfig::InterpolationType INTERPOLATION_DEFAULT
+  = GOConfig::INTERPOLATION_POLYPHASE;
 
 static const wxString COUNT = wxT("Count");
 static const wxString ENABLED = wxT(".Enabled");
@@ -148,7 +153,13 @@ GOConfig::GOConfig(wxString instance)
       this, wxT("General"), wxT("ReleaseConcurrency"), 1, MAX_CPU, 1),
     LoadConcurrency(
       this, wxT("General"), wxT("LoadConcurrency"), 0, MAX_CPU, 1),
-    InterpolationType(this, wxT("General"), wxT("InterpolationType"), 0, 1, 0),
+    m_InterpolationType(
+      this,
+      wxT("General"),
+      wxT("InterpolationType"),
+      INTERPOLATION_LINEAR,
+      INTERPOLATION_POLYPHASE,
+      INTERPOLATION_DEFAULT),
     WaveFormatBytesPerSample(this, wxT("General"), wxT("WaveFormat"), 1, 4, 4),
     RecordDownmix(this, wxT("General"), wxT("RecordDownmix"), false),
     AttackLoad(this, wxT("General"), wxT("AttackLoad"), 0, 1, 1),
@@ -188,8 +199,19 @@ GOConfig::GOConfig(wxString instance)
       1024 * 1024,
       GOMemoryPool::GetSystemMemoryLimit()),
     SamplesPerBuffer(
-      this, wxT("General"), wxT("SamplesPerBuffer"), 1, MAX_FRAME_SIZE, 1024),
-    SampleRate(this, wxT("General"), wxT("SampleRate"), 1000, 100000, 44100),
+      this,
+      wxT("General"),
+      wxT("SamplesPerBuffer"),
+      1,
+      MAX_FRAME_SIZE,
+      SAMPLES_PER_BUFFER_DEFAULT),
+    SampleRate(
+      this,
+      wxT("General"),
+      wxT("SampleRate"),
+      1000,
+      192000,
+      SAMPLE_RATE_DEFAULT),
     Volume(this, wxT("General"), wxT("Volume"), -120, 20, -15),
     PolyphonyLimit(
       this, wxT("General"), wxT("PolyphonyLimit"), 0, MAX_POLYPHONY, 2048),
@@ -218,9 +240,6 @@ GOConfig::GOConfig(wxString instance)
       this, wxT("General"), wxT("CheckForUpdatesAtStartup"), true),
     m_MidiIn(MIDI_IN),
     m_MidiOut(MIDI_OUT) {}
-
-GOConfig::~GOConfig() { /* Flush(); */
-}
 
 void load_ports_config(
   GOConfigReader &cfg,

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -44,6 +44,12 @@ typedef struct {
 enum class GOInitialLoadType { LOAD_NONE, LOAD_LAST_USED, LOAD_FIRST };
 
 class GOConfig : public GOSettingStore, public GOOrganList {
+public:
+  enum InterpolationType {
+    INTERPOLATION_LINEAR = 0,
+    INTERPOLATION_POLYPHASE,
+  };
+
 private:
   wxString m_InstanceName;
   wxString m_ConfigFileName;
@@ -68,7 +74,6 @@ private:
 
 public:
   GOConfig(wxString instance);
-  ~GOConfig();
 
   GOSettingDirectory OrganSettingsPath;
   GOSettingDirectory OrganCachePath;
@@ -77,7 +82,7 @@ public:
   GOSettingUnsigned ReleaseConcurrency;
   GOSettingUnsigned LoadConcurrency;
 
-  GOSettingUnsigned InterpolationType;
+  GOSettingUnsigned m_InterpolationType;
   GOSettingUnsigned WaveFormatBytesPerSample;
   GOSettingBool RecordDownmix;
 

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsAudio.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsAudio.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -202,7 +202,8 @@ bool GOSettingsAudio::TransferDataToWindow() {
   m_SampleRate->Append(wxT("44100"));
   m_SampleRate->Append(wxT("48000"));
   m_SampleRate->Append(wxT("96000"));
-  m_SampleRate->Select(0);
+  m_SampleRate->Append(wxT("192000"));
+  m_SampleRate->Select(1);
   for (unsigned i = 0; i < m_SampleRate->GetCount(); i++)
     if (
       wxString::Format(wxT("%d"), m_config.SampleRate())

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsOptions.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsOptions.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -230,7 +230,7 @@ GOSettingsOptions::GOSettingsOptions(GOConfig &settings, wxWindow *parent)
   item6->Add(grid, 0, wxEXPAND | wxALL, 5);
   item9->Add(item6, 0, wxEXPAND | wxALL, 5);
 
-  m_Interpolation->Select(m_config.InterpolationType());
+  m_Interpolation->Select(m_config.m_InterpolationType());
   m_Concurrency->Select(m_config.Concurrency() - 1);
   m_ReleaseConcurrency->Select(m_config.ReleaseConcurrency() - 1);
   m_LoadConcurrency->Select(m_config.LoadConcurrency());
@@ -446,7 +446,7 @@ bool GOSettingsOptions::TransferDataFromWindow() {
   m_config.AttackLoad(m_AttackLoad->GetSelection());
   m_config.ReleaseLoad(m_ReleaseLoad->GetSelection());
   m_config.LoadChannels(m_Channels->GetSelection());
-  m_config.InterpolationType(m_Interpolation->GetSelection());
+  m_config.m_InterpolationType(m_Interpolation->GetSelection());
   m_config.MemoryLimit(m_MemoryLimit->GetValue());
   m_config.MetronomeBPM(m_MetronomeBPM->GetValue());
   m_config.MetronomeMeasure(m_MetronomeMeasure->GetValue());

--- a/src/grandorgue/sound/GOSound.cpp
+++ b/src/grandorgue/sound/GOSound.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -120,7 +120,7 @@ void GOSound::OpenSound() {
   m_SoundEngine.SetHardPolyphony(m_config.PolyphonyLimit());
   m_SoundEngine.SetScaledReleases(m_config.ScaleRelease());
   m_SoundEngine.SetRandomizeSpeaking(m_config.RandomizeSpeaking());
-  m_SoundEngine.SetInterpolationType(m_config.InterpolationType());
+  m_SoundEngine.SetInterpolationType(m_config.m_InterpolationType());
   m_SoundEngine.SetAudioGroupCount(audio_group_count);
   unsigned sample_rate = m_config.SampleRate();
   m_AudioRecorder.SetBytesPerSample(m_config.WaveFormatBytesPerSample());

--- a/src/grandorgue/sound/GOSoundDefs.h
+++ b/src/grandorgue/sound/GOSoundDefs.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -18,7 +18,7 @@
 #define SHORT_LOOP_LENGTH 256
 
 /* Maximum number of blocks (1 block is nChannels samples) per frame */
-#define MAX_FRAME_SIZE (1024)
+#define MAX_FRAME_SIZE (2048)
 
 /* Maximum number of channels the engine supports. This value cannot be
  * changed at present.


### PR DESCRIPTION
As discussed in #2115

- Changed default sample rate, samples per buffer and interpolation type to 48000, 512 and Polyphase
- Increased the maximum samples per buffer to 2048
- Increased the maximum supported sample rate to 192000
- Increased the maximum number of user-defined temperaments to 999