### PR TITLE
Added passing GOMidiObject to GOMidiEventDialog

### DIFF
--- a/src/grandorgue/GODocument.cpp
+++ b/src/grandorgue/GODocument.cpp
@@ -205,10 +205,7 @@ void GODocument::ShowMIDIEventDialog(
   void *element,
   const wxString &title,
   const wxString &dialogSelector,
-  GOMidiReceiver *event,
-  GOMidiSender *sender,
-  GOMidiShortcutReceiver *key,
-  GOMidiSender *division,
+  GOMidiObject &obj,
   GOMidiDialogListener *pDialogListener) {
   if (!showWindow(GODocument::MIDI_EVENT, element) && m_OrganController) {
     GOMidiEventDialog *dlg = new GOMidiEventDialog(
@@ -217,10 +214,7 @@ void GODocument::ShowMIDIEventDialog(
       title,
       m_OrganController->GetSettings(),
       dialogSelector,
-      event,
-      sender,
-      key,
-      division,
+      obj,
       pDialogListener);
     dlg->RegisterMIDIListener(m_OrganController->GetMidi());
     dlg->SetModificationListener(m_OrganController);

--- a/src/grandorgue/GODocument.h
+++ b/src/grandorgue/GODocument.h
@@ -17,10 +17,6 @@
 #include "threading/GOMutex.h"
 
 class GOOrganController;
-class GOMidiShortcutReceiver;
-class GOMidiEvent;
-class GOMidiReceiver;
-class GOMidiSender;
 class GOOrgan;
 class GOProgressDialog;
 class GOResizable;
@@ -69,10 +65,7 @@ public:
     void *element,
     const wxString &title,
     const wxString &dialogSelector,
-    GOMidiReceiver *event,
-    GOMidiSender *sender,
-    GOMidiShortcutReceiver *key,
-    GOMidiSender *division = nullptr,
+    GOMidiObject &obj,
     GOMidiDialogListener *pDialogListener = nullptr) override;
 };
 

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.cpp
@@ -11,6 +11,7 @@
 
 #include "config/GOConfig.h"
 #include "midi/dialog-creator/GOMidiDialogListener.h"
+#include "midi/objects/GOMidiObject.h"
 
 #include "GOMidiEventKeyTab.h"
 #include "GOMidiEventRecvTab.h"
@@ -22,6 +23,7 @@ GOMidiEventDialog::GOMidiEventDialog(
   const wxString &title,
   GOConfig &settings,
   const wxString &dialogSelector,
+  GOMidiObject *pMidiObject,
   GOMidiReceiver *event,
   GOMidiSender *sender,
   GOMidiShortcutReceiver *key,
@@ -60,6 +62,46 @@ GOMidiEventDialog::GOMidiEventDialog(
 
   LayoutDialog();
 }
+
+GOMidiEventDialog::GOMidiEventDialog(
+  GODocumentBase *doc,
+  wxWindow *parent,
+  const wxString &title,
+  GOConfig &settings,
+  const wxString &dialogSelector,
+  GOMidiObject &midiObject,
+  GOMidiDialogListener *pDialogListener)
+  : GOMidiEventDialog(
+    doc,
+    parent,
+    title,
+    settings,
+    dialogSelector,
+    &midiObject,
+    !midiObject.IsReadOnly() ? midiObject.GetMidiReceiver() : nullptr,
+    midiObject.GetMidiSender(),
+    !midiObject.IsReadOnly() ? midiObject.GetMidiShortcutReceiver() : nullptr,
+    midiObject.GetDivisionSender(),
+    pDialogListener) {}
+
+GOMidiEventDialog::GOMidiEventDialog(
+  wxWindow *parent,
+  const wxString &title,
+  GOConfig &settings,
+  const wxString &dialogSelector,
+  GOMidiReceiver *pReceiver)
+  : GOMidiEventDialog(
+    nullptr,
+    parent,
+    title,
+    settings,
+    dialogSelector,
+    nullptr,
+    pReceiver,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr) {}
 
 void GOMidiEventDialog::RegisterMIDIListener(GOMidi *midi) {
   if (m_recvPage)

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.h
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.h
@@ -21,6 +21,7 @@ class GOMidiEventKeyTab;
 class GOMidiEventRecvTab;
 class GOMidiEventSendTab;
 class GOMidiListener;
+class GOMidiObject;
 class GOMidiReceiver;
 class GOMidiSender;
 class GOMidiShortcutReceiver;
@@ -36,6 +37,24 @@ private:
   GOMidiEventSendTab *m_sendDivisionPage;
   GOMidiEventKeyTab *m_keyPage;
 
+  GOMidiEventDialog(
+    GODocumentBase *doc,
+    /*
+      if doc != NULL then the dialog is auto destroyed when closed
+      if doc == NULL then the caller should call ShowModal() and then should
+      call Destroy() if needed
+    */
+    wxWindow *parent,
+    const wxString &title,
+    GOConfig &settings,
+    const wxString &dialogSelector,
+    GOMidiObject *pMidiObject,
+    GOMidiReceiver *event,
+    GOMidiSender *sender,
+    GOMidiShortcutReceiver *key,
+    GOMidiSender *division = nullptr,
+    GOMidiDialogListener *pDialogListener = nullptr);
+
 public:
   GOMidiEventDialog(
     GODocumentBase *doc,
@@ -48,11 +67,15 @@ public:
     const wxString &title,
     GOConfig &settings,
     const wxString &dialogSelector,
-    GOMidiReceiver *event,
-    GOMidiSender *sender,
-    GOMidiShortcutReceiver *key,
-    GOMidiSender *division = NULL,
+    GOMidiObject &midiObject,
     GOMidiDialogListener *pDialogListener = nullptr);
+
+  GOMidiEventDialog(
+    wxWindow *parent,
+    const wxString &title,
+    GOConfig &settings,
+    const wxString &dialogSelector,
+    GOMidiReceiver *pReceiver);
 
   void RegisterMIDIListener(GOMidi *midi);
 

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
@@ -112,15 +112,12 @@ void GOSettingsMidiInitial::ConfigureInitial() {
   int index = m_Initials->GetGridCursorRow();
   GOConfigMidiObject *pObj = r_config.GetMidiInitialObject(index);
   GOMidiEventDialog dlg(
-    NULL,
     this,
     wxString::Format(
       _("Initial MIDI settings for %s"), r_config.GetEventTitle(index)),
     r_config,
     wxT("InitialSettings"),
-    pObj->GetMidiReceiver(),
-    NULL,
-    NULL);
+    pObj->GetMidiReceiver());
 
   dlg.RegisterMIDIListener(&r_midi);
   dlg.ShowModal();

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsOrgans.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsOrgans.cpp
@@ -627,16 +627,13 @@ void GOSettingsOrgans::OnOrganMidi(wxCommandEvent &event) {
   if (currOrganIndex >= 0) {
     OrganSlot *pOrganSlot = m_OrganSlotPtrsByGridLine[currOrganIndex];
     GOMidiEventDialog dlg(
-      NULL,
       this,
       wxString::Format(
         _("MIDI settings for organ %s"),
         pOrganSlot->p_CurrentOrgan->GetChurchName()),
       m_config,
       wxT("Organs"),
-      &pOrganSlot->p_CurrentOrgan->GetMIDIReceiver(),
-      NULL,
-      NULL);
+      &pOrganSlot->p_CurrentOrgan->GetMIDIReceiver());
 
     dlg.RegisterMIDIListener(&m_midi);
     dlg.ShowModal();

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreator.h
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreator.h
@@ -11,9 +11,7 @@
 class wxString;
 
 class GOMidiDialogListener;
-class GOMidiReceiver;
-class GOMidiSender;
-class GOMidiShortcutReceiver;
+class GOMidiObject;
 
 /**
  * An abstract class that can show a MIDIEventDialog
@@ -24,10 +22,7 @@ public:
     void *element,
     const wxString &title,
     const wxString &dialogSelector,
-    GOMidiReceiver *event,
-    GOMidiSender *sender,
-    GOMidiShortcutReceiver *key,
-    GOMidiSender *division = nullptr,
+    GOMidiObject &obj,
     GOMidiDialogListener *pDialogListener = nullptr)
     = 0;
 };

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.cpp
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.cpp
@@ -11,19 +11,9 @@ void GOMidiDialogCreatorProxy::ShowMIDIEventDialog(
   void *element,
   const wxString &title,
   const wxString &dialogSelector,
-  GOMidiReceiver *event,
-  GOMidiSender *sender,
-  GOMidiShortcutReceiver *key,
-  GOMidiSender *division,
+  GOMidiObject &obj,
   GOMidiDialogListener *pDialogListener) {
   if (p_creator)
     p_creator->ShowMIDIEventDialog(
-      element,
-      title,
-      dialogSelector,
-      event,
-      sender,
-      key,
-      division,
-      pDialogListener);
+      element, title, dialogSelector, obj, pDialogListener);
 }

--- a/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.h
+++ b/src/grandorgue/midi/dialog-creator/GOMidiDialogCreatorProxy.h
@@ -23,10 +23,7 @@ public:
     void *element,
     const wxString &title,
     const wxString &dialogSelector,
-    GOMidiReceiver *event,
-    GOMidiSender *sender,
-    GOMidiShortcutReceiver *key,
-    GOMidiSender *division = nullptr,
+    GOMidiObject &obj,
     GOMidiDialogListener *pDialogListener = nullptr) override;
 };
 

--- a/src/grandorgue/midi/objects/GOMidiPlayingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiPlayingObject.cpp
@@ -40,19 +40,10 @@ void GOMidiPlayingObject::AfterMidiLoaded() {
 }
 
 void GOMidiPlayingObject::ShowConfigDialog() {
-  const bool isReadOnly = IsReadOnly();
   const wxString title = wxString::Format(
     _("MIDI-Settings for %s - %s"), GetMidiTypeName(), GetName());
   const wxString selector
     = wxString::Format(wxT("%s.%s"), GetMidiTypeCode(), GetName());
 
-  r_OrganModel.ShowMIDIEventDialog(
-    this,
-    title,
-    selector,
-    isReadOnly ? nullptr : GetMidiReceiver(),
-    GetMidiSender(),
-    isReadOnly ? nullptr : GetMidiShortcutReceiver(),
-    GetDivisionSender(),
-    this);
+  r_OrganModel.ShowMIDIEventDialog(this, title, selector, *this, this);
 }


### PR DESCRIPTION
Earlier the MIDI dialog constructor was accepted the instances of all four MIDI elements independently.

Now it accepts a single GOMidiObject instance instead.

Because there this dialog may be used for GORegisteredOrgan that does not inherit from GOMidiObject, an auxiliary constructor has been created that accepts a GOMidiReceiver instance.

No GO behavior should be changed.