### PR TITLE
Intoduced a new class GOMidiObjectContext

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -143,6 +143,7 @@ loader/cache/GOCacheCleaner.cpp
 loader/cache/GOCacheWriter.cpp
 midi/dialog-creator/GOMidiDialogCreatorProxy.cpp
 midi/objects/GOMidiObject.cpp
+midi/objects/GOMidiObjectContext.cpp
 midi/objects/GOMidiObjectWithDivision.cpp
 midi/objects/GOMidiObjectWithShortcut.cpp
 midi/objects/GOMidiReceivingSendingObject.cpp

--- a/src/grandorgue/control/GOElementCreator.cpp
+++ b/src/grandorgue/control/GOElementCreator.cpp
@@ -19,6 +19,7 @@ void GOElementCreator::CreateButtons(
       organModel, this, pEntry->is_pushbutton, pEntry->is_piston);
     const unsigned buttonIndex = (unsigned)pEntry->value;
 
+    pButton->SetContext(pEntry->p_MidiContext);
     if (m_buttons.size() <= buttonIndex)
       m_buttons.resize(buttonIndex + 1);
     m_buttons[buttonIndex] = pButton;

--- a/src/grandorgue/control/GOElementCreator.h
+++ b/src/grandorgue/control/GOElementCreator.h
@@ -15,9 +15,10 @@
 
 class GOButtonControl;
 class GOConfigReader;
-class GOOrganModel;
 class GOEnclosure;
 class GOLabelControl;
+class GOMidiObjectContext;
+class GOOrganModel;
 
 class GOElementCreator : private GOButtonCallback {
 public:
@@ -27,6 +28,7 @@ public:
     bool is_public;
     bool is_pushbutton;
     bool is_piston;
+    const GOMidiObjectContext *p_MidiContext = nullptr;
   };
 
   const ButtonDefinitionEntry *p_ButtonDefinitions;

--- a/src/grandorgue/control/GOLabelControl.cpp
+++ b/src/grandorgue/control/GOLabelControl.cpp
@@ -14,9 +14,12 @@
 const wxString WX_MIDI_TYPE_CODE = wxT("Label");
 const wxString WX_MIDI_TYPE_NAME = _("Label");
 
