### PR TITLE
Fixed spelling MIDI

### DIFF
--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -239,7 +239,7 @@ The use of the cache increases the necessary disk space.
           <simpara>File: file operations, exit</simpara>
         </listitem>
         <listitem>
-          <simpara>Audio/Midi: manage settings</simpara>
+          <simpara>Audio/MIDI: manage settings</simpara>
         </listitem>
         <listitem>
           <simpara>Panel: manage additional panels</simpara>
@@ -482,7 +482,7 @@ volume spinner value; temperament setting; fine tuning data.
         <sect3>
           <title id="audiomidisettings">Settings...</title>
           <indexterm>
-            <primary>Audio/Midi Settings</primary>
+            <primary>Audio/MIDI Settings</primary>
           </indexterm>
           <para>
 Displays a tabbed dialog containing the various settings.
@@ -509,17 +509,17 @@ free the RAM it required.
 Closes and exits the GrandOrgue app.
 </para>
         <para>
-          Exit can also be fired by a MIDI message, see Audio/Midi menu &rarr; <link linkend="midiobjects">MIDI Objects</link> (look for type Button, element Exit).
+          Exit can also be fired by a MIDI message, see Audio/MIDI menu &rarr; <link linkend="midiobjects">MIDI Objects</link> (look for type Button, element Exit).
 </para>
         </sect3>
       </sect2>
       <sect2>
-        <title>Audio/Midi Menu</title>
+        <title>Audio/MIDI Menu</title>
         <indexterm>
           <primary>Audio Menu</primary>
         </indexterm>
         <para>
-The Audio/Midi menu contains commands for dealing with loaded organs and
+The Audio/MIDI menu contains commands for dealing with loaded organs and
 associated settings.
 </para>
         <sect3 id="temperamentsMenu">
@@ -553,7 +553,7 @@ Opens a bunch of menus and sub menus allowing to select a new tuning temperament
         </sect3>
         <sect3 id="midiobjects">
           <title>MIDI Objects</title>
-          <indexterm><primary>Midi Objects</primary></indexterm>
+          <indexterm><primary>MIDI Objects</primary></indexterm>
           <figure>
             <title>MIDI Objects</title>
             <mediaobject>
@@ -609,7 +609,7 @@ unnecessary, although it may be useful if you need to quickly stop the
 sound output, or if the sound is breaking up due to CPU overload.
 </para>
           <para>
-Panic button can also be fired by a MIDI message, see Audio/Midi menu &rarr; <link linkend="midiobjects">MIDI Objects</link> (look for type Button, element Panic).
+Panic button can also be fired by a MIDI message, see Audio/MIDI menu &rarr; <link linkend="midiobjects">MIDI Objects</link> (look for type Button, element Panic).
 </para>
         </sect3>
         <sect3 id="memoryset">
@@ -726,7 +726,7 @@ program will jump directly to the appropriate topic.
           </imageobject>
         </mediaobject>
         <para>
-This "button" is a shortcut to <link linkend="memoryset">Memory Set</link> in the <emphasis>Audio/Midi menu</emphasis>.</para>
+This "button" is a shortcut to <link linkend="memoryset">Memory Set</link> in the <emphasis>Audio/MIDI menu</emphasis>.</para>
         <para>The <emphasis>Shift</emphasis> key on the computer keyboard is a fugitive shortcut to this button: when the user clicks on a piston while holding the <emphasis>Shift</emphasis> key, the currently pulled drawstops are stored in the piston memory.</para>
       </sect2>
       <sect2>
@@ -837,7 +837,7 @@ unnecessary, although it may be useful if you need to quickly stop the
 sound output, or if the sound is breaking up due to CPU overload.
         </para>
         <para>
-Panic button can also be fired by a MIDI message, see Audio/Midi menu &rarr; <link linkend="midiobjects">MIDI Objects</link> (look for type Button, element Panic).
+Panic button can also be fired by a MIDI message, see Audio/MIDI menu &rarr; <link linkend="midiobjects">MIDI Objects</link> (look for type Button, element Panic).
 </para>
       </sect2>
     </sect1>
