### PR TITLE
Added some debug of building for MacOs

### DIFF
--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -33,7 +33,15 @@ esac
 GO_PRMS="-DCMAKE_BUILD_TYPE=Release $CMAKE_VERSION_PRMS"
 cmake -G "Unix Makefiles" $OS_PRMS $GO_PRMS . $SRC_DIR
 
-make -k $PARALLEL_PRMS VERBOSE=1 all || make -k 1 VERBOSE=1 all
+echo "Phase 1"
+
+if ! make -k $PARALLEL_PRMS VERBOSE=1 all; then
+
+  echo "Phase 2"
+  make -j 1 -k 1 VERBOSE=1 all
+fi
+
+echo "Phase 3"
 
 make VERBOSE=1 package
 


### PR DESCRIPTION
Sometimes Github builds for Macos fail. Each time it is too difficult to determine the root cause because the build log is huge and there is no any known search pattern.

This PR adds a debugging run of make without parallel and breaking after the first error.

No GO behavior should be changed.
