### PR TITLE
Fixed pre-commit githob actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           # load full history for nanoufo/copyright-hook pre-commit hook
           fetch-depth: 0
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: actions/setup-python@v5.5.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,4 +14,6 @@ jobs:
           # load full history for nanoufo/copyright-hook pre-commit hook
           fetch-depth: 0
       - uses: actions/setup-python@v5.5.0
+        with:
+          python_version: 3.12
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,5 +15,5 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5.5.0
         with:
-          python_version: 3.12
+          python-version: 3.12
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Since 15-apr no pre-commit actions could work on GitHub.

This PR fixes this problem.