### PR TITLE
Renamed class IniFileEnumEntry to GOConfigEnum::Entry and extracted to a separate file https://github.com/GrandOrgue/grandorgue/issues/1199

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 include(UsewxWidgets)
@@ -18,6 +18,7 @@ archive/GOArchiveEntryFile.cpp
 archive/GOArchiveManager.cpp
 archive/GOArchiveReader.cpp
 archive/GOArchiveWriter.cpp
+config/GOConfigEnum.cpp
 config/GOConfigFileReader.cpp
 config/GOConfigFileWriter.cpp
 config/GOConfigReader.cpp

--- a/src/core/config/GOConfigEnum.cpp
+++ b/src/core/config/GOConfigEnum.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOConfigEnum.h"
+
+#include <algorithm>
+
+static const wxString WX_EMPTY;
+
+const wxString &GOConfigEnum::GetName(int value) const {
+  const auto end = m_entries.end();
+  const auto found
+    = std::find_if(m_entries.cbegin(), end, [value](const Entry &e) {
+        return e.value == value;
+      });
+
+  return found != end ? found->name : WX_EMPTY;
+}
+
+int GOConfigEnum::GetValue(const wxString &name, int defaultValue) const {
+  const auto end = m_entries.end();
+  const auto found = std::find_if(
+    m_entries.cbegin(), end, [name](const Entry &e) { return e.name == name; });
+
+  return found != end ? found->value : defaultValue;
+}

--- a/src/core/config/GOConfigEnum.h
+++ b/src/core/config/GOConfigEnum.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOCONFIGENUM_H
+#define GOCONFIGENUM_H
+
+#include <vector>
+
+#include <wx/string.h>
+
+class GOConfigEnum {
+public:
+  struct Entry {
+    wxString name;
+    int value;
+  };
+
+private:
+  const std::vector<Entry> m_entries;
+
+public:
+  GOConfigEnum(const std::vector<Entry> &entries) : m_entries(entries) {}
+
+  const wxString &GetName(int value) const;
+  int GetValue(const wxString &name, int defaultValue) const;
+  int GetFirstValue() const { return m_entries[0].value; }
+};
+
+#endif /* GOCONFIGENUM_H */

--- a/src/core/config/GOConfigReader.h
+++ b/src/core/config/GOConfigReader.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,14 +14,10 @@
 #include <wx/string.h>
 
 #include "GOBool3.h"
+#include "GOConfigEnum.h"
 #include "GOLogicalColour.h"
 
 class GOConfigReaderDB;
-
-struct IniFileEnumEntry {
-  wxString name;
-  int value;
-};
 
 typedef enum { ODFSetting, CMBSetting } GOSettingType;
 
@@ -194,15 +190,13 @@ public:
     GOSettingType type,
     const wxString &group,
     const wxString &key,
-    const struct IniFileEnumEntry *entry,
-    unsigned count,
+    const GOConfigEnum &configEnum,
     bool required = true);
   int ReadEnum(
     GOSettingType type,
     const wxString &group,
     const wxString &key,
-    const struct IniFileEnumEntry *entry,
-    unsigned count,
+    const GOConfigEnum &configEnum,
     bool required,
     int defaultValue);
 

--- a/src/core/config/GOConfigWriter.cpp
+++ b/src/core/config/GOConfigWriter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,9 +10,9 @@
 #include <wx/intl.h>
 #include <wx/log.h>
 
+#include "GOConfigEnum.h"
+#include "GOConfigFileWriter.h"
 #include "GOUtil.h"
-#include "config/GOConfigFileWriter.h"
-#include "config/GOConfigReader.h"
 
 GOConfigWriter::GOConfigWriter(GOConfigFileWriter &cfg, bool prefix)
   : m_ConfigFile(cfg), m_Prefix(prefix) {}
