### PR TITLE
Added const and static qualifiers to some members of GOMidiReceiverBase and GOMidiSender

### DIFF
--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -91,7 +91,7 @@ void GOMidiReceiverBase::Load(
         sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]),
         false,
         default_type);
-      if (HasChannel(pattern.type))
+      if (hasChannel(pattern.type))
         pattern.channel = cfg.ReadInteger(
           CMBSetting,
           group,
@@ -135,7 +135,7 @@ void GOMidiReceiverBase::Load(
           wxString::Format(wxT("MIDIKeyShift%03d"), i + 1),
           -35,
           35);
-      else if (HasKey(pattern.type))
+      else if (hasKey(pattern.type))
         pattern.key = cfg.ReadInteger(
           CMBSetting,
           group,
@@ -143,7 +143,7 @@ void GOMidiReceiverBase::Load(
           0,
           0x200000);
 
-      if (HasLowerLimit(pattern.type))
+      if (hasLowerLimit(pattern.type))
         pattern.low_value = cfg.ReadInteger(
           CMBSetting,
           group,
@@ -160,7 +160,7 @@ void GOMidiReceiverBase::Load(
             false,
             1));
 
-      if (HasUpperLimit(pattern.type))
+      if (hasUpperLimit(pattern.type))
         pattern.high_value = cfg.ReadInteger(
           CMBSetting,
           group,
@@ -204,7 +204,7 @@ void GOMidiReceiverBase::Save(
         pattern.type,
         m_MidiTypes,
         sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
-      if (HasChannel(pattern.type))
+      if (hasChannel(pattern.type))
         cfg.WriteInteger(
           group,
           wxString::Format(wxT("MIDIChannel%03d"), i + 1),
@@ -229,16 +229,16 @@ void GOMidiReceiverBase::Save(
       if (m_type == MIDI_RECV_MANUAL)
         cfg.WriteInteger(
           group, wxString::Format(wxT("MIDIKeyShift%03d"), i + 1), pattern.key);
-      else if (HasKey(pattern.type))
+      else if (hasKey(pattern.type))
         cfg.WriteInteger(
           group, wxString::Format(wxT("MIDIKey%03d"), i + 1), pattern.key);
 
-      if (HasLowerLimit(pattern.type))
+      if (hasLowerLimit(pattern.type))
         cfg.WriteInteger(
           group,
           wxString::Format(wxT("MIDILowerLimit%03d"), i + 1),
           pattern.low_value);
-      if (HasUpperLimit(pattern.type))
+      if (hasUpperLimit(pattern.type))
         cfg.WriteInteger(
           group,
           wxString::Format(wxT("MIDIUpperLimit%03d"), i + 1),
@@ -247,7 +247,7 @@ void GOMidiReceiverBase::Save(
   }
 }
 
-bool GOMidiReceiverBase::HasChannel(GOMidiReceiverMessageType type) {
+bool GOMidiReceiverBase::hasChannel(GOMidiReceiverMessageType type) {
   if (
     type == MIDI_M_NOTE || type == MIDI_M_CTRL_CHANGE
     || type == MIDI_M_PGM_CHANGE || type == MIDI_M_PGM_RANGE
@@ -268,7 +268,7 @@ bool GOMidiReceiverBase::HasChannel(GOMidiReceiverMessageType type) {
   return false;
 }
 
-bool GOMidiReceiverBase::HasKey(GOMidiReceiverMessageType type) {
+bool GOMidiReceiverBase::hasKey(GOMidiReceiverMessageType type) {
   if (
     type == MIDI_M_NOTE || type == MIDI_M_CTRL_CHANGE
     || type == MIDI_M_PGM_CHANGE || type == MIDI_M_RPN_RANGE
@@ -291,7 +291,7 @@ bool GOMidiReceiverBase::HasKey(GOMidiReceiverMessageType type) {
   return false;
 }
 
-bool GOMidiReceiverBase::HasLowKey(GOMidiReceiverMessageType type) {
+bool GOMidiReceiverBase::HasLowKey(GOMidiReceiverMessageType type) const {
   if (m_type != MIDI_RECV_MANUAL)
     return false;
   if (
@@ -301,7 +301,7 @@ bool GOMidiReceiverBase::HasLowKey(GOMidiReceiverMessageType type) {
   return false;
 }
 
-bool GOMidiReceiverBase::HasHighKey(GOMidiReceiverMessageType type) {
+bool GOMidiReceiverBase::HasHighKey(GOMidiReceiverMessageType type) const {
   if (m_type != MIDI_RECV_MANUAL)
     return false;
   if (
@@ -311,7 +311,7 @@ bool GOMidiReceiverBase::HasHighKey(GOMidiReceiverMessageType type) {
   return false;
 }
 
-bool GOMidiReceiverBase::HasDebounce(GOMidiReceiverMessageType type) {
+bool GOMidiReceiverBase::HasDebounce(GOMidiReceiverMessageType type) const {
   if (m_type == MIDI_RECV_MANUAL)
     return false;
   if (m_type == MIDI_RECV_ENCLOSURE)
@@ -333,7 +333,7 @@ bool GOMidiReceiverBase::HasDebounce(GOMidiReceiverMessageType type) {
   return false;
 }
 
-bool GOMidiReceiverBase::HasLowerLimit(GOMidiReceiverMessageType type) {
+bool GOMidiReceiverBase::hasLowerLimit(GOMidiReceiverMessageType type) {
   if (
     type == MIDI_M_NOTE || type == MIDI_M_PGM_RANGE || type == MIDI_M_RPN_RANGE
     || type == MIDI_M_NRPN_RANGE || type == MIDI_M_CTRL_CHANGE
@@ -356,7 +356,7 @@ bool GOMidiReceiverBase::HasLowerLimit(GOMidiReceiverMessageType type) {
   return false;
 }
 
-bool GOMidiReceiverBase::HasUpperLimit(GOMidiReceiverMessageType type) {
+bool GOMidiReceiverBase::hasUpperLimit(GOMidiReceiverMessageType type) {
   if (
     type == MIDI_M_NOTE || type == MIDI_M_PGM_RANGE || type == MIDI_M_RPN_RANGE
     || type == MIDI_M_NRPN_RANGE || type == MIDI_M_CTRL_CHANGE
@@ -376,7 +376,7 @@ bool GOMidiReceiverBase::HasUpperLimit(GOMidiReceiverMessageType type) {
   return false;
 }
 
-unsigned GOMidiReceiverBase::KeyLimit(GOMidiReceiverMessageType type) {
+unsigned GOMidiReceiverBase::keyLimit(GOMidiReceiverMessageType type) {
   if (type == MIDI_M_PGM_CHANGE)
     return 0x200000;
   if (
@@ -387,7 +387,7 @@ unsigned GOMidiReceiverBase::KeyLimit(GOMidiReceiverMessageType type) {
   return 0x7f;
 }
 
-unsigned GOMidiReceiverBase::LowerValueLimit(GOMidiReceiverMessageType type) {
+unsigned GOMidiReceiverBase::lowerValueLimit(GOMidiReceiverMessageType type) {
   if (
     type == MIDI_M_RPN_RANGE || type == MIDI_M_NRPN_RANGE
     || type == MIDI_M_SYSEX_AHLBORN_GALANTI
@@ -409,7 +409,7 @@ unsigned GOMidiReceiverBase::LowerValueLimit(GOMidiReceiverMessageType type) {
   return 0x7f;
 }
 
-unsigned GOMidiReceiverBase::UpperValueLimit(GOMidiReceiverMessageType type) {
+unsigned GOMidiReceiverBase::upperValueLimit(GOMidiReceiverMessageType type) {
   if (
     type == MIDI_M_RPN_RANGE || type == MIDI_M_NRPN_RANGE
     || type == MIDI_M_SYSEX_AHLBORN_GALANTI
@@ -537,7 +537,7 @@ GOMidiMatchType GOMidiReceiverBase::Match(
 
     if (
       pattern.channel != -1 && pattern.channel != e.GetChannel()
-      && HasChannel(pattern.type))
+      && hasChannel(pattern.type))
       continue;
     if (pattern.deviceId != 0 && pattern.deviceId != e.GetDevice())
       continue;

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -188,7 +188,7 @@ void GOMidiReceiverBase::Preconfigure(GOConfigReader &cfg, wxString group) {}
 int GOMidiReceiverBase::GetTranspose() { return 0; }
 
 void GOMidiReceiverBase::Save(
-  GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) {
+  GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) const {
   if (!m_events.empty()) {
     cfg.WriteInteger(group, wxT("NumberOfMIDIEvents"), m_events.size());
     for (unsigned i = 0; i < m_events.size(); i++) {

--- a/src/core/midi/GOMidiReceiverBase.h
+++ b/src/core/midi/GOMidiReceiverBase.h
@@ -60,16 +60,16 @@ public:
   GOMidiMatchType Match(
     const GOMidiEvent &e, const KeyMap *pMidiMap, int &key, int &value);
 
-  bool HasDebounce(GOMidiReceiverMessageType type);
-  bool HasChannel(GOMidiReceiverMessageType type);
-  bool HasKey(GOMidiReceiverMessageType type);
-  bool HasLowKey(GOMidiReceiverMessageType type);
-  bool HasHighKey(GOMidiReceiverMessageType type);
-  bool HasLowerLimit(GOMidiReceiverMessageType type);
-  bool HasUpperLimit(GOMidiReceiverMessageType type);
-  unsigned KeyLimit(GOMidiReceiverMessageType type);
-  unsigned LowerValueLimit(GOMidiReceiverMessageType type);
-  unsigned UpperValueLimit(GOMidiReceiverMessageType type);
+  bool HasDebounce(GOMidiReceiverMessageType type) const;
+  static bool hasChannel(GOMidiReceiverMessageType type);
+  static bool hasKey(GOMidiReceiverMessageType type);
+  bool HasLowKey(GOMidiReceiverMessageType type) const;
+  bool HasHighKey(GOMidiReceiverMessageType type) const;
+  static bool hasLowerLimit(GOMidiReceiverMessageType type);
+  static bool hasUpperLimit(GOMidiReceiverMessageType type);
+  static unsigned keyLimit(GOMidiReceiverMessageType type);
+  static unsigned lowerValueLimit(GOMidiReceiverMessageType type);
+  static unsigned upperValueLimit(GOMidiReceiverMessageType type);
 };
 
 #endif

--- a/src/core/midi/GOMidiReceiverBase.h
+++ b/src/core/midi/GOMidiReceiverBase.h
@@ -50,7 +50,7 @@ public:
   GOMidiReceiverBase(GOMidiReceiverType type);
 
   virtual void Load(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
-  void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map);
+  void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) const;
   void PreparePlayback();
 
   void SetElementID(int id);

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventRecvTab.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventRecvTab.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -329,7 +329,7 @@ bool GOMidiEventRecvTab::TransferDataFromWindow() {
 
 void GOMidiEventRecvTab::OnTypeChange(wxCommandEvent &event) {
   GOMidiReceiverMessageType type = m_eventtype->GetCurrentValue();
-  if (m_original->HasChannel(type))
+  if (m_original->hasChannel(type))
     m_channel->Enable();
   else
     m_channel->Disable();
@@ -345,22 +345,22 @@ void GOMidiEventRecvTab::OnTypeChange(wxCommandEvent &event) {
     m_HighKey->Enable();
   else
     m_HighKey->Disable();
-  if (m_original->HasLowerLimit(type)) {
+  if (m_original->hasLowerLimit(type)) {
     m_LowValue->Enable();
-    m_LowValue->SetRange(0, m_original->LowerValueLimit(type));
+    m_LowValue->SetRange(0, m_original->lowerValueLimit(type));
   } else
     m_LowValue->Disable();
-  if (m_original->HasUpperLimit(type)) {
+  if (m_original->hasUpperLimit(type)) {
     m_HighValue->Enable();
-    m_HighValue->SetRange(0, m_original->UpperValueLimit(type));
+    m_HighValue->SetRange(0, m_original->upperValueLimit(type));
   } else
     m_HighValue->Disable();
-  if (m_original->HasKey(type)) {
+  if (m_original->hasKey(type)) {
     m_data->Enable();
     if (m_ReceiverType == MIDI_RECV_MANUAL)
       m_data->SetRange(-35, 35);
     else
-      m_data->SetRange(0, m_original->KeyLimit(type));
+      m_data->SetRange(0, m_original->keyLimit(type));
   } else
     m_data->Disable();
 
@@ -907,7 +907,7 @@ void GOMidiEventRecvTab::DetectEvent() {
               }
               break;
             case GOMidiEvent::MIDI_SYSEX_RODGERS_STOP_CHANGE:
-              for (unsigned i = 0; i < m_original->LowerValueLimit(
+              for (unsigned i = 0; i < m_original->lowerValueLimit(
                                      MIDI_M_SYSEX_RODGERS_STOP_CHANGE);
                    i++) {
                 if (

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventSendTab.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventSendTab.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -290,37 +290,37 @@ bool GOMidiEventSendTab::TransferDataFromWindow() {
 
 void GOMidiEventSendTab::OnTypeChange(wxCommandEvent &event) {
   GOMidiSenderMessageType type = m_eventtype->GetCurrentValue();
-  if (m_original->HasChannel(type))
+  if (m_original->hasChannel(type))
     m_channel->Enable();
   else
     m_channel->Disable();
   if (m_original->HasKey(type)) {
     m_key->Enable();
-    m_key->SetRange(0, m_original->KeyLimit(type));
+    m_key->SetRange(0, m_original->keyLimit(type));
   } else
     m_key->Disable();
-  if (m_original->IsNote(type))
+  if (m_original->isNote(type))
     m_noteOff->Enable();
   else
     m_noteOff->Disable();
-  if (m_original->HasLowValue(type)) {
+  if (m_original->hasLowValue(type)) {
     m_LowValue->Enable();
-    m_LowValue->SetRange(0, m_original->LowValueLimit(type));
+    m_LowValue->SetRange(0, m_original->lowValueLimit(type));
   } else
     m_LowValue->Disable();
-  if (m_original->HasHighValue(type)) {
+  if (m_original->hasHighValue(type)) {
     m_HighValue->Enable();
-    m_HighValue->SetRange(0, m_original->HighValueLimit(type));
+    m_HighValue->SetRange(0, m_original->highValueLimit(type));
   } else
     m_HighValue->Disable();
-  if (m_original->HasStart(type)) {
+  if (m_original->hasStart(type)) {
     m_StartValue->Enable();
-    m_StartValue->SetRange(0, m_original->StartLimit(type));
+    m_StartValue->SetRange(0, m_original->startLimit(type));
   } else
     m_StartValue->Disable();
-  if (m_original->HasLength(type)) {
+  if (m_original->hasLength(type)) {
     m_LengthValue->Enable();
-    m_LengthValue->SetRange(0, m_original->LengthLimit(type));
+    m_LengthValue->SetRange(0, m_original->lengthLimit(type));
   } else
     m_LengthValue->Disable();
   if (type == MIDI_S_HW_LCD || type == MIDI_S_HW_NAME_LCD)

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -141,7 +141,7 @@ void GOMidiSender::Load(
 }
 
 void GOMidiSender::Save(
-  GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) {
+  GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) const {
   if (!m_events.empty()) {
     cfg.WriteInteger(group, wxT("NumberOfMIDISendEvents"), m_events.size());
     for (unsigned i = 0; i < m_events.size(); i++) {

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -73,7 +73,7 @@ void GOMidiSender::Load(
         sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
 
     m_events[i].type = eventType;
-    if (HasChannel(eventType))
+    if (hasChannel(eventType))
       m_events[i].channel = cfg.ReadInteger(
         CMBSetting,
         group,
@@ -88,7 +88,7 @@ void GOMidiSender::Load(
         0,
         0x200000);
 
-    if (IsNote(eventType))
+    if (isNote(eventType))
       m_events[i].useNoteOff = cfg.ReadBoolean(
         CMBSetting,
         group,
@@ -96,27 +96,27 @@ void GOMidiSender::Load(
         false,
         true);
 
-    if (HasLowValue(eventType))
+    if (hasLowValue(eventType))
       m_events[i].low_value = cfg.ReadInteger(
         CMBSetting,
         group,
         wxString::Format(wxT("MIDISendLowValue%03d"), i + 1),
         0,
-        LowValueLimit(eventType),
+        lowValueLimit(eventType),
         false,
         0);
 
-    if (HasHighValue(eventType))
+    if (hasHighValue(eventType))
       m_events[i].high_value = cfg.ReadInteger(
         CMBSetting,
         group,
         wxString::Format(wxT("MIDISendHighValue%03d"), i + 1),
         0,
-        HighValueLimit(eventType),
+        highValueLimit(eventType),
         false,
         0x7f);
 
-    if (HasStart(eventType))
+    if (hasStart(eventType))
       m_events[i].start = cfg.ReadInteger(
         CMBSetting,
         group,
@@ -125,8 +125,8 @@ void GOMidiSender::Load(
         0x1f,
         false,
         0);
-    if (HasLength(eventType)) {
-      unsigned maxLength = LengthLimit(eventType);
+    if (hasLength(eventType)) {
+      unsigned maxLength = lengthLimit(eventType);
 
       m_events[i].length = cfg.ReadInteger(
         CMBSetting,
@@ -155,7 +155,7 @@ void GOMidiSender::Save(
         m_events[i].type,
         m_MidiTypes,
         sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
-      if (HasChannel(m_events[i].type))
+      if (hasChannel(m_events[i].type))
         cfg.WriteInteger(
           group,
           wxString::Format(wxT("MIDISendChannel%03d"), i + 1),
@@ -166,30 +166,30 @@ void GOMidiSender::Save(
           wxString::Format(wxT("MIDISendKey%03d"), i + 1),
           m_events[i].key);
 
-      if (IsNote(m_events[i].type))
+      if (isNote(m_events[i].type))
         cfg.WriteBoolean(
           group,
           wxString::Format(wxT("MIDISendNoteOff%03d"), i + 1),
           m_events[i].useNoteOff);
 
-      if (HasLowValue(m_events[i].type))
+      if (hasLowValue(m_events[i].type))
         cfg.WriteInteger(
           group,
           wxString::Format(wxT("MIDISendLowValue%03d"), i + 1),
           m_events[i].low_value);
 
-      if (HasHighValue(m_events[i].type))
+      if (hasHighValue(m_events[i].type))
         cfg.WriteInteger(
           group,
           wxString::Format(wxT("MIDISendHighValue%03d"), i + 1),
           m_events[i].high_value);
 
-      if (HasStart(m_events[i].type))
+      if (hasStart(m_events[i].type))
         cfg.WriteInteger(
           group,
           wxString::Format(wxT("MIDISendStart%03d"), i + 1),
           m_events[i].start);
-      if (HasLength(m_events[i].type))
+      if (hasLength(m_events[i].type))
         cfg.WriteInteger(
           group,
           wxString::Format(wxT("MIDISendLength%03d"), i + 1),
@@ -198,7 +198,7 @@ void GOMidiSender::Save(
   }
 }
 
-bool GOMidiSender::HasChannel(GOMidiSenderMessageType type) {
+bool GOMidiSender::hasChannel(GOMidiSenderMessageType type) {
   if (
     type == MIDI_S_NOTE || type == MIDI_S_NOTE_NO_VELOCITY
     || type == MIDI_S_CTRL || type == MIDI_S_RPN || type == MIDI_S_NRPN
@@ -214,7 +214,7 @@ bool GOMidiSender::HasChannel(GOMidiSenderMessageType type) {
   return false;
 }
 
-bool GOMidiSender::HasKey(GOMidiSenderMessageType type) {
+bool GOMidiSender::HasKey(GOMidiSenderMessageType type) const {
   if (m_type == MIDI_SEND_MANUAL)
     return false;
 
@@ -234,7 +234,7 @@ bool GOMidiSender::HasKey(GOMidiSenderMessageType type) {
   return false;
 }
 
-bool GOMidiSender::HasLowValue(GOMidiSenderMessageType type) {
+bool GOMidiSender::hasLowValue(GOMidiSenderMessageType type) {
   if (
     type == MIDI_S_NOTE_OFF || type == MIDI_S_CTRL_OFF || type == MIDI_S_RPN_OFF
     || type == MIDI_S_NRPN_OFF || type == MIDI_S_PGM_RANGE
@@ -247,7 +247,7 @@ bool GOMidiSender::HasLowValue(GOMidiSenderMessageType type) {
   return false;
 }
 
-bool GOMidiSender::HasHighValue(GOMidiSenderMessageType type) {
+bool GOMidiSender::hasHighValue(GOMidiSenderMessageType type) {
   if (
     type == MIDI_S_NOTE_ON || type == MIDI_S_CTRL_ON || type == MIDI_S_RPN_ON
     || type == MIDI_S_NRPN_ON || type == MIDI_S_PGM_RANGE
@@ -258,7 +258,7 @@ bool GOMidiSender::HasHighValue(GOMidiSenderMessageType type) {
   return false;
 }
 
-bool GOMidiSender::HasStart(GOMidiSenderMessageType type) {
+bool GOMidiSender::hasStart(GOMidiSenderMessageType type) {
   if (
     type == MIDI_S_HW_NAME_STRING || type == MIDI_S_HW_NAME_LCD
     || type == MIDI_S_HW_STRING || type == MIDI_S_HW_LCD)
@@ -266,7 +266,7 @@ bool GOMidiSender::HasStart(GOMidiSenderMessageType type) {
   return false;
 }
 
-bool GOMidiSender::HasLength(GOMidiSenderMessageType type) {
+bool GOMidiSender::hasLength(GOMidiSenderMessageType type) {
   if (
     type == MIDI_S_HW_NAME_STRING || type == MIDI_S_HW_NAME_LCD
     || type == MIDI_S_HW_STRING || type == MIDI_S_HW_LCD)
@@ -274,7 +274,7 @@ bool GOMidiSender::HasLength(GOMidiSenderMessageType type) {
   return false;
 }
 
-bool GOMidiSender::IsNote(GOMidiSenderMessageType type) {
+bool GOMidiSender::isNote(GOMidiSenderMessageType type) {
   if (
     type == MIDI_S_NOTE || type == MIDI_S_NOTE_NO_VELOCITY
     || type == MIDI_S_NOTE_ON || type == MIDI_S_NOTE_OFF)
@@ -283,7 +283,7 @@ bool GOMidiSender::IsNote(GOMidiSenderMessageType type) {
   return false;
 }
 
-unsigned GOMidiSender::KeyLimit(GOMidiSenderMessageType type) {
+unsigned GOMidiSender::keyLimit(GOMidiSenderMessageType type) {
   if (type == MIDI_S_PGM_ON || type == MIDI_S_PGM_OFF)
     return 0x200000;
 
@@ -297,7 +297,7 @@ unsigned GOMidiSender::KeyLimit(GOMidiSenderMessageType type) {
   return 0x7f;
 }
 
-unsigned GOMidiSender::LowValueLimit(GOMidiSenderMessageType type) {
+unsigned GOMidiSender::lowValueLimit(GOMidiSenderMessageType type) {
   if (type == MIDI_S_PGM_RANGE)
     return 0x200000;
   if (type == MIDI_S_RPN_RANGE || type == MIDI_S_NRPN_RANGE)
@@ -307,7 +307,7 @@ unsigned GOMidiSender::LowValueLimit(GOMidiSenderMessageType type) {
   return 0x7f;
 }
 
-unsigned GOMidiSender::HighValueLimit(GOMidiSenderMessageType type) {
+unsigned GOMidiSender::highValueLimit(GOMidiSenderMessageType type) {
   if (type == MIDI_S_PGM_RANGE)
     return 0x200000;
   if (type == MIDI_S_RPN_RANGE || type == MIDI_S_NRPN_RANGE)
@@ -315,7 +315,7 @@ unsigned GOMidiSender::HighValueLimit(GOMidiSenderMessageType type) {
   return 0x7f;
 }
 
-unsigned GOMidiSender::StartLimit(GOMidiSenderMessageType type) {
+unsigned GOMidiSender::startLimit(GOMidiSenderMessageType type) {
   if (type == MIDI_S_HW_NAME_STRING || type == MIDI_S_HW_STRING)
     return 15;
   if (type == MIDI_S_HW_NAME_LCD || type == MIDI_S_HW_LCD)
@@ -323,7 +323,7 @@ unsigned GOMidiSender::StartLimit(GOMidiSenderMessageType type) {
   return 0x00;
 }
 
-unsigned GOMidiSender::LengthLimit(GOMidiSenderMessageType type) {
+unsigned GOMidiSender::lengthLimit(GOMidiSenderMessageType type) {
   if (type == MIDI_S_HW_NAME_STRING || type == MIDI_S_HW_STRING)
     return 16;
   if (type == MIDI_S_HW_NAME_LCD || type == MIDI_S_HW_LCD)

--- a/src/grandorgue/midi/GOMidiSender.h
+++ b/src/grandorgue/midi/GOMidiSender.h
@@ -40,18 +40,18 @@ public:
   void SetLabel(const wxString &text);
   void SetName(const wxString &text);
 
-  bool HasChannel(GOMidiSenderMessageType type);
-  bool HasKey(GOMidiSenderMessageType type);
-  bool HasLowValue(GOMidiSenderMessageType type);
-  bool HasHighValue(GOMidiSenderMessageType type);
-  bool HasStart(GOMidiSenderMessageType type);
-  bool HasLength(GOMidiSenderMessageType type);
-  bool IsNote(GOMidiSenderMessageType type);
-  unsigned KeyLimit(GOMidiSenderMessageType type);
-  unsigned LowValueLimit(GOMidiSenderMessageType type);
-  unsigned HighValueLimit(GOMidiSenderMessageType type);
-  unsigned StartLimit(GOMidiSenderMessageType type);
-  unsigned LengthLimit(GOMidiSenderMessageType type);
+  static bool hasChannel(GOMidiSenderMessageType type);
+  bool HasKey(GOMidiSenderMessageType type) const;
+  static bool hasLowValue(GOMidiSenderMessageType type);
+  static bool hasHighValue(GOMidiSenderMessageType type);
+  static bool hasStart(GOMidiSenderMessageType type);
+  static bool hasLength(GOMidiSenderMessageType type);
+  static bool isNote(GOMidiSenderMessageType type);
+  static unsigned keyLimit(GOMidiSenderMessageType type);
+  static unsigned lowValueLimit(GOMidiSenderMessageType type);
+  static unsigned highValueLimit(GOMidiSenderMessageType type);
+  static unsigned startLimit(GOMidiSenderMessageType type);
+  static unsigned lengthLimit(GOMidiSenderMessageType type);
 };
 
 #endif

--- a/src/grandorgue/midi/GOMidiSender.h
+++ b/src/grandorgue/midi/GOMidiSender.h
@@ -31,7 +31,7 @@ public:
   void SetElementID(int id);
 
   void Load(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
-  void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map);
+  void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) const;
 
   void SetDisplay(bool state);
   void SetKey(unsigned key, unsigned velocity);

--- a/src/grandorgue/midi/GOMidiShortcutReceiver.cpp
+++ b/src/grandorgue/midi/GOMidiShortcutReceiver.cpp
@@ -24,7 +24,8 @@ void GOMidiShortcutReceiver::Load(GOConfigReader &cfg, const wxString &group) {
   }
 }
 
-void GOMidiShortcutReceiver::Save(GOConfigWriter &cfg, const wxString &group) {
+void GOMidiShortcutReceiver::Save(
+  GOConfigWriter &cfg, const wxString &group) const {
   if (m_ShortcutKey) {
     if (m_type == KEY_RECV_ENCLOSURE) {
       cfg.WriteInteger(group, wxT("PlusKey"), m_ShortcutKey);

--- a/src/grandorgue/midi/GOMidiShortcutReceiver.h
+++ b/src/grandorgue/midi/GOMidiShortcutReceiver.h
@@ -20,7 +20,7 @@ public:
   GOMidiShortcutReceiver(ReceiverType type) : GOMidiShortcutPattern(type) {}
 
   void Load(GOConfigReader &cfg, const wxString &group);
-  void Save(GOConfigWriter &cfg, const wxString &group);
+  void Save(GOConfigWriter &cfg, const wxString &group) const;
 
   MatchType Match(unsigned key);
 


### PR DESCRIPTION
This PR adds const and static qualifiers to some member functions of GOMidiReceiverBase and GOMidiSender

It also renames that members according to the current GrandOrgue naming conventions.

It is just refactoring. No GO behavior should be changed.