### PR TITLE
Fixed unability to save midi objects with Send configured to a preset

### DIFF
--- a/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.cpp
@@ -29,12 +29,6 @@ void GOMidiSendingObject::LoadMidiObject(
 
 void GOMidiSendingObject::SetElementId(int id) { m_sender.SetElementID(id); }
 
-void GOMidiSendingObject::SaveMidiObject(
-  GOConfigWriter &cfg, const wxString &group, GOMidiMap &midiMap) const {
-  GOMidiPlayingObject::SaveMidiObject(cfg, group, midiMap);
-  m_sender.Save(cfg, group, midiMap);
-}
-
 void GOMidiSendingObject::ResendMidi() {
   m_sender.SetName(GetName());
   SendCurrentMidiValue();

--- a/src/grandorgue/midi/objects/GOMidiSendingObject.h
+++ b/src/grandorgue/midi/objects/GOMidiSendingObject.h
@@ -28,10 +28,6 @@ protected:
 
   void LoadMidiObject(
     GOConfigReader &cfg, const wxString &group, GOMidiMap &midiMap) override;
-  void SaveMidiObject(
-    GOConfigWriter &cfg,
-    const wxString &group,
-    GOMidiMap &midiMap) const override;
 
   void SendMidiValue(bool value) { m_sender.SetDisplay(value); }
   void SendMidiValue(int value) { m_sender.SetValue(value); }


### PR DESCRIPTION
When GO was built with assertions-enabled, and some MIDI object was configured for sending MIDI events, there was unable to save the organ settings to a preset.

The reason was the GOMidiObject::p_MidiSender tried to be saved twice: from GOMidiObject::SaveMidiObject and from GOMidiSendingObject::SaveMidiObject that caused an assertion fail.

This PR fixes this issue: it removes GOMidiSendingObject::SaveMidiObject.