### PR TITLE
Introduced class GOMidiPlayingObject

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -161,6 +161,7 @@ midi/objects/GOMidiObject.cpp
 midi/objects/GOMidiObjectContext.cpp
 midi/objects/GOMidiObjectWithDivision.cpp
 midi/objects/GOMidiObjectWithShortcut.cpp
+midi/objects/GOMidiPlayingObject.cpp
 midi/objects/GOMidiReceivingSendingObject.cpp
 midi/objects/GOMidiSendingObject.cpp
 midi/ports/GOMidiInPort.cpp

--- a/src/grandorgue/gui/dialogs/GOMidiObjectsDialog.cpp
+++ b/src/grandorgue/gui/dialogs/GOMidiObjectsDialog.cpp
@@ -12,8 +12,9 @@
 
 #include "gui/size/GOAdditionalSizeKeeperProxy.h"
 #include "gui/wxcontrols/GOGrid.h"
-#include "midi/objects/GOMidiObject.h"
 #include "midi/objects/GOMidiObjectContext.h"
+#include "midi/objects/GOMidiPlayingObject.h"
+#include "model/GOOrganModel.h"
 
 #include "GOEvent.h"
 
@@ -43,7 +44,7 @@ enum {
 };
 
 GOMidiObjectsDialog::ObjectConfigListener::ObjectConfigListener(
-  GOMidiObjectsDialog &dialog, unsigned index, GOMidiObject *pObject)
+  GOMidiObjectsDialog &dialog, unsigned index, GOMidiPlayingObject *pObject)
   : r_dialog(dialog), m_index(index), p_object(pObject) {
   p_object->AddListener(this);
 }
