### PR TITLE
Fixed playing the last sample of a loop https://github.com/GrandOrgue/grandorgue/issues/2211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed playing the last sample of a loop https://github.com/GrandOrgue/grandorgue/issues/2211
 # 3.16.0 (2025-08-03)
 - Added more columns to the Initial MIDI tab of the Organ settings  https://github.com/GrandOrgue/grandorgue/issues/1974
 - Added capability of assigning any MIDI object events to the initial MIDI configuration https://github.com/GrandOrgue/grandorgue/issues/1974

--- a/src/core/go_defs.h.in
+++ b/src/core/go_defs.h.in
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -15,7 +15,7 @@
 /* Value which is used to identify a valid cached organ data file. 
   It must be changed every time when the cache structure is modefied
 */
-#define GRANDORGUE_CACHE_MAGIC 0x12341236
+#define GRANDORGUE_CACHE_MAGIC 0x12341237
 
 #cmakedefine HAVE_ATOMIC
 #cmakedefine HAVE_MUTEX

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -359,7 +359,7 @@ void GOSoundAudioSection::Setup(
         min_reqd_samples = loop.m_EndPosition + 1;
 
       start_seg.start_offset = loop.m_StartPosition;
-      end_seg.end_pos = loop.m_EndPosition;
+      end_seg.end_pos = loop.m_EndPosition + 1;
       end_seg.next_start_segment_index = i + 1;
       const unsigned loop_length = end_seg.end_pos - start_seg.start_offset;
       wxString loopError;

--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -355,12 +355,17 @@ void GOSoundAudioSection::Setup(
       EndSegment end_seg;
       const GOWaveLoop &loop = (*loop_points)[i];
 
-      if (loop.m_EndPosition + 1 > min_reqd_samples)
-        min_reqd_samples = loop.m_EndPosition + 1;
-
       start_seg.start_offset = loop.m_StartPosition;
+      /* According to
+       * https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Docs/RIFFNEW.pdf
+       * dwEnd is the position of the last sample of the loop, but we need the
+       * first position after this sample
+       */
       end_seg.end_pos = loop.m_EndPosition + 1;
+      if (end_seg.end_pos > min_reqd_samples)
+        min_reqd_samples = end_seg.end_pos;
       end_seg.next_start_segment_index = i + 1;
+
       const unsigned loop_length = end_seg.end_pos - start_seg.start_offset;
       wxString loopError;
 


### PR DESCRIPTION
Resolves: #2211 

Earlier GO did not play the last sample of a loop because considered dwEnd as a position after the last sample. Now it considers it as the position of the last sample itself so ii plays the sample correctly.

Because the positions might be in the cache file, the cache magic is also changed.
