### PR TITLE
Added resending midi events when exiting from MidiEventDialog https://github.com/GrandOrgue/grandorgue/issues/2062

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added resending midi events when exiting from MidiEventDialog https://github.com/GrandOrgue/grandorgue/issues/2062
 - Fixed incorrect default audio channels config https://github.com/GrandOrgue/grandorgue/issues/2115
 - Changed default sample rate, samples per buffer and interpolation type to 48000, 512 and Polyphase https://github.com/GrandOrgue/grandorgue/issues/2115
 - Increased the maximum samples per buffer to 2048 https://github.com/GrandOrgue/grandorgue/issues/2115

--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -212,7 +212,8 @@ void GODocument::ShowMIDIEventDialog(
   GOMidiReceiverBase *event,
   GOMidiSender *sender,
   GOMidiShortcutReceiver *key,
-  GOMidiSender *division) {
+  GOMidiSender *division,
+  GOMidiDialogListener *pDialogListener) {
   if (!showWindow(GODocument::MIDI_EVENT, element) && m_OrganController) {
     GOMidiEventDialog *dlg = new GOMidiEventDialog(
       this,
@@ -223,7 +224,8 @@ void GODocument::ShowMIDIEventDialog(
       event,
       sender,
       key,
-      division);
+      division,
+      pDialogListener);
     dlg->RegisterMIDIListener(m_OrganController->GetMidi());
     dlg->SetModificationListener(m_OrganController);
     registerWindow(GODocument::MIDI_EVENT, element, dlg);

--- a/src/grandorgue/GODocument.h
+++ b/src/grandorgue/GODocument.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -72,7 +72,8 @@ public:
     GOMidiReceiverBase *event,
     GOMidiSender *sender,
     GOMidiShortcutReceiver *key,
-    GOMidiSender *division = nullptr) override;
+    GOMidiSender *division = nullptr,
+    GOMidiDialogListener *pDialogListener = nullptr) override;
 };
 
 #endif

--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -69,16 +69,6 @@ void GOButtonControl::Push() {
   SetButtonState(m_Engaged ^ true);
 }
 