-GOLabelControl::GOLabelControl(GOOrganModel &organModel)
+GOLabelControl::GOLabelControl(
+  GOOrganModel &organModel, const GOMidiObjectContext *pContext)
   : GOMidiSendingObject(
-    organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME, MIDI_SEND_LABEL) {}
+    organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME, MIDI_SEND_LABEL) {
+  SetContext(pContext);
+}
 
 void GOLabelControl::SetContent(const wxString &name) {
   m_Content = name;

--- a/src/grandorgue/control/GOLabelControl.h
+++ b/src/grandorgue/control/GOLabelControl.h
@@ -14,6 +14,7 @@
 
 #include "GOControl.h"
 
+class GOMidiObjectContext;
 class GOOrganModel;
 
 class GOLabelControl : public GOControl, public GOMidiSendingObject {
@@ -24,7 +25,8 @@ protected:
   void SendEmptyMidiValue() override { SendMidiValue(wxEmptyString); }
 
 public:
-  GOLabelControl(GOOrganModel &organModel);
+  GOLabelControl(
+    GOOrganModel &organModel, const GOMidiObjectContext *pContext = nullptr);
   const wxString &GetContent() const { return m_Content; }
   void SetContent(const wxString &name);
 

--- a/src/grandorgue/midi/objects/GOMidiObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObject.cpp
@@ -12,6 +12,8 @@
 #include "midi/GOMidiReceiver.h"
 #include "model/GOOrganModel.h"
 
+#include "GOMidiObjectContext.h"
+
 GOMidiObject::GOMidiObject(
   GOOrganModel &organModel,
   const wxString &midiTypeCode,
@@ -23,7 +25,8 @@ GOMidiObject::GOMidiObject(
     p_MidiSender(nullptr),
     p_MidiReceiver(nullptr),
     p_ShortcutReceiver(nullptr),
-    p_DivisionSender(nullptr) {
+    p_DivisionSender(nullptr),
+    p_context(nullptr) {
   r_OrganModel.RegisterSoundStateHandler(this);
   r_OrganModel.RegisterMidiObject(this);
 }
@@ -32,6 +35,10 @@ GOMidiObject::~GOMidiObject() {
   r_OrganModel.UnregisterSaveableObject(this);
   r_OrganModel.UnRegisterMidiObject(this);
   r_OrganModel.UnRegisterSoundStateHandler(this);
+}
+
+wxString GOMidiObject::GetContextTitle() const {
+  return GOMidiObjectContext::getFullTitle(p_context);
 }
 
 void GOMidiObject::InitMidiObject(

--- a/src/grandorgue/midi/objects/GOMidiObject.h
+++ b/src/grandorgue/midi/objects/GOMidiObject.h
@@ -18,6 +18,7 @@
 #include "GOSaveableObject.h"
 
 class GOMidiMap;
+class GOMidiObjectContext;
 class GOMidiReceiver;
 class GOMidiSender;
 class GOMidiShortcutReceiver;
@@ -40,6 +41,8 @@ private:
   GOMidiReceiver *p_MidiReceiver;
   GOMidiShortcutReceiver *p_ShortcutReceiver;
   GOMidiSender *p_DivisionSender;
+
+  const GOMidiObjectContext *p_context;
 
 protected:
   GOMidiObject(
@@ -82,6 +85,11 @@ public:
   const wxString &GetMidiTypeName() const { return r_MidiTypeName; }
   const wxString &GetName() const { return m_name; }
   void SetName(const wxString &name) { m_name = name; }
+
+  const GOMidiObjectContext *GetContext() const { return p_context; }
+  void SetContext(const GOMidiObjectContext *pContext) { p_context = pContext; }
+
+  wxString GetContextTitle() const;
 
   virtual void Init(
     GOConfigReader &cfg, const wxString &group, const wxString &name) {

--- a/src/grandorgue/midi/objects/GOMidiObjectContext.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectContext.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOMidiObjectContext.h"
+
+const wxString WX_PATH_SEPARATOR = "/";
+
+GOMidiObjectContext::GOMidiObjectContext(
+  const wxString &name,
+  const wxString &title,
+  const GOMidiObjectContext *pParent)
+  : m_name(name), m_title(title), p_parent(pParent) {}
+
+wxString GOMidiObjectContext::getFullTitle(
+  const GOMidiObjectContext *pContext) {
+  wxString path;
+
+  for (; pContext; pContext = pContext->p_parent) {
+    if (!path.IsEmpty())
+      path = WX_PATH_SEPARATOR + path;
+    path = pContext->m_title + path;
+  }
+  return path;
+}

--- a/src/grandorgue/midi/objects/GOMidiObjectContext.h
+++ b/src/grandorgue/midi/objects/GOMidiObjectContext.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDIOBJECTCONTEXT_H
+#define GOMIDIOBJECTCONTEXT_H
+
+#include <wx/string.h>
+
+/**
+ * This class is used for describing a place where a midi object is used.
+ * There is a hierarhial tree of contexts. For example, setter, manuals/1/stops,
+ * manuals/1/divisionals
+ */
+
+class GOMidiObjectContext {
+private:
+  // Name. Not translated. Used for exports
+  wxString m_name;
+
+  // Title. Translated. Used in UI
+  wxString m_title;
+
+  // Parent context
+  const GOMidiObjectContext *p_parent;
+
+public:
+  GOMidiObjectContext(
+    const wxString &name,
+    const wxString &title,
+    const GOMidiObjectContext *pParent = nullptr);
+  GOMidiObjectContext()
+    : GOMidiObjectContext(wxEmptyString, wxEmptyString, nullptr) {}
+
+  const wxString &GetName() const { return m_name; }
+  const wxString &GetTitle() const { return m_title; }
+  void SetTitle(const wxString title) { m_title = title; }
+  const GOMidiObjectContext *GetParent() const { return p_parent; }
+
+  static wxString getFullTitle(const GOMidiObjectContext *pContext);
+};
+
+#endif /* GOMIDIOBJECTCONTEXT_H */


### PR DESCRIPTION
This is a next PR related to #1199 and #1740.

Earlier was a flat set of midi objects that often has the same names.

This PR introduces a context hierarchy. 

Each context has
- name - not translated
- title - translated
- pointer to a parent context (if exists).

Each midi objects may belong to some context.

This feature is not used yet. I'm planning to create the following context hierarchy

- manuals
    - 000
        - stops
        - couplers
        - divisionals
        - banked-divisionals
    - 001
- setter
    - generals
    - banked-generals
    - sequencer
    
No GO behavior should be changed now.