### PR TITLE
Fixed sending 'ON' strings in sysex MIDI messages https://github.com/GrandOrgue/grandorgue/issues/2260

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed sending 'ON' strings in sysex MIDI messages https://github.com/GrandOrgue/grandorgue/issues/2260
 - Fixed crash on exit from GrandOrgue on MacOs https://github.com/GrandOrgue/grandorgue/issues/2256
 - Fixed playing the last sample of a loop https://github.com/GrandOrgue/grandorgue/issues/2211
 # 3.16.0 (2025-08-03)

--- a/src/grandorgue/control/GOLabelControl.cpp
+++ b/src/grandorgue/control/GOLabelControl.cpp
@@ -11,6 +11,8 @@
 
 #include "model/GOOrganModel.h"
 
+const wxString GOLabelControl::WX_EMPTY_STRING = wxEmptyString;
+
 GOLabelControl::GOLabelControl(
   GOOrganModel &organModel, const GOMidiObjectContext *pContext)
   : GOMidiSendingObject(organModel, OBJECT_TYPE_LABEL, MIDI_SEND_LABEL) {

--- a/src/grandorgue/control/GOLabelControl.h
+++ b/src/grandorgue/control/GOLabelControl.h
@@ -18,11 +18,14 @@ class GOMidiObjectContext;
 class GOOrganModel;
 
 class GOLabelControl : public GOControl, public GOMidiSendingObject {
+private:
+  static const wxString WX_EMPTY_STRING;
+
 protected:
   wxString m_Content;
 
   void SendCurrentMidiValue() override { SendMidiValue(m_Content); }
-  void SendEmptyMidiValue() override { SendMidiValue(wxEmptyString); }
+  void SendEmptyMidiValue() override { SendMidiValue(WX_EMPTY_STRING); }
 
 public:
   GOLabelControl(


### PR DESCRIPTION
Resolves: #2260 

The reason of sending extra "ON" strings was in GOLabelControl::SendEmptyMidiValue(): it tried to send wxEmptyString that was converted to bool `true` instead of to wxString empty string.