### PR TITLE
Fixed crash on exit from GrandOrgue on MacOs https://github.com/GrandOrgue/grandorgue/issues/2256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on exit from GrandOrgue on MacOs https://github.com/GrandOrgue/grandorgue/issues/2256
 - Fixed playing the last sample of a loop https://github.com/GrandOrgue/grandorgue/issues/2211
 # 3.16.0 (2025-08-03)
 - Added more columns to the Initial MIDI tab of the Organ settings  https://github.com/GrandOrgue/grandorgue/issues/1974

--- a/src/grandorgue/sound/GOSound.cpp
+++ b/src/grandorgue/sound/GOSound.cpp
@@ -339,10 +339,14 @@ void GOSound::FillDeviceNamePattern(
 GOMidi &GOSound::GetMidi() { return m_midi; }
 
 void GOSound::ResetMeters() {
-  wxCommandEvent event(wxEVT_METERS, 0);
-  event.SetInt(0x1);
-  if (wxTheApp->GetTopWindow())
-    wxTheApp->GetTopWindow()->GetEventHandler()->AddPendingEvent(event);
+  wxWindow *const topWindow = wxTheApp ? wxTheApp->GetTopWindow() : nullptr;
+
+  if (topWindow) {
+    wxCommandEvent event(wxEVT_METERS, 0);
+
+    event.SetInt(0x1);
+    topWindow->GetEventHandler()->AddPendingEvent(event);
+  }
 }
 
 void GOSound::UpdateMeter() {


### PR DESCRIPTION
Resolves: #2256

WxWidgets 3.3 calls ~GOSound when the wxTheApp is already nullptr.

This PR fixes crash on accessing null wxTheApp