### PR TITLE
Renamed GOMidiMap::GetDeviceIdByLogicalName to EnsureLogicalName. Added a read-only version GOMidiMap::GetDeviceIdByLogicalName

### DIFF
--- a/src/grandorgue/midi/GOMidi.cpp
+++ b/src/grandorgue/midi/GOMidi.cpp
@@ -60,7 +60,7 @@ void GOMidi::Open() {
     if (pDevConf && pDevConf->m_IsEnabled)
       ((GOMidiInPort *)pPort)
         ->Open(
-          m_MidiMap.GetDeviceIdByLogicalName(pDevConf->GetLogicalName()),
+          m_MidiMap.EnsureLogicalName(pDevConf->GetLogicalName()),
           pDevConf->m_ChannelShift);
     else
       pPort->Close();
@@ -75,8 +75,7 @@ void GOMidi::Open() {
       pPort->IsToUse() && portsConfig.IsEnabled(portName, apiName)
       && (devConf = m_config.m_MidiOut.FindByPhysicalName(pPort->GetName(), portName, apiName))
       && devConf->m_IsEnabled)
-      pPort->Open(
-        m_MidiMap.GetDeviceIdByLogicalName(devConf->GetLogicalName()));
+      pPort->Open(m_MidiMap.EnsureLogicalName(devConf->GetLogicalName()));
     else
       pPort->Close();
   }

--- a/src/grandorgue/midi/GOMidiMap.h
+++ b/src/grandorgue/midi/GOMidiMap.h
@@ -19,7 +19,11 @@ private:
   GONameMap m_DeviceMap;
   GONameMap m_ElementMap;
 
-  static uint_fast16_t getIdByName(GONameMap &map, const wxString &name) {
+  static uint_fast16_t getIdByName(const GONameMap &map, const wxString &name) {
+    return map.GetIdByName(name.utf8_str().data());
+  }
+
+  static uint_fast16_t ensureName(GONameMap &map, const wxString &name) {
     return map.EnsureNameExists(name.utf8_str().data());
   }
 
@@ -35,8 +39,12 @@ private:
   }
 
 public:
-  uint_fast16_t GetDeviceIdByLogicalName(const wxString &name) {
+  uint_fast16_t GetDeviceIdByLogicalName(const wxString &name) const {
     return getIdByName(m_DeviceMap, name);
+  }
+
+  uint_fast16_t EnsureLogicalName(const wxString &name) {
+    return ensureName(m_DeviceMap, name);
   }
 
   template <typename AddingFun>

--- a/src/grandorgue/midi/GOMidiPlayer.cpp
+++ b/src/grandorgue/midi/GOMidiPlayer.cpp
@@ -69,7 +69,7 @@ GOMidiPlayer::GOMidiPlayer(GOOrganController *organController)
     m_IsPlaying(false),
     m_Pause(false) {
   CreateButtons(*organController, BUTTON_DEFS);
-  m_DeviceID = r_MidiMap.GetDeviceIdByLogicalName(_("GrandOrgue MIDI Player"));
+  m_DeviceID = r_MidiMap.EnsureLogicalName(_("GrandOrgue MIDI Player"));
   ResetUI();
 }
 

--- a/src/grandorgue/midi/GOMidiRecorder.cpp
+++ b/src/grandorgue/midi/GOMidiRecorder.cpp
@@ -104,7 +104,7 @@ void GOMidiRecorder::ButtonStateChanged(int id, bool newState) {
 }
 
 void GOMidiRecorder::SetOutputDevice(const wxString &device_id) {
-  m_OutputDevice = m_Map.GetDeviceIdByLogicalName(device_id);
+  m_OutputDevice = m_Map.EnsureLogicalName(device_id);
 }
 
 void GOMidiRecorder::SendEvent(GOMidiEvent &e) {

--- a/src/grandorgue/midi/elements/GOMidiReceiver.cpp
+++ b/src/grandorgue/midi/elements/GOMidiReceiver.cpp
@@ -91,7 +91,7 @@ void GOMidiReceiver::Load(
     for (unsigned i = 0; i < m_events.size(); i++) {
       auto &pattern = m_events[i];
 
-      pattern.deviceId = map.GetDeviceIdByLogicalName(cfg.ReadString(
+      pattern.deviceId = map.EnsureLogicalName(cfg.ReadString(
         CMBSetting,
         group,
         wxString::Format(wxT("MIDIDevice%03d"), i + 1),

--- a/src/grandorgue/midi/elements/GOMidiSender.cpp
+++ b/src/grandorgue/midi/elements/GOMidiSender.cpp
@@ -67,7 +67,7 @@ void GOMidiSender::Load(
 
   m_events.resize(event_cnt);
   for (unsigned i = 0; i < m_events.size(); i++) {
-    m_events[i].deviceId = map.GetDeviceIdByLogicalName(cfg.ReadString(
+    m_events[i].deviceId = map.EnsureLogicalName(cfg.ReadString(
       CMBSetting,
       group,
       wxString::Format(wxT("MIDISendDevice%03d"), i + 1),


### PR DESCRIPTION
A next PR is related to #2281

Earlier GOMidiMap::GetDeviceIdByLogicalName added automatically the device name to the map if it had not existed before.

1. It did not follow the name conventions for getters: GetXXX should not have a side effect
2. It is not always desired because we need do something (ex. put a warning message) if the device has been missed during import.

So this PR 
1. Makes GOMidiMap::GetDeviceIdByLogicalName read only
2. Adds an auto-inserting version of the method: GOMidiMap::EnsureLogicalName
3. Replaces all old calls to GOMidiMap::GetDeviceIdByLogicalNam with GOMidiMap::EnsureLogicalName

It is just refactoring. No GO behavior should be changed.