### PR TITLE
Added logging a warning message when importing MIDI objects referencing to a not-existing device https://github.com/GrandOrgue/grandorgue/issues/2281

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added logging a warning message when importing MIDI objects referencing to a not-existing device https://github.com/GrandOrgue/grandorgue/issues/2281
 - Fixed exporting MIDI Settings to yaml file https://github.com/GrandOrgue/grandorgue/issues/2333
 - Fixed creating an organ cache https://github.com/GrandOrgue/grandorgue/issues/2325
 - Removed support of MacOs 13. Now MacOs 14+-arm64 and MacOs 15-intel are only supported

--- a/src/grandorgue/midi/elements/GOMidiReceiver.cpp
+++ b/src/grandorgue/midi/elements/GOMidiReceiver.cpp
@@ -67,6 +67,8 @@ static const GOConfigEnum MIDI_RECEIVE_TYPES({
 GOMidiReceiver::GOMidiReceiver(GOMidiReceiverType type)
   : GOMidiReceiverEventPatternList(type), m_ElementID(-1) {}
 
+static const wxString WX_MIDI_DEVICE = wxT("MIDIDevice");
+
 void GOMidiReceiver::Load(
   bool isOdfCheck, GOConfigReader &cfg, const wxString &group, GOMidiMap &map) {
   if (!isOdfCheck) {
@@ -199,10 +201,7 @@ void GOMidiReceiver::Save(
     for (unsigned i = 0; i < m_events.size(); i++) {
       auto &pattern = m_events[i];
 
-      cfg.WriteString(
-        group,
-        wxString::Format(wxT("MIDIDevice%03d"), i + 1),
-        map.GetDeviceLogicalNameById(pattern.deviceId));
+      pattern.SaveDeviceId(cfg, group, WX_MIDI_DEVICE, i, map);
       cfg.WriteEnum(
         group,
         wxString::Format(wxT("MIDIEventType%03d"), i + 1),

--- a/src/grandorgue/midi/elements/GOMidiSender.cpp
+++ b/src/grandorgue/midi/elements/GOMidiSender.cpp
@@ -58,6 +58,8 @@ static const GOConfigEnum MIDI_SEND_TYPES({
   {wxT("RodgersStopChange"), MIDI_S_RODGERS_STOP_CHANGE},
 });
 
+static const wxString WX_MIDI_SEND_DEVICE = wxT("MIDISendDevice");
+
 void GOMidiSender::Load(
   GOConfigReader &cfg, const wxString &group, GOMidiMap &map) {
   m_events.resize(0);
@@ -153,10 +155,7 @@ void GOMidiSender::Save(
   if (!m_events.empty()) {
     cfg.WriteInteger(group, wxT("NumberOfMIDISendEvents"), m_events.size());
     for (unsigned i = 0; i < m_events.size(); i++) {
-      cfg.WriteString(
-        group,
-        wxString::Format(wxT("MIDISendDevice%03d"), i + 1),
-        map.GetDeviceLogicalNameById(m_events[i].deviceId));
+      m_events[i].SaveDeviceId(cfg, group, WX_MIDI_SEND_DEVICE, i, map);
       cfg.WriteEnum(
         group,
         wxString::Format(wxT("MIDISendEventType%03d"), i + 1),

--- a/src/grandorgue/midi/events/GOMidiEventPattern.h
+++ b/src/grandorgue/midi/events/GOMidiEventPattern.h
@@ -16,6 +16,8 @@ namespace YAML {
 class Node;
 };
 
+class GOConfigReader;
+class GOConfigWriter;
 class GOMidiMap;
 
 struct GOMidiEventPattern {
@@ -45,6 +47,40 @@ struct GOMidiEventPattern {
   virtual bool IsEmpty() const = 0;
 
   bool operator==(const GOMidiEventPattern &other) const;
+
+  /**
+   * Search the device name in the map and put it's id to deviceId. If the
+   * device is not yet in the map, add it automatically and put a warning
+   * message
+   * @param msgContext a string to put into the warning message
+   * @param deviceName a device name to search
+   * @param map a GOMidiMap instance with the MIDI device list
+   */
+  void FillDeviceId(
+    const wxString &msgContext, const wxString &deviceName, GOMidiMap &map);
+
+  /**
+   * Read deviceId from the ConfigReader
+   * @param cfg - a source ConfigReader
+   * @param group - the configuration section
+   * @param keykeyPrefix - the configuration key prefix
+   * @param patternIndex - the pattern index used to calculate the final
+   *   configuration key
+   * @param map a GOMidiMap instance with the MIDI device list
+   */
+  void LoadDeviceId(
+    GOConfigReader &cfg,
+    const wxString &group,
+    const wxString &keyPrefix,
+    unsigned patternIndex,
+    GOMidiMap &map);
+
+  void SaveDeviceId(
+    GOConfigWriter &cfg,
+    const wxString &group,
+    const wxString &keyPrefix,
+    unsigned patternIndex,
+    const GOMidiMap &map) const;
 
   void DeviceIdToYaml(YAML::Node &eventNode, const GOMidiMap &map) const;
   void DeviceIdFromYaml(


### PR DESCRIPTION
Resolves: #2281

Earlier, when loading a preset or importing MIDI settings, if some midi objects were referencing to a missed MIDI device, the user did not know what happened. The MIDI object just did  not work.

This PR

1. Introduce the new method ``GOMidiEventPattern::FillDeviceId`` that resolves the device name. If the name is not yet known it puts it into the dictionary and displays a warning message.
2. Both loading MIDI settings from a preset and a yaml-file now use ``GOMidiEventPattern::FillDeviceId``.
3. It introduces the ``GOMidiEventPattern::LoadDeviceId`` and `GOMidiEventPattern::SaveDeviceId`` methods.