-void GOButtonControl::PrepareRecording() {
-  GOMidiObjectWithShortcut::PrepareRecording();
-  SendMidiValue(m_Engaged);
-}
-
-void GOButtonControl::AbortPlayback() {
-  SendMidiValue(false);
-  GOMidiObjectWithShortcut::AbortPlayback();
-}
-
 void GOButtonControl::OnMidiReceived(
   const GOMidiEvent &event, GOMidiMatchType matchType, int key, int value) {
   switch (matchType) {
@@ -106,8 +96,8 @@ void GOButtonControl::OnMidiReceived(
 void GOButtonControl::Display(bool onoff) {
   if (m_Engaged == onoff)
     return;
-  SendMidiValue(onoff);
   m_Engaged = onoff;
+  SendCurrentMidiValue();
   r_OrganModel.SendControlChanged(this);
 }
 

--- a/src/grandorgue/control/GOButtonControl.h
+++ b/src/grandorgue/control/GOButtonControl.h
@@ -37,8 +37,8 @@ protected:
   void OnShortcutKeyReceived(
     GOMidiShortcutReceiver::MatchType matchType, int key) override;
 
-  void PrepareRecording() override;
-  void AbortPlayback() override;
+  void SendCurrentMidiValue() override { SendMidiValue(m_Engaged); }
+  void SendEmptyMidiValue() override { SendMidiValue(false); }
 
 public:
   GOButtonControl(

--- a/src/grandorgue/control/GOLabelControl.cpp
+++ b/src/grandorgue/control/GOLabelControl.cpp
@@ -18,31 +18,8 @@ GOLabelControl::GOLabelControl(GOOrganModel &organModel)
   : GOMidiSendingObject(
     organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME, MIDI_SEND_LABEL) {}
 
-const wxString &GOLabelControl::GetContent() { return m_Content; }
-
-void GOLabelControl::SetContent(wxString name) {
+void GOLabelControl::SetContent(const wxString &name) {
   m_Content = name;
-  SendMidiValue(m_Content);
+  SendCurrentMidiValue();
   r_OrganModel.SendControlChanged(this);
-}
-
-void GOLabelControl::AbortPlayback() {
-  SendMidiValue(wxEmptyString);
-  GOMidiSendingObject::AbortPlayback();
-}
-
-void GOLabelControl::PrepareRecording() {
-  GOMidiSendingObject::PrepareRecording();
-  SendMidiValue(m_Content);
-}
-
-wxString GOLabelControl::GetElementStatus() { return m_Content; }
-
-std::vector<wxString> GOLabelControl::GetElementActions() {
-  std::vector<wxString> actions;
-  return actions;
-}
-
-void GOLabelControl::TriggerElementActions(unsigned no) {
-  // Never called
 }

--- a/src/grandorgue/control/GOLabelControl.h
+++ b/src/grandorgue/control/GOLabelControl.h
@@ -10,32 +10,30 @@
 
 #include <wx/string.h>
 
-#include "midi/GOMidiSender.h"
 #include "midi/objects/GOMidiSendingObject.h"
-#include "sound/GOSoundStateHandler.h"
 
 #include "GOControl.h"
-#include "GOSaveableObject.h"
 
-class GOConfigReader;
-class GOConfigWriter;
 class GOOrganModel;
 
 class GOLabelControl : public GOControl, public GOMidiSendingObject {
 protected:
   wxString m_Content;
 
-  void AbortPlayback() override;
-  void PrepareRecording() override;
+  void SendCurrentMidiValue() override { SendMidiValue(m_Content); }
+  void SendEmptyMidiValue() override { SendMidiValue(wxEmptyString); }
 
 public:
   GOLabelControl(GOOrganModel &organModel);
-  const wxString &GetContent();
-  void SetContent(wxString name);
+  const wxString &GetContent() const { return m_Content; }
+  void SetContent(const wxString &name);
 
-  wxString GetElementStatus() override;
-  std::vector<wxString> GetElementActions() override;
-  void TriggerElementActions(unsigned no) override;
+  wxString GetElementStatus() override { return m_Content; }
+  std::vector<wxString> GetElementActions() override {
+    return std::vector<wxString>();
+  }
+  void TriggerElementActions(unsigned no) override { /* Never called */
+  }
 };
 
 #endif

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -9,6 +9,7 @@
 
 #include <wx/bookctrl.h>
 
+#include "midi/dialog-creator/GOMidiDialogListener.h"
 #include <config/GOConfig.h>
 
 #include "GOMidiEventKeyTab.h"
@@ -24,10 +25,12 @@ GOMidiEventDialog::GOMidiEventDialog(
   GOMidiReceiverBase *event,
   GOMidiSender *sender,
   GOMidiShortcutReceiver *key,
-  GOMidiSender *division)
+  GOMidiSender *division,
+  GOMidiDialogListener *pDialogListener)
   : GOTabbedDialog(
     parent, "MidiEvent", title, settings.m_DialogSizes, dialogSelector),
     GOView(doc, this),
+    p_DialogListener(pDialogListener),
     m_recvPage(NULL),
     m_sendPage(NULL),
     m_sendDivisionPage(NULL),
@@ -61,4 +64,12 @@ GOMidiEventDialog::GOMidiEventDialog(
 void GOMidiEventDialog::RegisterMIDIListener(GOMidi *midi) {
   if (m_recvPage)
     m_recvPage->RegisterMIDIListener(midi);
+}
+
+bool GOMidiEventDialog::TransferDataFromWindow() {
+  bool res = GOTabbedDialog::TransferDataFromWindow();
+
+  if (res && p_DialogListener)
+    p_DialogListener->OnSettingsApplied();
+  return res;
 }

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.h
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -15,19 +15,22 @@
 #include "modification/GOModificationProxy.h"
 
 class GOConfig;
-class GOMidiShortcutReceiver;
 class GOMidi;
-class GOMidiListener;
-class GOMidiReceiverBase;
-class GOMidiSender;
+class GOMidiDialogListener;
 class GOMidiEventKeyTab;
 class GOMidiEventRecvTab;
 class GOMidiEventSendTab;
+class GOMidiListener;
+class GOMidiReceiverBase;
+class GOMidiSender;
+class GOMidiShortcutReceiver;
 
 class GOMidiEventDialog : public GOTabbedDialog,
                           public GOView,
                           public GOModificationProxy {
 private:
+  GOMidiDialogListener *p_DialogListener;
+
   GOMidiEventRecvTab *m_recvPage;
   GOMidiEventSendTab *m_sendPage;
   GOMidiEventSendTab *m_sendDivisionPage;
@@ -48,9 +51,13 @@ public:
     GOMidiReceiverBase *event,
     GOMidiSender *sender,
     GOMidiShortcutReceiver *key,
-    GOMidiSender *division = NULL);
+    GOMidiSender *division = NULL,
+    GOMidiDialogListener *pDialogListener = nullptr);
 
   void RegisterMIDIListener(GOMidi *midi);
+
+private:
+  bool TransferDataFromWindow() override;
 };
 
 #endif /* MIDIEVENTDIALOG_H_ */

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreator.h
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreator.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,6 +10,7 @@
 
 class wxString;
 
+class GOMidiDialogListener;
 class GOMidiReceiverBase;
 class GOMidiSender;
 class GOMidiShortcutReceiver;
@@ -26,7 +27,8 @@ public:
     GOMidiReceiverBase *event,
     GOMidiSender *sender,
     GOMidiShortcutReceiver *key,
-    GOMidiSender *division = nullptr)
+    GOMidiSender *division = nullptr,
+    GOMidiDialogListener *pDialogListener = nullptr)
     = 0;
 };
 

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.cpp
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,8 +14,16 @@ void GOMidiDialogCreatorProxy::ShowMIDIEventDialog(
   GOMidiReceiverBase *event,
   GOMidiSender *sender,
   GOMidiShortcutReceiver *key,
-  GOMidiSender *division) {
+  GOMidiSender *division,
+  GOMidiDialogListener *pDialogListener) {
   if (p_creator)
     p_creator->ShowMIDIEventDialog(
-      element, title, dialogSelector, event, sender, key, division);
+      element,
+      title,
+      dialogSelector,
+      event,
+      sender,
+      key,
+      division,
+      pDialogListener);
 }

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.h
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -26,7 +26,8 @@ public:
     GOMidiReceiverBase *event,
     GOMidiSender *sender,
     GOMidiShortcutReceiver *key,
