### PR TITLE
Introduced the enum GOMidiObject::ObjectType

### DIFF
--- a/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GODivisionalButtonControl.cpp
@@ -12,15 +12,12 @@
 #include "model/GOManual.h"
 #include "model/GOOrganModel.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Divisional");
-static const wxString WX_MIDI_TYPE_NAME = _("Divisional");
-
 GODivisionalButtonControl::GODivisionalButtonControl(
   GOOrganModel &organModel,
   unsigned manualNumber,
   unsigned divisionalIndex,
   const GOMidiObjectContext *pContext)
-  : GOPushbuttonControl(organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME),
+  : GOPushbuttonControl(organModel, OBJECT_TYPE_DIVISIONAL),
     r_OrganModel(organModel),
     m_ManualN(manualNumber),
     m_DivisionalIndex(divisionalIndex),

--- a/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
+++ b/src/grandorgue/combinations/control/GOGeneralButtonControl.cpp
@@ -12,12 +12,9 @@
 #include "combinations/model/GOCombinationDefinition.h"
 #include "model/GOOrganModel.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("General");
-static const wxString WX_MIDI_TYPE_NAME = _("General");
-
 GOGeneralButtonControl::GOGeneralButtonControl(
   GOOrganModel &organModel, bool is_setter)
-  : GOPushbuttonControl(organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME),
+  : GOPushbuttonControl(organModel, OBJECT_TYPE_GENERAL),
     r_OrganModel(organModel),
     m_combination(r_OrganModel, is_setter) {}
 

--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -16,18 +16,12 @@
 
 GOButtonControl::GOButtonControl(
   GOOrganModel &organModel,
-  const wxString &midiTypeCode,
-  const wxString &midiTypeName,
+  ObjectType objectType,
   GOMidiReceiverType midiType,
   bool pushbutton,
   bool isPiston)
   : GOMidiObjectWithShortcut(
-    organModel,
-    midiTypeCode,
-    midiTypeName,
-    MIDI_SEND_BUTTON,
-    midiType,
-    KEY_RECV_BUTTON),
+    organModel, objectType, MIDI_SEND_BUTTON, midiType, KEY_RECV_BUTTON),
     m_Pushbutton(pushbutton),
     m_Displayed(false),
     m_Engaged(false),

--- a/src/grandorgue/control/GOButtonControl.h
+++ b/src/grandorgue/control/GOButtonControl.h
@@ -43,8 +43,7 @@ protected:
 public:
   GOButtonControl(
     GOOrganModel &organModel,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName,
+    ObjectType objectType,
     GOMidiReceiverType midiType,
     bool pushbutton,
     bool isPiston = false);

--- a/src/grandorgue/control/GOCallbackButtonControl.cpp
+++ b/src/grandorgue/control/GOCallbackButtonControl.cpp
@@ -11,21 +11,13 @@
 
 #include "control/GOButtonCallback.h"
 
