### PR TITLE
Reimplemented GOKeyConvert::Shortcut as GOConfigEnum::Entry

### DIFF
--- a/src/core/config/GOConfigEnum.h
+++ b/src/core/config/GOConfigEnum.h
@@ -19,10 +19,8 @@ public:
     int value;
   };
 
-private:
   const std::vector<Entry> m_entries;
 
-public:
   GOConfigEnum(const std::vector<Entry> &entries) : m_entries(entries) {}
 
   const wxString &GetName(int value) const;

--- a/src/grandorgue/GOKeyConvert.cpp
+++ b/src/grandorgue/GOKeyConvert.cpp
@@ -9,7 +9,7 @@
 
 #include <wx/intl.h>
 
-static GOKeyConvert::Shortcut shortcuts[] = {
+const GOConfigEnum GOKeyConvert::SHORTCUTS({
   {wxTRANSLATE("back"), 8},
   {wxTRANSLATE("tab"), 9},
   {wxTRANSLATE("return"), 13},
@@ -128,15 +128,7 @@ static GOKeyConvert::Shortcut shortcuts[] = {
   {wxTRANSLATE("}"), 221},
   {wxTRANSLATE("#"), 222},
   {wxTRANSLATE("`"), 223},
-};
-
-unsigned GOKeyConvert::getShortcutKeyCount() {
-  return sizeof(shortcuts) / sizeof(Shortcut);
-}
-
-const GOKeyConvert::Shortcut *GOKeyConvert::getShortcutKeys() {
-  return shortcuts;
-}
+});
 
 int GOKeyConvert::wXKtoVK(int what) {
   switch (what) {

--- a/src/grandorgue/GOKeyConvert.h
+++ b/src/grandorgue/GOKeyConvert.h
@@ -10,15 +10,11 @@
 
 #include <wx/string.h>
 
+#include "config/GOConfigEnum.h"
+
 class GOKeyConvert {
 public:
-  struct Shortcut {
-    wxString name;
-    unsigned key_code;
-  };
-
-  static unsigned getShortcutKeyCount();
-  static const Shortcut *getShortcutKeys();
+  static const GOConfigEnum SHORTCUTS;
 
   static int wXKtoVK(int what);
 };


### PR DESCRIPTION
This is a next PR related to #1199

It uses the `GOConfigEnum` class instead of the old code of converting between key codes and key names.
In the future it will be used for export and import shottcut keys to/from text files.

It is just refactoring. No GrandOrgue behavior should be changed.