-    GOMidiSender *division = nullptr) override;
+    GOMidiSender *division = nullptr,
+    GOMidiDialogListener *pDialogListener = nullptr) override;
 };
 
 #endif /* GOMIDIDIALOGCREATORPROXY_H */

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogListener.h
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogListener.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDIDIALOGLISTENER_H
+#define GOMIDIDIALOGLISTENER_H
+
+class GOMidiDialogListener {
+public:
+  virtual void OnSettingsApplied() = 0;
+};
+
+#endif /* GOMIDIDIALOGLISTENER_H */

--- a/src/grandorgue/midi/objects/GOMidiObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObject.cpp
@@ -56,5 +56,6 @@ void GOMidiObject::ShowConfigDialog() {
     isReadOnly ? nullptr : p_MidiReceiver,
     p_MidiSender,
     isReadOnly ? nullptr : p_ShortcutReceiver,
-    p_DivisionSender);
+    p_DivisionSender,
+    this);
 }

--- a/src/grandorgue/midi/objects/GOMidiObject.h
+++ b/src/grandorgue/midi/objects/GOMidiObject.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 
+#include "midi/dialog-creator/GOMidiDialogListener.h"
 #include "sound/GOSoundStateHandler.h"
 
 #include "GOSaveableObject.h"
@@ -22,7 +23,9 @@ class GOMidiSender;
 class GOMidiShortcutReceiver;
 class GOOrganModel;
 
