### PR TITLE
Fixed downloading appimagetool

### DIFF
--- a/build-scripts/for-appimage-x86_64/prepare-debian-based.sh
+++ b/build-scripts/for-appimage-x86_64/prepare-debian-based.sh
@@ -8,7 +8,7 @@ $DIR/../for-linux/prepare-debian-based.sh "" amd64
 # linuxdeploy, linuxdeploy-plugin-gtk and appimagetool must be downloaded
 sudo wget -P /usr/local/bin https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
 sudo wget -P /usr/local/bin https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-sudo wget -P /usr/local/bin https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+sudo wget -P /usr/local/bin https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
 
 # make them executable
 sudo chmod +x /usr/local/bin/linuxdeploy-plugin-gtk.sh


### PR DESCRIPTION
Recent github builds for appimage was failed because the `AppImageKit` repository is marked as obsolete. This PR fixes this problem.