### PR TITLE
Fixed unability to check for updates on slow internet connections

### DIFF
--- a/src/grandorgue/updater/settings.h
+++ b/src/grandorgue/updater/settings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2024-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -9,10 +9,11 @@
 
 #include "go_defs.h"
 
-const long TIMEOUT_MS = 5000;
+const long LOW_SPEED_TIME = 10;
+const long LOW_SPEED_LIMIT = 1024; // bytes per LOW_SPEED_TIME seconds
 const char *const USER_AGENT_HEADER = "User-Agent: GrandOrgue";
 const char *const RELEASES_API_URL
-  = "https://api.github.com/repos/" GITHUB_PROJECT "/releases?per_page=100";
+  = "https://api.github.com/repos/" GITHUB_PROJECT "/releases?per_page=3";
 const char *const DOWNLOAD_URL
   = "https://github.com/" GITHUB_PROJECT "/releases";
 


### PR DESCRIPTION
Sometimes GrandOrgue couldn't check for updates with a wrong json format error.

The reason was a timeout occured and only a part of responce json was fetched.

This PR

1. Adds check for errors after finishing fetching?
2. Replaces a timeout with a minimum of fetching speed.
3. Reduces of number of last releases read by GrandOrgue from 100 to 3

So now check for update works more stable.