### PR TITLE
Minor enchancements in GOConfig

### DIFF
--- a/src/grandorgue/config/GOConfig.cpp
+++ b/src/grandorgue/config/GOConfig.cpp
@@ -791,10 +791,6 @@ const unsigned GOConfig::GetTotalAudioChannels() const {
 
 unsigned GOConfig::GetDefaultLatency() { return 50; }
 
-GOMidiMap &GOConfig::GetMidiMap() { return m_MidiMap; }
-
-GOTemperamentList &GOConfig::GetTemperaments() { return m_Temperaments; }
-
 void GOConfig::Flush() {
   wxString tmp_name = m_ConfigFileName + wxT(".new");
   GOConfigFileWriter cfg_file;

--- a/src/grandorgue/config/GOConfig.h
+++ b/src/grandorgue/config/GOConfig.h
@@ -219,9 +219,10 @@ public:
     m_MidiPortsConfig = portsConfig;
   }
 
-  GOMidiMap &GetMidiMap();
+  GOMidiMap &GetMidiMap() { return m_MidiMap; }
+  const GOMidiMap &GetMidiMap() const { return m_MidiMap; }
 
-  GOTemperamentList &GetTemperaments();
+  GOTemperamentList &GetTemperaments() { return m_Temperaments; }
 
   const GOLogicalRect &GetMainWindowRect() const { return m_MainWindowRect; }
   void SetMainWindowRect(const GOLogicalRect &rect) { m_MainWindowRect = rect; }


### PR DESCRIPTION
This small PR

1. Moves GOConfig::GetMidiMap and GOConfig::GetTemperaments to the header
2. Introduces const version of GOConfig::GetMidiMap