### PR TITLE
Renamed GOSettingsMidiMessage to GOSettingsMidiInitial https://githubcom/GrandOrgue/grandorgue/issues/1974

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -84,7 +84,7 @@ gui/dialogs/settings/GOSettingsDeviceMatchDialog.cpp
 gui/dialogs/settings/GOSettingsDialog.cpp
 gui/dialogs/settings/GOSettingsMidiDeviceList.cpp
 gui/dialogs/settings/GOSettingsMidiDevices.cpp
-gui/dialogs/settings/GOSettingsMidiMessage.cpp
+gui/dialogs/settings/GOSettingsMidiInitial.cpp
 gui/dialogs/settings/GOSettingsPaths.cpp
 gui/dialogs/settings/GOSettingsPorts.cpp
 gui/dialogs/settings/GOSettingsOptions.cpp

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsDialog.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsDialog.cpp
@@ -16,7 +16,7 @@
 
 #include "GOSettingsAudio.h"
 #include "GOSettingsMidiDevices.h"
-#include "GOSettingsMidiMessage.h"
+#include "GOSettingsMidiInitial.h"
 #include "GOSettingsOptions.h"
 #include "GOSettingsOrgans.h"
 #include "GOSettingsPaths.h"
@@ -61,7 +61,7 @@ GOSettingsDialog::GOSettingsDialog(
   AddTab(m_AudioPage, PAGE_AUDIO, _("Audio"));
   m_MidiDevicePage = new SettingsMidiDevices(config, midi, notebook);
   AddTab(m_MidiDevicePage, PAGE_MIDI_DEVICES, _("MIDI Devices"));
-  m_MidiMessagePage = new GOSettingsMidiMessage(config, midi, notebook);
+  m_MidiMessagePage = new GOSettingsMidiInitial(config, midi, notebook);
   AddTab(m_MidiMessagePage, PAGE_INITIAL_MIDI, _("Initial MIDI"));
   m_OrgansPage
     = new GOSettingsOrgans(config, midi, this, PAGE_ORGANS, _("Organs"));

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsDialog.h
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsDialog.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -18,7 +18,7 @@ class GOSound;
 class GOSettingsAudioGroup;
 class GOSettingsAudio;
 class SettingsMidiDevices;
-class GOSettingsMidiMessage;
+class GOSettingsMidiInitial;
 class GOSettingsOptions;
 class GOSettingsPaths;
 class GOSettingsOrgans;
@@ -45,7 +45,7 @@ private:
   GOSettingsPaths *m_PathsPage;
   GOSettingsAudio *m_AudioPage;
   SettingsMidiDevices *m_MidiDevicePage;
-  GOSettingsMidiMessage *m_MidiMessagePage;
+  GOSettingsMidiInitial *m_MidiMessagePage;
   GOSettingsOrgans *m_OrgansPage;
   GOSettingsReverb *m_ReverbPage;
   GOSettingsTemperaments *m_TemperamentsPage;

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
@@ -5,7 +5,7 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOSettingsMidiMessage.h"
+#include "GOSettingsMidiInitial.h"
 
 #include <wx/button.h>
 #include <wx/listctrl.h>
@@ -15,13 +15,13 @@
 #include "config/GOConfig.h"
 #include "gui/dialogs/midi-event/GOMidiEventDialog.h"
 
-BEGIN_EVENT_TABLE(GOSettingsMidiMessage, wxPanel)
-EVT_LIST_ITEM_SELECTED(ID_EVENTS, GOSettingsMidiMessage::OnEventsClick)
-EVT_LIST_ITEM_ACTIVATED(ID_EVENTS, GOSettingsMidiMessage::OnEventsDoubleClick)
-EVT_BUTTON(ID_PROPERTIES, GOSettingsMidiMessage::OnProperties)
+BEGIN_EVENT_TABLE(GOSettingsMidiInitial, wxPanel)
+EVT_LIST_ITEM_SELECTED(ID_EVENTS, GOSettingsMidiInitial::OnEventsClick)
+EVT_LIST_ITEM_ACTIVATED(ID_EVENTS, GOSettingsMidiInitial::OnEventsDoubleClick)
+EVT_BUTTON(ID_PROPERTIES, GOSettingsMidiInitial::OnProperties)
 END_EVENT_TABLE()
 
-GOSettingsMidiMessage::GOSettingsMidiMessage(
+GOSettingsMidiInitial::GOSettingsMidiInitial(
   GOConfig &settings, GOMidi &midi, wxWindow *parent)
   : wxPanel(parent, wxID_ANY), m_config(settings), m_midi(midi) {
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
@@ -69,11 +69,11 @@ GOSettingsMidiMessage::GOSettingsMidiMessage(
   m_Events->SetColumnWidth(2, wxLIST_AUTOSIZE_USEHEADER);
 }
 
-void GOSettingsMidiMessage::OnEventsClick(wxListEvent &event) {
+void GOSettingsMidiInitial::OnEventsClick(wxListEvent &event) {
   m_Properties->Enable();
 }
 
-void GOSettingsMidiMessage::OnEventsDoubleClick(wxListEvent &event) {
+void GOSettingsMidiInitial::OnEventsDoubleClick(wxListEvent &event) {
   m_Properties->Enable();
   int index = m_Events->GetFirstSelected();
 
@@ -94,7 +94,7 @@ void GOSettingsMidiMessage::OnEventsDoubleClick(wxListEvent &event) {
   m_Events->SetItem(index, 2, recv->GetEventCount() > 0 ? _("Yes") : _("No"));
 }
 
-void GOSettingsMidiMessage::OnProperties(wxCommandEvent &event) {
+void GOSettingsMidiInitial::OnProperties(wxCommandEvent &event) {
   wxListEvent listevent;
   OnEventsDoubleClick(listevent);
 }

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.h
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.h
@@ -1,12 +1,12 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GOSETTINGSMIDIMESSAGE_H
-#define GOSETTINGSMIDIMESSAGE_H
+#ifndef GOSETTINGSMIDIINITIAL_H
+#define GOSETTINGSMIDIINITIAL_H
 
 #include <wx/panel.h>
 
@@ -16,7 +16,7 @@ class wxButton;
 class wxListEvent;
 class wxListView;
 
-class GOSettingsMidiMessage : public wxPanel {
+class GOSettingsMidiInitial : public wxPanel {
   enum {
     ID_EVENTS,
     ID_PROPERTIES,
@@ -33,9 +33,9 @@ private:
   void OnProperties(wxCommandEvent &event);
 
 public:
-  GOSettingsMidiMessage(GOConfig &settings, GOMidi &midi, wxWindow *parent);
+  GOSettingsMidiInitial(GOConfig &settings, GOMidi &midi, wxWindow *parent);
 
   DECLARE_EVENT_TABLE()
 };
 
-#endif
+#endif // GOSETTINGSMIDIINITIAL_H


### PR DESCRIPTION
This is the first PR related to #1974.

It is just renaming a class and files. No GO behavior should be changed.