### PR TITLE
Fixed resetting devices of MIDI events on editing if the device was missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed resetting devices of MIDI events on editing if the device was missed
 - Added logging a warning message when importing MIDI objects referencing to a not-existing device https://github.com/GrandOrgue/grandorgue/issues/2281
 - Fixed exporting MIDI Settings to yaml file https://github.com/GrandOrgue/grandorgue/issues/2333
 - Fixed creating an organ cache https://github.com/GrandOrgue/grandorgue/issues/2325

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -72,6 +72,7 @@ gui/dialogs/common/GODialogSizeSet.cpp
 gui/dialogs/common/GODialogTab.cpp
 gui/dialogs/common/GOSimpleDialog.cpp
 gui/dialogs/common/GOTabbedDialog.cpp
+gui/dialogs/midi-event/GOMidiEventDeviceChoice.cpp
 gui/dialogs/midi-event/GOMidiEventDialog.cpp
 gui/dialogs/midi-event/GOMidiEventKeyTab.cpp
 gui/dialogs/midi-event/GOMidiEventRecvTab.cpp

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDeviceChoice.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDeviceChoice.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOMidiEventDeviceChoice.h"
+
+#include "config/GOMidiDeviceConfigList.h"
+#include "config/GOPortsConfig.h"
+#include "midi/GOMidiMap.h"
+#include "midi/events/GOMidiBasePatternList.h"
+#include "midi/events/GOMidiEventPattern.h"
+
+void GOMidiEventDeviceChoice::AddDevice(
+  uint_fast16_t id, const wxString &name) {
+  size_t index = m_DeviceIdsByIndex.size();
+  int itemIndex = Append(name);
+
+  assert((int)index == itemIndex);
+  m_DeviceIdsByIndex.push_back(id);
+  m_IndicesById[id] = static_cast<uint16_t>(index);
+}
+
+static const wxString WX_MISSING = _(" - MISSING");
+
+void GOMidiEventDeviceChoice::FillWithDevices(
+  const GOPortsConfig &portsConfig,
+  const GOMidiDeviceConfigList &availableDevices,
+  const GOMidiMap &m_MidiMap,
+  const GOMidiBasePatternList &patterns) {
+  Clear();
+  AddDevice(GONameMap::ID_NOT_IN_FILE, _("Any device"));
+  for (GOMidiDeviceConfig *pDevConf : availableDevices)
+    if (
+      portsConfig.IsEnabled(pDevConf->GetPortName(), pDevConf->GetApiName())
+      && pDevConf->m_IsEnabled) {
+      const wxString &logicalName = pDevConf->GetLogicalName();
+
+      AddDevice(m_MidiMap.GetDeviceIdByLogicalName(logicalName), logicalName);
+    }
+  for (unsigned l = patterns.GetEventCount(), i = 0; i < l; i++) {
+    uint_fast16_t deviceId = patterns.GetBasePattern(i).deviceId;
+
+    if (!m_IndicesById.contains(deviceId))
+      AddDevice(
+        deviceId, m_MidiMap.GetDeviceLogicalNameById(deviceId) + WX_MISSING);
+  }
+}
+
+uint_fast16_t GOMidiEventDeviceChoice::GetSelectedDeviceId() const {
+  int selectedIndex = GetSelection();
+
+  return selectedIndex >= 0 ? m_DeviceIdsByIndex[selectedIndex] : 0;
+}
+
+void GOMidiEventDeviceChoice::SetSelectedDeviceId(uint_fast16_t deviceId) {
+  const auto it = m_IndicesById.find(deviceId);
+  const auto index = it != m_IndicesById.end() ? it->second : 0;
+
+  SetSelection((int)index);
+}

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDeviceChoice.h
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDeviceChoice.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOMIDIEVENTDEVICECHOICE_H
+#define GOMIDIEVENTDEVICECHOICE_H
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include <wx/choice.h>
+
+class GOMidiBasePatternList;
+class GOMidiDeviceConfigList;
+class GOMidiMap;
+class GOPortsConfig;
+
+/**
+ * A visual control for selecting a MIDI device among a list of available
+ * devices or "Any Device"
+ */
+class GOMidiEventDeviceChoice : public wxChoice {
+private:
+  // device id in the same order as they are in wxChoice
+  std::vector<uint16_t> m_DeviceIdsByIndex;
+
+  // map devices ids to the index in wxChoice
+  std::unordered_map<uint16_t, unsigned> m_IndicesById;
+
+  // add a device to the choice list
+  void AddDevice(uint_fast16_t id, const wxString &name);
+
+public:
+  GOMidiEventDeviceChoice(wxWindow *pParent, wxWindowID id)
+    : wxChoice(pParent, id) {}
+
+  /**
+   * Make a choice list from "Any Device", all available devices, enabled with
+   *   portsConfig, and all referenced devices from patterns that are marked as
+   *   MISSING
+   * @param portsConfig - a config that enables or deisables MIDI ports
+   * @param availableDevices - configured MIDI devices
+   * @param m_MidiMap - a map between Device Id and Device Name
+   * @param patterns - a list of MIDI events
+   */
+  void FillWithDevices(
+    const GOPortsConfig &portsConfig,
+    const GOMidiDeviceConfigList &availableDevices,
+    const GOMidiMap &m_MidiMap,
+    const GOMidiBasePatternList &patterns);
+
+  /**
+   * The Id of the selected device or "Any Device"
+   */
+  uint_fast16_t GetSelectedDeviceId() const;
+
+  /**
+   * Select the device with the id
+   * @param deviceId an identifier of device to select
+   */
+  void SetSelectedDeviceId(uint_fast16_t deviceId);
+};
+
+#endif /* GOMIDIEVENTDEVICECHOICE_H */

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventRecvTab.h
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventRecvTab.h
@@ -27,20 +27,21 @@ class wxToggleButton;
 
 class GOConfig;
 class GOMidiDeviceConfigList;
