### PR TITLE
Fixed segfault if an exception had been occured during the initialising phase

### DIFF
--- a/src/grandorgue/GOApp.h
+++ b/src/grandorgue/GOApp.h
@@ -71,7 +71,7 @@ protected:
   bool m_IsGuiOnly = false;
 
 public:
-  void SetRestart();
+  void SetRestart() { m_Restart = true; }
 };
 
 DECLARE_APP(GOApp)


### PR DESCRIPTION
Earlier if an eception had been occured inside GOApp::OnInit, GrandOrgue crashed.

Now the exception message is displayed and GrandOrgue exits with a non-zero return code.