### PR TITLE
Added support of optional enum entry in CMB settings

### DIFF
--- a/src/core/config/GOConfigReader.cpp
+++ b/src/core/config/GOConfigReader.cpp
@@ -610,11 +610,6 @@ int GOConfigReader::ReadEnum(
   const GOConfigEnum &configEnum,
   bool required,
   int defaultValue) {
-  if (configEnum.GetName(defaultValue).IsEmpty()) {
-    wxLogError(_("Invalid enum default value"));
-    defaultValue = configEnum.GetFirstValue();
-  }
-
   wxString strValue;
   int enumValue;
 


### PR DESCRIPTION
Earlier there were no capability of reading an optional GOConfigEnum entry.

This small change adds this capability. Now specifying `-1` as default allows to distinguish an absent entry from any enum value.

No GO behavior should be changed unless the new ReadEnum calls are added with the `-1` as default.