### PR TITLE
Moved filtering of empty events from the GOMidiEvent dialog tabs to GOMidiEventPatternList

### DIFF
--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventRecvTab.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventRecvTab.cpp
@@ -312,17 +312,6 @@ void GOMidiEventRecvTab::RegisterMIDIListener(GOMidi *midi) {
 
 bool GOMidiEventRecvTab::TransferDataFromWindow() {
   StoreEvent();
-
-  bool empty_event;
-  do {
-    empty_event = false;
-    for (unsigned i = 0; i < m_midi.GetEventCount(); i++)
-      if (m_midi.GetEvent(i).type == MIDI_M_NONE) {
-        m_midi.DeleteEvent(i);
-        empty_event = true;
-      }
-  } while (empty_event);
-
   if (m_original->RenewFrom(m_midi))
     GOModificationProxy::OnIsModifiedChanged(true);
   return true;

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventSendTab.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventSendTab.cpp
@@ -270,19 +270,6 @@ GOMidiEventSendTab::~GOMidiEventSendTab() {}
 bool GOMidiEventSendTab::TransferDataFromWindow() {
   // save the current event being edited
   StoreEvent();
-
-  // Delete empty events.
-  bool empty_event;
-  do {
-    empty_event = false;
-    for (unsigned i = 0; i < m_midi.GetEventCount(); i++)
-      if (m_midi.GetEvent(i).type == MIDI_S_NONE) {
-        m_midi.DeleteEvent(i);
-        empty_event = true;
-      }
-  } while (empty_event);
-  // The event with index 0 is also deleted so the dialog can't be used more
-
   if (m_original->RenewFrom(m_midi))
     OnIsModifiedChanged(true);
   return true;

--- a/src/grandorgue/midi/events/GOMidiEventPattern.h
+++ b/src/grandorgue/midi/events/GOMidiEventPattern.h
@@ -40,6 +40,8 @@ struct GOMidiEventPattern {
       high_value(iHighValue),
       useNoteOff(iUseNoteOff) {}
 
+  virtual bool IsEmpty() const = 0;
+
   bool operator==(const GOMidiEventPattern &other) const;
 
   void DeviceIdToYaml(YAML::Node &eventNode, const GOMidiMap &map) const;

--- a/src/grandorgue/midi/events/GOMidiEventPatternList.h
+++ b/src/grandorgue/midi/events/GOMidiEventPatternList.h
@@ -47,10 +47,21 @@ public:
    */
 
   bool RenewFrom(const GOMidiEventPatternList &newList) {
-    bool result = newList.m_type != m_type || newList.m_events != m_events;
+    std::vector<MidiEventPattern> nonEmptyEvents;
 
-    if (result)
-      *this = newList;
+    // copy not empty events.
+    std::copy_if(
+      newList.m_events.begin(),
+      newList.m_events.end(),
+      std::back_inserter(nonEmptyEvents),
+      [](const MidiEventPattern &x) { return !x.IsEmpty(); });
+
+    bool result = newList.m_type != m_type || nonEmptyEvents != m_events;
+
+    if (result) {
+      m_type = newList.m_type;
+      m_events = nonEmptyEvents;
+    }
     return result;
   }
 };

--- a/src/grandorgue/midi/events/GOMidiEventPatternList.h
+++ b/src/grandorgue/midi/events/GOMidiEventPatternList.h
@@ -8,6 +8,7 @@
 #ifndef GOMIDIEVENTPATTERNLIST_H
 #define GOMIDIEVENTPATTERNLIST_H
 
+#include <algorithm>
 #include <vector>
 
 template <class MidiType, class MidiEventPattern> class GOMidiEventPatternList {

--- a/src/grandorgue/midi/events/GOMidiReceiverEventPattern.h
+++ b/src/grandorgue/midi/events/GOMidiReceiverEventPattern.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -23,6 +23,8 @@ struct GOMidiReceiverEventPattern : public GOMidiEventPattern {
       low_key(0),
       high_key(0),
       debounce_time(0) {}
+
+  bool IsEmpty() const override { return type == MIDI_M_NONE; }
 
   bool operator==(const GOMidiReceiverEventPattern &other) const;
 

--- a/src/grandorgue/midi/events/GOMidiSenderEventPattern.h
+++ b/src/grandorgue/midi/events/GOMidiSenderEventPattern.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -21,6 +21,8 @@ struct GOMidiSenderEventPattern : public GOMidiEventPattern {
       type(MIDI_S_NONE),
       start(0),
       length(0) {}
+
+  bool IsEmpty() const override { return type == MIDI_S_NONE; }
 
   bool operator==(const GOMidiSenderEventPattern &other) const;
 


### PR DESCRIPTION
This PR moves filtering of empty events code from the MIDI event dialog to the GOMidiEventPatternList class

Now the dialog `TransferDataFromWindow()` may be called more than once because it does not more modifies the m_midi members.

No GO behavior should be changed.
