### PR TITLE
Replaced inheritence of inititial MIDI settings with usage of GOConfigMidiInitial https://github.com/GrandOrgue/grandorgue/issues/1974

### DIFF
--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -11,7 +11,7 @@
 #include <wx/gdicmn.h>
 #include <wx/string.h>
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 #include "gui/dialogs/common/GODialogSizeSet.h"
@@ -55,7 +55,19 @@ private:
   std::vector<GOAudioDeviceConfig> m_AudioDeviceConfig;
 
   GOPortsConfig m_MidiPortsConfig;
+
+  /* Thre are two sets of initial MIDI objects: built-in and user-added.
+   * The built-in MIDI objects are matched by ReceiverType and MIDIInputNumber.
+   * The user-added MIDI objects are matched by path.
+   * In this vector the first indices correspond the built-in objects and the
+   * rest indices correspond the user-added objects.
+   */
   ptr_vector<GOConfigMidiObject> m_InitialMidiObjects;
+  // Used for finding a user-added Initial MIDI object
+  std::
+    unordered_map<wxString, GOConfigMidiObject *, wxStringHash, wxStringEqual>
+      m_InitialMidiObjectsByPath;
+
   GOMidiMap m_MidiMap;
   GOTemperamentList m_Temperaments;
 
@@ -168,12 +180,19 @@ public:
   const wxString &GetResourceDirectory() const { return m_ResourceDir; }
   const wxString GetPackageDirectory();
 
-  unsigned GetEventCount() const;
+  // return count of built-in initial MIDI objects
+  static unsigned getMidiBuiltinCount();
+
+  // return count of all initial MIDI objects, both built-in and user-addeds
+  unsigned GetMidiInitialCount() const { return m_InitialMidiObjects.size(); }
   const wxString &GetEventGroup(unsigned index) const;
   wxString GetEventTitle(unsigned index);
-  const GOMidiReceiver *GetMidiEvent(unsigned index) const;
-  const GOMidiReceiver *FindMidiEvent(
-    GOMidiReceiverType type, unsigned index) const;
+  GOConfigMidiObject *GetMidiInitialObject(unsigned index);
+  // search among built-in MIDI objects
+  GOConfigMidiObject *FindMidiInitialObject(
+    GOMidiObject::ObjectType type, unsigned index);
+  // search among user-added MIDI objects
+  GOConfigMidiObject *FindMidiInitialObject(const wxString &path);
 
   const std::vector<wxString> &GetAudioGroups();
   void SetAudioGroups(const std::vector<wxString> &audio_groups);

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
@@ -87,17 +87,17 @@ void GOSettingsMidiInitial::CaptureAdditionalSizes(
 }
 
 bool GOSettingsMidiInitial::TransferDataToWindow() {
-  const unsigned nInitials = r_config.GetEventCount();
+  const unsigned nInitials = r_config.GetMidiInitialCount();
 
   m_Initials->ClearGrid();
   m_Initials->AppendRows(nInitials);
   for (unsigned i = 0; i < nInitials; i++) {
-    const GOMidiReceiver *recv = r_config.GetMidiEvent(i);
+    const GOConfigMidiObject *pObj = r_config.GetMidiInitialObject(i);
 
     m_Initials->SetCellValue(i, GRID_COL_GROUP, r_config.GetEventGroup(i));
     m_Initials->SetCellValue(i, GRID_COL_NAME, r_config.GetEventTitle(i));
     m_Initials->SetCellValue(
-      i, GRID_COL_CONFIGURED, recv->GetEventCount() > 0 ? _("Yes") : _("No"));
+      i, GRID_COL_CONFIGURED, pObj->IsMidiConfigured() ? _("Yes") : _("No"));
   }
   return true;
 }
@@ -110,8 +110,7 @@ void GOSettingsMidiInitial::OnInitialsSelected(wxGridEvent &event) {
 
 void GOSettingsMidiInitial::ConfigureInitial() {
   int index = m_Initials->GetGridCursorRow();
-  GOMidiReceiver *recv
-    = const_cast<GOMidiReceiver *>(r_config.GetMidiEvent(index));
+  GOConfigMidiObject *pObj = r_config.GetMidiInitialObject(index);
   GOMidiEventDialog dlg(
     NULL,
     this,
@@ -119,12 +118,12 @@ void GOSettingsMidiInitial::ConfigureInitial() {
       _("Initial MIDI settings for %s"), r_config.GetEventTitle(index)),
     r_config,
     wxT("InitialSettings"),
-    recv,
+    pObj->GetMidiReceiver(),
     NULL,
     NULL);
 
   dlg.RegisterMIDIListener(&r_midi);
   dlg.ShowModal();
   m_Initials->SetCellValue(
-    index, GRID_COL_CONFIGURED, recv->GetEventCount() > 0 ? _("Yes") : _("No"));
+    index, GRID_COL_CONFIGURED, pObj->IsMidiConfigured() ? _("Yes") : _("No"));
 }

