### PR TITLE
Introduced enums of MIDI element types

### DIFF
--- a/src/grandorgue/midi/elements/GOMidiReceiver.cpp
+++ b/src/grandorgue/midi/elements/GOMidiReceiver.cpp
@@ -8,13 +8,21 @@
 #include "GOMidiReceiver.h"
 
 #include "config/GOConfig.h"
-#include "config/GOConfigEnum.h"
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 #include "midi/GOMidiMap.h"
 #include "midi/events/GOMidiEvent.h"
 #include "midi/events/GORodgers.h"
 #include "yaml/go-wx-yaml.h"
+
+const GOConfigEnum GOMidiReceiver::RECEIVER_TYPES({
+  {wxT("Drawstop"), MIDI_RECV_DRAWSTOP},
+  {wxT("Button"), MIDI_RECV_BUTTON},
+  {wxT("Enclosure"), MIDI_RECV_ENCLOSURE},
+  {wxT("Manual"), MIDI_RECV_MANUAL},
+  {wxT("Setter"), MIDI_RECV_SETTER},
+  {wxT("Organ"), MIDI_RECV_ORGAN},
+});
 
 static const GOConfigEnum MIDI_RECEIVE_TYPES({
   {wxT("ControlChange"), MIDI_M_CTRL_CHANGE},

--- a/src/grandorgue/midi/elements/GOMidiReceiver.h
+++ b/src/grandorgue/midi/elements/GOMidiReceiver.h
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 
+#include "config/GOConfigEnum.h"
 #include "midi/events/GOMidiMatchType.h"
 #include "midi/events/GOMidiReceiverEventPatternList.h"
 
@@ -24,7 +25,8 @@ class GOMidiMap;
 class GOMidiReceiver : public GOMidiReceiverEventPatternList,
                        public GOMidiElement {
 public:
-  constexpr static unsigned KEY_MAP_SIZE = 128;
+  static const GOConfigEnum RECEIVER_TYPES;
+  static constexpr unsigned KEY_MAP_SIZE = 128;
   using KeyMap = uint8_t[KEY_MAP_SIZE];
 
 private:

--- a/src/grandorgue/midi/elements/GOMidiSender.cpp
+++ b/src/grandorgue/midi/elements/GOMidiSender.cpp
@@ -10,7 +10,6 @@
 #include <wx/intl.h>
 #include <yaml-cpp/node/node.h>
 
-#include "config/GOConfigEnum.h"
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 #include "midi/GOMidiMap.h"
@@ -18,6 +17,13 @@
 #include "yaml/go-wx-yaml.h"
 
 #include "GOMidiSendProxy.h"
+
+const GOConfigEnum GOMidiSender::SENDER_TYPES({
+  {wxT("Button"), MIDI_SEND_BUTTON},
+  {wxT("Label"), MIDI_SEND_LABEL},
+  {wxT("Enclosure"), MIDI_SEND_ENCLOSURE},
+  {wxT("Manual"), MIDI_SEND_MANUAL},
+});
 
 GOMidiSender::GOMidiSender(GOMidiSenderType type)
   : GOMidiSenderEventPatternList(type), m_ElementID(-1), p_proxy(nullptr) {}

--- a/src/grandorgue/midi/elements/GOMidiSender.h
+++ b/src/grandorgue/midi/elements/GOMidiSender.h
@@ -11,6 +11,7 @@
 #include <wx/string.h>
 #include <yaml-cpp/yaml.h>
 
+#include "config/GOConfigEnum.h"
 #include "midi/events/GOMidiSenderEventPatternList.h"
 
 #include "GOMidiElement.h"
@@ -21,6 +22,9 @@ class GOMidiMap;
 class GOMidiSendProxy;
 
 class GOMidiSender : public GOMidiSenderEventPatternList, public GOMidiElement {
+public:
+  static const GOConfigEnum SENDER_TYPES;
+
 private:
   int m_ElementID;
   GOMidiSendProxy *p_proxy;

--- a/src/grandorgue/midi/elements/GOMidiShortcutReceiver.cpp
+++ b/src/grandorgue/midi/elements/GOMidiShortcutReceiver.cpp
@@ -13,6 +13,11 @@
 
 #include "GOKeyConvert.h"
 
+const GOConfigEnum GOMidiShortcutReceiver::SHORTCUT_RECEIVER_TYPES({
+  {wxT("Button"), KEY_RECV_BUTTON},
+  {wxT("Enclosure"), KEY_RECV_ENCLOSURE},
+});
+
 void GOMidiShortcutReceiver::Load(GOConfigReader &cfg, const wxString &group) {
   if (m_type == KEY_RECV_ENCLOSURE) {
     m_ShortcutKey

--- a/src/grandorgue/midi/elements/GOMidiShortcutReceiver.h
+++ b/src/grandorgue/midi/elements/GOMidiShortcutReceiver.h
@@ -10,6 +10,7 @@
 
 #include <wx/string.h>
 
+#include "config/GOConfigEnum.h"
 #include "midi/events/GOMidiShortcutPattern.h"
 
 #include "GOMidiElement.h"
@@ -20,6 +21,8 @@ class GOConfigWriter;
 class GOMidiShortcutReceiver : public GOMidiShortcutPattern,
                                public GOMidiElement {
 public:
+  static const GOConfigEnum SHORTCUT_RECEIVER_TYPES;
+
   GOMidiShortcutReceiver(GOMidiShortcutReceiverType type)
     : GOMidiShortcutPattern(type) {}
 


### PR DESCRIPTION
This is a next PR related to #1974.

It introduces the GOConfigEnum  instances for GOMidiSenderType, GOMidiReceiverType and GOMidiShortcutReceiverType for converting between the enum values and strings. It will be used later for saving and loading custom MIDI object settings.

No GO behavior should be changed.
