### PR TITLE
Implemented Save and Load of Initial MIDI objects with GOConfigMidiInitial

### DIFF
--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -79,8 +79,6 @@ private:
   void LoadOrgans(GOConfigReader &cfg);
   void SaveOrgans(GOConfigWriter &cfg);
 
-  wxString GetEventSection(unsigned index);
-
   void LoadDefaults();
 
 public:


### PR DESCRIPTION
Earlier GOConfig saved and restored only the Receiver part of the InitialMidiObject.

Now it exports and restores all MIDI elements of the objects.

It adds a capability that will be used in the future. It also changed the GrandOrgueConfig file format, so after saving it with the new version and restoring it with the old one the Initial MIDI settings would be lost. But after reading an old-version GrandOrgueConfig all initial MIDI settings should be imported successfully.
