### PR TITLE
Replaced wxListView with wxGrid in GOSettingsMidiInitial

### DIFF
--- a/src/grandorgue/gui/dialogs/settings/GOSettingsDialog.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsDialog.cpp
@@ -61,8 +61,9 @@ GOSettingsDialog::GOSettingsDialog(
   AddTab(m_AudioPage, PAGE_AUDIO, _("Audio"));
   m_MidiDevicePage = new SettingsMidiDevices(config, midi, notebook);
   AddTab(m_MidiDevicePage, PAGE_MIDI_DEVICES, _("MIDI Devices"));
-  m_MidiMessagePage = new GOSettingsMidiInitial(config, midi, notebook);
-  AddTab(m_MidiMessagePage, PAGE_INITIAL_MIDI, _("Initial MIDI"));
+  m_MidiMessagePage = new GOSettingsMidiInitial(
+    config, midi, this, PAGE_INITIAL_MIDI, _("Initial MIDI"));
+  AddTab(m_MidiMessagePage);
   m_OrgansPage
     = new GOSettingsOrgans(config, midi, this, PAGE_ORGANS, _("Organs"));
   AddTab(m_OrgansPage);

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
@@ -15,6 +15,7 @@
 #include "gui/dialogs/midi-event/GOMidiEventDialog.h"
 #include "gui/size/GOAdditionalSizeKeeperProxy.h"
 #include "gui/wxcontrols/GOGrid.h"
+#include "midi/elements/GOMidiReceiver.h"
 
 BEGIN_EVENT_TABLE(GOSettingsMidiInitial, GODialogTab)
 EVT_GRID_CMD_SELECT_CELL(ID_INITIALS, GOSettingsMidiInitial::OnInitialsSelected)
@@ -53,9 +54,9 @@ GOSettingsMidiInitial::GOSettingsMidiInitial(
   m_Initials->CreateGrid(0, GRID_N_COLS, wxGrid::wxGridSelectRows);
   m_Initials->HideRowLabels();
   m_Initials->EnableEditing(false);
-  m_Initials->SetColSize(GRID_COL_GROUP, 50);
+  m_Initials->SetColSize(GRID_COL_GROUP, 100);
   m_Initials->SetColLabelValue(GRID_COL_GROUP, _("Group"));
-  m_Initials->SetColSize(GRID_COL_NAME, 100);
+  m_Initials->SetColSize(GRID_COL_NAME, 150);
   m_Initials->SetColLabelValue(GRID_COL_NAME, _("Name"));
   m_Initials->SetColSize(GRID_COL_CONFIGURED, 100);
   m_Initials->SetColLabelValue(GRID_COL_CONFIGURED, _("Configured"));

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
@@ -8,23 +8,32 @@
 #include "GOSettingsMidiInitial.h"
 
 #include <wx/button.h>
-#include <wx/listctrl.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
 #include "config/GOConfig.h"
 #include "gui/dialogs/midi-event/GOMidiEventDialog.h"
-#include "midi/elements/GOMidiReceiver.h"
+#include "gui/size/GOAdditionalSizeKeeperProxy.h"
+#include "gui/wxcontrols/GOGrid.h"
 
-BEGIN_EVENT_TABLE(GOSettingsMidiInitial, wxPanel)
-EVT_LIST_ITEM_SELECTED(ID_EVENTS, GOSettingsMidiInitial::OnEventsClick)
-EVT_LIST_ITEM_ACTIVATED(ID_EVENTS, GOSettingsMidiInitial::OnEventsDoubleClick)
+BEGIN_EVENT_TABLE(GOSettingsMidiInitial, GODialogTab)
+EVT_GRID_CMD_SELECT_CELL(ID_INITIALS, GOSettingsMidiInitial::OnInitialsSelected)
+EVT_GRID_CMD_CELL_LEFT_DCLICK(
+  ID_INITIALS, GOSettingsMidiInitial::OnInitialsDoubleClick)
 EVT_BUTTON(ID_PROPERTIES, GOSettingsMidiInitial::OnProperties)
 END_EVENT_TABLE()
 
+const wxString WX_INITIALS = wxT("Initials");
+
+enum { GRID_COL_GROUP = 0, GRID_COL_NAME, GRID_COL_CONFIGURED, GRID_N_COLS };
+
 GOSettingsMidiInitial::GOSettingsMidiInitial(
-  GOConfig &settings, GOMidi &midi, wxWindow *parent)
-  : wxPanel(parent, wxID_ANY), m_config(settings), m_midi(midi) {
+  GOConfig &settings,
+  GOMidi &midi,
+  GOTabbedDialog *pDlg,
+  const wxString &name,
+  const wxString &label)
+  : GODialogTab(pDlg, name, label), r_config(settings), r_midi(midi) {
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   topSizer->AddSpacer(5);
   topSizer->Add(
@@ -38,64 +47,83 @@ GOSettingsMidiInitial::GOSettingsMidiInitial(
     wxALL);
   topSizer->AddSpacer(5);
 
-  m_Events = new wxListView(
-    this,
-    ID_EVENTS,
-    wxDefaultPosition,
-    wxDefaultSize,
-    wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_HRULES | wxLC_VRULES);
-  m_Events->InsertColumn(0, _("Group"));
-  m_Events->InsertColumn(1, _("Element"));
-  m_Events->InsertColumn(2, _("MIDI Event"));
-  topSizer->Add(m_Events, 1, wxEXPAND | wxALL, 5);
+  m_Initials
+    = new GOGrid(this, ID_INITIALS, wxDefaultPosition, wxSize(100, 40));
+
+  m_Initials->CreateGrid(0, GRID_N_COLS, wxGrid::wxGridSelectRows);
+  m_Initials->HideRowLabels();
+  m_Initials->EnableEditing(false);
+  m_Initials->SetColSize(GRID_COL_GROUP, 50);
+  m_Initials->SetColLabelValue(GRID_COL_GROUP, _("Group"));
+  m_Initials->SetColSize(GRID_COL_NAME, 100);
+  m_Initials->SetColLabelValue(GRID_COL_NAME, _("Name"));
+  m_Initials->SetColSize(GRID_COL_CONFIGURED, 100);
+  m_Initials->SetColLabelValue(GRID_COL_CONFIGURED, _("Configured"));
+
+  topSizer->Add(m_Initials, 1, wxEXPAND | wxALL, 5);
   m_Properties = new wxButton(this, ID_PROPERTIES, _("P&roperties..."));
   m_Properties->Disable();
   topSizer->Add(m_Properties, 0, wxALIGN_RIGHT | wxALL, 5);
 
-  for (unsigned i = 0; i < m_config.GetEventCount(); i++) {
-    const GOMidiReceiver *recv = m_config.GetMidiEvent(i);
-
-    m_Events->InsertItem(i, m_config.GetEventGroup(i));
-    m_Events->SetItemPtrData(i, (wxUIntPtr)recv);
-    m_Events->SetItem(i, 1, m_config.GetEventTitle(i));
-    m_Events->SetItem(i, 2, recv->GetEventCount() > 0 ? _("Yes") : _("No"));
-  }
-
   topSizer->AddSpacer(5);
   this->SetSizer(topSizer);
   topSizer->Fit(this);
-
-  m_Events->SetColumnWidth(0, wxLIST_AUTOSIZE);
-  m_Events->SetColumnWidth(1, wxLIST_AUTOSIZE);
-  m_Events->SetColumnWidth(2, wxLIST_AUTOSIZE_USEHEADER);
 }
 
-void GOSettingsMidiInitial::OnEventsClick(wxListEvent &event) {
-  m_Properties->Enable();
+void GOSettingsMidiInitial::ApplyAdditionalSizes(
+  const GOAdditionalSizeKeeper &sizeKeeper) {
+  GOAdditionalSizeKeeperProxy proxyGrid(
+    const_cast<GOAdditionalSizeKeeper &>(sizeKeeper), WX_INITIALS);
+
+  m_Initials->ApplyColumnSizes(proxyGrid);
 }
 
-void GOSettingsMidiInitial::OnEventsDoubleClick(wxListEvent &event) {
-  m_Properties->Enable();
-  int index = m_Events->GetFirstSelected();
+void GOSettingsMidiInitial::CaptureAdditionalSizes(
+  GOAdditionalSizeKeeper &sizeKeeper) const {
+  GOAdditionalSizeKeeperProxy proxyGrid(sizeKeeper, WX_INITIALS);
 
+  m_Initials->CaptureColumnSizes(proxyGrid);
+}
+
+bool GOSettingsMidiInitial::TransferDataToWindow() {
+  const unsigned nInitials = r_config.GetEventCount();
+
+  m_Initials->ClearGrid();
+  m_Initials->AppendRows(nInitials);
+  for (unsigned i = 0; i < nInitials; i++) {
+    const GOMidiReceiver *recv = r_config.GetMidiEvent(i);
+
+    m_Initials->SetCellValue(i, GRID_COL_GROUP, r_config.GetEventGroup(i));
+    m_Initials->SetCellValue(i, GRID_COL_NAME, r_config.GetEventTitle(i));
+    m_Initials->SetCellValue(
+      i, GRID_COL_CONFIGURED, recv->GetEventCount() > 0 ? _("Yes") : _("No"));
+  }
+  return true;
+}
+
+void GOSettingsMidiInitial::OnInitialsSelected(wxGridEvent &event) {
+  int index = m_Initials->GetGridCursorRow();
+
+  m_Properties->Enable(index >= 0);
+}
+
+void GOSettingsMidiInitial::ConfigureInitial() {
+  int index = m_Initials->GetGridCursorRow();
   GOMidiReceiver *recv
-    = (GOMidiReceiver *)m_Events->GetItemData(m_Events->GetFirstSelected());
+    = const_cast<GOMidiReceiver *>(r_config.GetMidiEvent(index));
   GOMidiEventDialog dlg(
     NULL,
     this,
     wxString::Format(
-      _("Initial MIDI settings for %s"), m_config.GetEventTitle(index)),
-    m_config,
+      _("Initial MIDI settings for %s"), r_config.GetEventTitle(index)),
+    r_config,
     wxT("InitialSettings"),
     recv,
     NULL,
     NULL);
-  dlg.RegisterMIDIListener(&m_midi);
-  dlg.ShowModal();
-  m_Events->SetItem(index, 2, recv->GetEventCount() > 0 ? _("Yes") : _("No"));
-}
 
-void GOSettingsMidiInitial::OnProperties(wxCommandEvent &event) {
-  wxListEvent listevent;
-  OnEventsDoubleClick(listevent);
+  dlg.RegisterMIDIListener(&r_midi);
+  dlg.ShowModal();
+  m_Initials->SetCellValue(
+    index, GRID_COL_CONFIGURED, recv->GetEventCount() > 0 ? _("Yes") : _("No"));
 }

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.h
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.h
@@ -8,32 +8,48 @@
 #ifndef GOSETTINGSMIDIINITIAL_H
 #define GOSETTINGSMIDIINITIAL_H
 
-#include <wx/panel.h>
+#include "gui/dialogs/common/GODialogTab.h"
 
-class GOMidi;
-class GOConfig;
 class wxButton;
-class wxListEvent;
-class wxListView;
+class wxGridEvent;
 
-class GOSettingsMidiInitial : public wxPanel {
+class GOConfig;
+class GOGrid;
+class GOMidi;
+
+class GOSettingsMidiInitial : public GODialogTab {
   enum {
-    ID_EVENTS,
+    ID_INITIALS,
     ID_PROPERTIES,
   };
 
 private:
-  GOConfig &m_config;
-  GOMidi &m_midi;
-  wxListView *m_Events;
+  GOConfig &r_config;
+  GOMidi &r_midi;
+
+  GOGrid *m_Initials;
   wxButton *m_Properties;
 
-  void OnEventsClick(wxListEvent &event);
-  void OnEventsDoubleClick(wxListEvent &event);
-  void OnProperties(wxCommandEvent &event);
+  void ApplyAdditionalSizes(const GOAdditionalSizeKeeper &sizeKeeper) override;
+  void CaptureAdditionalSizes(
+    GOAdditionalSizeKeeper &sizeKeeper) const override;
+
+  bool TransferDataToWindow() override;
+
+  void OnInitialsSelected(wxGridEvent &event);
+
+  void ConfigureInitial();
+
+  void OnInitialsDoubleClick(wxGridEvent &event) { ConfigureInitial(); }
+  void OnProperties(wxCommandEvent &event) { ConfigureInitial(); }
 
 public:
-  GOSettingsMidiInitial(GOConfig &settings, GOMidi &midi, wxWindow *parent);
+  GOSettingsMidiInitial(
+    GOConfig &settings,
+    GOMidi &midi,
+    GOTabbedDialog *pDlg,
+    const wxString &name,
+    const wxString &label);
 
   DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
This is a next PR related to #1974

It 
1. replaces the wx control is used for listing the initial MIDI objects;
2. renames some GOSettingsMidiInitial members;
3. renames the column titles: `Element` -> `Name`, `MIDI Event` -> `Configured`.

I'm going to add more columns to this grid, so I'm not change the screenshot now.