### PR TITLE
Fixed build for macos

### DIFF
--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -38,7 +38,7 @@ echo "Phase 1"
 if ! make -k $PARALLEL_PRMS VERBOSE=1 all; then
 
   echo "Phase 2"
-  make -j1 -k 1 VERBOSE=1 all
+  make -j1 -k1 VERBOSE=1 all
 fi
 
 echo "Phase 3"


### PR DESCRIPTION
Earlier an error "make: *** No rule to make target `1'" occured sometimes.