### PR TITLE
Fixed displaying an invalid user-defined temperament name in the Master Control panel https://github.com/GrandOrgue/grandorgue/discussions/2362

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed displaying an invalid user-defined temperament name in the Master Control panel https://github.com/GrandOrgue/grandorgue/discussions/2362
 - Fixed saving a SYSEX ID https://github.com/GrandOrgue/grandorgue/issues/2353
 # 3.16.3 (2025-12-26)
 - Fixed resetting devices of MIDI events on editing if the device was missed

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -973,7 +973,7 @@ void GOOrganController::Reset() {
 }
 
 void GOOrganController::SetTemperament(const GOTemperament &temperament) {
-  m_TemperamentLabel.SetContent(wxGetTranslation(temperament.GetName()));
+  m_TemperamentLabel.SetContent(temperament.GetTitle());
   for (unsigned k = 0; k < m_ranks.size(); k++)
     m_ranks[k]->SetTemperament(temperament);
 }

--- a/src/grandorgue/gui/dialogs/settings/GOSettingsTemperaments.cpp
+++ b/src/grandorgue/gui/dialogs/settings/GOSettingsTemperaments.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -146,7 +146,7 @@ bool GOSettingsTemperaments::TransferDataFromWindow() {
   for (unsigned i = 0; i < m_Ptrs.size(); i++) {
     if (!m_Ptrs[i])
       m_Ptrs[i] = new GOTemperamentUser(
-        wxString::Format(wxT("UserTemperament%d-%d"), time, i),
+        wxString::Format(wxT("UserTemperament%ld-%d"), time, i),
         m_List->GetCellValue(i, 1),
         m_List->GetCellValue(i, 0),
         m_List->GetCellValue(i, 0));


### PR DESCRIPTION
The reason was the label displayed a surrogate name instead of title.

The title corresponds to a translated tame for a built-in temperament and the value of the Name column for the user-defined temperament.