### PR TITLE
Added the const qualifier to GOMidiMap::GetDeviceLogicalNameById

### DIFF
--- a/src/grandorgue/midi/GOMidiMap.cpp
+++ b/src/grandorgue/midi/GOMidiMap.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -17,7 +17,7 @@ GOMidiMap::GOMidiMap() : m_DeviceMap(), m_ElementMap() {
 
 GOMidiMap::~GOMidiMap() {}
 
-const wxString &GOMidiMap::GetDeviceLogicalNameById(unsigned id) {
+const wxString &GOMidiMap::GetDeviceLogicalNameById(unsigned id) const {
   assert(id <= m_DeviceMap.size());
   return m_DeviceMap[id];
 }

--- a/src/grandorgue/midi/GOMidiMap.h
+++ b/src/grandorgue/midi/GOMidiMap.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -22,7 +22,7 @@ public:
   ~GOMidiMap();
 
   unsigned GetDeviceIdByLogicalName(const wxString &str);
-  const wxString &GetDeviceLogicalNameById(unsigned id);
+  const wxString &GetDeviceLogicalNameById(unsigned id) const;
 
   unsigned GetElementByString(const wxString &str);
   const wxString &GetElementByID(unsigned id);


### PR DESCRIPTION
This is a very small PR.

No GrandOrgue behavior should be changed.