### PR TITLE
Introduced the class GOGUIMidiControl

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -119,6 +119,7 @@ gui/panels/GOGUIHW1Background.cpp
 gui/panels/GOGUIHW1DisplayMetrics.cpp
 gui/panels/GOGUIImage.cpp
 gui/panels/GOGUILayoutEngine.cpp
+gui/panels/GOGUIMidiControl.cpp
 gui/panels/GOGUIPanelView.cpp
 gui/panels/GOGUISetterDisplayMetrics.cpp
 gui/panels/GOGUILabel.cpp

--- a/src/grandorgue/document-base/GOView.h
+++ b/src/grandorgue/document-base/GOView.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -22,6 +22,8 @@ public:
   virtual ~GOView();
 
   bool HasDocument() const { return m_doc != NULL; }
+
+  GODocumentBase *GetDocument() const { return m_doc; }
 
   virtual void RemoveView();
   void ShowView();

--- a/src/grandorgue/gui/panels/GOGUIButton.cpp
+++ b/src/grandorgue/gui/panels/GOGUIButton.cpp
@@ -21,7 +21,7 @@
 
 GOGUIButton::GOGUIButton(
   GOGUIPanel *panel, GOButtonControl *control, bool is_piston)
-  : GOGUIMidiControl(panel, control),
+  : GOGUIMidiControl(panel, control, control),
     m_IsPiston(is_piston),
     m_DispKeyLabelOnLeft(true),
     m_ButtonControl(control),

--- a/src/grandorgue/gui/panels/GOGUIButton.cpp
+++ b/src/grandorgue/gui/panels/GOGUIButton.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -21,7 +21,7 @@
 
 GOGUIButton::GOGUIButton(
   GOGUIPanel *panel, GOButtonControl *control, bool is_piston)
-  : GOGUIControl(panel, control),
+  : GOGUIMidiControl(panel, control),
     m_IsPiston(is_piston),
     m_DispKeyLabelOnLeft(true),
     m_ButtonControl(control),
@@ -387,10 +387,9 @@ bool GOGUIButton::HandleMousePress(
       > m_Radius * m_Radius)
       return false;
   }