@@ -941,7 +941,7 @@ displayed in chronological order: oldest on the first line.
   </chapter>
   <chapter id="midieventeditor">
     <title>MIDI Event Editor</title>
-    <indexterm><primary>Midi Event Editor</primary></indexterm>
+    <indexterm><primary>MIDI Event Editor</primary></indexterm>
     <para>
 Every console element, including those defined on <link
 linkend="panel">panels</link>, is configurable with this editor. The
@@ -4390,7 +4390,7 @@ role="strong">STOP</emphasis> button is depressed.
               </row>
               <row>
                 <entry><emphasis role="strong">MIDI player</emphasis></entry>
-                <entry>This is the folder where GrandOrgue looks for MIDI recording files. It is opened when the <link linkend="PlayMidi">Audio/Midi &gt; Load MIDI</link> menu item is selected.</entry>
+                <entry>This is the folder where GrandOrgue looks for MIDI recording files. It is opened when the <link linkend="PlayMidi">Audio/MIDI &gt; Load MIDI</link> menu item is selected.</entry>
                 <entry>Default: <emphasis>MIDI player</emphasis></entry>
               </row>
             </tbody>
@@ -4802,7 +4802,7 @@ role="strong">STOP</emphasis> button is depressed.
           </mediaobject>
         </figure>
         <para>
-          This dialog allows to define matching rules for audio/midi device
+          This dialog allows to define matching rules for audio/MIDI device
           names  
         </para>
         <variablelist>
@@ -4900,7 +4900,7 @@ role="strong">STOP</emphasis> button is depressed.
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term>Midi ports</term>
+          <term>MIDI ports</term>
           <listitem>
             <para>
               By checking or unchecking the MIDI ports it's possible to filter
@@ -5349,14 +5349,14 @@ recorded release tail of wet samples.
         <title>User-defined Temperaments</title>
         <mediaobject><imageobject><imagedata fileref="images/settings_temperaments.png" /></imageobject></mediaobject>
       </figure>
-      <para>This tab enables the user to add his own custom temperaments. User-defined temperaments are displayed in dynamic submenus in the <emphasis>Audio/Midi &gt; Temperaments</emphasis> menu.</para>
+      <para>This tab enables the user to add his own custom temperaments. User-defined temperaments are displayed in dynamic submenus in the <emphasis>Audio/MIDI &gt; Temperaments</emphasis> menu.</para>
       <para>The <emphasis role="bold">Add</emphasis> button adds a new "empty" line.</para>
       <para>The <emphasis role="bold">Delete</emphasis> button deletes the selected line.</para>
       <variablelist>
         <varlistentry>
           <term>Group</term>
           <listitem><simpara>
-Defines the submenu label in the <emphasis>Audio/Midi &gt;
+Defines the submenu label in the <emphasis>Audio/MIDI &gt;
 Temperaments</emphasis> menu. The submenus are dynamically added as soon as
 this screen has entries. Entries having the same <emphasis
 role="bold">Group</emphasis> attribute are grouped in the same submenu.
@@ -6305,7 +6305,7 @@ controls.
           <varlistentry>
             <term>Hidden buttons</term>
             <listitem>
-              <simpara>There are two hidden buttons, <link linkend="panicButton">Panic</link> and <link linkend="fileExit">Exit GO</link>, that serve as MIDI receivers only, not visible in this panel for mouse interaction. To configure them, go to Audio/Midi menu &rarr; <link linkend="midiobjects">MIDI Objects</link> and look for type Button, elements Panic resp. Exit to assign MIDI events that will fire the two functions. 
+              <simpara>There are two hidden buttons, <link linkend="panicButton">Panic</link> and <link linkend="fileExit">Exit GO</link>, that serve as MIDI receivers only, not visible in this panel for mouse interaction. To configure them, go to Audio/MIDI menu &rarr; <link linkend="midiobjects">MIDI Objects</link> and look for type Button, elements Panic resp. Exit to assign MIDI events that will fire the two functions. 
               </simpara>
             </listitem>
           </varlistentry>
