### PR TITLE
Renamed GOEventHandlerList::GetMidiConfigurators to GetMidiObjects

### DIFF
--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -186,7 +186,7 @@ void GODocument::ShowMidiList() {
         this,
         NULL,
         m_OrganController->GetConfig().m_DialogSizes,
-        m_OrganController->GetMidiConfigurators()));
+        m_OrganController->GetMidiObjects()));
   }
 }
 

--- a/src/grandorgue/model/GOEventHandlerList.h
+++ b/src/grandorgue/model/GOEventHandlerList.h
@@ -77,7 +77,7 @@ public:
     const {
     return m_CombinationButtonSets.AsVector();
   }
-  const std::vector<GOMidiObject *> &GetMidiConfigurators() const {
+  const std::vector<GOMidiObject *> &GetMidiObjects() const {
     return m_MidiObjects.AsVector();
   }
   const std::vector<GOEventHandler *> &GetMidiEventHandlers() const {


### PR DESCRIPTION
This is just renaming. No GrandOrgue behavior should be changed.