### PR TITLE
Introduced class GOStringSet

### DIFF
--- a/src/core/GOStringSet.h
+++ b/src/core/GOStringSet.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSTRINGSET_H
+#define GOSTRINGSET_H
+
+#include <unordered_set>
+
+#include <wx/hashmap.h>
+#include <wx/string.h>
+
+using GOStringSet = std::unordered_set<wxString, wxStringHash, wxStringEqual>;
+
+#endif /* GOSTRINGSET_H */

--- a/src/core/config/GOConfigReader.h
+++ b/src/core/config/GOConfigReader.h
@@ -8,14 +8,12 @@
 #ifndef GOCONFIGREADER_H
 #define GOCONFIGREADER_H
 
-#include <unordered_set>
-
-#include <wx/hashmap.h>
 #include <wx/string.h>
 
 #include "GOBool3.h"
 #include "GOConfigEnum.h"
 #include "GOLogicalColour.h"
+#include "GOStringSet.h"
 
 class GOConfigReaderDB;
 
@@ -23,10 +21,8 @@ typedef enum { ODFSetting, CMBSetting } GOSettingType;
 
 class GOConfigReader {
 private:
-  using StringSet = std::unordered_set<wxString, wxStringHash, wxStringEqual>;
-
   GOConfigReaderDB &m_Config;
-  StringSet m_GroupsInUse;
+  GOStringSet m_GroupsInUse;
   bool m_Strict;
   bool m_IsHw1Check;
 


### PR DESCRIPTION
This is a very small PR that allows to use a set of wxString outside the `GOConfigReader` class.

No GO behavior should be changed.
