### PR TITLE
Extracted the inner enum GOMidiShortcutPattern::ReceiverType to the high-level class GOMidiShortcutReceiverType

### DIFF
--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -27,7 +27,7 @@ GOButtonControl::GOButtonControl(
     midiTypeName,
     MIDI_SEND_BUTTON,
     midiType,
-    GOMidiShortcutReceiver::KEY_RECV_BUTTON),
+    KEY_RECV_BUTTON),
     m_Pushbutton(pushbutton),
     m_Displayed(false),
     m_Engaged(false),

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventKeyTab.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventKeyTab.cpp
@@ -32,9 +32,8 @@ GOMidiEventKeyTab::GOMidiEventKeyTab(
   wxBoxSizer *sizer = new wxStaticBoxSizer(
     wxVERTICAL,
     this,
-    m_key.GetType() == GOMidiShortcutPattern::KEY_RECV_ENCLOSURE
-      ? _("&Plus-Shortcut:")
-      : _("&Shortcut:"));
+    m_key.GetType() == KEY_RECV_ENCLOSURE ? _("&Plus-Shortcut:")
+                                          : _("&Shortcut:"));
   m_keyselect = new wxChoice(this, ID_KEY_SELECT);
   sizer->Add(m_keyselect, 1, wxEXPAND);
 
@@ -44,7 +43,7 @@ GOMidiEventKeyTab::GOMidiEventKeyTab(
 
   topSizer->Add(sizer, 0, wxALL | wxEXPAND, 6);
 
-  if (m_key.GetType() == GOMidiShortcutPattern::KEY_RECV_ENCLOSURE) {
+  if (m_key.GetType() == KEY_RECV_ENCLOSURE) {
     sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("&Minus-Shortcut:"));
     m_keyminusselect = new wxChoice(this, ID_MINUS_KEY_SELECT);
     sizer->Add(m_keyminusselect, 1, wxEXPAND);

--- a/src/grandorgue/midi/elements/GOMidiShortcutReceiver.h
+++ b/src/grandorgue/midi/elements/GOMidiShortcutReceiver.h
@@ -20,7 +20,8 @@ class GOConfigWriter;
 class GOMidiShortcutReceiver : public GOMidiShortcutPattern,
                                public GOMidiElement {
 public:
-  GOMidiShortcutReceiver(ReceiverType type) : GOMidiShortcutPattern(type) {}
+  GOMidiShortcutReceiver(GOMidiShortcutReceiverType type)
+    : GOMidiShortcutPattern(type) {}
 
   void Load(GOConfigReader &cfg, const wxString &group);
   void Save(GOConfigWriter &cfg, const wxString &group) const;

--- a/src/grandorgue/midi/events/GOMidiShortcutPattern.h
+++ b/src/grandorgue/midi/events/GOMidiShortcutPattern.h
@@ -8,12 +8,10 @@
 #ifndef GOMIDISHORTCUTPATTERN_H
 #define GOMIDISHORTCUTPATTERN_H
 
+#include "GOMidiShortcutReceiverType.h"
+
 class GOMidiShortcutPattern {
 public:
-  enum ReceiverType {
-    KEY_RECV_BUTTON,
-    KEY_RECV_ENCLOSURE,
-  };
   enum MatchType {
     KEY_MATCH_NONE,
     KEY_MATCH,
@@ -21,15 +19,15 @@ public:
   };
 
 protected:
-  ReceiverType m_type;
+  GOMidiShortcutReceiverType m_type;
   unsigned m_ShortcutKey = 0;
   unsigned m_MinusKey = 0;
 
 public:
-  GOMidiShortcutPattern(ReceiverType type) : m_type(type) {}
+  GOMidiShortcutPattern(GOMidiShortcutReceiverType type) : m_type(type) {}
   virtual ~GOMidiShortcutPattern() {}
 
-  ReceiverType GetType() const { return m_type; }
+  GOMidiShortcutReceiverType GetType() const { return m_type; }
 
   unsigned GetShortcut() const { return m_ShortcutKey; }
   void SetShortcut(unsigned key) { m_ShortcutKey = key; }

--- a/src/grandorgue/midi/events/GOMidiShortcutReceiverType.h
+++ b/src/grandorgue/midi/events/GOMidiShortcutReceiverType.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDISHORTCUTRECEIVERTYPE_H
+#define GOMIDISHORTCUTRECEIVERTYPE_H
+
+enum GOMidiShortcutReceiverType {
+  KEY_RECV_BUTTON,
+  KEY_RECV_ENCLOSURE,
+};
+
+#endif /* GOMIDISHORTCUTRECEIVERTYPE_H */

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
@@ -13,7 +13,7 @@ GOMidiObjectWithShortcut::GOMidiObjectWithShortcut(
   const wxString &midiTypeName,
   GOMidiSenderType senderType,
   GOMidiReceiverType receiverType,
-  GOMidiShortcutReceiver::ReceiverType shortcutType)
+  GOMidiShortcutReceiverType shortcutType)
   : GOMidiReceivingSendingObject(
     organModel, midiTypeCode, midiTypeName, senderType, receiverType),
     m_ShortcutReceiver(shortcutType) {

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
@@ -25,7 +25,7 @@ protected:
     const wxString &midiTypeName,
     GOMidiSenderType senderType,
     GOMidiReceiverType receiverType,
-    GOMidiShortcutReceiver::ReceiverType shortcutType);
+    GOMidiShortcutReceiverType shortcutType);
 
   virtual ~GOMidiObjectWithShortcut();
 

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -24,7 +24,7 @@ GOEnclosure::GOEnclosure(GOOrganModel &organModel)
     WX_MIDI_TYPE_NAME,
     MIDI_SEND_ENCLOSURE,
     MIDI_RECV_ENCLOSURE,
-    GOMidiShortcutReceiver::KEY_RECV_ENCLOSURE),
+    KEY_RECV_ENCLOSURE),
     m_IsOdfDefined(false),
     m_DefaultAmpMinimumLevel(0),
     m_Displayed1(false),


### PR DESCRIPTION
This is a small refactoring. No GO behavior should be changed.