### PR TITLE
Exposed WX_MIDI_TYPE_CODE and WX_MIDI_TYPE_NAME constants

### DIFF
--- a/src/grandorgue/control/GOCallbackButtonControl.cpp
+++ b/src/grandorgue/control/GOCallbackButtonControl.cpp
@@ -11,8 +11,8 @@
 
 #include "control/GOButtonCallback.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Button");
-static const wxString WX_MIDI_TYPE_NAME = _("Button");
+const wxString GOCallbackButtonControl::WX_MIDI_TYPE_CODE = wxT("Button");
+const wxString GOCallbackButtonControl::WX_MIDI_TYPE_NAME = _("Button");
 
 GOCallbackButtonControl::GOCallbackButtonControl(
   GOOrganModel &organModel,

--- a/src/grandorgue/control/GOCallbackButtonControl.h
+++ b/src/grandorgue/control/GOCallbackButtonControl.h
@@ -13,6 +13,10 @@
 class GOButtonCallback;
 
 class GOCallbackButtonControl : public GOButtonControl {
+public:
+  static const wxString WX_MIDI_TYPE_CODE;
+  static const wxString WX_MIDI_TYPE_NAME;
+
 protected:
   GOButtonCallback *m_callback;
 

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -14,8 +14,8 @@
 
 #include "GOOrganModel.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Enclosure");
-static const wxString WX_MIDI_TYPE_NAME = _("Enclosure");
+const wxString GOEnclosure::WX_MIDI_TYPE_CODE = wxT("Enclosure");
+const wxString GOEnclosure::WX_MIDI_TYPE_NAME = _("Enclosure");
 
 GOEnclosure::GOEnclosure(GOOrganModel &organModel)
   : GOMidiObjectWithShortcut(

--- a/src/grandorgue/model/GOEnclosure.h
+++ b/src/grandorgue/model/GOEnclosure.h
@@ -21,6 +21,10 @@ class GOConfigWriter;
 class GOOrganModel;
 
 class GOEnclosure : public GOControl, public GOMidiObjectWithShortcut {
+public:
+  static const wxString WX_MIDI_TYPE_CODE;
+  static const wxString WX_MIDI_TYPE_NAME;
+
 private:
   bool m_IsOdfDefined;
   uint8_t m_DefaultAmpMinimumLevel;

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -20,9 +20,9 @@
 #include "GOSwitch.h"
 #include "GOTremulant.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Manual");
-static const wxString WX_MIDI_TYPE_NAME = _("Manual");
-static const wxString WX_ODF_OBJ_NUM_FMT = wxT("%03u");
+const wxString GOManual::WX_MIDI_TYPE_CODE = wxT("Manual");
+const wxString GOManual::WX_MIDI_TYPE_NAME = _("Manual");
+const wxString WX_ODF_OBJ_NUM_FMT = wxT("%03u");
 
 GOManual::GOManual(
   GOOrganModel &organModel,

--- a/src/grandorgue/model/GOManual.h
+++ b/src/grandorgue/model/GOManual.h
@@ -29,6 +29,10 @@ class GOTremulant;
 class GOManual : public GOControl,
                  public GOMidiObjectWithDivision,
                  private GOCombinationButtonSet {
+public:
+  static const wxString WX_MIDI_TYPE_CODE;
+  static const wxString WX_MIDI_TYPE_NAME;
+
 private:
   std::vector<GOCoupler *> m_InputCouplers;
   /* Keyboard state */


### PR DESCRIPTION
This PR adds capability of using WX_MIDI_TYPE_CODE and WX_MIDI_TYPE_NAME constants outside their classes.

They will be used in the future.

No GO behavior should be changed.