@@ -60,7 +61,7 @@ GOMidiObjectsDialog::GOMidiObjectsDialog(
   GODocumentBase *doc,
   wxWindow *parent,
   GODialogSizeSet &dialogSizes,
-  const std::vector<GOMidiObject *> &midiObjects)
+  const std::vector<GOMidiPlayingObject *> &midiObjects)
   : GOSimpleDialog(
     parent,
     wxT("MIDI Objects"),
@@ -131,7 +132,7 @@ void GOMidiObjectsDialog::CaptureAdditionalSizes(
 }
 
 void GOMidiObjectsDialog::RefreshIsConfigured(
-  unsigned row, GOMidiObject *pObj) {
+  unsigned row, GOMidiPlayingObject *pObj) {
   m_ObjectsGrid->SetCellValue(
     row, GRID_COL_CONFIGURED, pObj->IsMidiConfigured() ? _("Yes") : _("No"));
 }
@@ -147,7 +148,7 @@ bool GOMidiObjectsDialog::TransferDataToWindow() {
   m_ObjectListeners.reserve(newRowCnt);
   m_ObjectsGrid->AppendRows(newRowCnt);
   for (unsigned i = 0; i < newRowCnt; i++) {
-    GOMidiObject *pObj = r_MidiObjects[i];
+    GOMidiPlayingObject *pObj = r_MidiObjects[i];
 
     m_ObjectListeners.emplace_back(*this, i, pObj);
     pObj->AddListener(&m_ObjectListeners[i]);
@@ -162,7 +163,7 @@ bool GOMidiObjectsDialog::TransferDataToWindow() {
   return true;
 }
 
-GOMidiObject *GOMidiObjectsDialog::GetSelectedObject() const {
+GOMidiPlayingObject *GOMidiObjectsDialog::GetSelectedObject() const {
   return r_MidiObjects[m_ObjectsGrid->GetGridCursorRow()];
 }
 
@@ -170,7 +171,7 @@ void GOMidiObjectsDialog::ConfigureSelectedObject() {
   int row = m_ObjectsGrid->GetGridCursorRow();
 
   if (row >= 0) {
-    GOMidiObject *pObj = r_MidiObjects[row];
+    GOMidiPlayingObject *pObj = r_MidiObjects[row];
 
     pObj->ShowConfigDialog();
   }
@@ -184,7 +185,7 @@ void GOMidiObjectsDialog::OnSelectCell(wxGridEvent &event) {
   m_StatusButton->Enable(isAnySelected);
   if (isAnySelected) {
     m_ObjectsGrid->SelectRow(index);
-    GOMidiObject *obj = r_MidiObjects[index];
+    GOMidiPlayingObject *obj = r_MidiObjects[index];
     std::vector<wxString> actions = obj->GetElementActions();
 
     for (unsigned i = 0; i < m_ActionButtons.size(); i++)
@@ -199,7 +200,7 @@ void GOMidiObjectsDialog::OnSelectCell(wxGridEvent &event) {
 }
 
 void GOMidiObjectsDialog::OnStatusButton(wxCommandEvent &event) {
-  GOMidiObject *obj = GetSelectedObject();
+  GOMidiPlayingObject *obj = GetSelectedObject();
   wxString status = obj->GetElementStatus();
 
   GOMessageBox(
@@ -209,7 +210,7 @@ void GOMidiObjectsDialog::OnStatusButton(wxCommandEvent &event) {
 }
 
 void GOMidiObjectsDialog::OnActionButton(wxCommandEvent &event) {
-  GOMidiObject *obj = GetSelectedObject();
+  GOMidiPlayingObject *obj = GetSelectedObject();
   obj->TriggerElementActions(event.GetId() - ID_BUTTON);
 }
 

--- a/src/grandorgue/gui/dialogs/GOMidiObjectstDialog.h
+++ b/src/grandorgue/gui/dialogs/GOMidiObjectstDialog.h
@@ -18,21 +18,23 @@ class wxButton;
 class wxGridEvent;
 
 class GOGrid;
-class GOMidiObject;
+class GOMidiPlayingObject;
+class GOOrganModel;
 
 class GOMidiObjectsDialog : public GOSimpleDialog, public GOView {
-private:
-  const std::vector<GOMidiObject *> &r_MidiObjects;
+  const std::vector<GOMidiPlayingObject *> &r_MidiObjects;
 
   class ObjectConfigListener : public GOMidiDialogListener {
   private:
     GOMidiObjectsDialog &r_dialog;
     unsigned m_index;
-    GOMidiObject *p_object;
+    GOMidiPlayingObject *p_object;
 
   public:
     ObjectConfigListener(
-      GOMidiObjectsDialog &dialog, unsigned index, GOMidiObject *pObject);
+      GOMidiObjectsDialog &dialog,
+      unsigned index,
+      GOMidiPlayingObject *pObject);
     ~ObjectConfigListener();
 
     void OnSettingsApplied() override;
@@ -49,17 +51,17 @@ public:
     GODocumentBase *doc,
     wxWindow *parent,
     GODialogSizeSet &dialogSizes,
-    const std::vector<GOMidiObject *> &midiObjects);
+    const std::vector<GOMidiPlayingObject *> &midiObjects);
 
 private:
   void ApplyAdditionalSizes(const GOAdditionalSizeKeeper &sizeKeeper) override;
   void CaptureAdditionalSizes(
     GOAdditionalSizeKeeper &sizeKeeper) const override;
 
-  void RefreshIsConfigured(unsigned row, GOMidiObject *pObj);
+  void RefreshIsConfigured(unsigned row, GOMidiPlayingObject *pObj);
   bool TransferDataToWindow() override;
 
-  GOMidiObject *GetSelectedObject() const;
+  GOMidiPlayingObject *GetSelectedObject() const;
   void ConfigureSelectedObject();
 
   void OnSelectCell(wxGridEvent &event);

--- a/src/grandorgue/midi/objects/GOMidiObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObject.cpp
@@ -7,37 +7,22 @@
 
 #include "GOMidiObject.h"
 
-#include <wx/intl.h>
-
 #include "midi/elements/GOMidiReceiver.h"
 #include "midi/elements/GOMidiSender.h"
 #include "midi/elements/GOMidiShortcutReceiver.h"
-#include "model/GOOrganModel.h"
 
 #include "GOMidiObjectContext.h"
 
 GOMidiObject::GOMidiObject(
-  GOOrganModel &organModel,
-  const wxString &midiTypeCode,
-  const wxString &midiType)
-  : r_OrganModel(organModel),
-    r_MidiMap(organModel.GetConfig().GetMidiMap()),
+  GOMidiMap &midiMap, const wxString &midiTypeCode, const wxString &midiType)
+  : r_MidiMap(midiMap),
     r_MidiTypeCode(midiTypeCode),
     r_MidiTypeName(midiType),
     p_MidiSender(nullptr),
     p_MidiReceiver(nullptr),
     p_ShortcutReceiver(nullptr),
     p_DivisionSender(nullptr),
-    p_context(nullptr) {
-  r_OrganModel.RegisterSoundStateHandler(this);
-  r_OrganModel.RegisterMidiObject(this);
-}
-
-GOMidiObject::~GOMidiObject() {
-  r_OrganModel.UnregisterSaveableObject(this);
-  r_OrganModel.UnRegisterMidiObject(this);
-  r_OrganModel.UnRegisterSoundStateHandler(this);
-}
+    p_context(nullptr) {}
 
 wxString GOMidiObject::GetContextTitle() const {
   return GOMidiObjectContext::getFullTitle(p_context);
@@ -54,24 +39,5 @@ void GOMidiObject::InitMidiObject(
   GOConfigReader &cfg, const wxString &group, const wxString &name) {
   SetGroup(group);
   m_name = name;
-  r_OrganModel.RegisterSaveableObject(this);
   LoadMidiObject(cfg, group, r_MidiMap);
-}
-
-void GOMidiObject::ShowConfigDialog() {
-  const bool isReadOnly = IsReadOnly();
-  const wxString title
-    = wxString::Format(_("MIDI-Settings for %s - %s"), r_MidiTypeName, m_name);
-  const wxString selector
-    = wxString::Format(wxT("%s.%s"), r_MidiTypeCode, m_name);
-
-  r_OrganModel.ShowMIDIEventDialog(
-    this,
-    title,
-    selector,
-    isReadOnly ? nullptr : p_MidiReceiver,
-    p_MidiSender,
-    isReadOnly ? nullptr : p_ShortcutReceiver,
-    p_DivisionSender,
-    this);
 }

--- a/src/grandorgue/midi/objects/GOMidiObject.h
+++ b/src/grandorgue/midi/objects/GOMidiObject.h
@@ -24,12 +24,7 @@ class GOMidiSender;
 class GOMidiShortcutReceiver;
 class GOOrganModel;
 
-class GOMidiObject : public GOSoundStateHandler,
-                     public GOSaveableObject,
-                     public GOMidiConfigDispatcher {
-protected:
-  GOOrganModel &r_OrganModel;
-
+class GOMidiObject : public GOSaveableObject, public GOMidiConfigDispatcher {
 private:
   GOMidiMap &r_MidiMap;
   const wxString &r_MidiTypeCode;
@@ -46,11 +41,9 @@ private:
 
 protected:
   GOMidiObject(
-    GOOrganModel &organModel,
+    GOMidiMap &midiMap,
     const wxString &midiTypeCode,
     const wxString &midiTypeName);
-
-  virtual ~GOMidiObject();
 
   GOMidiSender *GetMidiSender() const { return p_MidiSender; }
   void SetMidiSender(GOMidiSender *pMidiSender) { p_MidiSender = pMidiSender; }
@@ -110,17 +103,6 @@ public:
   }
 
   virtual bool IsReadOnly() const { return false; }
-
-  void PreparePlayback() override {}
-  void PrepareRecording() override {}
-  void AbortPlayback() override {}
-
-  void ShowConfigDialog();
-
-  // Used in the GOMidiList dialog
-  virtual wxString GetElementStatus() = 0;
-  virtual std::vector<wxString> GetElementActions() = 0;
-  virtual void TriggerElementActions(unsigned no) = 0;
 };
 
 #endif

--- a/src/grandorgue/midi/objects/GOMidiPlayingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiPlayingObject.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOMidiPlayingObject.h"
+
+#include <wx/intl.h>
+
+#include "model/GOOrganModel.h"
+
+GOMidiPlayingObject::GOMidiPlayingObject(
+  GOOrganModel &organModel,
+  const wxString &midiTypeCode,
+  const wxString &midiTypeName)
+  : GOMidiObject(
+    organModel.GetConfig().GetMidiMap(), midiTypeCode, midiTypeName),
+    r_OrganModel(organModel) {
+  r_OrganModel.RegisterSoundStateHandler(this);
+  r_OrganModel.RegisterMidiObject(this);
+  r_OrganModel.RegisterSaveableObject(this);
+}
+
+GOMidiPlayingObject::~GOMidiPlayingObject() {
+  r_OrganModel.UnregisterSaveableObject(this);
+  r_OrganModel.UnRegisterMidiObject(this);
+  r_OrganModel.UnRegisterSoundStateHandler(this);
+}
+
+void GOMidiPlayingObject::ShowConfigDialog() {
+  const bool isReadOnly = IsReadOnly();
+  const wxString title = wxString::Format(
+    _("MIDI-Settings for %s - %s"), GetMidiTypeName(), GetName());
+  const wxString selector
+    = wxString::Format(wxT("%s.%s"), GetMidiTypeCode(), GetName());
+
+  r_OrganModel.ShowMIDIEventDialog(
+    this,
+    title,
+    selector,
+    isReadOnly ? nullptr : GetMidiReceiver(),
+    GetMidiSender(),
+    isReadOnly ? nullptr : GetMidiShortcutReceiver(),
+    GetDivisionSender(),
+    this);
+}

--- a/src/grandorgue/midi/objects/GOMidiPlayingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiPlayingObject.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDIPLAYINGOBJECT_H
+#define GOMIDIPLAYINGOBJECT_H
+
+#include "GOMidiObject.h"
+
+class GOMidiPlayingObject : public GOMidiObject, public GOSoundStateHandler {
+protected:
+  GOOrganModel &r_OrganModel;
+
+public:
+  GOMidiPlayingObject(
+    GOOrganModel &organModel,
+    const wxString &midiTypeCode,
+    const wxString &midiTypeName);
+
+  virtual ~GOMidiPlayingObject();
+
+  void ShowConfigDialog();
+
+  void PreparePlayback() override {}
+  void PrepareRecording() override {}
+  void AbortPlayback() override {}
+
+  // Used in the GOMidiList dialog
+  virtual wxString GetElementStatus() = 0;
+  virtual std::vector<wxString> GetElementActions() = 0;
+  virtual void TriggerElementActions(unsigned no) = 0;
+};
+
+#endif /* GOMIDIPLAYINGOBJECT_H */

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
@@ -14,7 +14,7 @@ GOMidiSendingObject::GOMidiSendingObject(
   const wxString &midiTypeCode,
   const wxString &midiTypeName,
   GOMidiSenderType senderType)
-  : GOMidiObject(organModel, midiTypeCode, midiTypeName),
+  : GOMidiPlayingObject(organModel, midiTypeCode, midiTypeName),
     m_sender(organModel, senderType) {
   SetMidiSender(&m_sender);
 }
@@ -23,7 +23,7 @@ GOMidiSendingObject::~GOMidiSendingObject() { SetMidiSender(nullptr); }
 
 void GOMidiSendingObject::LoadMidiObject(
   GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) {
-  GOMidiObject::LoadMidiObject(cfg, group, midiMap);
+  GOMidiPlayingObject::LoadMidiObject(cfg, group, midiMap);
   m_sender.Load(cfg, group, midiMap);
 }
 
@@ -31,7 +31,7 @@ void GOMidiSendingObject::SetElementId(int id) { m_sender.SetElementID(id); }
 
 void GOMidiSendingObject::SaveMidiObject(
   GOConfigWriter &cfg, const wxString &group, GOMidiMap &midiMap) const {
-  GOMidiObject::SaveMidiObject(cfg, group, midiMap);
+  GOMidiPlayingObject::SaveMidiObject(cfg, group, midiMap);
   m_sender.Save(cfg, group, midiMap);
 }
 
@@ -42,21 +42,21 @@ void GOMidiSendingObject::ResendMidi() {
 
 void GOMidiSendingObject::OnSettingsApplied() {
   ResendMidi();
-  GOMidiObject::OnSettingsApplied();
+  GOMidiPlayingObject::OnSettingsApplied();
 }
 
 void GOMidiSendingObject::PreparePlayback() {
-  GOMidiObject::PreparePlayback();
+  GOMidiPlayingObject::PreparePlayback();
   m_sender.SetName(GetName());
 }
 
 void GOMidiSendingObject::PrepareRecording() {
-  GOMidiObject::PrepareRecording();
+  GOMidiPlayingObject::PrepareRecording();
   SendCurrentMidiValue();
 }
 
 void GOMidiSendingObject::AbortPlayback() {
   SendEmptyMidiValue();
-  GOMidiObject::AbortPlayback();
+  GOMidiPlayingObject::AbortPlayback();
   m_sender.SetName(wxEmptyString);
 }

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.h
@@ -10,11 +10,11 @@
 
 #include "midi/elements/GOMidiSender.h"
 
-#include "GOMidiObject.h"
+#include "GOMidiPlayingObject.h"
 
 class GOOrganModel;
 
-class GOMidiSendingObject : public GOMidiObject {
+class GOMidiSendingObject : public GOMidiPlayingObject {
 private:
   GOMidiSender m_sender;
 

--- a/src/grandorgue/model/GOEventHandlerList.h
+++ b/src/grandorgue/model/GOEventHandlerList.h
@@ -17,7 +17,7 @@ class GOCombinationButtonSet;
 class GOControl;
 class GOControlChangedHandler;
 class GOEventHandler;
-class GOMidiObject;
+class GOMidiPlayingObject;
 class GOReferencingObject;
 class GOSoundStateHandler;
 class GOSaveableObject;
@@ -61,7 +61,7 @@ private:
   UPVector<GOReferencingObject> m_ReferencingObjects;
   UPVector<GOCombinationButtonSet> m_CombinationButtonSets;
   UPVector<GOControlChangedHandler> m_ControlChangedHandlers;
-  UPVector<GOMidiObject> m_MidiObjects;
+  UPVector<GOMidiPlayingObject> m_MidiObjects;
   UPVector<GOEventHandler> m_MidiEventHandlers;
   UPVector<GOSoundStateHandler> m_SoundStateHandlers;
   UPVector<GOSaveableObject> m_SaveableObjects;
@@ -77,7 +77,7 @@ public:
     const {
     return m_CombinationButtonSets.AsVector();
   }
-  const std::vector<GOMidiObject *> &GetMidiObjects() const {
+  const std::vector<GOMidiPlayingObject *> &GetMidiObjects() const {
     return m_MidiObjects.AsVector();
   }
   const std::vector<GOEventHandler *> &GetMidiEventHandlers() const {
@@ -116,9 +116,11 @@ public:
     m_ControlChangedHandlers.Remove(handler);
   }
 
-  void RegisterMidiObject(GOMidiObject *obj) { m_MidiObjects.Add(obj); }
+  void RegisterMidiObject(GOMidiPlayingObject *obj) { m_MidiObjects.Add(obj); }
 
-  void UnRegisterMidiObject(GOMidiObject *obj) { m_MidiObjects.Remove(obj); }
+  void UnRegisterMidiObject(GOMidiPlayingObject *obj) {
+    m_MidiObjects.Remove(obj);
+  }
 
   void RegisterEventHandler(GOEventHandler *handler) {
     m_MidiEventHandlers.Add(handler);


### PR DESCRIPTION
For enchancing the initial MIDI tab of the organ settings, it has to operate with an GOMidiObject  instead of an GOMidiReceiver.

Earlier GOMidiObject was depending on the GOOrganModel instance of the current open organ, but the initial MIDI tab must be available even when there is no any current organ open.

So this PR extracts a part of GOMidiObject into a separate class GOMidiPlayingObject.

It is just refactoring. No GO behavior should be changed.