@@ -36,18 +36,16 @@ void GOConfigWriter::WriteFloat(wxString group, wxString key, float value) {
 }
 
 void GOConfigWriter::WriteEnum(
-  wxString group,
-  wxString key,
-  int value,
-  const struct IniFileEnumEntry *entry,
-  unsigned count) {
-  for (unsigned i = 0; i < count; i++)
-    if (entry[i].value == value) {
-      WriteString(group, key, entry[i].name);
-      return;
-    }
-  wxLogError(
-    _("Invalid enum value for /%s/%s: %d"), group.c_str(), key.c_str(), value);
+  const wxString &group,
+  const wxString &key,
+  const GOConfigEnum &configEnum,
+  int value) {
+  const wxString &valueName = configEnum.GetName(value);
+
+  if (valueName.IsEmpty())
+    wxLogError(_("Invalid enum value for /%s/%s: %d"), group, key, value);
+  else
+    WriteString(group, key, valueName);
 }
 
 void GOConfigWriter::WriteBooleanTriple(

--- a/src/core/config/GOConfigWriter.h
+++ b/src/core/config/GOConfigWriter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,8 +10,8 @@
 
 #include <wx/string.h>
 
+class GOConfigEnum;
 class GOConfigFileWriter;
-struct IniFileEnumEntry;
 
 class GOConfigWriter {
 private:
@@ -24,11 +24,10 @@ public:
   void WriteString(wxString group, wxString key, wxString value);
   void WriteInteger(wxString group, wxString key, int value);
   void WriteEnum(
-    wxString group,
-    wxString key,
-    int value,
-    const struct IniFileEnumEntry *entry,
-    unsigned count);
+    const wxString &group,
+    const wxString &key,
+    const GOConfigEnum &confEnum,
+    int value);
   void WriteFloat(wxString group, wxString key, float value);
   /**
    * Saves 0 as N, 1 as Y. -1 is not saved at all

--- a/src/core/midi/GOMidiReceiverBase.cpp
+++ b/src/core/midi/GOMidiReceiverBase.cpp
@@ -10,6 +10,7 @@
 #include "GOMidiEvent.h"
 #include "GOMidiMap.h"
 #include "GORodgers.h"
+#include "config/GOConfigEnum.h"
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
@@ -21,7 +22,7 @@ GOMidiReceiverBase::GOMidiReceiverBase(GOMidiReceiverType type)
 
 void GOMidiReceiverBase::SetElementID(int id) { m_ElementID = id; }
 
-const struct IniFileEnumEntry GOMidiReceiverBase::m_MidiTypes[] = {
+static const GOConfigEnum MIDI_RECEIVE_TYPES({
   {wxT("ControlChange"), MIDI_M_CTRL_CHANGE},
   {wxT("Note"), MIDI_M_NOTE},
   {wxT("ProgramChange"), MIDI_M_PGM_CHANGE},
@@ -59,7 +60,7 @@ const struct IniFileEnumEntry GOMidiReceiverBase::m_MidiTypes[] = {
   {wxT("NoteNoVelocity"), MIDI_M_NOTE_NO_VELOCITY},
   {wxT("NoteShortOctave"), MIDI_M_NOTE_SHORT_OCTAVE},
   {wxT("NoteNormal"), MIDI_M_NOTE_NORMAL},
-};
+});
 
 void GOMidiReceiverBase::Load(
   GOConfigReader &cfg, const wxString &group, GOMidiMap &map) {
@@ -87,8 +88,7 @@ void GOMidiReceiverBase::Load(
         CMBSetting,
         group,
         wxString::Format(wxT("MIDIEventType%03d"), i + 1),
-        m_MidiTypes,
-        sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]),
+        MIDI_RECEIVE_TYPES,
         false,
         default_type);
       if (hasChannel(pattern.type))
@@ -201,9 +201,8 @@ void GOMidiReceiverBase::Save(
       cfg.WriteEnum(
         group,
         wxString::Format(wxT("MIDIEventType%03d"), i + 1),
-        pattern.type,
-        m_MidiTypes,
-        sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
+        MIDI_RECEIVE_TYPES,
+        pattern.type);
       if (hasChannel(pattern.type))
         cfg.WriteInteger(
           group,

--- a/src/core/midi/GOMidiReceiverBase.h
+++ b/src/core/midi/GOMidiReceiverBase.h
@@ -18,7 +18,6 @@ class GOConfigReader;
 class GOConfigWriter;
 class GOMidiEvent;
 class GOMidiMap;
-struct IniFileEnumEntry;
 
 class GOMidiReceiverBase : public GOMidiReceiverEventPatternList {
 public:
@@ -32,7 +31,6 @@ private:
     int key;
   } midi_internal_match;
 
-  static const struct IniFileEnumEntry m_MidiTypes[];
   int m_ElementID;
   std::vector<GOTime> m_last;
   std::vector<midi_internal_match> m_Internal;

--- a/src/core/settings/GOSettingEnum.cpp
+++ b/src/core/settings/GOSettingEnum.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,33 +10,27 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
+class GOConfigEnum;
+
 template <class T>
 GOSettingEnum<T>::GOSettingEnum(
   GOSettingStore *store,
-  wxString group,
-  wxString name,
-  const struct IniFileEnumEntry *entries,
-  unsigned count,
+  const wxString &group,
+  const wxString &name,
+  const GOConfigEnum &configEnum,
   T default_value)
   : GOSetting(store, group, name),
+    r_enum(configEnum),
     m_Value(default_value),
-    m_DefaultValue(default_value),
-    m_Entries(entries),
-    m_Count(count) {}
+    m_DefaultValue(default_value) {}
 
 template <class T> void GOSettingEnum<T>::Load(GOConfigReader &cfg) {
   (*this)((T)cfg.ReadEnum(
-    CMBSetting,
-    m_Group,
-    m_Name,
-    m_Entries,
-    m_Count,
-    false,
-    (int)m_DefaultValue));
+    CMBSetting, m_Group, m_Name, r_enum, false, (int)m_DefaultValue));
 }
 
 template <class T> void GOSettingEnum<T>::Save(GOConfigWriter &cfg) {
-  cfg.WriteEnum(m_Group, m_Name, (int)m_Value, m_Entries, m_Count);
+  cfg.WriteEnum(m_Group, m_Name, r_enum, (int)m_Value);
 }
 
 template <class T> void GOSettingEnum<T>::setDefaultValue(T default_value) {

--- a/src/core/settings/GOSettingEnum.h
+++ b/src/core/settings/GOSettingEnum.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,14 +8,14 @@
 #ifndef GOSETTINGENUM_H
 #define GOSETTINGENUM_H
 
+#include "config/GOConfigEnum.h"
 #include "settings/GOSetting.h"
 
 template <class T> class GOSettingEnum : private GOSetting {
 private:
+  const GOConfigEnum &r_enum;
   T m_Value;
   T m_DefaultValue;
-  const struct IniFileEnumEntry *m_Entries;
-  unsigned m_Count;
 
   void Load(GOConfigReader &cfg);
   void Save(GOConfigWriter &cfg);
@@ -23,10 +23,9 @@ private:
 public:
   GOSettingEnum(
     GOSettingStore *store,
-    wxString group,
-    wxString name,
-    const struct IniFileEnumEntry *entries,
-    unsigned count,
+    const wxString &group,
+    const wxString &name,
+    const GOConfigEnum &configEnum,
     T default_value);
 
   void setDefaultValue(T default_value);

--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -134,11 +134,11 @@ const GOMidiSetting GOConfig::m_MIDISettings[] = {
   {MIDI_RECV_SETTER, 29, wxTRANSLATE("Metronome"), wxTRANSLATE("Measure +")},
 };
 
-const struct IniFileEnumEntry GOConfig::m_InitialLoadTypes[] = {
+static const GOConfigEnum INITIAL_LOAD_TYPES({
   {wxT("N"), (int)GOInitialLoadType::LOAD_NONE},
   {wxT("Y"), (int)GOInitialLoadType::LOAD_LAST_USED},
   {wxT("First"), (int)GOInitialLoadType::LOAD_FIRST},
-};
+});
 
 GOConfig::GOConfig(wxString instance)
   : m_InstanceName(instance),
@@ -171,8 +171,7 @@ GOConfig::GOConfig(wxString instance)
       this,
       wxT("General"),
       wxT("LoadLastFile"),
-      m_InitialLoadTypes,
-      sizeof(m_InitialLoadTypes) / sizeof(m_InitialLoadTypes[0]),
+      INITIAL_LOAD_TYPES,
       GOInitialLoadType::LOAD_LAST_USED),
     ODFCheck(this, wxT("General"), wxT("StrictODFCheck"), false),
     ODFHw1Check(this, wxT("General"), wxT("ODFHw1Check"), false),

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -66,7 +66,6 @@ private:
   GOLogicalRect m_MainWindowRect;
 
   static const GOMidiSetting m_MIDISettings[];
-  static const struct IniFileEnumEntry m_InitialLoadTypes[];
 
   wxString GetEventSection(unsigned index);
 

--- a/src/grandorgue/midi/GOMidiSender.cpp
+++ b/src/grandorgue/midi/GOMidiSender.cpp
@@ -9,6 +9,7 @@
 
 #include <wx/intl.h>
 
+#include "config/GOConfigEnum.h"
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 #include "midi/GOMidiEvent.h"
@@ -21,7 +22,7 @@ GOMidiSender::GOMidiSender(GOMidiSendProxy &proxy, GOMidiSenderType type)
 
 GOMidiSender::~GOMidiSender() {}
 
-const struct IniFileEnumEntry GOMidiSender::m_MidiTypes[] = {
+static const GOConfigEnum MIDI_SEND_TYPES({
   {wxT("Note"), MIDI_S_NOTE},
   {wxT("NoteNoVelocity"), MIDI_S_NOTE_NO_VELOCITY},
   {wxT("ControlChange"), MIDI_S_CTRL},
@@ -45,7 +46,7 @@ const struct IniFileEnumEntry GOMidiSender::m_MidiTypes[] = {
   {wxT("HWLCD"), MIDI_S_HW_LCD},
   {wxT("HWString"), MIDI_S_HW_STRING},
   {wxT("RodgersStopChange"), MIDI_S_RODGERS_STOP_CHANGE},
-};
+});
 
 void GOMidiSender::SetElementID(int id) { m_ElementID = id; }
 
@@ -69,8 +70,7 @@ void GOMidiSender::Load(
         CMBSetting,
         group,
         wxString::Format(wxT("MIDISendEventType%03d"), i + 1),
-        m_MidiTypes,
-        sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
+        MIDI_SEND_TYPES);
 
     m_events[i].type = eventType;
     if (hasChannel(eventType))
@@ -152,9 +152,8 @@ void GOMidiSender::Save(
       cfg.WriteEnum(
         group,
         wxString::Format(wxT("MIDISendEventType%03d"), i + 1),
-        m_events[i].type,
-        m_MidiTypes,
-        sizeof(m_MidiTypes) / sizeof(m_MidiTypes[0]));
+        MIDI_SEND_TYPES,
+        m_events[i].type);
       if (hasChannel(m_events[i].type))
         cfg.WriteInteger(
           group,

--- a/src/grandorgue/midi/GOMidiSender.h
+++ b/src/grandorgue/midi/GOMidiSender.h
@@ -16,11 +16,9 @@ class GOConfigReader;
 class GOConfigWriter;
 class GOMidiMap;
 class GOMidiSendProxy;
-struct IniFileEnumEntry;
 
 class GOMidiSender : public GOMidiSenderEventPatternList {
 private:
-  static const struct IniFileEnumEntry m_MidiTypes[];
   GOMidiSendProxy &r_proxy;
   int m_ElementID;
 

--- a/src/grandorgue/model/GOCoupler.cpp
+++ b/src/grandorgue/model/GOCoupler.cpp
@@ -79,11 +79,11 @@ void GOCoupler::SetRecursive(bool isRecursive) {
   m_CoupleToSubsequentDownwardIntramanualCouplers = isRecursive;
 }
 
-const struct IniFileEnumEntry GOCoupler::m_coupler_types[] = {
-  {wxT("Normal"), COUPLER_NORMAL},
-  {wxT("Bass"), COUPLER_BASS},
-  {wxT("Melody"), COUPLER_MELODY},
-};
+static const GOConfigEnum COUPLER_TYPES({
+  {wxT("Normal"), GOCoupler::COUPLER_NORMAL},
+  {wxT("Bass"), GOCoupler::COUPLER_BASS},
+  {wxT("Melody"), GOCoupler::COUPLER_MELODY},
+});
 
 void GOCoupler::Init(
   GOConfigReader &cfg,
@@ -168,8 +168,7 @@ void GOCoupler::Load(GOConfigReader &cfg, const wxString &group) {
       ODFSetting,
       group,
       wxT("CouplerType"),
-      m_coupler_types,
-      sizeof(m_coupler_types) / sizeof(m_coupler_types[0]),
+      COUPLER_TYPES,
       false,
       COUPLER_NORMAL);
     if (m_CouplerType == COUPLER_BASS || m_CouplerType == COUPLER_MELODY) {

--- a/src/grandorgue/model/GOCoupler.h
+++ b/src/grandorgue/model/GOCoupler.h
@@ -14,15 +14,12 @@
 
 class GOConfigReader;
 class GOConfigWriter;
-struct IniFileEnumEntry;
 
 class GOCoupler : public GODrawstop {
 public:
   typedef enum { COUPLER_NORMAL, COUPLER_BASS, COUPLER_MELODY } GOCouplerType;
 
 private:
-  static const struct IniFileEnumEntry m_coupler_types[];
-
   bool m_IsVirtual;
   bool m_UnisonOff;
   bool m_CoupleToSubsequentUnisonIntermanualCouplers;

--- a/src/grandorgue/model/GODrawstop.cpp
+++ b/src/grandorgue/model/GODrawstop.cpp
@@ -9,21 +9,22 @@
 
 #include <wx/intl.h>
 
+#include "config/GOConfigEnum.h"
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
 #include "GOOrganModel.h"
 #include "GOSwitch.h"
 
-const struct IniFileEnumEntry GODrawstop::m_function_types[] = {
-  {wxT("Input"), FUNCTION_INPUT},
-  {wxT("And"), FUNCTION_AND},
-  {wxT("Or"), FUNCTION_OR},
-  {wxT("Not"), FUNCTION_NOT},
-  {wxT("Nand"), FUNCTION_NAND},
-  {wxT("Nor"), FUNCTION_NOR},
-  {wxT("Xor"), FUNCTION_XOR},
-};
+static const GOConfigEnum FUNCTION_TYPES({
+  {wxT("Input"), GODrawstop::FUNCTION_INPUT},
+  {wxT("And"), GODrawstop::FUNCTION_AND},
+  {wxT("Or"), GODrawstop::FUNCTION_OR},
+  {wxT("Not"), GODrawstop::FUNCTION_NOT},
+  {wxT("Nand"), GODrawstop::FUNCTION_NAND},
+  {wxT("Nor"), GODrawstop::FUNCTION_NOR},
+  {wxT("Xor"), GODrawstop::FUNCTION_XOR},
+});
 
 GODrawstop::GODrawstop(
   GOOrganModel &organModel,
@@ -103,13 +104,7 @@ void GODrawstop::SetupIsToStoreInCmb() {
 
 void GODrawstop::Load(GOConfigReader &cfg, const wxString &group) {
   m_Type = (GOFunctionType)cfg.ReadEnum(
-    ODFSetting,
-    group,
-    wxT("Function"),
-    m_function_types,
-    sizeof(m_function_types) / sizeof(m_function_types[0]),
-    false,
-    FUNCTION_INPUT);
+    ODFSetting, group, wxT("Function"), FUNCTION_TYPES, false, FUNCTION_INPUT);
 
   if (m_Type == FUNCTION_INPUT) {
     m_Engaged = cfg.ReadBoolean(ODFSetting, group, wxT("DefaultToEngaged"));

--- a/src/grandorgue/model/GODrawstop.h
+++ b/src/grandorgue/model/GODrawstop.h
@@ -29,7 +29,6 @@ public:
   };
 
 private:
-  static const struct IniFileEnumEntry m_function_types[];
   GOFunctionType m_Type;
   int m_GCState;
   std::unordered_map<wxString, bool, wxStringHash, wxStringEqual>

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -22,10 +22,10 @@
     }                                                                          \
   } while (0)
 
-const struct IniFileEnumEntry GOTremulant::m_tremulant_types[] = {
+static const GOConfigEnum TREMULANT_TYPES({
   {wxT("Synth"), GOSynthTrem},
   {wxT("Wave"), GOWavTrem},
-};
+});
 
 static const wxString WX_MIDI_TYPE_CODE = wxT("Tremulant");
 static const wxString WX_MIDI_TYPE_NAME = _("Tremulant");
@@ -62,8 +62,7 @@ void GOTremulant::Load(
     ODFSetting,
     group,
     wxT("TremulantType"),
-    m_tremulant_types,
-    sizeof(m_tremulant_types) / sizeof(m_tremulant_types[0]),
+    TREMULANT_TYPES,
     false,
     GOSynthTrem);
   if (m_TremulantType == GOSynthTrem) {

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -19,13 +19,11 @@ class GOConfigReader;
 class GOConfigWriter;
 class GOMemoryPool;
 struct GOSoundSampler;
-struct IniFileEnumEntry;
 
 typedef enum { GOSynthTrem, GOWavTrem } GOTremulantType;
 
 class GOTremulant : public GODrawstop, private GOCacheObject {
 private:
-  static const struct IniFileEnumEntry m_tremulant_types[];
   GOTremulantType m_TremulantType;
   int m_Period;
   int m_StartRate;


### PR DESCRIPTION
Relates to #1199

Earlier the converting between enum names and enum values was internal in the `GOConfigReader` class, so it could be used only for reading and writing ODF/CMB files.

This PR introduces a new class `GOConfigEnum` with two functions `getName` and `getValue`, so they can me used, for example, for export and import midi settings in yaml format.

It is just refactoring. No GrandOrgue behavior should be changes.

