### PR TITLE
Fixed crash on reloading an organ https://github.com/GrandOrgue/grandorgue/issues/2185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on reloading an organ https://github.com/GrandOrgue/grandorgue/issues/2185
 - Removed support of linux distributions with GLIBC versions before 2.35 (ubuntu<22, debian<12, fedora<36, oracle linux<9)
 - Added capability of customising minimum amplitude level of enclosures added internally by GrandOrgue https://github.com/GrandOrgue/grandorgue/issues/782
 - Added resending midi events when exiting from MidiEventDialog https://github.com/GrandOrgue/grandorgue/issues/2062

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -144,15 +144,17 @@ GOOrganController::~GOOrganController() {
   m_tremulants.clear();
   m_ranks.clear();
   m_VirtualCouplers.Cleanup();
-  if (m_timer)
-    delete m_timer;
-  if (m_bitmaps)
-    delete m_bitmaps;
   GOOrganModel::Cleanup();
   GOOrganModel::SetModelModificationListener(nullptr);
   GOOrganModel::SetMidiDialogCreator(nullptr);
   GOOrganModel::SetCombinationController(nullptr);
   m_elementcreators.clear();
+  // some elementcreator may reference to m_timer so we respect the deletion
+  // order
+  if (m_bitmaps)
+    delete m_bitmaps;
+  if (m_timer)
+    delete m_timer;
 }
 
 void GOOrganController::SetOrganModified(bool modified) {


### PR DESCRIPTION
Resolves: #2185

The reason of the crash was using a GOTimer instance that had already deleted from another objects that had not yet been deleted.

This PR changes the deletion order.