### PR TITLE
Moved implementations of LoadMidiObject and SaveMidiObject from subclasses to GOMidiObject

### DIFF
--- a/src/grandorgue/midi/objects/GOMidiObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObject.cpp
@@ -15,6 +15,8 @@
 
 #include "GOMidiObjectContext.h"
 
+static const wxString WX_DIVISIONAL_GROUP_SUFFIX = wxT("Divisional");
+
 GOMidiObject::GOMidiObject(
   GOMidiMap &midiMap, const wxString &midiTypeCode, const wxString &midiType)
   : r_MidiMap(midiMap),
@@ -34,6 +36,38 @@ wxString GOMidiObject::GetContextTitle() const {
   return GOMidiObjectContext::getFullTitle(p_context);
 }
 
+static wxString divisional_group(const wxString &group) {
+  return group + WX_DIVISIONAL_GROUP_SUFFIX;
+}
+
+void GOMidiObject::LoadMidiObject(
+  GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) {
+  if (p_MidiSender)
+    p_MidiSender->Load(cfg, group, midiMap);
+  if (!IsReadOnly()) {
+    if (p_MidiReceiver)
+      p_MidiReceiver->Load(false, cfg, group, midiMap);
+    if (p_ShortcutReceiver)
+      p_ShortcutReceiver->Load(cfg, group);
+  }
+  if (p_DivisionSender)
+    p_DivisionSender->Load(cfg, divisional_group(group), midiMap);
+}
+
+void GOMidiObject::SaveMidiObject(
+  GOConfigWriter &cfg, const wxString &group, GOMidiMap &midiMap) const {
+  if (p_MidiSender)
+    p_MidiSender->Save(cfg, group, midiMap);
+  if (!IsReadOnly()) {
+    if (p_MidiReceiver)
+      p_MidiReceiver->Save(cfg, group, midiMap);
+    if (p_ShortcutReceiver)
+      p_ShortcutReceiver->Save(cfg, group);
+  }
+  if (p_DivisionSender)
+    p_DivisionSender->Save(cfg, divisional_group(group), midiMap);
+}
+
 bool GOMidiObject::IsMidiConfigured() const {
   return (p_MidiSender && p_MidiSender->IsMidiConfigured())
     || (p_MidiReceiver && p_MidiReceiver->IsMidiConfigured())
@@ -46,6 +80,7 @@ void GOMidiObject::InitMidiObject(
   SetGroup(group);
   m_name = name;
   LoadMidiObject(cfg, group, r_MidiMap);
+  AfterMidiLoaded();
 }
 
 void GOMidiObject::SubToYaml(
@@ -115,4 +150,5 @@ void GOMidiObject::FromYaml(
   SubFromYaml(objNode, objPath, WX_SHORTCUT, p_ShortcutReceiver, usedPaths);
   SubFromYaml(objNode, objPath, WX_DIVISION, p_DivisionSender, usedPaths);
   check_all_used(objNode, objPath, usedPaths);
+  AfterMidiLoaded();
 }

--- a/src/grandorgue/midi/objects/GOMidiObject.h
+++ b/src/grandorgue/midi/objects/GOMidiObject.h
@@ -65,17 +65,17 @@ protected:
     p_DivisionSender = pDivisionSender;
   }
 
+protected:
+  virtual void LoadMidiObject(
+    GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap);
+  virtual void SaveMidiObject(
+    GOConfigWriter &cfg, const wxString &group, GOMidiMap &midiMap) const;
+  virtual void AfterMidiLoaded() {}
+
 private:
   void InitMidiObject(
     GOConfigReader &cfg, const wxString &group, const wxString &name);
 
-protected:
-  virtual void LoadMidiObject(
-    GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) {}
-  virtual void SaveMidiObject(
-    GOConfigWriter &cfg, const wxString &group, GOMidiMap &midiMap) const {}
-
-private:
   void SubToYaml(
     YAML::Node &yamlNode,
     const wxString &objPath,

--- a/src/grandorgue/midi/objects/GOMidiObjectWithDivision.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithDivision.cpp
@@ -26,17 +26,3 @@ GOMidiObjectWithDivision::~GOMidiObjectWithDivision() {
   SetDivisionSender(nullptr);
   m_DivisionSender.SetProxy(nullptr);
 }
-
-static const wxString WX_DIVISION = wxT("Division");
-
-void GOMidiObjectWithDivision::LoadMidiObject(
-  GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) {
-  GOMidiReceivingSendingObject::LoadMidiObject(cfg, group, midiMap);
-  m_DivisionSender.Load(cfg, group + WX_DIVISION, midiMap);
-}
-
-void GOMidiObjectWithDivision::SaveMidiObject(
-  GOConfigWriter &cfg, const wxString &group, GOMidiMap &midiMap) const {
-  GOMidiReceivingSendingObject::SaveMidiObject(cfg, group, midiMap);
-  m_DivisionSender.Save(cfg, group + WX_DIVISION, midiMap);
-}

--- a/src/grandorgue/midi/objects/GOMidiObjectWithDivision.h
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithDivision.h
@@ -24,13 +24,6 @@ protected:
 
   ~GOMidiObjectWithDivision();
 
-  void LoadMidiObject(
-    GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) override;
-  void SaveMidiObject(
-    GOConfigWriter &cfg,
-    const wxString &group,
-    GOMidiMap &midiMap) const override;
-
   void SendDivisionMidiKey(unsigned key, unsigned value) {
     m_DivisionSender.SetKey(key, value);
   }

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
@@ -24,22 +24,6 @@ GOMidiObjectWithShortcut::~GOMidiObjectWithShortcut() {
   SetMidiShortcutReceiver(nullptr);
 }
 
-void GOMidiObjectWithShortcut::LoadMidiObject(
-  GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) {
-  GOMidiReceivingSendingObject::LoadMidiObject(cfg, group, midiMap);
-  if (!IsReadOnly()) {
-    m_ShortcutReceiver.Load(cfg, group);
-  }
-}
-
-void GOMidiObjectWithShortcut::SaveMidiObject(
-  GOConfigWriter &cfg, const wxString &group, GOMidiMap &midiMap) const {
-  GOMidiReceivingSendingObject::SaveMidiObject(cfg, group, midiMap);
-  if (!IsReadOnly()) {
-    m_ShortcutReceiver.Save(cfg, group);
-  }
-}
-
 void GOMidiObjectWithShortcut::HandleKey(int key) {
   if (!IsReadOnly()) {
     auto matchType = m_ShortcutReceiver.Match(key);

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
@@ -29,13 +29,6 @@ protected:
 
   virtual ~GOMidiObjectWithShortcut();
 
-  void LoadMidiObject(
-    GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) override;
-  void SaveMidiObject(
-    GOConfigWriter &cfg,
-    const wxString &group,
-    GOMidiMap &midiMap) const override;
-
   virtual void OnShortcutKeyReceived(
     GOMidiShortcutReceiver::MatchType matchType, int key)
     = 0;

--- a/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.cpp
@@ -52,11 +52,8 @@ void GOMidiReceivingSendingObject::Load(
   GOMidiSendingObject::Load(cfg, group, name);
 }
 
-void GOMidiReceivingSendingObject::LoadMidiObject(
-  GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) {
-  GOMidiSendingObject::LoadMidiObject(cfg, group, midiMap);
+void GOMidiReceivingSendingObject::AfterMidiLoaded() {
   if (!IsReadOnly()) {
-    m_receiver.Load(r_OrganModel.GetConfig().ODFCheck(), cfg, group, midiMap);
     if (!m_receiver.IsMidiConfigured() && m_MidiInputNumber >= 0) {
       const GOMidiReceiver *pInitialEvents
         = r_OrganModel.GetConfig().FindMidiEvent(
@@ -65,14 +62,6 @@ void GOMidiReceivingSendingObject::LoadMidiObject(
       if (pInitialEvents)
         m_receiver.RenewFrom(*pInitialEvents);
     }
-  }
-}
-
-void GOMidiReceivingSendingObject::SaveMidiObject(
-  GOConfigWriter &cfg, const wxString &group, GOMidiMap &midiMap) const {
-  GOMidiSendingObject::SaveMidiObject(cfg, group, midiMap);
-  if (!IsReadOnly()) {
-    m_receiver.Save(cfg, group, midiMap);
   }
 }
 

--- a/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.h
@@ -47,6 +47,8 @@ public:
   virtual void SetElementId(int id) override;
 
 protected:
+  void AfterMidiLoaded() override;
+
   // Now it is present only for the symmetry with Load
   // TODO: add the initialMidiNumber parameter
   void Init(
@@ -57,12 +59,6 @@ protected:
     const wxString &group,
     const wxString &name,
     bool mayHaveOdfMidiInputNumber);
-  virtual void LoadMidiObject(
-    GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) override;
-  virtual void SaveMidiObject(
-    GOConfigWriter &cfg,
-    const wxString &group,
-    GOMidiMap &midiMap) const override;
 
   void PreparePlayback() override;
 


### PR DESCRIPTION
It is a next PR related to #1974 

Earlier the  LoadMidiObjectt and SaveMidiObject methods were implemented in several places. Now there is one general implementation in GOMidiObject.

It is just refactoring. No GO behavior should be changed.