### PR TITLE
Eliminated writting default value of midi setup to the cmb file https://github.com/GrandOrgue/grandorgue/issues/1199

### DIFF
--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -188,60 +188,62 @@ void GOMidiReceiverBase::Preconfigure(GOConfigReader &cfg, wxString group) {}
 int GOMidiReceiverBase::GetTranspose() { return 0; }
 
 void GOMidiReceiverBase::Save(
-  GOConfigWriter &cfg, wxString group, GOMidiMap &map) {
-  cfg.WriteInteger(group, wxT("NumberOfMIDIEvents"), m_events.size());
-  for (unsigned i = 0; i < m_events.size(); i++) {
-    auto &pattern = m_events[i];
+  GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) {
+  if (!m_events.empty()) {
+    cfg.WriteInteger(group, wxT("NumberOfMIDIEvents"), m_events.size());
+    for (unsigned i = 0; i < m_events.size(); i++) {
+      auto &pattern = m_events[i];
 
-    cfg.WriteString(
-      group,
-      wxString::Format(wxT("MIDIDevice%03d"), i + 1),
-      map.GetDeviceLogicalNameById(pattern.deviceId));
-    cfg.WriteEnum(
-      group,
-      wxString::Format(wxT("MIDIEventType%03d"), i + 1),
-      pattern.type,
-      m_MidiTypes,
-      sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
-    if (HasChannel(pattern.type))
-      cfg.WriteInteger(
+      cfg.WriteString(
         group,
-        wxString::Format(wxT("MIDIChannel%03d"), i + 1),
-        pattern.channel);
-    if (HasDebounce(pattern.type))
-      cfg.WriteInteger(
+        wxString::Format(wxT("MIDIDevice%03d"), i + 1),
+        map.GetDeviceLogicalNameById(pattern.deviceId));
+      cfg.WriteEnum(
         group,
-        wxString::Format(wxT("MIDIDebounce%03d"), i + 1),
-        pattern.debounce_time);
+        wxString::Format(wxT("MIDIEventType%03d"), i + 1),
+        pattern.type,
+        m_MidiTypes,
+        sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
+      if (HasChannel(pattern.type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDIChannel%03d"), i + 1),
+          pattern.channel);
+      if (HasDebounce(pattern.type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDIDebounce%03d"), i + 1),
+          pattern.debounce_time);
 
-    if (HasLowKey(pattern.type))
-      cfg.WriteInteger(
-        group,
-        wxString::Format(wxT("MIDILowerKey%03d"), i + 1),
-        pattern.low_key);
-    if (HasHighKey(pattern.type))
-      cfg.WriteInteger(
-        group,
-        wxString::Format(wxT("MIDIUpperKey%03d"), i + 1),
-        pattern.high_key);
+      if (HasLowKey(pattern.type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDILowerKey%03d"), i + 1),
+          pattern.low_key);
+      if (HasHighKey(pattern.type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDIUpperKey%03d"), i + 1),
+          pattern.high_key);
 
-    if (m_type == MIDI_RECV_MANUAL)
-      cfg.WriteInteger(
-        group, wxString::Format(wxT("MIDIKeyShift%03d"), i + 1), pattern.key);
-    else if (HasKey(pattern.type))
-      cfg.WriteInteger(
-        group, wxString::Format(wxT("MIDIKey%03d"), i + 1), pattern.key);
+      if (m_type == MIDI_RECV_MANUAL)
+        cfg.WriteInteger(
+          group, wxString::Format(wxT("MIDIKeyShift%03d"), i + 1), pattern.key);
+      else if (HasKey(pattern.type))
+        cfg.WriteInteger(
+          group, wxString::Format(wxT("MIDIKey%03d"), i + 1), pattern.key);
 
-    if (HasLowerLimit(pattern.type))
-      cfg.WriteInteger(
-        group,
-        wxString::Format(wxT("MIDILowerLimit%03d"), i + 1),
-        pattern.low_value);
-    if (HasUpperLimit(pattern.type))
-      cfg.WriteInteger(
-        group,
-        wxString::Format(wxT("MIDIUpperLimit%03d"), i + 1),
-        pattern.high_value);
+      if (HasLowerLimit(pattern.type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDILowerLimit%03d"), i + 1),
+          pattern.low_value);
+      if (HasUpperLimit(pattern.type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDIUpperLimit%03d"), i + 1),
+          pattern.high_value);
+    }
   }
 }
 

--- a/src/core/midi/GOMidiReceiverBase.h
+++ b/src/core/midi/GOMidiReceiverBase.h
@@ -50,7 +50,7 @@ public:
   GOMidiReceiverBase(GOMidiReceiverType type);
 
   virtual void Load(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
-  void Save(GOConfigWriter &cfg, wxString group, GOMidiMap &map);
+  void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map);
   void PreparePlayback();
 
   void SetElementID(int id);

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -49,7 +49,8 @@ const struct IniFileEnumEntry GOMidiSender::m_MidiTypes[] = {
 
 void GOMidiSender::SetElementID(int id) { m_ElementID = id; }
 
-void GOMidiSender::Load(GOConfigReader &cfg, wxString group, GOMidiMap &map) {
+void GOMidiSender::Load(
+  GOConfigReader &cfg, const wxString &group, GOMidiMap &map) {
   m_events.resize(0);
 
   int event_cnt = cfg.ReadInteger(
@@ -139,58 +140,61 @@ void GOMidiSender::Load(GOConfigReader &cfg, wxString group, GOMidiMap &map) {
   }
 }
 
-void GOMidiSender::Save(GOConfigWriter &cfg, wxString group, GOMidiMap &map) {
-  cfg.WriteInteger(group, wxT("NumberOfMIDISendEvents"), m_events.size());
-  for (unsigned i = 0; i < m_events.size(); i++) {
-    cfg.WriteString(
-      group,
-      wxString::Format(wxT("MIDISendDevice%03d"), i + 1),
-      map.GetDeviceLogicalNameById(m_events[i].deviceId));
-    cfg.WriteEnum(
-      group,
-      wxString::Format(wxT("MIDISendEventType%03d"), i + 1),
-      m_events[i].type,
-      m_MidiTypes,
-      sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
-    if (HasChannel(m_events[i].type))
-      cfg.WriteInteger(
+void GOMidiSender::Save(
+  GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) {
+  if (!m_events.empty()) {
+    cfg.WriteInteger(group, wxT("NumberOfMIDISendEvents"), m_events.size());
+    for (unsigned i = 0; i < m_events.size(); i++) {
+      cfg.WriteString(
         group,
-        wxString::Format(wxT("MIDISendChannel%03d"), i + 1),
-        m_events[i].channel);
-    if (HasKey(m_events[i].type))
-      cfg.WriteInteger(
+        wxString::Format(wxT("MIDISendDevice%03d"), i + 1),
+        map.GetDeviceLogicalNameById(m_events[i].deviceId));
+      cfg.WriteEnum(
         group,
-        wxString::Format(wxT("MIDISendKey%03d"), i + 1),
-        m_events[i].key);
+        wxString::Format(wxT("MIDISendEventType%03d"), i + 1),
+        m_events[i].type,
+        m_MidiTypes,
+        sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
+      if (HasChannel(m_events[i].type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDISendChannel%03d"), i + 1),
+          m_events[i].channel);
+      if (HasKey(m_events[i].type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDISendKey%03d"), i + 1),
+          m_events[i].key);
 
-    if (IsNote(m_events[i].type))
-      cfg.WriteBoolean(
-        group,
-        wxString::Format(wxT("MIDISendNoteOff%03d"), i + 1),
-        m_events[i].useNoteOff);
+      if (IsNote(m_events[i].type))
+        cfg.WriteBoolean(
+          group,
+          wxString::Format(wxT("MIDISendNoteOff%03d"), i + 1),
+          m_events[i].useNoteOff);
 
-    if (HasLowValue(m_events[i].type))
-      cfg.WriteInteger(
-        group,
-        wxString::Format(wxT("MIDISendLowValue%03d"), i + 1),
-        m_events[i].low_value);
+      if (HasLowValue(m_events[i].type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDISendLowValue%03d"), i + 1),
+          m_events[i].low_value);
 
-    if (HasHighValue(m_events[i].type))
-      cfg.WriteInteger(
-        group,
-        wxString::Format(wxT("MIDISendHighValue%03d"), i + 1),
-        m_events[i].high_value);
+      if (HasHighValue(m_events[i].type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDISendHighValue%03d"), i + 1),
+          m_events[i].high_value);
 
-    if (HasStart(m_events[i].type))
-      cfg.WriteInteger(
-        group,
-        wxString::Format(wxT("MIDISendStart%03d"), i + 1),
-        m_events[i].start);
-    if (HasLength(m_events[i].type))
-      cfg.WriteInteger(
-        group,
-        wxString::Format(wxT("MIDISendLength%03d"), i + 1),
-        m_events[i].length);
+      if (HasStart(m_events[i].type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDISendStart%03d"), i + 1),
+          m_events[i].start);
+      if (HasLength(m_events[i].type))
+        cfg.WriteInteger(
+          group,
+          wxString::Format(wxT("MIDISendLength%03d"), i + 1),
+          m_events[i].length);
+    }
   }
 }
 

--- a/src/grandorgue/midi/GOMidiSender.h
+++ b/src/grandorgue/midi/GOMidiSender.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -30,8 +30,8 @@ public:
 
   void SetElementID(int id);
 
-  void Load(GOConfigReader &cfg, wxString group, GOMidiMap &map);
-  void Save(GOConfigWriter &cfg, wxString group, GOMidiMap &map);
+  void Load(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
+  void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map);
 
   void SetDisplay(bool state);
   void SetKey(unsigned key, unsigned velocity);

--- a/src/grandorgue/midi/GOMidiShortcutReceiver.cpp
+++ b/src/grandorgue/midi/GOMidiShortcutReceiver.cpp
@@ -10,7 +10,7 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
-void GOMidiShortcutReceiver::Load(GOConfigReader &cfg, wxString group) {
+void GOMidiShortcutReceiver::Load(GOConfigReader &cfg, const wxString &group) {
   if (m_type == KEY_RECV_ENCLOSURE) {
     m_ShortcutKey
       = cfg.ReadInteger(CMBSetting, group, wxT("PlusKey"), 0, 255, false, 0);
@@ -24,12 +24,15 @@ void GOMidiShortcutReceiver::Load(GOConfigReader &cfg, wxString group) {
   }
 }
 
-void GOMidiShortcutReceiver::Save(GOConfigWriter &cfg, wxString group) {
-  if (m_type == KEY_RECV_ENCLOSURE) {
-    cfg.WriteInteger(group, wxT("PlusKey"), m_ShortcutKey);
-    cfg.WriteInteger(group, wxT("MinusKey"), m_MinusKey);
-  } else {
-    cfg.WriteInteger(group, wxT("ShortcutKey"), m_ShortcutKey);
+void GOMidiShortcutReceiver::Save(GOConfigWriter &cfg, const wxString &group) {
+  if (m_ShortcutKey) {
+    if (m_type == KEY_RECV_ENCLOSURE) {
+      cfg.WriteInteger(group, wxT("PlusKey"), m_ShortcutKey);
+      if (m_MinusKey)
+        cfg.WriteInteger(group, wxT("MinusKey"), m_MinusKey);
+    } else {
+      cfg.WriteInteger(group, wxT("ShortcutKey"), m_ShortcutKey);
+    }
   }
 }
 

--- a/src/grandorgue/midi/GOMidiShortcutReceiver.h
+++ b/src/grandorgue/midi/GOMidiShortcutReceiver.h
@@ -19,8 +19,8 @@ class GOMidiShortcutReceiver : public GOMidiShortcutPattern {
 public:
   GOMidiShortcutReceiver(ReceiverType type) : GOMidiShortcutPattern(type) {}
 
-  void Load(GOConfigReader &cfg, wxString group);
-  void Save(GOConfigWriter &cfg, wxString group);
+  void Load(GOConfigReader &cfg, const wxString &group);
+  void Save(GOConfigWriter &cfg, const wxString &group);
 
   MatchType Match(unsigned key);
 


### PR DESCRIPTION
A next PR relating to #1199

Most of MIDI objects do not have any MIDI events assigned to them. Earlier when a user saved organ settings to a preset (*.cmb) file, the default values of MIDI object properties also were written to the file.

Now the default values are not written to .cmb, so only objects with any midi assignments appear in the saved files.

It changes nothing in loading the preset files, but it will be used for exporting MIDI settings to separate files in the future.