### PR TITLE
Switched compilation to the c++ 20 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -43,7 +43,7 @@ endif()
 
 # Define a c++ standard
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard whose features are requested to build this project")
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard whose features are requested to build this project")
 
 # Build configuration options
 option(RTAUDIO_USE_CORE       "Enable RtAudio support for Core Audio (Rt and PortAudio - OS X only)" ON)


### PR DESCRIPTION
The minimal ubuntu version where we build GrandOrgue is 22.
Ubuntu 22.04 ships with gcc 11.
gcc 11 supports most of features of c++ 20.

So I do not see any reasons for restricting c++ by 17.

This PR switches the c++ version standard used for GrandOrgue compilation.

No GO behavior should be changed.