### PR TITLE
Fixed incorrect default audio channels config https://github.com/GrandOrgue/grandorgue/issues/2115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed incorrect default audio channels config https://github.com/GrandOrgue/grandorgue/issues/2115
 - Changed default sample rate, samples per buffer and interpolation type to 48000, 512 and Polyphase https://github.com/GrandOrgue/grandorgue/issues/2115
 - Increased the maximum samples per buffer to 2048 https://github.com/GrandOrgue/grandorgue/issues/2115
 - Increased the maximum supported sample rate to 192000 https://github.com/GrandOrgue/grandorgue/issues/2115

--- a/src/grandorgue/config/GOAudioDeviceConfig.cpp
+++ b/src/grandorgue/config/GOAudioDeviceConfig.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -27,8 +27,8 @@ GOAudioDeviceConfig::GOAudioDeviceConfig(
   std::vector<GroupOutput> &leftOutput = m_ChannelOutputs[0];
   std::vector<GroupOutput> &rightOutput = m_ChannelOutputs[1];
   for (const auto &groupName : audioGroups) {
-    leftOutput.emplace_back(groupName, true, DEFAULT_VOLUME);
-    rightOutput.emplace_back(groupName, false, DEFAULT_VOLUME);
+    leftOutput.emplace_back(groupName, DEFAULT_VOLUME, MUTE_VOLUME);
+    rightOutput.emplace_back(groupName, MUTE_VOLUME, DEFAULT_VOLUME);
   }
 }
 


### PR DESCRIPTION
Resolves: #2115.

Earlier, if GrandOrgue started without any config, the auto-created channel distribution was wrong.
![image](https://github.com/user-attachments/assets/f9f418ca-3d00-47b3-b068-ab743058a935)

Now it creates a right channel distribution:
![image](https://github.com/user-attachments/assets/37c27e02-387a-448d-b95f-cdeb7135084d)