+class GOMidiEventDeviceChoice;
 
 class GOMidiEventRecvTab : public wxPanel,
                            public GOModificationProxy,
                            protected GOMidiCallback {
 private:
-  GOMidiDeviceConfigList &m_MidiIn;
-  GOMidiMap &m_MidiMap;
+  const GOConfig &r_config;
 
   GOMidiReceiver *m_original;
   GOMidiReceiverEventPatternList m_midi;
   GOMidiReceiverType m_ReceiverType;
   GOMidiListener m_listener;
   GOChoice<GOMidiReceiverMessageType> *m_eventtype;
-  wxChoice *m_eventno, *m_channel, *m_device;
+  wxChoice *m_eventno, *m_channel;
+  GOMidiEventDeviceChoice *m_device;
   wxStaticText *m_DataLabel;
   wxSpinCtrl *m_data;
   wxSpinCtrl *m_LowKey;
@@ -118,7 +119,8 @@ public:
   ~GOMidiEventRecvTab();
   void RegisterMIDIListener(GOMidi *midi);
 
-  virtual bool TransferDataFromWindow() override;
+  bool TransferDataToWindow() override;
+  bool TransferDataFromWindow() override;
   GOMidiReceiverEventPattern GetCurrentEvent();
 
   DECLARE_EVENT_TABLE()

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventSendTab.h
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventSendTab.h
@@ -21,21 +21,21 @@ class wxCheckBox;
 
 class GOConfig;
 class GOMidiDeviceConfigList;
+class GOMidiEventDeviceChoice;
 class GOMidiMap;
 class GOMidiEventRecvTab;
 class GOTabbedDialog;
 
 class GOMidiEventSendTab : public GODialogTab, public GOModificationProxy {
 private:
-  GOMidiDeviceConfigList &m_MidiIn;
-  GOMidiDeviceConfigList &m_MidiOut;
-  GOMidiMap &m_MidiMap;
+  const GOConfig &r_config;
 
   GOMidiSender *m_original;
   GOMidiEventRecvTab *m_recv;
   GOMidiSenderEventPatternList m_midi;
   GOChoice<GOMidiSenderMessageType> *m_eventtype;
-  wxChoice *m_eventno, *m_channel, *m_device;
+  wxChoice *m_eventno, *m_channel;
+  GOMidiEventDeviceChoice *m_device;
   wxStaticText *m_KeyLabel;
   wxSpinCtrl *m_key;
   wxCheckBox *m_noteOff;
@@ -86,6 +86,7 @@ public:
     GOConfig &config);
   ~GOMidiEventSendTab();
 
+  bool TransferDataToWindow() override;
   virtual bool TransferDataFromWindow() override;
 
   DECLARE_EVENT_TABLE()


### PR DESCRIPTION
This PR also relates to #2281.

Earlier, when a MIDI object had a configured event that was referencing to a MIDI device that was not present in the system, the MIDI event editor was showing the device as "Any device". And after closing the editor this event was reset to "Any Device".

This PR:
1. Introduces a new wx control `GOMidiEventDeviceChoice`.
2. GOMidiEventDeviceChoice shows the device names of the missing device, marking them with "- MISSING"
3. GOMidiEventRecvTab and GOMidiEventRecvTab now use the new control
4. When closing the MIDI event editor, the reference to the missing device persists.