-  if (right) {
-    m_ButtonControl->ShowConfigDialog();
+  if (HandleMidiConfig(right))
     return true;
-  } else {
+  else {
     if (state.GetControl() == this)
       return true;
     state.SetControl(this);

--- a/src/grandorgue/gui/panels/GOGUIButton.h
+++ b/src/grandorgue/gui/panels/GOGUIButton.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,11 +13,11 @@
 #include "primitives/GOBitmap.h"
 #include "primitives/GOFont.h"
 
-#include "GOGUIControl.h"
+#include "GOGUIMidiControl.h"
 
 class GOButtonControl;
 
-class GOGUIButton : public GOGUIControl {
+class GOGUIButton : public GOGUIMidiControl {
 protected:
   bool m_IsPiston;
   bool m_DispKeyLabelOnLeft;

--- a/src/grandorgue/gui/panels/GOGUIControl.cpp
+++ b/src/grandorgue/gui/panels/GOGUIControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,9 +11,9 @@
 #include "GOOrganController.h"
 #include "config/GOConfigReader.h"
 
-GOGUIControl::GOGUIControl(GOGUIPanel *panel, void *control)
+GOGUIControl::GOGUIControl(GOGUIPanel *panel, GOControl *pControl)
   : m_panel(panel),
-    m_control(control),
+    p_control(pControl),
     m_BoundingRect(0, 0, 0, 0),
     m_DrawPending(false) {
   m_metrics = panel->GetDisplayMetrics();
@@ -38,7 +38,7 @@ void GOGUIControl::Layout() {}
 void GOGUIControl::Save(GOConfigWriter &cfg) {}
 
 void GOGUIControl::ControlChanged(GOControl *control) {
-  if (control == m_control)
+  if (control == p_control)
     if (!m_DrawPending) {
       m_DrawPending = true;
       m_panel->AddEvent(this);

--- a/src/grandorgue/gui/panels/GOGUIControl.h
+++ b/src/grandorgue/gui/panels/GOGUIControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,6 +13,7 @@
 
 #include "control/GOControlChangedHandler.h"
 
+#include "GOGUIPanel.h"
 #include "GOSaveableObject.h"
 
 class GOGUIDisplayMetrics;
@@ -41,6 +42,10 @@ protected:
 public:
   GOGUIControl(GOGUIPanel *panel, void *control);
   virtual ~GOGUIControl();
+
+  GODocumentBase *GetDocument() const {
+    return m_panel ? m_panel->GetDocument() : nullptr;
+  }
 
   virtual void Load(GOConfigReader &cfg, wxString group);
   virtual void Layout();

--- a/src/grandorgue/gui/panels/GOGUIControl.h
+++ b/src/grandorgue/gui/panels/GOGUIControl.h
@@ -22,6 +22,7 @@ class GOGUIMouseState;
 class GOGUIPanel;
 class GOBitmap;
 class GOConfigReader;
+class GOControl;
 class GODC;
 
 class GOGUIControl : private GOSaveableObject,
@@ -30,7 +31,7 @@ protected:
   GOGUIPanel *m_panel;
   GOGUIDisplayMetrics *m_metrics;
   GOGUILayoutEngine *m_layout;
-  void *m_control;
+  GOControl *p_control;
   wxRect m_BoundingRect;
   bool m_DrawPending;
 
@@ -40,7 +41,7 @@ protected:
   void ControlChanged(GOControl *control) override;
 
 public:
-  GOGUIControl(GOGUIPanel *panel, void *control);
+  GOGUIControl(GOGUIPanel *panel, GOControl *pControl);
   virtual ~GOGUIControl();
 
   GODocumentBase *GetDocument() const {

--- a/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
+++ b/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
@@ -20,7 +20,7 @@
 #include "GOGUIPanel.h"
 
 GOGUIEnclosure::GOGUIEnclosure(GOGUIPanel *panel, GOEnclosure *control)
-  : GOGUIMidiControl(panel, control),
+  : GOGUIMidiControl(panel, control, control),
     m_enclosure(control),
     m_FontSize(0),
     m_FontName(),

--- a/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
+++ b/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
@@ -20,7 +20,7 @@
 #include "GOGUIPanel.h"
 
 GOGUIEnclosure::GOGUIEnclosure(GOGUIPanel *panel, GOEnclosure *control)
-  : GOGUIControl(panel, control),
+  : GOGUIMidiControl(panel, control),
     m_enclosure(control),
     m_FontSize(0),
     m_FontName(),
@@ -320,10 +320,9 @@ bool GOGUIEnclosure::HandleMousePress(
   int x, int y, bool right, GOGUIMouseState &state) {
   if (!m_BoundingRect.Contains(x, y))
     return false;
-  if (right) {
-    m_enclosure->ShowConfigDialog();
+  if (HandleMidiConfig(right))
     return true;
-  } else {
+  else {
     unsigned value;
     if (!m_MouseRect.Contains(x, y))
       return false;

--- a/src/grandorgue/gui/panels/GOGUIEnclosure.h
+++ b/src/grandorgue/gui/panels/GOGUIEnclosure.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -15,11 +15,11 @@
 #include "primitives/GOBitmap.h"
 #include "primitives/GOFont.h"
 
-#include "GOGUIControl.h"
+#include "GOGUIMidiControl.h"
 
 class GOEnclosure;
 
-class GOGUIEnclosure : public GOGUIControl {
+class GOGUIEnclosure : public GOGUIMidiControl {
 private:
   GOEnclosure *m_enclosure;
   unsigned m_FontSize;

--- a/src/grandorgue/gui/panels/GOGUILabel.cpp
+++ b/src/grandorgue/gui/panels/GOGUILabel.cpp
@@ -20,7 +20,7 @@
 #include "GOOrganController.h"
 
 GOGUILabel::GOGUILabel(GOGUIPanel *panel, GOLabelControl *label)
-  : GOGUIMidiControl(panel, label),
+  : GOGUIMidiControl(panel, label, label),
     m_DispXpos(0),
     m_DispYpos(0),
     m_Label(label),

--- a/src/grandorgue/gui/panels/GOGUILabel.cpp
+++ b/src/grandorgue/gui/panels/GOGUILabel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -20,7 +20,7 @@
 #include "GOOrganController.h"
 
 GOGUILabel::GOGUILabel(GOGUIPanel *panel, GOLabelControl *label)
-  : GOGUIControl(panel, label),
+  : GOGUIMidiControl(panel, label),
     m_DispXpos(0),
     m_DispYpos(0),
     m_Label(label),
@@ -327,13 +327,5 @@ void GOGUILabel::Draw(GODC &dc) {
 
 bool GOGUILabel::HandleMousePress(
   int x, int y, bool right, GOGUIMouseState &state) {
-  if (!m_BoundingRect.Contains(x, y))
-    return false;
-  if (right) {
-    if (!m_Label)
-      return false;
-    m_Label->ShowConfigDialog();
-    return true;
-  } else
-    return false;
+  return m_BoundingRect.Contains(x, y) && m_Label && HandleMidiConfig(right);
 }

--- a/src/grandorgue/gui/panels/GOGUILabel.h
+++ b/src/grandorgue/gui/panels/GOGUILabel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,12 +12,12 @@
 
 #include "primitives/GOFont.h"
 
-#include "GOGUIControl.h"
+#include "GOGUIMidiControl.h"
 
 class GOBitmap;
 class GOLabelControl;
 
-class GOGUILabel : public GOGUIControl {
+class GOGUILabel : public GOGUIMidiControl {
 private:
   int m_DispXpos;
   int m_DispYpos;

--- a/src/grandorgue/gui/panels/GOGUIManual.cpp
+++ b/src/grandorgue/gui/panels/GOGUIManual.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -21,7 +21,7 @@
 
 GOGUIManual::GOGUIManual(
   GOGUIPanel *panel, GOManual *manual, unsigned manual_number)
-  : GOGUIControl(panel, manual),
+  : GOGUIMidiControl(panel, manual),
     m_manual(manual),
     m_ManualNumber(manual_number),
     m_Keys() {
@@ -468,10 +468,9 @@ bool GOGUIManual::HandleMousePress(
   if (!m_BoundingRect.Contains(x, y))
     return false;
 
-  if (right) {
-    m_manual->ShowConfigDialog();
+  if (HandleMidiConfig(right))
     return true;
-  } else {
+  else {
     for (unsigned i = 0; i < m_Keys.size(); i++) {
       if (m_Keys[i].MouseRect.Contains(x, y)) {
         if (

--- a/src/grandorgue/gui/panels/GOGUIManual.cpp
+++ b/src/grandorgue/gui/panels/GOGUIManual.cpp
@@ -21,7 +21,7 @@
 
 GOGUIManual::GOGUIManual(
   GOGUIPanel *panel, GOManual *manual, unsigned manual_number)
-  : GOGUIMidiControl(panel, manual),
+  : GOGUIMidiControl(panel, manual, manual),
     m_manual(manual),
     m_ManualNumber(manual_number),
     m_Keys() {

--- a/src/grandorgue/gui/panels/GOGUIManual.h
+++ b/src/grandorgue/gui/panels/GOGUIManual.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,11 +12,11 @@
 
 #include "primitives/GOBitmap.h"
 
-#include "GOGUIControl.h"
+#include "GOGUIMidiControl.h"
 
 class GOManual;
 
-class GOGUIManual : public GOGUIControl {
+class GOGUIManual : public GOGUIMidiControl {
 private:
   typedef struct {
     unsigned MidiNumber;

--- a/src/grandorgue/gui/panels/GOGUIMidiControl.cpp
+++ b/src/grandorgue/gui/panels/GOGUIMidiControl.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "midi/objects/GOMidiPlayingObject.h"
+
+#include "GOGUIMidiControl.h"
+
+bool GOGUIMidiControl::HandleMidiConfig(bool isRightClick) {
+
+  if (isRightClick && p_MidiObject)
+    p_MidiObject->ShowConfigDialog();
+  return isRightClick;
+}

--- a/src/grandorgue/gui/panels/GOGUIMidiControl.h
+++ b/src/grandorgue/gui/panels/GOGUIMidiControl.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOGUIMIDICONTROL_H
+#define GOGUIMIDICONTROL_H
+
+#include "GOGUIControl.h"
+
+class GOMidiPlayingObject;
+
+/**
+ * A Gui control related with a MIDI object
+ */
+class GOGUIMidiControl : public GOGUIControl {
+private:
+  GOMidiPlayingObject *p_MidiObject;
+
+public:
+  GOGUIMidiControl(GOGUIPanel *pPanel, GOMidiPlayingObject *pMidiObject)
+    : GOGUIControl(pPanel, pMidiObject), p_MidiObject(pMidiObject) {}
+
+  /**
+   * Opens a MIDI configuration dialog on a right mouse click
+   * @param isRightClick is it a right mouse click
+   * @return the value of isRightClick
+   */
+  bool HandleMidiConfig(bool isRightClick);
+};
+
+#endif /* GOGUIMIDICONTROL_H */

--- a/src/grandorgue/gui/panels/GOGUIMidiControl.h
+++ b/src/grandorgue/gui/panels/GOGUIMidiControl.h
@@ -20,8 +20,9 @@ private:
   GOMidiPlayingObject *p_MidiObject;
 
 public:
-  GOGUIMidiControl(GOGUIPanel *pPanel, GOMidiPlayingObject *pMidiObject)
-    : GOGUIControl(pPanel, pMidiObject), p_MidiObject(pMidiObject) {}
+  GOGUIMidiControl(
+    GOGUIPanel *pPanel, GOControl *pControl, GOMidiPlayingObject *pMidiObject)
+    : GOGUIControl(pPanel, pControl), p_MidiObject(pMidiObject) {}
 
   /**
    * Opens a MIDI configuration dialog on a right mouse click

--- a/src/grandorgue/gui/panels/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanel.cpp
@@ -75,7 +75,9 @@ GOBitmap GOGUIPanel::LoadBitmap(wxString filename, wxString maskname) {
   return m_OrganController->GetBitmapCache().GetBitmap(filename, maskname);
 }
 
-void GOGUIPanel::SetView(GOGUIPanelView *view) { m_view = view; }
+GODocumentBase *GOGUIPanel::GetDocument() const {
+  return m_view ? m_view->GetDocument() : nullptr;
+}
 
 void GOGUIPanel::Init(
   GOConfigReader &cfg,

--- a/src/grandorgue/gui/panels/GOGUIPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -16,16 +16,17 @@
 #include "gui/size/GOSizeKeeper.h"
 #include "primitives/GOBitmap.h"
 
+class GOButtonControl;
+class GOConfigReader;
+class GOConfigWriter;
+class GODC;
+class GODocumentBase;
 class GOGUIControl;
 class GOGUIDisplayMetrics;
 class GOGUILayoutEngine;
 class GOGUIMouseState;
-class GOGUIPanelWidget;
-class GOConfigReader;
-class GOConfigWriter;
-class GOButtonControl;
-class GODC;
 class GOGUIPanelView;
+class GOGUIPanelWidget;
 class GOOrganController;
 
 #define GOBitmapPrefix "../GO:"
@@ -82,7 +83,9 @@ public:
   void Load(GOConfigReader &cfg, const wxString &group) override;
   void Layout();
 
-  void SetView(GOGUIPanelView *view);
+  GOGUIPanelView *GetView() const { return m_view; }
+  void SetView(GOGUIPanelView *view) { m_view = view; }
+  GODocumentBase *GetDocument() const;
 
   GOOrganController *GetOrganFile();
   const wxString &GetName();


### PR DESCRIPTION
Earlier each GUI control class (GOGUIButton, GOGUIEnclosure, GUGOManual, GOGUILabel) had an own code of handling right-click events and displaying the MIDI event dialog.

This PR introduces a single place GOGUIMidiControl for this code.

It is just refactoring. No GO behavior should be changed.