### PR TITLE
Added capability to have GOMidiSender without a GOMidiSendProxy instance

### DIFF
--- a/src/grandorgue/midi/elements/GOMidiSender.h
+++ b/src/grandorgue/midi/elements/GOMidiSender.h
@@ -22,13 +22,17 @@ class GOMidiSendProxy;
 
 class GOMidiSender : public GOMidiSenderEventPatternList, public GOMidiElement {
 private:
-  GOMidiSendProxy &r_proxy;
   int m_ElementID;
+  GOMidiSendProxy *p_proxy;
 
 public:
-  GOMidiSender(GOMidiSendProxy &proxy, GOMidiSenderType type);
+  GOMidiSender(GOMidiSenderType type);
 
-  void SetElementID(int id);
+  int GetElementId() const { return m_ElementID; }
+  void SetElementID(int id) { m_ElementID = id; }
+
+  GOMidiSendProxy *GetProxy() const { return p_proxy; }
+  void SetProxy(GOMidiSendProxy *pProxy) { p_proxy = pProxy; }
 
   void Load(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
   void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) const;

--- a/src/grandorgue/midi/objects/GOMidiObjectWithDivision.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithDivision.cpp
@@ -17,12 +17,14 @@ GOMidiObjectWithDivision::GOMidiObjectWithDivision(
   GOMidiReceiverType receiverType)
   : GOMidiReceivingSendingObject(
     organModel, midiTypeCode, midiTypeName, senderType, receiverType),
-    m_DivisionSender(organModel, MIDI_SEND_MANUAL) {
+    m_DivisionSender(MIDI_SEND_MANUAL) {
+  m_DivisionSender.SetProxy(&organModel);
   SetDivisionSender(&m_DivisionSender);
 }
 
 GOMidiObjectWithDivision::~GOMidiObjectWithDivision() {
   SetDivisionSender(nullptr);
+  m_DivisionSender.SetProxy(nullptr);
 }
 
 static const wxString WX_DIVISION = wxT("Division");

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
@@ -14,12 +14,15 @@ GOMidiSendingObject::GOMidiSendingObject(
   const wxString &midiTypeCode,
   const wxString &midiTypeName,
   GOMidiSenderType senderType)
-  : GOMidiPlayingObject(organModel, midiTypeCode, midiTypeName),
-    m_sender(organModel, senderType) {
+  : GOMidiPlayingObject(organModel, midiTypeCode, midiTypeName), m_sender(senderType) {
+  m_sender.SetProxy(&organModel);
   SetMidiSender(&m_sender);
 }
 
-GOMidiSendingObject::~GOMidiSendingObject() { SetMidiSender(nullptr); }
+GOMidiSendingObject::~GOMidiSendingObject() {
+  SetMidiSender(nullptr);
+  m_sender.SetProxy(nullptr);
+}
 
 void GOMidiSendingObject::LoadMidiObject(
   GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) {

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
@@ -14,7 +14,8 @@ GOMidiSendingObject::GOMidiSendingObject(
   const wxString &midiTypeCode,
   const wxString &midiTypeName,
   GOMidiSenderType senderType)
-  : GOMidiPlayingObject(organModel, midiTypeCode, midiTypeName), m_sender(senderType) {
+  : GOMidiPlayingObject(organModel, midiTypeCode, midiTypeName),
+    m_sender(senderType) {
   m_sender.SetProxy(&organModel);
   SetMidiSender(&m_sender);
 }


### PR DESCRIPTION
This small PR replaces GOMidiSendProxy &GOMidiSender::r_proxy with GOMidiSendProxy *GOMidiSender::p_proxy. It make capability of creating a GOMidiSender instance without having a GOMidiSendProxy object.

It will be necessary for saving MidiSender coniguration in GrandOrgue config without having opened an organ.

It is hust refactoring. No GO behavior should be changed.