### PR TITLE
Removed support of linux distributions with GLIBC versions before 2.35 (ubuntu<22, debian<12, fedora<36, oracle linux<9)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,39 +97,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - run_on: ubuntu-20.04
+          - run_on: ubuntu-22.04
             for: linux
             prepare: "debian-based"
             build_on: linux
 
-          - run_on: ubuntu-20.04
+          - run_on: ubuntu-22.04
             for: linux
             prepare: "debian-based"
             build_on: linux
             pkg_suffix: wx32
 
-          - run_on: ubuntu-20.04
+          - run_on: ubuntu-22.04
             for: appimage-x86_64
             prepare: "debian-based"
             build_on: linux
 
-          - run_on: ubuntu-20.04
+          - run_on: ubuntu-22.04
             for: linux-armhf
             prepare: "debian-based"
             build_on: linux
     
-          - run_on: ubuntu-20.04
+          - run_on: ubuntu-22.04
             for: linux-armhf
             prepare: "debian-based"
             build_on: linux
             pkg_suffix: wx32
 
-          - run_on: ubuntu-20.04
+          - run_on: ubuntu-22.04
             for: linux-aarch64
             prepare: "debian-based"
             build_on: linux
 
-          - run_on: ubuntu-20.04
+          - run_on: ubuntu-22.04
             for: linux-aarch64
             prepare: "debian-based"
             build_on: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed support of linux distributions with GLIBC versions before 2.35 (ubuntu<22, debian<12, fedora<36, oracle linux<9)
 - Added capability of customising minimum amplitude level of enclosures added internally by GrandOrgue https://github.com/GrandOrgue/grandorgue/issues/782
 - Added resending midi events when exiting from MidiEventDialog https://github.com/GrandOrgue/grandorgue/issues/2062
 - Fixed incorrect default audio channels config https://github.com/GrandOrgue/grandorgue/issues/2115


### PR DESCRIPTION
Since Github drops support of ubuntu 20 runners (https://github.com/actions/runner-images/issues/11101), this PR switches building from ubuntu 20 to ubuntu 22.04 runners.

It causes GrandOrgue won't be more installable on linux distributions with glibc<2.35 https://repology.org/project/glibc/versions