### PR TITLE
Removed references from GOMidiReceiver to GOConfig

### DIFF
--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -251,7 +251,7 @@ GOConfig::GOConfig(wxString instance)
 }
 
 GOOrgan *GOConfig::CloneOrgan(const GOOrgan &newOrgan) const {
-  return new GORegisteredOrgan(*this, newOrgan);
+  return new GORegisteredOrgan(newOrgan);
 }
 
 bool GOConfig::IsValidOrgan(const GOOrgan *pOrgan) const {
@@ -415,7 +415,7 @@ void GOConfig::Load() {
       cfg, MIDI_PORTS, GOMidiPortFactory::getInstance(), m_MidiPortsConfig);
 
     for (unsigned i = 0; i < GetEventCount(); i++)
-      m_MIDIEvents[i]->Load(cfg, GetEventSection(i), m_MidiMap);
+      m_MIDIEvents[i]->Load(ODFCheck(), cfg, GetEventSection(i), m_MidiMap);
 
     long cpus = wxThread::GetCPUCount();
     if (cpus == -1)
@@ -463,8 +463,7 @@ void GOConfig::LoadDefaults() {
   m_ConfigFileName = GOStdPath::GetConfigDir() + wxFileName::GetPathSeparator()
     + wxT("GrandOrgueConfig") + m_InstanceName;
   for (unsigned i = 0; i < GetEventCount(); i++)
-    m_MIDIEvents.push_back(
-      new GOMidiReceiver(*this, INTERNAL_MIDI_DESCS[i].type));
+    m_MIDIEvents.push_back(new GOMidiReceiver(INTERNAL_MIDI_DESCS[i].type));
   m_ResourceDir = GOStdPath::GetResourceDir();
 
   OrganPath.SetDefaultValue(GOStdPath::GetGrandOrgueSubDir(_("Organs")));

--- a/src/grandorgue/config/GORegisteredOrgan.cpp
+++ b/src/grandorgue/config/GORegisteredOrgan.cpp
@@ -11,9 +11,8 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
-GORegisteredOrgan::GORegisteredOrgan(
-  const GOConfig &config, const GOOrgan &organ)
-  : GOOrgan(organ), m_midi(config, MIDI_RECV_ORGAN) {
+GORegisteredOrgan::GORegisteredOrgan(const GOOrgan &organ)
+  : GOOrgan(organ), m_midi(MIDI_RECV_ORGAN) {
   const GORegisteredOrgan *pRegOrgan
     = dynamic_cast<const GORegisteredOrgan *>(&organ);
 
@@ -30,10 +29,10 @@ GORegisteredOrgan::GORegisteredOrgan(
     cfg.ReadString(CMBSetting, group, wxT("ChurchName")),
     cfg.ReadString(CMBSetting, group, wxT("OrganBuilder")),
     cfg.ReadString(CMBSetting, group, wxT("RecordingDetail"))),
-    m_midi(config, MIDI_RECV_ORGAN) {
+    m_midi(MIDI_RECV_ORGAN) {
   m_LastUse = cfg.ReadInteger(
     CMBSetting, group, wxT("LastUse"), 0, INT_MAX, false, m_LastUse);
-  m_midi.Load(cfg, group, config.GetMidiMap());
+  m_midi.Load(config.ODFCheck(), cfg, group, config.GetMidiMap());
 }
 
 void GORegisteredOrgan::Save(

--- a/src/grandorgue/config/GORegisteredOrgan.h
+++ b/src/grandorgue/config/GORegisteredOrgan.h
@@ -21,7 +21,7 @@ private:
   GOMidiReceiver m_midi;
 
 public:
-  GORegisteredOrgan(const GOConfig &config, const GOOrgan &organ);
+  GORegisteredOrgan(const GOOrgan &organ);
   GORegisteredOrgan(
     GOConfig &config, GOConfigReader &cfg, const wxString &group);
 

--- a/src/grandorgue/midi/elements/GOMidiReceiver.h
+++ b/src/grandorgue/midi/elements/GOMidiReceiver.h
@@ -16,7 +16,6 @@
 #include "GOMidiElement.h"
 #include "GOTime.h"
 
-class GOConfig;
 class GOConfigReader;
 class GOConfigWriter;
 class GOMidiEvent;
@@ -35,8 +34,6 @@ private:
     int key;
   } midi_internal_match;
 
-  const GOConfig &r_config;
-
   int m_ElementID;
   std::vector<GOTime> m_last;
   std::vector<midi_internal_match> m_Internal;
@@ -48,13 +45,14 @@ private:
   void deleteInternal(unsigned device);
   unsigned createInternal(unsigned device);
 
-protected:
-  int GetTranspose() const;
-
 public:
-  GOMidiReceiver(const GOConfig &config, GOMidiReceiverType type);
+  GOMidiReceiver(GOMidiReceiverType type);
 
-  void Load(GOConfigReader &cfg, const wxString &group, GOMidiMap &map);
+  void Load(
+    bool isOdfCheck,
+    GOConfigReader &cfg,
+    const wxString &group,
+    GOMidiMap &map);
   void Save(GOConfigWriter &cfg, const wxString &group, GOMidiMap &map) const;
 
   void ToYaml(YAML::Node &yamlNode, GOMidiMap &map) const override;
@@ -70,9 +68,12 @@ public:
   void SetElementID(int id) { m_ElementID = id; }
 
   GOMidiMatchType Match(const GOMidiEvent &e);
-  GOMidiMatchType Match(const GOMidiEvent &e, int &value);
   GOMidiMatchType Match(
-    const GOMidiEvent &e, const KeyMap *pMidiMap, int &key, int &value);
+    const GOMidiEvent &e,
+    const KeyMap *pMidiMap,
+    int transpose,
+    int &key,
+    int &value);
 
   bool HasDebounce(GOMidiReceiverMessageType type) const;
   static bool hasChannel(GOMidiReceiverMessageType type);

--- a/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.cpp
@@ -17,7 +17,7 @@ GOMidiReceivingSendingObject::GOMidiReceivingSendingObject(
   GOMidiReceiverType receiverType)
   : GOMidiSendingObject(organModel, midiTypeCode, midiTypeName, senderType),
     m_ReceiverType(receiverType),
-    m_receiver(organModel.GetConfig(), receiverType),
+    m_receiver(receiverType),
     p_ReceiverKeyMap(nullptr),
     m_MidiInputNumber(-1) {
   SetMidiReceiver(&m_receiver);
@@ -56,7 +56,7 @@ void GOMidiReceivingSendingObject::LoadMidiObject(
   GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) {
   GOMidiSendingObject::LoadMidiObject(cfg, group, midiMap);
   if (!IsReadOnly()) {
-    m_receiver.Load(cfg, group, midiMap);
+    m_receiver.Load(r_OrganModel.GetConfig().ODFCheck(), cfg, group, midiMap);
     if (!m_receiver.IsMidiConfigured() && m_MidiInputNumber >= 0) {
       const GOMidiReceiver *pInitialEvents
         = r_OrganModel.GetConfig().FindMidiEvent(
@@ -92,8 +92,13 @@ void GOMidiReceivingSendingObject::ProcessMidi(const GOMidiEvent &event) {
   if (!IsReadOnly()) {
     int key;
     int value;
-    GOMidiMatchType matchType
-      = m_receiver.Match(event, p_ReceiverKeyMap, key, value);
+
+    GOMidiMatchType matchType = m_receiver.Match(
+      event,
+      p_ReceiverKeyMap,
+      r_OrganModel.GetConfig().Transpose(),
+      key,
+      value);
 
     if (matchType > MIDI_MATCH_NONE)
       OnMidiReceived(event, matchType, key, value);


### PR DESCRIPTION
This PR removes the looped dependency between GOMidiReceiver and GOConfig.

Now only GOConfig depends on GOMidiReceiver.

It is just refactoring. No GO Behavior should be changed.