### PR TITLE
Fixed displaying more than 10 enclosures on the CouplerManualsAndVolume panel https://github.com/GrandOrgue/grandorgue/issues/2100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed displaying more than 10 enclosures on the CouplerManualsAndVolume panel https://github.com/GrandOrgue/grandorgue/issues/2100
 # 3.16.1 (2025-08-28)
 - Fixed sending 'ON' strings in sysex MIDI messages https://github.com/GrandOrgue/grandorgue/issues/2260
 - Fixed crash on exit from GrandOrgue on MacOs https://github.com/GrandOrgue/grandorgue/issues/2256

--- a/src/grandorgue/gui/panels/GOGUISetterDisplayMetrics.cpp
+++ b/src/grandorgue/gui/panels/GOGUISetterDisplayMetrics.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -59,13 +59,16 @@ GOGUISetterDisplayMetrics::GOGUISetterDisplayMetrics(
     break;
 
   case GOGUI_SETTER_FLOATING:
-    x_size
-      = 40
-      + std::max(
-          10
-            * organController->GetManual(organController->GetODFManualCount())
-                ->GetLogicalKeyCount(),
-          (unsigned)10 * 40);
+    x_size = std::max(
+      10
+          * organController->GetManual(organController->GetODFManualCount())
+              ->GetLogicalKeyCount()
+        + 40,
+      GetEnclosureWidth()
+          * (
+            // one enclosure per windchest + master volume
+            organController->GetWindchestCount() + 1)
+        + 6);
     y_size = (organController->GetManualAndPedalCount()
               - organController->GetODFManualCount() + 1)
         * 60


### PR DESCRIPTION
Resolves: #2100

This PR adds calculating the width of the CouplerManualsAndVolume panel based on the number of windchest.
