### PR TITLE
Added capability of settings Save, Division and Shortcut elements of Initial MIDI objects https://github.com/GrandOrgue/grandorgue/issues/1974

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Added capability of settings Save, Division and Shortcut elements of Initial MIDI objects https://github.com/GrandOrgue/grandorgue/issues/1974
+- Added capability of setting Send, Division and Shortcut events for Initial MIDI objects https://github.com/GrandOrgue/grandorgue/issues/1974
 - Reduced decimal numbers for PitchLabel https://github.com/GrandOrgue/grandorgue/issues/2234
 - Added support of exporting current midi settings to a text file and of importing them from both text and .cmb files https://github.com/GrandOrgue/grandorgue/issues/1199
 - Fixed crash on reloading an organ https://github.com/GrandOrgue/grandorgue/issues/2185

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added capability of settings Save, Division and Shortcut elements of Initial MIDI objects https://github.com/GrandOrgue/grandorgue/issues/1974
 - Reduced decimal numbers for PitchLabel https://github.com/GrandOrgue/grandorgue/issues/2234
 - Added support of exporting current midi settings to a text file and of importing them from both text and .cmb files https://github.com/GrandOrgue/grandorgue/issues/1199
 - Fixed crash on reloading an organ https://github.com/GrandOrgue/grandorgue/issues/2185

--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -55,11 +55,13 @@ static const wxString MIDI_IN(wxT("MIDIIn"));
 static const wxString MIDI_OUT(wxT("MIDIOut"));
 static const wxString SOUND_PORTS = wxT("SoundPorts");
 static const wxString GENERAL = wxT("General");
+static const wxString WX_USER_ADDED = wxT("User-added");
 static const wxString WX_MIDI_INITIAL_COUNT = wxT("MidiInitialCount");
 static const wxString WX_MIDI_INITIAL_FMT = wxT("MidiInitial%03u");
 static const wxString WX_MIDI_INPUT_NUMBER = wxT("MidiInputNumber");
 static const wxString WX_PATH = wxT("Path");
 static const wxString WX_OBJECT_TYPE = wxT("ObjectType");
+static const wxString WX_NAME = wxT("Name");
 static const wxString WX_FMT_D = wxT("%d");
 
 struct initial_midi_group_desc {
@@ -476,7 +478,11 @@ void GOConfig::Load() {
           auto it = m_InitialMidiObjectsByPath.find(path);
 
           if (it == m_InitialMidiObjectsByPath.end()) {
-            pObj = new GOConfigMidiObject(m_MidiMap, objectType);
+            const wxString name
+              = cfg.ReadString(CMBSetting, group, WX_NAME, false);
+
+            pObj = new GOConfigMidiObject(
+              m_MidiMap, objectType, WX_USER_ADDED, path, name);
             m_InitialMidiObjectsByPath[path] = pObj;
           }
         }
@@ -699,8 +705,10 @@ void GOConfig::Flush() {
     if (i < midiInitialBuiltinCount)
       cfg.WriteInteger(
         group, WX_MIDI_INPUT_NUMBER, INTERNAL_MIDI_DESCS[i].m_index);
-    else // A user-added MIDI object. Match it by path
-      cfg.WriteString(group, WX_PATH, pObj->GetPath());
+    else { // A user-added MIDI object. Match it by path
+      cfg.WriteString(group, WX_PATH, pObj->GetMatchingBy());
+      cfg.WriteString(group, WX_NAME, pObj->GetName());
+    }
     pObj->SaveMidiObject(cfg, group, m_MidiMap);
   }
 

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -79,8 +79,6 @@ private:
   void LoadOrgans(GOConfigReader &cfg);
   void SaveOrgans(GOConfigWriter &cfg);
 
-  wxString GetEventSection(unsigned index);
-
   void LoadDefaults();
 
 public:

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
@@ -15,7 +15,6 @@
 #include "gui/dialogs/midi-event/GOMidiEventDialog.h"
 #include "gui/size/GOAdditionalSizeKeeperProxy.h"
 #include "gui/wxcontrols/GOGrid.h"
-#include "midi/elements/GOMidiReceiver.h"
 
 BEGIN_EVENT_TABLE(GOSettingsMidiInitial, GODialogTab)
 EVT_GRID_CMD_SELECT_CELL(ID_INITIALS, GOSettingsMidiInitial::OnInitialsSelected)
@@ -94,8 +93,8 @@ bool GOSettingsMidiInitial::TransferDataToWindow() {
   for (unsigned i = 0; i < nInitials; i++) {
     const GOConfigMidiObject *pObj = r_config.GetMidiInitialObject(i);
 
-    m_Initials->SetCellValue(i, GRID_COL_GROUP, r_config.GetEventGroup(i));
-    m_Initials->SetCellValue(i, GRID_COL_NAME, r_config.GetEventTitle(i));
+    m_Initials->SetCellValue(i, GRID_COL_GROUP, pObj->GetObjectGroup());
+    m_Initials->SetCellValue(i, GRID_COL_NAME, pObj->GetName());
     m_Initials->SetCellValue(
       i, GRID_COL_CONFIGURED, pObj->IsMidiConfigured() ? _("Yes") : _("No"));
   }
@@ -114,8 +113,7 @@ void GOSettingsMidiInitial::ConfigureInitial() {
   GOMidiEventDialog dlg(
     nullptr,
     this,
-    wxString::Format(
-      _("Initial MIDI settings for %s"), r_config.GetEventTitle(index)),
+    wxString::Format(_("Initial MIDI settings for %s"), pObj->GetName()),
     r_config,
     wxT("InitialSettings"),
     *pObj);
@@ -123,5 +121,7 @@ void GOSettingsMidiInitial::ConfigureInitial() {
   dlg.RegisterMIDIListener(&r_midi);
   dlg.ShowModal();
   m_Initials->SetCellValue(
-    index, GRID_COL_CONFIGURED, pObj->IsMidiConfigured() ? _("Yes") : _("No"));
+    index,
+    GRID_COL_CONFIGURED,
+    pObj->IsMidiConfigured() > 0 ? _("Yes") : _("No"));
 }

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsMidiInitial.cpp
@@ -112,12 +112,13 @@ void GOSettingsMidiInitial::ConfigureInitial() {
   int index = m_Initials->GetGridCursorRow();
   GOConfigMidiObject *pObj = r_config.GetMidiInitialObject(index);
   GOMidiEventDialog dlg(
+    nullptr,
     this,
     wxString::Format(
       _("Initial MIDI settings for %s"), r_config.GetEventTitle(index)),
     r_config,
     wxT("InitialSettings"),
-    pObj->GetMidiReceiver());
+    *pObj);
 
   dlg.RegisterMIDIListener(&r_midi);
   dlg.ShowModal();


### PR DESCRIPTION
Now it is possible to edit all elements of InitialMIDI objects with the Properties dialog from the Initial MIDI settings tab.

It also changed the GrandOrgueConfig file format, so after saving it with the new version and restoring it with the old one the Initial MIDI settings would be lost. But after reading an old-version GrandOrgueConfig all initial MIDI settings should be imported successfully.