### PR TITLE
Enchanced starting logging

### DIFF
--- a/src/grandorgue/GOApp.h
+++ b/src/grandorgue/GOApp.h
@@ -2,7 +2,7 @@
  * GrandOrgue - a free pipe organ simulator
  *
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -22,16 +22,33 @@
 #ifndef GOAPP_H
 #define GOAPP_H
 
+#include <memory>
+
 #include <wx/app.h>
 
+class GOConfig;
 class GOFrame;
 class GOLog;
 class GOSound;
-class GOConfig;
 
 class GOApp : public wxApp {
 private:
-  bool m_Restart;
+  /**
+   * A temporary logging class.
+   * It logs all Warning and Error log messages to stderr, all other messages to
+   * stdout. It alse displays all Error messages to a modal message box.
+   * It is used only before initialising the GOLog instance, including during
+   * reading the GrandOrgueConfig
+   */
+  class TemporaryLog : public wxLog {
+  protected:
+    void DoLogTextAtLevel(wxLogLevel level, const wxString &msg) override;
+  };
+
+  // A temporary logging instance
+  std::unique_ptr<TemporaryLog> m_TemporaryLog
+    = std::make_unique<TemporaryLog>();
+  bool m_Restart = false;
 
 #ifdef __WXMAC__
   virtual void MacOpenFile(const wxString &fileName) override;
@@ -44,17 +61,16 @@ private:
   virtual void CleanUp() override;
 
 protected:
-  GOFrame *m_Frame;
+  GOFrame *m_Frame = nullptr;
   wxLocale m_locale;
-  GOConfig *m_config;
-  GOSound *m_soundSystem;
-  GOLog *m_Log;
+  GOConfig *m_config = nullptr;
+  GOSound *m_soundSystem = nullptr;
+  GOLog *m_Log = nullptr;
   wxString m_FileName;
   wxString m_InstanceName;
-  bool m_IsGuiOnly;
+  bool m_IsGuiOnly = false;
 
 public:
-  GOApp();
   void SetRestart();
 };
 


### PR DESCRIPTION
Earlier all warning messages during reading GrandOrgueConfig brought modal message box.

Now only errors cause modal message box. All messages with a lower level (including warnings) just appear in stdout/stderr.

It also makes small `GOApp` code enchancements: removes a constructor, replaces NULL with nullptr.