-class GOMidiObject : public GOSoundStateHandler, public GOSaveableObject {
+class GOMidiObject : public GOSoundStateHandler,
+                     public GOSaveableObject,
+                     protected GOMidiDialogListener {
 protected:
   GOOrganModel &r_OrganModel;
 

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
@@ -35,6 +35,11 @@ void GOMidiSendingObject::SaveMidiObject(
   m_sender.Save(cfg, group, midiMap);
 }
 
+void GOMidiSendingObject::ResendMidi() {
+  m_sender.SetName(GetName());
+  SendCurrentMidiValue();
+}
+
 void GOMidiSendingObject::PreparePlayback() {
   GOMidiObject::PreparePlayback();
   m_sender.SetName(GetName());
@@ -44,9 +49,4 @@ void GOMidiSendingObject::AbortPlayback() {
   SendEmptyMidiValue();
   GOMidiObject::AbortPlayback();
   m_sender.SetName(wxEmptyString);
-}
-
-void GOMidiSendingObject::ResendMidi() {
-  m_sender.SetName(GetName());
-  SendCurrentMidiValue();
 }

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
@@ -41,6 +41,12 @@ void GOMidiSendingObject::PreparePlayback() {
 }
 
 void GOMidiSendingObject::AbortPlayback() {
+  SendEmptyMidiValue();
   GOMidiObject::AbortPlayback();
   m_sender.SetName(wxEmptyString);
+}
+
+void GOMidiSendingObject::ResendMidi() {
+  m_sender.SetName(GetName());
+  SendCurrentMidiValue();
 }

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
@@ -45,6 +45,11 @@ void GOMidiSendingObject::PreparePlayback() {
   m_sender.SetName(GetName());
 }
 
+void GOMidiSendingObject::PrepareRecording() {
+  GOMidiObject::PrepareRecording();
+  SendCurrentMidiValue();
+}
+
 void GOMidiSendingObject::AbortPlayback() {
   SendEmptyMidiValue();
   GOMidiObject::AbortPlayback();

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.h
@@ -38,13 +38,29 @@ protected:
   void SendMidiKey(unsigned key, unsigned value) {
     m_sender.SetKey(key, value);
   }
-  void ResetMidiKey() { m_sender.ResetKey(); }
+  void SendEmptyMidiKey() { m_sender.ResetKey(); }
+
+  /**
+   * The midi object should send the current midi value with certain
+   * SendMidiValue()
+   */
+  virtual void SendCurrentMidiValue() {}
+  /**
+   * The midi object should send the empty midi value with certain
+   * SendMidiValue()
+   */
+  virtual void SendEmptyMidiValue() {}
 
   void PreparePlayback() override;
   void AbortPlayback() override;
 
 public:
   virtual void SetElementId(int id);
+
+  /**
+   * Send current object state event again. It calls SendCurrentMidiValue()
+   */
+  void ResendMidi();
 };
 
 #endif /* GOMIDISENDINGOBJECT_H */

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.h
@@ -51,16 +51,18 @@ protected:
    */
   virtual void SendEmptyMidiValue() {}
 
+  /**
+   * Send current object state event again. It calls SendCurrentMidiValue()
+   */
+  void ResendMidi();
+
+  void OnSettingsApplied() override { ResendMidi(); }
+
   void PreparePlayback() override;
   void AbortPlayback() override;
 
 public:
   virtual void SetElementId(int id);
-
-  /**
-   * Send current object state event again. It calls SendCurrentMidiValue()
-   */
-  void ResendMidi();
 };
 
 #endif /* GOMIDISENDINGOBJECT_H */

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.h
@@ -59,6 +59,7 @@ protected:
   void OnSettingsApplied() override { ResendMidi(); }
 
   void PreparePlayback() override;
+  void PrepareRecording() override;
   void AbortPlayback() override;
 
 public:

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -84,7 +84,7 @@ void GOEnclosure::Save(GOConfigWriter &cfg) {
 void GOEnclosure::SetEnclosureValue(uint8_t n) {
   if (n != m_MIDIValue) {
     m_MIDIValue = n;
-    SendMidiValue(m_MIDIValue);
+    SendCurrentMidiValue();
   }
   r_OrganModel.UpdateVolume();
   r_OrganModel.SendControlChanged(this);
@@ -126,16 +126,6 @@ bool GOEnclosure::IsDisplayed(bool new_format) {
     return m_Displayed2;
   else
     return m_Displayed1;
-}
-
-void GOEnclosure::PrepareRecording() {
-  GOMidiReceivingSendingObject::PrepareRecording();
-  SendMidiValue(m_MIDIValue);
-}
-
-void GOEnclosure::AbortPlayback() {
-  SendMidiValue(0);
-  GOMidiReceivingSendingObject::AbortPlayback();
 }
 
 wxString GOEnclosure::GetElementStatus() {

--- a/src/grandorgue/model/GOEnclosure.h
+++ b/src/grandorgue/model/GOEnclosure.h
@@ -42,10 +42,10 @@ private:
   void LoadFromCmb(GOConfigReader &cfg, uint8_t defaultValue);
   void Save(GOConfigWriter &cfg) override;
 
-  void SetIntEnclosureValue(int n) { SetEnclosureValue(std::clamp(n, 0, 127)); }
+  void SendCurrentMidiValue() override { SendMidiValue(m_MIDIValue); }
+  void SendEmptyMidiValue() override { SendMidiValue(0); }
 
-  void PrepareRecording() override;
-  void AbortPlayback() override;
+  void SetIntEnclosureValue(int n) { SetEnclosureValue(std::clamp(n, 0, 127)); }
 
 public:
   static constexpr uint8_t MAX_MIDI_VALUE = 127;

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -480,7 +480,7 @@ void GOManual::PreparePlayback() {
 }
 
 void GOManual::PrepareRecording() {
-  ResetMidiKey();
+  SendEmptyMidiKey();
   GOMidiReceivingSendingObject::PrepareRecording();
   for (unsigned i = 0; i < m_KeyVelocity.size(); i++)
     if (m_KeyVelocity[i] > 0)

--- a/src/grandorgue/model/GORank.cpp
+++ b/src/grandorgue/model/GORank.cpp
@@ -187,7 +187,7 @@ void GORank::SetTemperament(const GOTemperament &temperament) {
 }
 
 void GORank::PreparePlayback() {
-  ResetMidiKey();
+  SendEmptyMidiKey();
   for (unsigned i = 0; i < m_MaxNoteVelocities.size(); i++)
     m_MaxNoteVelocities[i] = 0;
   for (unsigned i = 0; i < m_NoteStopVelocities.size(); i++)


### PR DESCRIPTION
Resolves: #2062

This PR adds sending midi events on exiting from the Midi Events Dialog with the `OK` button.