### PR TITLE
Extracted enum GOMidiSenderType into a separate header file

### DIFF
--- a/src/grandorgue/midi/events/GOMidiSenderEventPatternList.h
+++ b/src/grandorgue/midi/events/GOMidiSenderEventPatternList.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,13 +10,7 @@
 
 #include "GOMidiEventPatternList.h"
 #include "GOMidiSenderEventPattern.h"
-
-typedef enum {
-  MIDI_SEND_BUTTON,
-  MIDI_SEND_LABEL,
-  MIDI_SEND_ENCLOSURE,
-  MIDI_SEND_MANUAL,
-} GOMidiSenderType;
+#include "GOMidiSenderType.h"
 
 using GOMidiSenderEventPatternList
   = GOMidiEventPatternList<GOMidiSenderType, GOMidiSenderEventPattern>;

--- a/src/grandorgue/midi/events/GOMidiSenderType.h
+++ b/src/grandorgue/midi/events/GOMidiSenderType.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDISENDERTYPE_H
+#define GOMIDISENDERTYPE_H
+
+typedef enum {
+  MIDI_SEND_BUTTON,
+  MIDI_SEND_LABEL,
+  MIDI_SEND_ENCLOSURE,
+  MIDI_SEND_MANUAL,
+} GOMidiSenderType;
+
+#endif /* GOMIDISENDERTYPE_H */


### PR DESCRIPTION
For the symmetry with GOMidiReceiverType,

No GO behavior should be changed.