### PR TITLE
Added validation of the device logical names for leading/trailing spaces in the Device Matching Dialog https://github.com/GrandOrgue/grandorgue/issues/2278

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added validation of the device logical names for leading/trailing spaces in the Device Matching Dialog https://github.com/GrandOrgue/grandorgue/issues/2278
 # 3.16.2 (2025-11-10)
 - Added option of BAS/MEL coupler behaviour to fix missed notes https://github.com/GrandOrgue/grandorgue/issues/1672
 - Fixed displaying more than 10 enclosures on the CouplerManualsAndVolume panel https://github.com/GrandOrgue/grandorgue/issues/2100

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsDeviceMatchDialog.h
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsDeviceMatchDialog.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -34,7 +34,9 @@ private:
 
   bool ValidateLogicalName(wxString &errMsg);
   bool ValidateRegex(wxString &errMsg);
+  bool ValidateAll(wxString &errMsg);
 
+  void OnShow(wxShowEvent &event);
   void OnLogicalNameChanged(wxCommandEvent &event);
   void OnRegexChanged(wxCommandEvent &event);
   void OnHelp(wxCommandEvent &event);


### PR DESCRIPTION
Resolves: #2278

Because the problems mantioned in the issue were caused by a trailing space in the device name, I added the validation of the name

1. When the Device Matching Dialog becomes open.
2. When the Logical name is changed.