--- a/src/grandorgue/midi/objects/GOMidiPlayingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiPlayingObject.cpp
@@ -26,6 +26,19 @@ GOMidiPlayingObject::~GOMidiPlayingObject() {
   r_OrganModel.UnRegisterSoundStateHandler(this);
 }
 
+const GOMidiObject *GOMidiPlayingObject::FindInitialMidiObject() const {
+  return r_OrganModel.GetConfig().FindMidiInitialObject(GetPath());
+}
+
+void GOMidiPlayingObject::AfterMidiLoaded() {
+  if (!IsMidiConfigured()) {
+    const GOMidiObject *pInitialObj = FindInitialMidiObject();
+
+    if (pInitialObj)
+      CopyMidiSettingFrom(*pInitialObj);
+  }
+}
+
 void GOMidiPlayingObject::ShowConfigDialog() {
   const bool isReadOnly = IsReadOnly();
   const wxString title = wxString::Format(

--- a/src/grandorgue/midi/objects/GOMidiPlayingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiPlayingObject.h
@@ -19,6 +19,15 @@ public:
 
   virtual ~GOMidiPlayingObject();
 
+  /* Try to find the initial MIDI settings suitable for tthis objects.
+   * This implementation searches only among user-added MIDI objects. The
+   * subclasses may implement more complex searching.
+   */
+  virtual const GOMidiObject *FindInitialMidiObject() const;
+
+  // if MIDI is not configured then try
+  void AfterMidiLoaded() override;
+
   void ShowConfigDialog();
 
   void PreparePlayback() override {}

--- a/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.cpp
@@ -28,6 +28,20 @@ GOMidiReceivingSendingObject::~GOMidiReceivingSendingObject() {
   SetMidiReceiver(nullptr);
 }
 
+const GOMidiObject *GOMidiReceivingSendingObject::FindInitialMidiObject()
+  const {
+  // at first, try to find among user-added initial MIDI objects
+  const GOMidiObject *pInitialObj
+    = GOMidiSendingObject::FindInitialMidiObject();
+
+  // if it is not configured then try to find among built-in MIDI objects
+  if (
+    !(pInitialObj && pInitialObj->IsMidiConfigured()) && m_MidiInputNumber >= 0)
+    pInitialObj = r_OrganModel.GetConfig().FindMidiInitialObject(
+      GetObjectType(), m_MidiInputNumber);
+  return pInitialObj;
+}
+
 void GOMidiReceivingSendingObject::Init(
   GOConfigReader &cfg, const wxString &group, const wxString &name) {
   GOMidiSendingObject::Init(cfg, group, name);
@@ -49,19 +63,6 @@ void GOMidiReceivingSendingObject::Load(
       false,
       m_MidiInputNumber);
   GOMidiSendingObject::Load(cfg, group, name);
-}
-
-void GOMidiReceivingSendingObject::AfterMidiLoaded() {
-  if (!IsReadOnly()) {
-    if (!m_receiver.IsMidiConfigured() && m_MidiInputNumber >= 0) {
-      const GOMidiReceiver *pInitialEvents
-        = r_OrganModel.GetConfig().FindMidiEvent(
-          m_ReceiverType, m_MidiInputNumber);
-
-      if (pInitialEvents)
-        m_receiver.RenewFrom(*pInitialEvents);
-    }
-  }
 }
 
 void GOMidiReceivingSendingObject::SetElementId(int id) {

--- a/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiReceivingSendingObject.h
@@ -46,7 +46,7 @@ public:
   virtual void SetElementId(int id) override;
 
 protected:
-  void AfterMidiLoaded() override;
+  virtual const GOMidiObject *FindInitialMidiObject() const override;
 
   // Now it is present only for the symmetry with Load
   // TODO: add the initialMidiNumber parameter


### PR DESCRIPTION
This is a next PR related to #1974.

Now there are two parts of Initial MIDI objects: built-in ones and user-added.

Earlier the inheritance was at the GOMidiReceiver level. Now it is at the GOMidiObject level. It allows to use the initial MIDI settings of all elements of MIDI objects, not only of the Receive path. But now the InitialMidi settings does not allow to set up them.

This PR breaks the inheritance of the Setter/Prev and Setter/Next buttons. #2224 should fix it.



