### PR TITLE
Fixed "The procedure entry point ... could not be located" on Windows after a cross build on Ubuntu-22.04 https://github.com/GrandOrgue/grandorgue/issues/2190

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
             prepare: osx
             build_on: osx
 
-          - run_on: ubuntu-22.04
+          - run_on: ubuntu-latest
             for: win64
             prepare: "debian-based"
             build_on: linux

--- a/build-scripts/for-win64/prepare-debian-based-mingw.sh
+++ b/build-scripts/for-win64/prepare-debian-based-mingw.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+# this gcc version interval has a bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116159
+GCC_BAD_VERSION_START=11
+GCC_BAD_VERSION_END=14.3
+GCC_MINGW_BUGFIX_VERSION=26.1.1
+
+# determine an available mingw version
+GCC_AVAILABLE_VERSION=$(apt-cache policy g++-mingw-w64 | sed 's/-/ /' | awk '/Candidate:/ { print $2; }' | sort | tail -n 1)
+
+if [[ "$GCC_AVAILABLE_VERSION" < "$GCC_BAD_VERSION_START" ]] \
+  || [[ "$GCC_BAD_VERSION_END" < "$GCC_AVAILABLE_VERSION" ]]; then
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    g++-mingw-w64-x86-64-posix \
+    gcc-mingw-w64-x86-64-posix \
+    gcc-mingw-w64-x86-64-posix-runtime \
+    gcc-mingw-w64-base
+else
+  #check installed version
+  MINGW_INSALLED_VERSION=$(dpkg-query -W -f='${Version}' g++-mingw-w64-x86-64-posix 2>/dev/null | sed 's/.*+//' || true)
+
+  if [[ "$MINGW_INSALLED_VERSION" != "$GCC_MINGW_BUGFIX_VERSION" ]]; then
+    mkdir -p deb/mingw
+
+    rm -rf deb/mingw
+    wget -P deb/mingw\
+      https://github.com/GrandOrgue/GccMingwW64/releases/download/${GCC_MINGW_BUGFIX_VERSION}/g++-mingw-w64-x86-64-posix_13.3.0-6ubuntu2.24.04+${GCC_MINGW_BUGFIX_VERSION}_amd64.deb \
+      https://github.com/GrandOrgue/GccMingwW64/releases/download/${GCC_MINGW_BUGFIX_VERSION}/gcc-mingw-w64-x86-64-posix_13.3.0-6ubuntu2.24.04+${GCC_MINGW_BUGFIX_VERSION}_amd64.deb \
+      https://github.com/GrandOrgue/GccMingwW64/releases/download/${GCC_MINGW_BUGFIX_VERSION}/gcc-mingw-w64-x86-64-posix-runtime_13.3.0-6ubuntu2.24.04+${GCC_MINGW_BUGFIX_VERSION}_amd64.deb \
+      https://github.com/GrandOrgue/GccMingwW64/releases/download/${GCC_MINGW_BUGFIX_VERSION}/gcc-mingw-w64-base_13.3.0-6ubuntu2.24.04+${GCC_MINGW_BUGFIX_VERSION}_amd64.deb
+
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ./deb/mingw/*.deb
+  fi
+
+fi

--- a/build-scripts/for-win64/prepare-debian-based.sh
+++ b/build-scripts/for-win64/prepare-debian-based.sh
@@ -10,12 +10,16 @@ sudo apt-get update
 # remove an odd version of packages that prevents installing wine32
 $BASE_DIR/../for-linux/prepare-debian-based-align-libs.sh $TARGET_ARCH i386
 
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wget
+
+$BASE_DIR/prepare-debian-based-mingw.sh
+
 # install dependencies for wine32
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   libgcc-s1:i386 libstdc++6:i386
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  wget unzip cmake g++ pkg-config g++-mingw-w64-x86-64 nsis \
+  wget unzip cmake g++ pkg-config nsis \
   docbook-xsl xsltproc gettext po4a imagemagick zip \
   wine32 winbind pipx
 
@@ -54,7 +58,7 @@ if [ ! -d /usr/local/asio-sdk ]; then
 	wget -O $DL_DIR/asiosdk.zip https://www.steinberg.net/asiosdk
 	sudo unzip -o $DL_DIR/asiosdk.zip -d /usr/local/
 	rm -rf $DL_DIR
-	SDK_DIR=`ls -1d /usr/local/asiosdk* | tail -1`
+	SDK_DIR=`ls -1d /usr/local/ASIOSDK | tail -1`
 	sudo ln -sf `basename $SDK_DIR` /usr/local/asio-sdk
 fi
 


### PR DESCRIPTION
Resolves: #2190

The reason of wrong cross-build on Ubuntu 24.04 was a bug in MinGw that was introduced in gcc-11 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116159 and was fixed in gcc-14.3 https://gcc.gnu.org/g:2003f890b13b8ec35b6112fc13c7e69e61cd9162 .

Ubuntu 24.04 ships with gcc 13.2 that is influenced by this bug.

I had tried to backport gcc-14 to Ubuntu 24.04 without success.

So I backported the fix from 14.3 to 13.2 and I built mingw 26.1.1 with this fix in a new repository: https://github.com/GrandOrgue/GccMingwW64 

This PR installs this patched gсс-mingw packages instead of the standard ones. Now GrandOrgue can run on windows without dll issues.