@@ -6474,7 +6474,7 @@ current preset file.
         <title>Temperament</title>
         <para>
 The second row controls the ability to navigate the temperaments list. The temperament selection in the master controls panels is mirrored in the
-<link linkend="temperamentsMenu">Temperament</link> menu item of the <emphasis>Audio/Midi</emphasis> menu.
+<link linkend="temperamentsMenu">Temperament</link> menu item of the <emphasis>Audio/MIDI</emphasis> menu.
         </para>
         <informaltable frame="none">
           <tgroup cols="2">
@@ -10353,7 +10353,7 @@ fraction in the sample to 0 unless Pipe999MIDIPitchFraction is also specified.
 	(float 0 - 100, default: -1) If -1, use pitch information from the
 	Pipe999 sample, else override the information in the sample with this
 	value. Describes the actual existing pitch fraction in cent over the
-	normal (440hz equal) tone of the midi key specified in the sample or in
+	normal (440hz equal) tone of the MIDI key specified in the sample or in
 	the Pipe999MIDIKeyNumber. This setting (together with
 	Pipe999MIDIKeyNumber) is used when retuning to other temperaments.
       </para>

--- a/src/grandorgue/combinations/control/GOCombinationButtonSet.cpp
+++ b/src/grandorgue/combinations/control/GOCombinationButtonSet.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,7 +12,7 @@
 void GOCombinationButtonSet::updateOneButtonLight(
   GOButtonControl *pButton, GOButtonControl *buttonToLight) {
   if (pButton) {
-    // switch off and then on is necessary for sending midi events
+    // switch off and then on is necessary for sending MIDI events
     pButton->Display(false);
     if (pButton == buttonToLight)
       pButton->Display(true);

--- a/src/grandorgue/config/GOMidiDeviceConfigList.h
+++ b/src/grandorgue/config/GOMidiDeviceConfigList.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -69,7 +69,7 @@ public:
     const GOMidiDeviceConfig &devConfSrc, GOMidiDeviceConfig &devConfDst) const;
 
   /**
-   * Add a midi device config to the list
+   * Add a MIDI device config to the list
    * @param devConf the source config
    * @param outputList the list for finding output device by name
    * @return the reference to the new device
@@ -79,8 +79,8 @@ public:
     const GOMidiDeviceConfigList *outputList = NULL);
 
   /**
-   * Add a midi device to the list
-   * @param logicalName the logical name of the midi device
+   * Add a MIDI device to the list
+   * @param logicalName the logical name of the MIDI device
    * @param regEx regex for matching with physical device
    * @param isEnabled is this device enabled
    * @param physicalName the physicalName this device is matched with

--- a/src/grandorgue/gui/dialogs/GOMidiObjectsDialog.cpp
+++ b/src/grandorgue/gui/dialogs/GOMidiObjectsDialog.cpp
@@ -8,33 +8,19 @@
 #include "GOMidiObjectstDialog.h"
 
 #include <wx/button.h>
-#include <wx/filedlg.h>
-#include <wx/filename.h>
-#include <wx/log.h>
-#include <wx/msgdlg.h>
 #include <wx/sizer.h>
 
-#include "config/GOConfigFileReader.h"
-#include "config/GOConfigFileWriter.h"
-#include "config/GOConfigReader.h"
-#include "config/GOConfigReaderDB.h"
-#include "config/GOConfigWriter.h"
 #include "gui/size/GOAdditionalSizeKeeperProxy.h"
 #include "gui/wxcontrols/GOGrid.h"
 #include "midi/objects/GOMidiObject.h"
 #include "midi/objects/GOMidiObjectContext.h"
-#include "model/GOOrganModel.h"
-#include "yaml/GOYamlModel.h"
 
 #include "GOEvent.h"
-#include "go-message-boxes.h"
 
 enum {
   ID_LIST = 200,
   ID_EDIT,
   ID_STATUS,
-  ID_BUTTON_EXPORT,
-  ID_BUTTON_IMPORT,
   ID_BUTTON,
   ID_BUTTON_LAST = ID_BUTTON + 2,
 };
@@ -44,8 +30,6 @@ EVT_GRID_CMD_SELECT_CELL(ID_LIST, GOMidiObjectsDialog::OnSelectCell)
 EVT_GRID_CMD_CELL_LEFT_DCLICK(ID_LIST, GOMidiObjectsDialog::OnObjectDoubleClick)
 EVT_BUTTON(ID_EDIT, GOMidiObjectsDialog::OnConfigureButton)
 EVT_BUTTON(ID_STATUS, GOMidiObjectsDialog::OnStatusButton)
-EVT_BUTTON(ID_BUTTON_EXPORT, GOMidiObjectsDialog::OnExportButton)
-EVT_BUTTON(ID_BUTTON_IMPORT, GOMidiObjectsDialog::OnImportButton)
 EVT_COMMAND_RANGE(
   ID_BUTTON, ID_BUTTON_LAST, wxEVT_BUTTON, GOMidiObjectsDialog::OnActionButton)
 END_EVENT_TABLE()
@@ -57,32 +41,6 @@ enum {
   GRID_COL_CONFIGURED,
   GRID_N_COLS,
 };
-
-static wxString concat_file_specs(const wxString &one, const wxString &two) {
-  return wxString::Format("%s|%s", one, two);
-}
-
-static wxString concat_file_spec(const wxString &descFmt, const wxString &pat) {
-  return concat_file_specs(wxString::Format(descFmt, pat), pat);
-}
-
-static const wxString WX_GRID_MIDI_OBJECTS = wxT("GridMidiObjects");
-static const wxString WX_MIDI_SETTINGS = wxT("MIDI Settings");
-static const wxString WX_MIDI_SETTINGS_EXT_PURE = wxT("yaml");
-static const wxString WX_MIDI_SETTINGS_EXT
-  = wxT(".") + WX_MIDI_SETTINGS_EXT_PURE;
-static const wxString WX_MIDI_SETTINGS_FILE_PAT
-  = wxT("*") + WX_MIDI_SETTINGS_EXT;
-static const wxString WX_MIDI_FILES_SPEC
-  = concat_file_spec(_("Midi Settings files (%s)"), WX_MIDI_SETTINGS_FILE_PAT);
-static const wxString WX_CMB_FILE_PAT = wxT("*.cmb");
-static const wxString WX_CMB_FILES_SPEC
-  = concat_file_spec(_("Settings files (%s)"), WX_CMB_FILE_PAT);
-static const wxString WX_IMPORT_SPEC
-  = concat_file_specs(WX_MIDI_FILES_SPEC, WX_CMB_FILES_SPEC);
-static const wxString WX_ERROR = _("Error");
-static const wxString WX_ORGAN = wxT("Organ");
-static const wxString WX_ORGAN_NAME = wxT("ChurchName");
 
 GOMidiObjectsDialog::ObjectConfigListener::ObjectConfigListener(
   GOMidiObjectsDialog &dialog, unsigned index, GOMidiObject *pObject)
@@ -99,19 +57,20 @@ void GOMidiObjectsDialog::ObjectConfigListener::OnSettingsApplied() {
 }
 
 GOMidiObjectsDialog::GOMidiObjectsDialog(
-  GODocumentBase *doc, wxWindow *parent, GOOrganModel &organModel)
+  GODocumentBase *doc,
+  wxWindow *parent,
+  GODialogSizeSet &dialogSizes,
+  const std::vector<GOMidiObject *> &midiObjects)
   : GOSimpleDialog(
     parent,
     wxT("MIDI Objects"),
     _("MIDI Objects"),
-    organModel.GetConfig().m_DialogSizes,
+    dialogSizes,
     wxEmptyString,
     0,
     wxCLOSE | wxHELP),
     GOView(doc, this),
-    m_ExportImportDir(organModel.GetConfig().ExportImportPath()),
-    m_OrganName(organModel.GetOrganName()),
-    r_MidiObjects(organModel.GetMidiObjects()) {
+    r_MidiObjects(midiObjects) {
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   topSizer->AddSpacer(5);
 
@@ -150,23 +109,10 @@ GOMidiObjectsDialog::GOMidiObjectsDialog(
   topSizer->Add(buttons, 0, wxALIGN_RIGHT | wxALL, 1);
 
   topSizer->AddSpacer(5);
-
-  // add a custom button 'Reason into the space of the standard dialog button
-  wxSizer *const pButtonSizer = GetButtonSizer();
-
-  if (pButtonSizer) {
-    pButtonSizer->InsertSpacer(2, 10);
-    m_ExportButton = new wxButton(this, ID_BUTTON_EXPORT, _("Export"));
-    pButtonSizer->Insert(
-      3, m_ExportButton, 0, wxALIGN_CENTRE_VERTICAL | wxLEFT | wxRIGHT, 2);
-    m_ImportButton = new wxButton(this, ID_BUTTON_IMPORT, _("Import"));
-    pButtonSizer->Insert(
-      4, m_ImportButton, 0, wxALIGN_CENTRE_VERTICAL | wxLEFT | wxRIGHT, 2);
-    pButtonSizer->InsertSpacer(6, 10);
-  }
-
   LayoutWithInnerSizer(topSizer);
 }
+
+static const wxString WX_GRID_MIDI_OBJECTS = wxT("GridMidiObjects");
 
 void GOMidiObjectsDialog::ApplyAdditionalSizes(
   const GOAdditionalSizeKeeper &sizeKeeper) {
@@ -265,169 +211,6 @@ void GOMidiObjectsDialog::OnStatusButton(wxCommandEvent &event) {
 void GOMidiObjectsDialog::OnActionButton(wxCommandEvent &event) {
   GOMidiObject *obj = GetSelectedObject();
   obj->TriggerElementActions(event.GetId() - ID_BUTTON);
-}
-
-wxString GOMidiObjectsDialog::ExportMidiSettings(
-  const wxString &fileName) const {
-  GOYamlModel::Out yamlOut(m_OrganName, WX_MIDI_SETTINGS);
-  YAML::Node &rootNode = yamlOut.m_GlobalNode;
-
-  for (const auto pObj : r_MidiObjects)
-    pObj->ToYaml(rootNode);
-
-  const wxString errMsg = yamlOut.writeTo(fileName);
-
-  if (!errMsg.IsEmpty())
-    wxLogError(errMsg);
-  return errMsg;
-}
-
-/**
- * Check the organName of the imported midi settings file. If it differs from
- * the current organ name then ask for the user
- * @param fileName the midi setting file name
- * @param organName the organ the midi settings file was saved of
- * @return true if the churchNames are the same or the user agree with importing
- *   the midi settings file
- */
-bool GOMidiObjectsDialog::IsToImportSettingsFor(
-  const wxString &fileName, const wxString &savedOrganName) const {
-  bool isToImport = true;
-
-  if (savedOrganName != m_OrganName) {
-    wxLogWarning(
-      _("This MIDI settings file '%s' was originally made for another organ "
-        "'%s'"),
-      fileName,
-      savedOrganName);
-    isToImport = wxMessageBox(
-                   wxString::Format(
-                     _("This MIDI settings file '%s' was originally made for "
-                       "another organ '%s'. Importing it can cause various "
-                       "problems. Should it really be imported?"),
-                     fileName,
-                     savedOrganName),
-                   _("Import MIDI Settings"),
-                   wxYES_NO,
-                   nullptr)
-      == wxYES;
-  }
-  return isToImport;
-}
-
-template <typename ImportObjFun>
-void GOMidiObjectsDialog::ImportAllObjects(ImportObjFun importObjFun) {
-  for (unsigned l = r_MidiObjects.size(), i = 0; i < l; i++) {
-    const auto pObj = r_MidiObjects[i];
-
-    importObjFun(*pObj);
-    RefreshIsConfigured(i, pObj);
-  }
-}
-
-wxString GOMidiObjectsDialog::ImportMidiSettings(const wxString &fileName) {
-  wxString errMsg;
-  const wxString fileExt = wxFileName(fileName).GetExt();
-
-  try {
-    if (fileExt == WX_MIDI_SETTINGS_EXT_PURE) {
-      GOYamlModel::In yamlIn(m_OrganName, fileName, WX_MIDI_SETTINGS);
-      const YAML::Node &rootNode = yamlIn.m_GlobalNode;
-      GOStringSet &usedPaths = yamlIn.m_UsedPaths;
-
-      if (is_to_import_to_this_organ(
-            m_OrganName,
-            WX_MIDI_SETTINGS,
-            fileName,
-            yamlIn.GetFileOrganName())) {
-        ImportAllObjects([&rootNode, &usedPaths](GOMidiObject &obj) {
-          obj.FromYaml(rootNode, usedPaths);
-        });
-        yamlIn.CheckAllUsed();
-      }
-    } else {
-      GOConfigFileReader cmbFile;
-
-      if (!cmbFile.Read(fileName))
-        throw wxString::Format(_("Unable to read '%s'"), fileName);
-
-      GOConfigReaderDB ini;
-      ini.ReadData(cmbFile, CMBSetting, false);
-      GOConfigReader cfg(ini);
-
-      wxString savedOrganName
-        = cfg.ReadString(CMBSetting, WX_ORGAN, WX_ORGAN_NAME);
-
-      if (is_to_import_to_this_organ(
-            m_OrganName, WX_MIDI_SETTINGS, fileName, savedOrganName))
-        ImportAllObjects(
-          [&cfg](GOMidiObject &obj) { obj.LoadMidiSettings(cfg); });
-    }
-  } catch (const wxString &error) {
-    errMsg = error;
-  } catch (const std::exception &e) {
-    errMsg = e.what();
-  } catch (...) { // We must not allow unhandled exceptions here
-    errMsg.Printf("Unknown exception");
-  }
-  if (!errMsg.IsEmpty()) {
-    wxLogError(errMsg);
-    GOMessageBox(errMsg, _("Import error"), wxOK | wxICON_ERROR, NULL);
-  }
-  return errMsg;
-}
-
-void GOMidiObjectsDialog::OnExportButton(wxCommandEvent &event) {
-  wxFileDialog dlg(
-    this,
-    _("Export MIDI Settings"),
-    m_ExportImportDir,
-    m_OrganName + WX_MIDI_SETTINGS_EXT,
-    WX_MIDI_FILES_SPEC,
-    wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
-
-  if (dlg.ShowModal() == wxID_OK) {
-    wxString exportedFilePath = dlg.GetPath();
-
-    if (!exportedFilePath.EndsWith(WX_MIDI_SETTINGS_EXT, nullptr))
-      exportedFilePath += WX_MIDI_SETTINGS_EXT;
-    const wxString errMsg = ExportMidiSettings(exportedFilePath);
-
-    if (!errMsg.IsEmpty())
-      GOMessageBox(
-        wxString::Format(
-          _("Failed to export MIDI settings to '%s': %s"),
-          exportedFilePath,
-          errMsg),
-        WX_ERROR,
-        wxOK | wxICON_ERROR,
-        this);
-  }
-}
-
-void GOMidiObjectsDialog::OnImportButton(wxCommandEvent &event) {
-  wxFileDialog dlg(
-    this,
-    _("Import Midi Settings"),
-    m_ExportImportDir,
-    m_OrganName + WX_MIDI_SETTINGS_EXT,
-    WX_IMPORT_SPEC,
-    wxFD_OPEN | wxFD_FILE_MUST_EXIST);
-
-  if (dlg.ShowModal() == wxID_OK) {
-    const wxString &importedFilePath = dlg.GetPath();
-    const wxString errMsg = ImportMidiSettings(importedFilePath);
-
-    if (!errMsg.IsEmpty())
-      GOMessageBox(
-        wxString::Format(
-          _("Failed to import MIDI settings from '%s': %s"),
-          importedFilePath,
-          errMsg),
-        WX_ERROR,
-        wxOK | wxICON_ERROR,
-        this);
-  }
 }
 
 void GOMidiObjectsDialog::OnHide() {

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiDevices.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiDevices.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -30,7 +30,7 @@ END_EVENT_TABLE()
 SettingsMidiDevices::SettingsMidiDevices(
   GOConfig &settings, GOMidi &midi, wxWindow *parent)
   : wxPanel(parent, wxID_ANY),
-    GOSettingsPorts(this, GOMidiPortFactory::getInstance(), _("Midi &ports")),
+    GOSettingsPorts(this, GOMidiPortFactory::getInstance(), _("MIDI &ports")),
     m_config(settings),
     m_Midi(midi),
     m_InDevices(m_Midi.GetInDevices(), m_config.m_MidiIn, this, ID_INDEVICES),
@@ -40,7 +40,7 @@ SettingsMidiDevices::SettingsMidiDevices(
   wxBoxSizer *box1 = new wxBoxSizer(wxHORIZONTAL);
 
   wxBoxSizer *midiPropSizer
-    = new wxStaticBoxSizer(wxVERTICAL, this, _("&Midi properties"));
+    = new wxStaticBoxSizer(wxVERTICAL, this, _("&MIDI properties"));
 
   m_AutoAddInput = new wxCheckBox();
   m_CheckOnStartup = new (wxCheckBox);

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiMessage.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiMessage.cpp
@@ -30,7 +30,7 @@ GOSettingsMidiMessage::GOSettingsMidiMessage(
     new wxStaticText(
       this,
       wxID_ANY,
-      _("Attention:\nThese initial midi settings only affect "
+      _("Attention:\nThese initial MIDI settings only affect "
         "the first load of a organ.\nRight-click on manuals, "
         "stops, ... to do further changes.")),
     0,

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsPaths.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsPaths.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -143,7 +143,7 @@ GOSettingsPaths::GOSettingsPaths(GOConfig &settings, wxWindow *parent)
     wxEXPAND);
 
   grid->Add(
-    new wxStaticText(this, wxID_ANY, _("Midi player:")),
+    new wxStaticText(this, wxID_ANY, _("MIDI player:")),
     0,
     wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT);
   grid->Add(

--- a/src/grandorgue/gui/frames/GOFrame.cpp
+++ b/src/grandorgue/gui/frames/GOFrame.cpp
@@ -267,7 +267,7 @@ GOFrame::GOFrame(
 
   wxMenuBar *menu_bar = new wxMenuBar;
   menu_bar->Append(m_file_menu, _("&File"));
-  menu_bar->Append(m_audio_menu, _("&Audio/Midi"));
+  menu_bar->Append(m_audio_menu, _("&Audio/MIDI"));
   menu_bar->Append(m_panel_menu, _("&Panel"));
   menu_bar->Append(help_menu, _("&Help"));
   SetMenuBar(menu_bar);

--- a/src/grandorgue/midi/GOMidiRecorder.cpp
+++ b/src/grandorgue/midi/GOMidiRecorder.cpp
@@ -30,7 +30,7 @@ enum {
 };
 
 static const GOMidiObjectContext MIDI_CONTEXT(
-  wxT("MidiRecorder"), _("MidiRecorder"));
+  wxT("MidiRecorder"), _("MIDIRecorder"));
 
 const GOElementCreator::ButtonDefinitionEntry BUTTON_DEFS[] = {
   {wxT("MidiRecorderRecord"),

--- a/src/grandorgue/midi/objects/GOMidiObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObject.cpp
@@ -61,7 +61,7 @@ void GOMidiObject::InitMidiObject(
 void GOMidiObject::ShowConfigDialog() {
   const bool isReadOnly = IsReadOnly();
   const wxString title
-    = wxString::Format(_("Midi-Settings for %s - %s"), r_MidiTypeName, m_name);
+    = wxString::Format(_("MIDI-Settings for %s - %s"), r_MidiTypeName, m_name);
   const wxString selector
     = wxString::Format(wxT("%s.%s"), r_MidiTypeCode, m_name);
 


### PR DESCRIPTION
This PR brings MIDI to uppercase in strings, comments and the help.

`Midi` remains in CammelCase in most class and variable names.

No GO behavior should be changed.