### PR TITLE
Introduced a class GORegisteredOrgan

### DIFF
--- a/src/core/GOOrgan.cpp
+++ b/src/core/GOOrgan.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -16,47 +16,27 @@
 #include "GOHash.h"
 #include "GOOrganList.h"
 #include "archive/GOArchiveFile.h"
-#include "config/GOConfigReader.h"
-#include "config/GOConfigWriter.h"
 
 GOOrgan::GOOrgan(
-  wxString odf,
-  wxString archive,
-  wxString archivePath,
-  wxString church_name,
-  wxString organ_builder,
-  wxString recording_detail)
+  const wxString &odf,
+  const wxString &archive,
+  const wxString &archivePath,
+  const wxString &church_name,
+  const wxString &organ_builder,
+  const wxString &recording_detail)
   : m_ODF(odf),
     m_ChurchName(church_name),
     m_OrganBuilder(organ_builder),
     m_RecordingDetail(recording_detail),
     m_ArchiveID(archive),
     m_ArchivePath(archivePath),
-    m_NamesInitialized(true),
-    m_midi(MIDI_RECV_ORGAN) {
+    m_NamesInitialized(true) {
   m_LastUse = wxGetUTCTime();
 }
 
-GOOrgan::GOOrgan(wxString odf)
-  : m_ODF(odf), m_NamesInitialized(false), m_midi(MIDI_RECV_ORGAN) {
+GOOrgan::GOOrgan(wxString odf) : m_ODF(odf), m_NamesInitialized(false) {
   m_LastUse = wxGetUTCTime();
 }
-
-GOOrgan::GOOrgan(GOConfigReader &cfg, wxString group, GOMidiMap &map)
-  : m_midi(MIDI_RECV_ORGAN) {
-  m_ODF = cfg.ReadString(CMBSetting, group, wxT("ODFPath"));
-  m_ChurchName = cfg.ReadString(CMBSetting, group, wxT("ChurchName"));
-  m_OrganBuilder = cfg.ReadString(CMBSetting, group, wxT("OrganBuilder"));
-  m_RecordingDetail = cfg.ReadString(CMBSetting, group, wxT("RecordingDetail"));
-  m_ArchiveID = cfg.ReadString(CMBSetting, group, wxT("Archiv"), false);
-  m_ArchivePath = cfg.ReadString(CMBSetting, group, wxT("ArchivePath"), false);
-  m_LastUse = cfg.ReadInteger(
-    CMBSetting, group, wxT("LastUse"), 0, INT_MAX, false, wxGetUTCTime());
-  m_NamesInitialized = true;
-  m_midi.Load(cfg, group, map);
-}
-
-GOOrgan::~GOOrgan() {}
 
 void GOOrgan::Update(const GOOrgan &organ) {
   if (m_NamesInitialized) {
@@ -85,38 +65,12 @@ const wxString &GOOrgan::GetRecordingDetail() const {
   return m_RecordingDetail;
 }
 
-GOMidiReceiverBase &GOOrgan::GetMIDIReceiver() { return m_midi; }
-
 const wxString GOOrgan::GetUITitle() const {
   return wxString::Format(
     _("%s, %s"), m_ChurchName.c_str(), m_OrganBuilder.c_str());
 }
 
 long GOOrgan::GetLastUse() const { return m_LastUse; }
-
-void GOOrgan::Save(GOConfigWriter &cfg, wxString group, GOMidiMap &map) {
-  cfg.WriteString(group, wxT("ODFPath"), m_ODF);
-  cfg.WriteString(group, wxT("ChurchName"), m_ChurchName);
-  cfg.WriteString(group, wxT("OrganBuilder"), m_OrganBuilder);
-  cfg.WriteString(group, wxT("RecordingDetail"), m_RecordingDetail);
-  if (m_ArchiveID != wxEmptyString) {
-    cfg.WriteString(group, wxT("Archiv"), m_ArchiveID);
-    cfg.WriteString(group, wxT("ArchivePath"), m_ArchivePath);
-  }
-  cfg.WriteInteger(group, wxT("LastUse"), m_LastUse);
-  m_midi.Save(cfg, group, map);
-}
-
-bool GOOrgan::Match(const GOMidiEvent &e) {
-  switch (m_midi.Match(e)) {
-  case MIDI_MATCH_CHANGE:
-  case MIDI_MATCH_ON:
-    return true;
-
-  default:
-    return false;
-  }
-}
 
 bool GOOrgan::IsUsable(const GOOrganList &organs) const {
   bool res;

--- a/src/core/GOOrgan.h
+++ b/src/core/GOOrgan.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,15 +10,10 @@
 
 #include <wx/string.h>
 
-#include "midi/GOMidiReceiverBase.h"
-
-class GOConfigReader;
-class GOConfigWriter;
-class GOMidiMap;
 class GOOrganList;
 
 class GOOrgan {
-private:
+protected:
   wxString m_ODF;
   wxString m_ChurchName;
   wxString m_OrganBuilder;
@@ -27,23 +22,19 @@ private:
   wxString m_ArchivePath;
   bool m_NamesInitialized;
   long m_LastUse;
-  GOMidiReceiverBase m_midi;
 
 public:
   GOOrgan(
-    wxString odf,
-    wxString archive,
-    wxString archivePath,
-    wxString church_name,
-    wxString organ_builder,
-    wxString recording_detail);
+    const wxString &odf,
+    const wxString &archive,
+    const wxString &archivePath,
+    const wxString &church_name,
+    const wxString &organ_builder,
+    const wxString &recording_detail);
   explicit GOOrgan(wxString odf);
-  GOOrgan(GOConfigReader &cfg, wxString group, GOMidiMap &map);
-  virtual ~GOOrgan();
+  virtual ~GOOrgan() {}
 
   void Update(const GOOrgan &organ);
-
-  void Save(GOConfigWriter &cfg, wxString group, GOMidiMap &map);
 
   const wxString &GetODFPath() const;
   void SetODFPath(const wxString &newPath) { m_ODF = newPath; }
@@ -61,9 +52,6 @@ public:
   const wxString GetOrganHash() const;
   long GetLastUse() const;
   const wxString GetUITitle() const;
-  GOMidiReceiverBase &GetMIDIReceiver();
-  const GOMidiReceiverBase &GetMIDIReceiver() const;
-  bool Match(const GOMidiEvent &e);
 
   bool IsUsable(const GOOrganList &organs) const;
 };

--- a/src/core/GOOrganList.h
+++ b/src/core/GOOrganList.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,11 +12,9 @@
 
 #include "ptrvector.h"
 
-class GOArchiveFile;
-class GOConfigReader;
-class GOConfigWriter;
-class GOMidiMap;
-class GOOrgan;
+#include "archive/GOArchiveFile.h"
+
+#include "GOOrgan.h"
 
 class GOOrganList {
 private:
@@ -24,22 +22,26 @@ private:
   ptr_vector<GOArchiveFile> m_ArchiveList;
 
 protected:
-  void Load(GOConfigReader &cfg, GOMidiMap &map);
-  void Save(GOConfigWriter &cfg, GOMidiMap &map);
+  virtual GOOrgan *CloneOrgan(const GOOrgan &newOrgan) const;
+  void AddNewOrgan(GOOrgan *pOrgan) { m_OrganList.push_back(pOrgan); }
+  void AddNewArchive(GOArchiveFile *pArchive) {
+    m_ArchiveList.push_back(pArchive);
+  }
 
 public:
-  GOOrganList();
-  ~GOOrganList();
-
+  void ClearOrgans() { m_OrganList.clear(); }
   void AddOrgan(const GOOrgan &organ);
   void RemoveInvalidTmpOrgans();
   const ptr_vector<GOOrgan> &GetOrganList() const { return m_OrganList; }
   ptr_vector<GOOrgan> &GetOrganList() { return m_OrganList; }
   std::vector<const GOOrgan *> GetLRUOrganList();
 
+  void ClearArchives() { m_ArchiveList.clear(); }
   void AddArchive(const GOArchiveFile &archive);
-  ptr_vector<GOArchiveFile> &GetArchiveList();
-  const ptr_vector<GOArchiveFile> &GetArchiveList() const;
+  ptr_vector<GOArchiveFile> &GetArchiveList() { return m_ArchiveList; }
+  const ptr_vector<GOArchiveFile> &GetArchiveList() const {
+    return m_ArchiveList;
+  }
   const GOArchiveFile *GetArchiveByID(
     const wxString &id, bool useable = false) const;
   const GOArchiveFile *GetArchiveByPath(const wxString &path) const;

--- a/src/core/archive/GOArchiveFile.cpp
+++ b/src/core/archive/GOArchiveFile.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -55,7 +55,7 @@ wxString GOArchiveFile::getArchiveHash(const wxString &path) {
   return hash.getStringHash();
 }
 
-void GOArchiveFile::Save(GOConfigWriter &cfg, wxString group) {
+void GOArchiveFile::Save(GOConfigWriter &cfg, const wxString &group) const {
   cfg.WriteString(group, wxT("ID"), m_ID);
   cfg.WriteString(group, wxT("Path"), m_Path);
   cfg.WriteString(group, wxT("Name"), m_Name);

--- a/src/core/archive/GOArchiveFile.h
+++ b/src/core/archive/GOArchiveFile.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -41,7 +41,7 @@ public:
   void Update(const GOArchiveFile &archive);
   wxString GetCurrentFileID() const;
 
-  void Save(GOConfigWriter &cfg, wxString group);
+  void Save(GOConfigWriter &cfg, const wxString &group) const;
 
   const wxString &GetID() const;
   const wxString &GetPath() const;

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -57,6 +57,7 @@ config/GOMidiDeviceConfig.cpp
 config/GOMidiDeviceConfigList.cpp
 config/GOPortsConfig.cpp
 config/GOPortFactory.cpp
+config/GORegisteredOrgan.cpp
 control/GOButtonControl.cpp
 control/GOCallbackButtonControl.cpp
 control/GOElementCreator.cpp

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -67,6 +67,11 @@ private:
 
   static const GOMidiSetting m_MIDISettings[];
 
+  GOOrgan *CloneOrgan(const GOOrgan &newOrgan) const override;
+
+  void LoadOrgans(GOConfigReader &cfg);
+  void SaveOrgans(GOConfigWriter &cfg);
+
   wxString GetEventSection(unsigned index);
 
   void LoadDefaults();

--- a/src/grandorgue/config/GORegisteredOrgan.cpp
+++ b/src/grandorgue/config/GORegisteredOrgan.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GORegisteredOrgan.h"
+
+#include "config/GOConfigReader.h"
+#include "config/GOConfigWriter.h"
+
+GORegisteredOrgan::GORegisteredOrgan(
+  GOConfigReader &cfg, const wxString &group, GOMidiMap &map)
+  : GOOrgan(
+    cfg.ReadString(CMBSetting, group, wxT("ODFPath")),
+    cfg.ReadString(CMBSetting, group, wxT("Archiv"), false),
+    cfg.ReadString(CMBSetting, group, wxT("ArchivePath"), false),
+    cfg.ReadString(CMBSetting, group, wxT("ChurchName")),
+    cfg.ReadString(CMBSetting, group, wxT("OrganBuilder")),
+    cfg.ReadString(CMBSetting, group, wxT("RecordingDetail"))),
+    m_midi(MIDI_RECV_ORGAN) {
+  m_LastUse = cfg.ReadInteger(
+    CMBSetting, group, wxT("LastUse"), 0, INT_MAX, false, m_LastUse);
+  m_midi.Load(cfg, group, map);
+}
+
+void GORegisteredOrgan::Save(
+  GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) const {
+  cfg.WriteString(group, wxT("ODFPath"), m_ODF);
+  cfg.WriteString(group, wxT("ChurchName"), m_ChurchName);
+  cfg.WriteString(group, wxT("OrganBuilder"), m_OrganBuilder);
+  cfg.WriteString(group, wxT("RecordingDetail"), m_RecordingDetail);
+  if (m_ArchiveID != wxEmptyString) {
+    cfg.WriteString(group, wxT("Archiv"), m_ArchiveID);
+    cfg.WriteString(group, wxT("ArchivePath"), m_ArchivePath);
+  }
+  cfg.WriteInteger(group, wxT("LastUse"), m_LastUse);
+  m_midi.Save(cfg, group, map);
+}
+
+bool GORegisteredOrgan::Match(const GOMidiEvent &e) {
+  switch (m_midi.Match(e)) {
+  case MIDI_MATCH_CHANGE:
+  case MIDI_MATCH_ON:
+    return true;
+
+  default:
+    return false;
+  }
+}

--- a/src/grandorgue/config/GORegisteredOrgan.h
+++ b/src/grandorgue/config/GORegisteredOrgan.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOREGISTEREDORGAN_H
+#define GOREGISTEREDORGAN_H
+
+#include "GOOrgan.h"
+
+#include "midi/GOMidiReceiverBase.h"
+
+class GOConfigReader;
+class GOConfigWriter;
+class GOMidiMap;
+
+class GORegisteredOrgan : public GOOrgan {
+private:
+  GOMidiReceiverBase m_midi;
+
+public:
+  GORegisteredOrgan(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
+
+  GOMidiReceiverBase &GetMIDIReceiver() { return m_midi; }
+  const GOMidiReceiverBase &GetMIDIReceiver() const { return m_midi; }
+
+  void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) const;
+
+  bool Match(const GOMidiEvent &e);
+};
+
+#endif /* GOREGISTEREDORGAN_H */

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsOrgans.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsOrgans.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -28,12 +28,12 @@
 #include "archive/GOArchiveFile.h"
 #include "archive/GOArchiveIndex.h"
 #include "config/GOConfig.h"
+#include "config/GORegisteredOrgan.h"
 #include "files/GOStdFileName.h"
 #include "gui/dialogs/midi-event/GOMidiEventDialog.h"
 #include "gui/size/GOAdditionalSizeKeeperProxy.h"
 #include "gui/wxcontrols/GOGrid.h"
 
-#include "GOOrgan.h"
 #include "GOOrganController.h"
 
 static const wxString EMPTY_STRING = wxEmptyString;
@@ -290,7 +290,8 @@ GOSettingsOrgans::PackageSlotSet GOSettingsOrgans::GetUsedPackages(
   return packagesUsed;
 }
 
-void GOSettingsOrgans::DisplayMidiCell(unsigned rowN, GOOrgan *pOrgan) {
+void GOSettingsOrgans::DisplayMidiCell(
+  unsigned rowN, GORegisteredOrgan *pOrgan) {
   m_GridOrgans->SetCellValue(
     rowN,
     GRID_COL_MIDI,
@@ -302,7 +303,7 @@ void GOSettingsOrgans::DisplayPathCell(unsigned rowN, const wxString &path) {
 }
 
 void GOSettingsOrgans::FillGridRow(unsigned rowN, OrganSlot &organSlot) {
-  GOOrgan *o = organSlot.p_CurrentOrgan;
+  GORegisteredOrgan *o = organSlot.p_CurrentOrgan;
   wxString title = o->GetChurchName();
 
   if (!o->IsUsable(m_config))
@@ -351,8 +352,9 @@ bool GOSettingsOrgans::TransferDataToWindow() {
     GOOrgan *o = m_OrigOrganList[i];
     wxString hash = o->GetOrganHash();
 
-    organSlot.p_OrigOrgan = o;
-    organSlot.p_CurrentOrgan = o;
+    organSlot.p_OrigOrgan = dynamic_cast<GORegisteredOrgan *>(o);
+    ;
+    organSlot.p_CurrentOrgan = organSlot.p_OrigOrgan;
     organSlot.is_packaged = !o->GetArchiveID().IsEmpty();
     organSlot.m_CurrentPath
       = organSlot.is_packaged ? o->GetArchivePath() : o->GetODFPath();
@@ -645,7 +647,8 @@ void GOSettingsOrgans::ReplaceOrganPath(
   OrganSlot *pOrganSlot = m_OrganSlotPtrsByGridLine[index];
 
   if (pOrganSlot->m_CurrentPath != newPath) {
-    GOOrgan *pNewOrgan = new GOOrgan(*pOrganSlot->p_CurrentOrgan);
+    GORegisteredOrgan *pNewOrgan
+      = new GORegisteredOrgan(*pOrganSlot->p_CurrentOrgan);
 
     if (pOrganSlot->is_packaged)
       pNewOrgan->SetArchivePath(newPath);

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsOrgans.h
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsOrgans.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -28,6 +28,7 @@ class GOArchiveFile;
 class GOConfig;
 class GOGrid;
 class GOOrgan;
+class GORegisteredOrgan;
 
 class GOSettingsOrgans : public GODialogTab {
 public:
@@ -54,8 +55,8 @@ private:
   };
   using PackageSlotSet = std::unordered_set<const PackageSlot *>;
   struct OrganSlot {
-    GOOrgan *p_OrigOrgan;
-    GOOrgan *p_CurrentOrgan;
+    GORegisteredOrgan *p_OrigOrgan;
+    GORegisteredOrgan *p_CurrentOrgan;
     bool is_packaged;
     wxString m_CurrentPath;
     bool is_AnyCacheExisting;
@@ -111,7 +112,7 @@ private:
   void RefreshButtons();
   VisibleOrganRecs GetCurrentOrganRecs();
 
-  void DisplayMidiCell(unsigned rowN, GOOrgan *pOrgan);
+  void DisplayMidiCell(unsigned rowN, GORegisteredOrgan *pOrgan);
   void DisplayPathCell(unsigned rowN, const wxString &path);
   void FillGridRow(unsigned rowN, OrganSlot &organSlot);
   void ReorderOrgans(const VisibleOrganRecs &newSortedRecs);

--- a/src/grandorgue/gui/frames/GOFrame.cpp
+++ b/src/grandorgue/gui/frames/GOFrame.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -26,6 +26,7 @@
 #include "archive/GOArchiveManager.h"
 #include "combinations/GOSetter.h"
 #include "config/GOConfig.h"
+#include "config/GORegisteredOrgan.h"
 #include "files/GOStdFileName.h"
 #include "gui/dialogs/GONewReleaseDialog.h"
 #include "gui/dialogs/GOProgressDialog.h"
@@ -49,7 +50,6 @@
 #include "GOApp.h"
 #include "GODocument.h"
 #include "GOEvent.h"
-#include "GOOrgan.h"
 #include "GOOrganController.h"
 #include "Images.h"
 #include "go_defs.h"
@@ -1347,11 +1347,14 @@ void GOFrame::OnMidiEvent(const GOMidiEvent &event) {
 
   if (event.IsAllowedToReload()) {
     ptr_vector<GOOrgan> &organs = m_config.GetOrganList();
-    for (auto pOrgan : organs)
-      if (pOrgan->Match(event) && pOrgan->IsUsable(m_config)) {
-        SendLoadOrgan(*pOrgan);
+    for (auto pOrgan : organs) {
+      GORegisteredOrgan *pO = dynamic_cast<GORegisteredOrgan *>(pOrgan);
+
+      if (pO && pO->Match(event) && pO->IsUsable(m_config)) {
+        SendLoadOrgan(*pO);
         break;
       }
+    }
   }
 }
 


### PR DESCRIPTION
In order to moving MIDI classes from `core` to `grandorgue` directories, this PR splits the `GOOrgan` class to two parts

- GOOrgan itself that does not depend on MIDI and rests in the `core` direcory
- GORegisteredOrgan that has a MIDI receiver and resides in the grandorgue/config directory

It is just refactoring. No GO behavior should be changed.