### PR TITLE
Load pitch and show it to labels on organ load

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -296,6 +296,12 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   }
 
   m_PitchLabel.Load(cfg, wxT("SetterMasterPitch"), _("organ pitch"));
+
+  // Load current pitch and write it to labels on loading of organ
+  const float currentPitch
+    = GetRootPipeConfigNode().GetPipeConfig().GetManualTuning();
+  m_PitchLabel.SetContent(wxString::Format(_("%f cent"), currentPitch));
+
   m_TemperamentLabel.Load(
     cfg, wxT("SetterMasterTemperament"), _("temperament"));
   m_MainWindowData.Load(cfg);


### PR DESCRIPTION
issue #2233

I added the lines for loading the current pitch to the labels directly after the labels itself are loaded.
If this is the wrong location please let me know.

