### PR TITLE
Fixed windows builds temporary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
             prepare: osx
             build_on: osx
 
-          - run_on: ubuntu-latest
+          - run_on: ubuntu-22.04
             for: win64
             prepare: "debian-based"
             build_on: linux


### PR DESCRIPTION
All windows builds have been broken since Github switched `ubuntu-latest` fro 22.04 to 24.04. This PR temporary fixes #2190 by reverting build to 22.04.

Future investigation is needed for solving the issue with recent ubuntu versions.

