### PR TITLE
Fixed crash on closing an organ when the MidiObjects dialog was open

### DIFF
--- a/src/grandorgue/gui/dialogs/GOMidiObjectsDialog.cpp
+++ b/src/grandorgue/gui/dialogs/GOMidiObjectsDialog.cpp
@@ -212,3 +212,9 @@ void GOMidiObjectsDialog::OnActionButton(wxCommandEvent &event) {
   GOMidiObject *obj = GetSelectedObject();
   obj->TriggerElementActions(event.GetId() - ID_BUTTON);
 }
+
+void GOMidiObjectsDialog::OnHide() {
+  // remove references to the organ objects before destructing
+  m_ObjectListeners.clear();
+  GOSimpleDialog::OnHide();
+}

--- a/src/grandorgue/gui/dialogs/GOMidiObjectstDialog.h
+++ b/src/grandorgue/gui/dialogs/GOMidiObjectstDialog.h
@@ -68,6 +68,8 @@ private:
   void OnStatusButton(wxCommandEvent &event);
   void OnActionButton(wxCommandEvent &event);
 
+  void OnHide() override;
+
   DECLARE_EVENT_TABLE()
 };
 


### PR DESCRIPTION
This PR fixes a bug introduced by #2146

With this PR GrandOrgue does not more crash when closing an organ while the MidiObject dialog is open.

