### PR TITLE
Fixed compilation on a recent gcc https://github.com/GrandOrgue/grandorgue/discussions/2183

### DIFF
--- a/src/core/GOWave.h
+++ b/src/core/GOWave.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,9 +8,10 @@
 #ifndef GOWAVE_H
 #define GOWAVE_H
 
-#include <wx/string.h>
-
+#include <cstdint>
 #include <vector>
+
+#include <wx/string.h>
 
 #include "GOBuffer.h"
 #include "GOWaveLoop.h"


### PR DESCRIPTION
This PR allows to compile GrandOrgue with recent gcc versions.