### PR TITLE
Added support of saving not compressed ini files https://github.com/GrandOrgue/grandorgue/issues/1199

### DIFF
--- a/src/core/config/GOConfigFileWriter.h
+++ b/src/core/config/GOConfigFileWriter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -23,8 +23,8 @@ public:
   GOConfigFileWriter();
 
   void AddEntry(wxString group, wxString name, wxString value);
-  bool GetFileContent(GOBuffer<uint8_t> &buffer);
-  bool Save(wxString filename);
+  bool GetFileContent(GOBuffer<uint8_t> &buffer, bool isToCompress = true);
+  bool Save(const wxString &fileName, bool isToCompress = true);
 };
 
 #endif


### PR DESCRIPTION
A next PR related to #1199.

Earlier GOConfigFileWriter can save any settings only in compressed format. 

This PR adds the capability of saving as uncompressed text file.

Now this feature is not used for config and ,cmb files, but in the future it will be used for exporting MIDI settings.