### PR TITLE
Changed types of GOMidiEventPattern members

### DIFF
--- a/src/grandorgue/midi/GOMidiMap.h
+++ b/src/grandorgue/midi/GOMidiMap.h
@@ -8,6 +8,8 @@
 #ifndef GOMIDIMAP_H
 #define GOMIDIMAP_H
 
+#include <cstdint>
+
 #include <wx/string.h>
 
 #include "GONameMap.h"
@@ -17,40 +19,40 @@ private:
   GONameMap m_DeviceMap;
   GONameMap m_ElementMap;
 
-  static unsigned getIdByName(GONameMap &map, const wxString &name) {
+  static uint_fast16_t getIdByName(GONameMap &map, const wxString &name) {
     return map.EnsureNameExists(name.utf8_str().data());
   }
 
   template <typename AddingFun>
-  static unsigned ensureName(
+  static uint_fast16_t ensureName(
     GONameMap &map, const wxString &name, AddingFun addingFun) {
     return map.EnsureNameExists(name.utf8_str().data(), addingFun);
   }
 
-  static wxString getNameById(const GONameMap &map, unsigned id) {
+  static wxString getNameById(const GONameMap &map, uint_fast16_t id) {
     return wxString::FromUTF8(
       map.GetNameById(static_cast<GONameMap::IdType>(id)).c_str());
   }
 
 public:
-  unsigned GetDeviceIdByLogicalName(const wxString &name) {
+  uint_fast16_t GetDeviceIdByLogicalName(const wxString &name) {
     return getIdByName(m_DeviceMap, name);
   }
 
   template <typename AddingFun>
-  unsigned EnsureLogicalName(const wxString &name, AddingFun addingFun) {
+  uint_fast16_t EnsureLogicalName(const wxString &name, AddingFun addingFun) {
     return ensureName(m_DeviceMap, name, addingFun);
   }
 
-  wxString GetDeviceLogicalNameById(unsigned id) const {
+  wxString GetDeviceLogicalNameById(uint_fast16_t id) const {
     return getNameById(m_DeviceMap, id);
   }
 
-  unsigned GetElementByString(const wxString &str) {
+  uint_fast16_t GetElementByString(const wxString &str) {
     return getIdByName(m_ElementMap, str);
   }
 
-  wxString GetElementByID(unsigned id) const {
+  wxString GetElementByID(uint_fast16_t id) const {
     return getNameById(m_ElementMap, id);
   }
 };

--- a/src/grandorgue/midi/events/GOMidiEventPattern.cpp
+++ b/src/grandorgue/midi/events/GOMidiEventPattern.cpp
@@ -41,10 +41,14 @@ void GOMidiEventPattern::DeviceIdFromYaml(
 }
 
 int GOMidiEventPattern::convertValueBetweenRanges(
-  int srcValue, int srcLow, int srcHigh, int dstLow, int dstHigh) {
-  const int dstAbsLow = std::min(dstLow, dstHigh);
-  const int dstAbsHigh = std::max(dstLow, dstHigh);
-  int dstValue = srcValue - srcLow;
+  int_fast8_t srcValue,
+  int_fast8_t srcLow,
+  int_fast8_t srcHigh,
+  int_fast8_t dstLow,
+  int_fast8_t dstHigh) {
+  const int_fast8_t dstAbsLow = std::min(dstLow, dstHigh);
+  const int_fast8_t dstAbsHigh = std::max(dstLow, dstHigh);
+  int_fast8_t dstValue = srcValue - srcLow;
 
   if (srcHigh != srcLow)
     dstValue = dstLow

--- a/src/grandorgue/midi/events/GOMidiEventPattern.h
+++ b/src/grandorgue/midi/events/GOMidiEventPattern.h
@@ -8,6 +8,8 @@
 #ifndef GOMIDIEVENTPATTERN_H
 #define GOMIDIEVENTPATTERN_H
 
+#include <cstdint>
+
 #include "GOStringSet.h"
 
 namespace YAML {
@@ -19,19 +21,19 @@ class GOMidiMap;
 struct GOMidiEventPattern {
   enum { MIN_VALUE = 0, MAX_VALUE = 127 };
 
-  unsigned deviceId;
-  int channel;
-  int key;
-  int low_value;
-  int high_value;
+  uint16_t deviceId;
+  int8_t channel;
+  int8_t key;
+  int8_t low_value;
+  int8_t high_value;
   bool useNoteOff;
 
   GOMidiEventPattern(
-    unsigned uDeviceId,
-    int iChannel,
-    int iKey,
-    int iLowValue = 0,
-    int iHighValue = 0,
+    uint_fast16_t uDeviceId,
+    int_fast8_t iChannel,
+    int_fast8_t iKey,
+    int_fast8_t iLowValue = 0,
+    int_fast8_t iHighValue = 0,
     bool iUseNoteOff = true)
     : deviceId(uDeviceId),
       channel(iChannel),
@@ -63,7 +65,11 @@ struct GOMidiEventPattern {
    * @return the destination value
    **/
   static int convertValueBetweenRanges(
-    int srcValue, int srcLow, int srcHigh, int dstLow, int dstHigh);
+    int_fast8_t srcValue,
+    int_fast8_t srcLow,
+    int_fast8_t srcHigh,
+    int_fast8_t dstLow,
+    int_fast8_t dstHigh);
 };
 
 #endif /* GOMIDIEVENTPATTERN_H */


### PR DESCRIPTION
This PR replaces field types `int` and `unsigned` of MIDI-related structures with `uint16_t` and `in8_t`.

It is just a small refactoring. No GO behaviur should be changed.