-const wxString GOCallbackButtonControl::WX_MIDI_TYPE_CODE = wxT("Button");
-const wxString GOCallbackButtonControl::WX_MIDI_TYPE_NAME = _("Button");
-
 GOCallbackButtonControl::GOCallbackButtonControl(
   GOOrganModel &organModel,
   GOButtonCallback *callback,
   bool isPushbutton,
   bool isPiston)
   : GOButtonControl(
-    organModel,
-    WX_MIDI_TYPE_CODE,
-    WX_MIDI_TYPE_NAME,
-    MIDI_RECV_SETTER,
-    isPushbutton,
-    isPiston),
+    organModel, OBJECT_TYPE_BUTTON, MIDI_RECV_SETTER, isPushbutton, isPiston),
     m_callback(callback) {}
 
 void GOCallbackButtonControl::Push() {

--- a/src/grandorgue/control/GOLabelControl.cpp
+++ b/src/grandorgue/control/GOLabelControl.cpp
@@ -11,13 +11,9 @@
 
 #include "model/GOOrganModel.h"
 
-const wxString WX_MIDI_TYPE_CODE = wxT("Label");
-const wxString WX_MIDI_TYPE_NAME = _("Label");
-
 GOLabelControl::GOLabelControl(
   GOOrganModel &organModel, const GOMidiObjectContext *pContext)
-  : GOMidiSendingObject(
-    organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME, MIDI_SEND_LABEL) {
+  : GOMidiSendingObject(organModel, OBJECT_TYPE_LABEL, MIDI_SEND_LABEL) {
   SetContext(pContext);
 }
 

--- a/src/grandorgue/control/GOPistonControl.cpp
+++ b/src/grandorgue/control/GOPistonControl.cpp
@@ -19,12 +19,8 @@
 #include "model/GOSwitch.h"
 #include "model/GOTremulant.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Piston");
-static const wxString WX_MIDI_TYPE_NAME = _("Piston");
-
 GOPistonControl::GOPistonControl(GOOrganModel &organModel)
-  : GOPushbuttonControl(organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME),
-    drawstop(nullptr) {
+  : GOPushbuttonControl(organModel, OBJECT_TYPE_PISTON), drawstop(nullptr) {
   organModel.RegisterControlChangedHandler(this);
 }
 

--- a/src/grandorgue/control/GOPushbuttonControl.h
+++ b/src/grandorgue/control/GOPushbuttonControl.h
@@ -12,12 +12,8 @@
 
 class GOPushbuttonControl : public GOButtonControl {
 public:
-  GOPushbuttonControl(
-    GOOrganModel &organModel,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName)
-    : GOButtonControl(
-      organModel, midiTypeCode, midiTypeName, MIDI_RECV_BUTTON, true) {}
+  GOPushbuttonControl(GOOrganModel &organModel, ObjectType objectType)
+    : GOButtonControl(organModel, objectType, MIDI_RECV_BUTTON, true) {}
 };
 
 #endif

--- a/src/grandorgue/midi/objects/GOMidiObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObject.cpp
@@ -7,6 +7,8 @@
 
 #include "GOMidiObject.h"
 
+#include <wx/intl.h>
+
 #include "midi/elements/GOMidiReceiver.h"
 #include "midi/elements/GOMidiSender.h"
 #include "midi/elements/GOMidiShortcutReceiver.h"
@@ -15,11 +17,41 @@
 
 #include "GOMidiObjectContext.h"
 
-GOMidiObject::GOMidiObject(
-  GOMidiMap &midiMap, const wxString &midiTypeCode, const wxString &midiType)
+const GOConfigEnum GOMidiObject::OBJECT_TYPES({
+  {wxT("Label"), (int)OBJECT_TYPE_LABEL},
+  {wxT("Rank"), (int)OBJECT_TYPE_RANK},
+  {wxT("Manual"), (int)OBJECT_TYPE_MANUAL},
+  {wxT("Enclosure"), (int)OBJECT_TYPE_ENCLOSURE},
+  {wxT("Button"), (int)OBJECT_TYPE_BUTTON},
+  {wxT("Piston"), (int)OBJECT_TYPE_PISTON},
+  {wxT("Stop"), (int)OBJECT_TYPE_STOP},
+  {wxT("Switch"), (int)OBJECT_TYPE_SWITCH},
+  {wxT("Tremulant"), (int)OBJECT_TYPE_TREMULANT},
+  {wxT("General"), (int)OBJECT_TYPE_GENERAL},
+  {wxT("Divisional"), (int)OBJECT_TYPE_DIVISIONAL},
+  {wxT("Coupler"), (int)OBJECT_TYPE_COUPLER},
+  {wxT("DivisionalCoupler"), (int)OBJECT_TYPE_DIVISIONAL_COUPLER},
+});
+
+const wxString GOMidiObject::OBJECT_TYPE_NAMES[] = {
+  _("Label"),
+  _("Rank"),
+  _("Manual"),
+  _("Enclosure"),
+  _("Button"),
+  _("Piston"),
+  _("Stop"),
+  _("Switch"),
+  _("Tremulant"),
+  _("General"),
+  _("Divisional"),
+  _("Coupler"),
+  _("Divisional Coupler"),
+};
+
+GOMidiObject::GOMidiObject(GOMidiMap &midiMap, ObjectType objectType)
   : r_MidiMap(midiMap),
-    r_MidiTypeCode(midiTypeCode),
-    r_MidiTypeName(midiType),
+    m_ObjectType(objectType),
     p_MidiSender(nullptr),
     p_MidiReceiver(nullptr),
     p_ShortcutReceiver(nullptr),

--- a/src/grandorgue/midi/objects/GOMidiObject.h
+++ b/src/grandorgue/midi/objects/GOMidiObject.h
@@ -12,6 +12,7 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include "config/GOConfigEnum.h"
 #include "midi/dialog-creator/GOMidiConfigDispatcher.h"
 #include "sound/GOSoundStateHandler.h"
 
@@ -27,10 +28,29 @@ class GOMidiSender;
 class GOOrganModel;
 
 class GOMidiObject : public GOSaveableObject, public GOMidiConfigDispatcher {
+public:
+  enum ObjectType {
+    OBJECT_TYPE_LABEL,
+    OBJECT_TYPE_RANK,
+    OBJECT_TYPE_MANUAL,
+    OBJECT_TYPE_ENCLOSURE,
+    OBJECT_TYPE_BUTTON,
+    OBJECT_TYPE_PISTON,
+    OBJECT_TYPE_STOP,
+    OBJECT_TYPE_SWITCH,
+    OBJECT_TYPE_TREMULANT,
+    OBJECT_TYPE_GENERAL,
+    OBJECT_TYPE_DIVISIONAL,
+    OBJECT_TYPE_COUPLER,
+    OBJECT_TYPE_DIVISIONAL_COUPLER,
+  };
+
+  static const GOConfigEnum OBJECT_TYPES;
+  static const wxString OBJECT_TYPE_NAMES[];
+
 private:
   GOMidiMap &r_MidiMap;
-  const wxString &r_MidiTypeCode;
-  const wxString &r_MidiTypeName;
+  ObjectType m_ObjectType;
 
   wxString m_NameForContext;
   wxString m_name;
@@ -43,10 +63,7 @@ private:
   const GOMidiObjectContext *p_context;
 
 protected:
-  GOMidiObject(
-    GOMidiMap &midiMap,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName);
+  GOMidiObject(GOMidiMap &midiMap, ObjectType objectType);
 
   GOMidiSender *GetMidiSender() const { return p_MidiSender; }
   void SetMidiSender(GOMidiSender *pMidiSender) { p_MidiSender = pMidiSender; }
@@ -89,8 +106,14 @@ private:
 
 public:
   GOMidiMap &GetMidiMap() { return r_MidiMap; }
-  const wxString &GetMidiTypeCode() const { return r_MidiTypeCode; }
-  const wxString &GetMidiTypeName() const { return r_MidiTypeName; }
+
+  const wxString &GetMidiTypeCode() const {
+    return OBJECT_TYPES.GetName((int)m_ObjectType);
+  }
+
+  const wxString &GetMidiTypeName() const {
+    return OBJECT_TYPE_NAMES[m_ObjectType];
+  }
 
   const wxString &GetName() const { return m_name; }
   void SetName(const wxString &name) { m_name = name; }

--- a/src/grandorgue/midi/objects/GOMidiObjectWithDivision.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithDivision.cpp
@@ -11,12 +11,11 @@
 
 GOMidiObjectWithDivision::GOMidiObjectWithDivision(
   GOOrganModel &organModel,
-  const wxString &midiTypeCode,
-  const wxString &midiTypeName,
+  ObjectType objectType,
   GOMidiSenderType senderType,
   GOMidiReceiverType receiverType)
   : GOMidiReceivingSendingObject(
-    organModel, midiTypeCode, midiTypeName, senderType, receiverType),
+    organModel, objectType, senderType, receiverType),
     m_DivisionSender(MIDI_SEND_MANUAL) {
   m_DivisionSender.SetProxy(&organModel);
   SetDivisionSender(&m_DivisionSender);

--- a/src/grandorgue/midi/objects/GOMidiObjectWithDivision.h
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithDivision.h
@@ -17,8 +17,7 @@ private:
 protected:
   GOMidiObjectWithDivision(
     GOOrganModel &organModel,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName,
+    ObjectType objectType,
     GOMidiSenderType senderType,
     GOMidiReceiverType receiverType);
 

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
@@ -9,13 +9,12 @@
 
 GOMidiObjectWithShortcut::GOMidiObjectWithShortcut(
   GOOrganModel &organModel,
-  const wxString &midiTypeCode,
-  const wxString &midiTypeName,
+  ObjectType objectType,
   GOMidiSenderType senderType,
   GOMidiReceiverType receiverType,
   GOMidiShortcutReceiverType shortcutType)
   : GOMidiReceivingSendingObject(
-    organModel, midiTypeCode, midiTypeName, senderType, receiverType),
+    organModel, objectType, senderType, receiverType),
     m_ShortcutReceiver(shortcutType) {
   SetMidiShortcutReceiver(&m_ShortcutReceiver);
 }

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
@@ -21,8 +21,7 @@ private:
 protected:
   GOMidiObjectWithShortcut(
     GOOrganModel &organModel,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName,
+    ObjectType objectType,
     GOMidiSenderType senderType,
     GOMidiReceiverType receiverType,
     GOMidiShortcutReceiverType shortcutType);

--- a/src/grandorgue/midi/objects/GOMidiPlayingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiPlayingObject.cpp
@@ -12,11 +12,8 @@
 #include "model/GOOrganModel.h"
 
 GOMidiPlayingObject::GOMidiPlayingObject(
-  GOOrganModel &organModel,
-  const wxString &midiTypeCode,
-  const wxString &midiTypeName)
-  : GOMidiObject(
-    organModel.GetConfig().GetMidiMap(), midiTypeCode, midiTypeName),
+  GOOrganModel &organModel, ObjectType objectType)
+  : GOMidiObject(organModel.GetConfig().GetMidiMap(), objectType),
     r_OrganModel(organModel) {
   r_OrganModel.RegisterSoundStateHandler(this);
   r_OrganModel.RegisterMidiObject(this);

--- a/src/grandorgue/midi/objects/GOMidiPlayingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiPlayingObject.h
@@ -15,10 +15,7 @@ protected:
   GOOrganModel &r_OrganModel;
 
 public:
-  GOMidiPlayingObject(
-    GOOrganModel &organModel,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName);
+  GOMidiPlayingObject(GOOrganModel &organModel, ObjectType objectType);
 
   virtual ~GOMidiPlayingObject();
 

--- a/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.cpp
@@ -11,11 +11,10 @@
 
 GOMidiReceivingSendingObject::GOMidiReceivingSendingObject(
   GOOrganModel &organModel,
-  const wxString &midiTypeCode,
-  const wxString &midiTypeName,
+  ObjectType objectType,
   GOMidiSenderType senderType,
   GOMidiReceiverType receiverType)
-  : GOMidiSendingObject(organModel, midiTypeCode, midiTypeName, senderType),
+  : GOMidiSendingObject(organModel, objectType, senderType),
     m_ReceiverType(receiverType),
     m_receiver(receiverType),
     p_ReceiverKeyMap(nullptr),

--- a/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.h
@@ -25,8 +25,7 @@ private:
 protected:
   GOMidiReceivingSendingObject(
     GOOrganModel &organModel,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName,
+    ObjectType objectType,
     GOMidiSenderType senderType,
     GOMidiReceiverType receiverType);
 

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
@@ -10,12 +10,8 @@
 #include "model/GOOrganModel.h"
 
 GOMidiSendingObject::GOMidiSendingObject(
-  GOOrganModel &organModel,
-  const wxString &midiTypeCode,
-  const wxString &midiTypeName,
-  GOMidiSenderType senderType)
-  : GOMidiPlayingObject(organModel, midiTypeCode, midiTypeName),
-    m_sender(senderType) {
+  GOOrganModel &organModel, ObjectType objectType, GOMidiSenderType senderType)
+  : GOMidiPlayingObject(organModel, objectType), m_sender(senderType) {
   m_sender.SetProxy(&organModel);
   SetMidiSender(&m_sender);
 }

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.h
@@ -21,8 +21,7 @@ private:
 protected:
   GOMidiSendingObject(
     GOOrganModel &organModel,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName,
+    ObjectType objectType,
     GOMidiSenderType senderType);
 
   ~GOMidiSendingObject();

--- a/src/grandorgue/model/GOCoupler.cpp
+++ b/src/grandorgue/model/GOCoupler.cpp
@@ -15,15 +15,12 @@
 #include "GOManual.h"
 #include "GOOrganModel.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Coupler");
-static const wxString WX_MIDI_TYPE_NAME = _("Coupler");
-
 GOCoupler::GOCoupler(
   GOOrganModel &organModel,
   unsigned sourceManual,
   bool isVirtual,
   const GOMidiObjectContext *pContext)
-  : GODrawstop(organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME),
+  : GODrawstop(organModel, OBJECT_TYPE_COUPLER),
     m_IsVirtual(isVirtual),
     m_UnisonOff(false),
     m_CoupleToSubsequentUnisonIntermanualCouplers(false),

--- a/src/grandorgue/model/GODivisionalCoupler.cpp
+++ b/src/grandorgue/model/GODivisionalCoupler.cpp
@@ -15,11 +15,8 @@
 
 #include "GOOrganModel.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("DivisionalCoupler");
-static const wxString WX_MIDI_TYPE_NAME = _("Divisional Coupler");
-
 GODivisionalCoupler::GODivisionalCoupler(GOOrganModel &organModel)
-  : GODrawstop(organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME),
+  : GODrawstop(organModel, OBJECT_TYPE_DIVISIONAL_COUPLER),
     m_BiDirectionalCoupling(false),
     m_manuals(0) {}
 

--- a/src/grandorgue/model/GODrawstop.cpp
+++ b/src/grandorgue/model/GODrawstop.cpp
@@ -26,12 +26,8 @@ static const GOConfigEnum FUNCTION_TYPES({
   {wxT("Xor"), GODrawstop::FUNCTION_XOR},
 });
 
-GODrawstop::GODrawstop(
-  GOOrganModel &organModel,
-  const wxString &midiTypeCode,
-  const wxString &midiTypeName)
-  : GOButtonControl(
-    organModel, midiTypeCode, midiTypeName, MIDI_RECV_DRAWSTOP, false),
+GODrawstop::GODrawstop(GOOrganModel &organModel, ObjectType objectType)
+  : GOButtonControl(organModel, objectType, MIDI_RECV_DRAWSTOP, false),
     m_Type(FUNCTION_INPUT),
     m_GCState(0),
     m_ControlledDrawstops(),

--- a/src/grandorgue/model/GODrawstop.h
+++ b/src/grandorgue/model/GODrawstop.h
@@ -67,10 +67,7 @@ protected:
   void StartPlayback() override;
 
 public:
-  GODrawstop(
-    GOOrganModel &organModel,
-    const wxString &midiTypeCode,
-    const wxString &midiTypeName);
+  GODrawstop(GOOrganModel &organModel, ObjectType objectType);
 
   /* + For tests only */
   GOFunctionType GetFunctionType() const { return m_Type; }

--- a/src/grandorgue/model/GOEnclosure.cpp
+++ b/src/grandorgue/model/GOEnclosure.cpp
@@ -14,14 +14,10 @@
 
 #include "GOOrganModel.h"
 
-const wxString GOEnclosure::WX_MIDI_TYPE_CODE = wxT("Enclosure");
-const wxString GOEnclosure::WX_MIDI_TYPE_NAME = _("Enclosure");
-
 GOEnclosure::GOEnclosure(GOOrganModel &organModel)
   : GOMidiObjectWithShortcut(
     organModel,
-    WX_MIDI_TYPE_CODE,
-    WX_MIDI_TYPE_NAME,
+    OBJECT_TYPE_ENCLOSURE,
     MIDI_SEND_ENCLOSURE,
     MIDI_RECV_ENCLOSURE,
     KEY_RECV_ENCLOSURE),

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -20,8 +20,6 @@
 #include "GOSwitch.h"
 #include "GOTremulant.h"
 
-const wxString GOManual::WX_MIDI_TYPE_CODE = wxT("Manual");
-const wxString GOManual::WX_MIDI_TYPE_NAME = _("Manual");
 const wxString WX_ODF_OBJ_NUM_FMT = wxT("%03u");
 
 GOManual::GOManual(
@@ -29,11 +27,7 @@ GOManual::GOManual(
   unsigned manualNumber,
   const GOMidiObjectContext *pParentContext)
   : GOMidiObjectWithDivision(
-    organModel,
-    WX_MIDI_TYPE_CODE,
-    WX_MIDI_TYPE_NAME,
-    MIDI_SEND_MANUAL,
-    MIDI_RECV_MANUAL),
+    organModel, OBJECT_TYPE_MANUAL, MIDI_SEND_MANUAL, MIDI_RECV_MANUAL),
     m_InputCouplers(),
     m_KeyVelocity(0),
     m_RemoteVelocity(),

--- a/src/grandorgue/model/GORank.cpp
+++ b/src/grandorgue/model/GORank.cpp
@@ -19,12 +19,8 @@
 #include "GOSoundingPipe.h"
 #include "GOWindchest.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Rank");
-static const wxString WX_MIDI_TYPE_NAME = _("Rank");
-
 GORank::GORank(GOOrganModel &organModel)
-  : GOMidiSendingObject(
-    organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME, MIDI_SEND_MANUAL),
+  : GOMidiSendingObject(organModel, OBJECT_TYPE_RANK, MIDI_SEND_MANUAL),
     r_OrganModel(organModel),
     m_StopCount(0),
     m_NoteStopVelocities(),

--- a/src/grandorgue/model/GOStop.cpp
+++ b/src/grandorgue/model/GOStop.cpp
@@ -14,14 +14,11 @@
 #include "GOOrganModel.h"
 #include "GORank.h"
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Stop");
-static const wxString WX_MIDI_TYPE_NAME = _("Stop");
-
 GOStop::GOStop(
   GOOrganModel &organModel,
   unsigned first_midi_note_number,
   GOMidiObjectContext *pContext)
-  : GODrawstop(organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME),
+  : GODrawstop(organModel, OBJECT_TYPE_STOP),
     m_RankInfo(0),
     m_KeyVelocity(0),
     m_FirstMidiNoteNumber(first_midi_note_number),

--- a/src/grandorgue/model/GOSwitch.cpp
+++ b/src/grandorgue/model/GOSwitch.cpp
@@ -9,11 +9,8 @@
 
 #include <wx/intl.h>
 
-const wxString WX_MIDI_TYPE_CODE = wxT("Drawstop");
-const wxString WX_MIDI_TYPE_NAME = _("Drawstop");
-
 GOSwitch::GOSwitch(GOOrganModel &organModel)
-  : GODrawstop(organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME) {}
+  : GODrawstop(organModel, OBJECT_TYPE_SWITCH) {}
 
 void GOSwitch::AssociateWithManual(int manualN, unsigned indexInManual) {
   m_AssociatedManualN = m_AssociatedManualN < -1 ? manualN : -1;

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -27,11 +27,8 @@ static const GOConfigEnum TREMULANT_TYPES({
   {wxT("Wave"), GOWavTrem},
 });
 
-static const wxString WX_MIDI_TYPE_CODE = wxT("Tremulant");
-static const wxString WX_MIDI_TYPE_NAME = _("Tremulant");
-
 GOTremulant::GOTremulant(GOOrganModel &organModel)
-  : GODrawstop(organModel, WX_MIDI_TYPE_CODE, WX_MIDI_TYPE_NAME),
+  : GODrawstop(organModel, OBJECT_TYPE_TREMULANT),
     m_TremulantType(GOSynthTrem),
     m_Period(0),
     m_StartRate(0),


### PR DESCRIPTION
Earlier each terminal subclass of GOMidiObject had it's own string constants `WX_MIDI_TYPE_CODE` and `WX_MIDI_TYPE_NAME`. They were passed as a parameters to constructors of generic `GOMIdiObjects` and were stored here.

Now the `GOMidiObject` class has an enum `ObjectType` and a m_ObjectType field. All subclasses pass only the enum value. Getting MidiTypeCode and MidiTypeName are implemented with static data.

The main purpose of this change is capability of sving ObjectType in the initial MIDI settings in the future.

The only GO behavior change is renaming `Drawstop` to `Switch` in the MIDI config editor dialog. No other changes should appear.