### PR TITLE
Fixed inheritance of setter MIDI settings

### DIFF
--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -735,10 +735,6 @@ GOSetter::GOSetter(GOOrganController *organController)
   m_buttons[ID_SETTER_AUDIO_PANIC]->SetMidiInputNumber(25);
   m_buttons[ID_SETTER_FILE_EXIT]->SetMidiInputNumber(26);
 
-  m_buttons[ID_SETTER_PREV]->SetShortcutKey(37);
-  m_buttons[ID_SETTER_NEXT]->SetShortcutKey(39);
-  m_buttons[ID_SETTER_CURRENT]->SetShortcutKey(40);
-
   SetSetterType(GOSetterState::SETTER_REGULAR);
   SetCrescendoType(m_crescendobank);
 
@@ -812,6 +808,10 @@ void GOSetter::Load(GOConfigReader &cfg) {
   m_buttons[ID_SETTER_PREV]->Init(cfg, wxT("SetterPrev"), _("Previous"));
   m_buttons[ID_SETTER_NEXT]->Init(cfg, wxT("SetterNext"), _("Next"));
   m_buttons[ID_SETTER_SET]->Init(cfg, wxT("SetterSet"), _("Set"));
+  m_buttons[ID_SETTER_PREV]->SetDefaultShortcutKey(37);
+  m_buttons[ID_SETTER_NEXT]->SetDefaultShortcutKey(39);
+  m_buttons[ID_SETTER_CURRENT]->SetDefaultShortcutKey(40);
+
   m_buttons[ID_SETTER_M1]->Init(cfg, wxT("SetterM1"), _("-1"));
   m_buttons[ID_SETTER_M10]->Init(cfg, wxT("SetterM10"), _("-10"));
   m_buttons[ID_SETTER_M100]->Init(cfg, wxT("SetterM100"), _("-100"));

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
@@ -23,6 +23,11 @@ GOMidiObjectWithShortcut::~GOMidiObjectWithShortcut() {
   SetMidiShortcutReceiver(nullptr);
 }
 
+void GOMidiObjectWithShortcut::SetDefaultShortcutKey(unsigned key) {
+  if (!m_ShortcutReceiver.IsMidiConfigured())
+    m_ShortcutReceiver.SetShortcut(key);
+}
+
 void GOMidiObjectWithShortcut::HandleKey(int key) {
   if (!IsReadOnly()) {
     auto matchType = m_ShortcutReceiver.Match(key);

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
@@ -33,7 +33,9 @@ protected:
     = 0;
 
 public:
-  void SetShortcutKey(unsigned key) { m_ShortcutReceiver.SetShortcut(key); }
+  // Set the shortcut key if it is not configured
+  // Should be called after Init()
+  void SetDefaultShortcutKey(unsigned key);
 };
 
 #endif /* GOMIDIOBJECTWITHSHORTCUT_H */


### PR DESCRIPTION
This small preparing  PR changes initializing of the default shortcut.

Earlier, the MidiShortcutRec was initialized before calling to `Init`, so it would prevent inheritance from Initial MIDI settings.

Now it is initialized after `Init` and only if has not yet configured. So it will allow to get MIDI settings in the future.

No current GO behavior should be changed.