### PR TITLE
Renamed some GOBitmap members

### DIFF
--- a/src/grandorgue/gui/panels/GOGUIButton.cpp
+++ b/src/grandorgue/gui/panels/GOGUIButton.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -82,13 +82,13 @@ void GOGUIButton::Init(
 
   x = -1;
   y = -1;
-  w = m_OnBitmap.GetWidth();
-  h = m_OnBitmap.GetHeight();
+  w = m_OnBitmap.GetSourceWidth();
+  h = m_OnBitmap.GetSourceHeight();
   m_BoundingRect = wxRect(x, y, w, h);
 
   if (
-    m_OnBitmap.GetWidth() != m_OffBitmap.GetWidth()
-    || m_OnBitmap.GetHeight() != m_OffBitmap.GetHeight())
+    m_OnBitmap.GetSourceWidth() != m_OffBitmap.GetSourceWidth()
+    || m_OnBitmap.GetSourceHeight() != m_OffBitmap.GetSourceHeight())
     throw wxString::Format(
       _("bitmap size does not match for '%s'"), group.c_str());
 
@@ -233,7 +233,7 @@ void GOGUIButton::Load(GOConfigReader &cfg, wxString group) {
     1,
     m_metrics->GetScreenWidth(),
     false,
-    m_OnBitmap.GetWidth());
+    m_OnBitmap.GetSourceWidth());
   h = cfg.ReadInteger(
     ODFSetting,
     group,
@@ -241,12 +241,12 @@ void GOGUIButton::Load(GOConfigReader &cfg, wxString group) {
     1,
     m_metrics->GetScreenHeight(),
     false,
-    m_OnBitmap.GetHeight());
+    m_OnBitmap.GetSourceHeight());
   m_BoundingRect = wxRect(x, y, w, h);
 
   if (
-    m_OnBitmap.GetWidth() != m_OffBitmap.GetWidth()
-    || m_OnBitmap.GetHeight() != m_OffBitmap.GetHeight())
+    m_OnBitmap.GetSourceWidth() != m_OffBitmap.GetSourceWidth()
+    || m_OnBitmap.GetSourceHeight() != m_OffBitmap.GetSourceHeight())
     throw wxString::Format(
       _("bitmap size does not match for '%s'"), group.c_str());
 
@@ -255,7 +255,7 @@ void GOGUIButton::Load(GOConfigReader &cfg, wxString group) {
     group,
     wxT("TileOffsetX"),
     0,
-    m_OnBitmap.GetWidth() - 1,
+    m_OnBitmap.GetSourceWidth() - 1,
     false,
     0);
   m_TileOffsetY = cfg.ReadInteger(
@@ -263,7 +263,7 @@ void GOGUIButton::Load(GOConfigReader &cfg, wxString group) {
     group,
     wxT("TileOffsetY"),
     0,
-    m_OnBitmap.GetHeight() - 1,
+    m_OnBitmap.GetSourceHeight() - 1,
     false,
     0);
 
@@ -402,9 +402,9 @@ bool GOGUIButton::HandleMousePress(
 }
 
 void GOGUIButton::PrepareDraw(double scale, GOBitmap *background) {
-  m_OnBitmap.PrepareTileBitmap(
+  m_OnBitmap.BuildTileBitmap(
     scale, m_BoundingRect, m_TileOffsetX, m_TileOffsetY, background);
-  m_OffBitmap.PrepareTileBitmap(
+  m_OffBitmap.BuildTileBitmap(
     scale, m_BoundingRect, m_TileOffsetX, m_TileOffsetY, background);
 }
 

--- a/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
+++ b/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -49,8 +49,8 @@ void GOGUIEnclosure::Init(GOConfigReader &cfg, wxString group) {
 
   for (unsigned i = 1; i < m_Bitmaps.size(); i++)
     if (
-      m_Bitmaps[0].GetWidth() != m_Bitmaps[i].GetWidth()
-      || m_Bitmaps[0].GetHeight() != m_Bitmaps[i].GetHeight())
+      m_Bitmaps[0].GetSourceWidth() != m_Bitmaps[i].GetSourceWidth()
+      || m_Bitmaps[0].GetSourceHeight() != m_Bitmaps[i].GetSourceHeight())
       throw wxString::Format(
         _("bitmap size does not match for '%s'"), group.c_str());
 
@@ -58,8 +58,8 @@ void GOGUIEnclosure::Init(GOConfigReader &cfg, wxString group) {
 
   x = -1;
   y = -1;
-  w = m_Bitmaps[0].GetWidth();
-  h = m_Bitmaps[0].GetHeight();
+  w = m_Bitmaps[0].GetSourceWidth();
+  h = m_Bitmaps[0].GetSourceHeight();
   m_BoundingRect = wxRect(x, y, w, h);
 
   m_TileOffsetX = 0;
@@ -124,8 +124,8 @@ void GOGUIEnclosure::Load(GOConfigReader &cfg, wxString group) {
 
   for (unsigned i = 1; i < m_Bitmaps.size(); i++)
     if (
-      m_Bitmaps[0].GetWidth() != m_Bitmaps[i].GetWidth()
-      || m_Bitmaps[0].GetHeight() != m_Bitmaps[i].GetHeight())
+      m_Bitmaps[0].GetSourceWidth() != m_Bitmaps[i].GetSourceWidth()
+      || m_Bitmaps[0].GetSourceHeight() != m_Bitmaps[i].GetSourceHeight())
       throw wxString::Format(
         _("bitmap size does not match for '%s'"), group.c_str());
 
@@ -154,7 +154,7 @@ void GOGUIEnclosure::Load(GOConfigReader &cfg, wxString group) {
     1,
     m_metrics->GetScreenWidth(),
     false,
-    m_Bitmaps[0].GetWidth());
+    m_Bitmaps[0].GetSourceWidth());
   h = cfg.ReadInteger(
     ODFSetting,
     group,
@@ -162,7 +162,7 @@ void GOGUIEnclosure::Load(GOConfigReader &cfg, wxString group) {
     1,
     m_metrics->GetScreenHeight(),
     false,
-    m_Bitmaps[0].GetHeight());
+    m_Bitmaps[0].GetSourceHeight());
   m_BoundingRect = wxRect(x, y, w, h);
 
   m_TileOffsetX = cfg.ReadInteger(
@@ -170,7 +170,7 @@ void GOGUIEnclosure::Load(GOConfigReader &cfg, wxString group) {
     group,
     wxT("TileOffsetX"),
     0,
-    m_Bitmaps[0].GetWidth() - 1,
+    m_Bitmaps[0].GetSourceWidth() - 1,
     false,
     0);
   m_TileOffsetY = cfg.ReadInteger(
@@ -178,7 +178,7 @@ void GOGUIEnclosure::Load(GOConfigReader &cfg, wxString group) {
     group,
     wxT("TileOffsetY"),
     0,
-    m_Bitmaps[0].GetHeight() - 1,
+    m_Bitmaps[0].GetSourceHeight() - 1,
     false,
     0);
 
@@ -300,7 +300,7 @@ void GOGUIEnclosure::Layout() {
 
 void GOGUIEnclosure::PrepareDraw(double scale, GOBitmap *background) {
   for (unsigned i = 0; i < m_Bitmaps.size(); i++)
-    m_Bitmaps[i].PrepareTileBitmap(
+    m_Bitmaps[i].BuildTileBitmap(
       scale, m_BoundingRect, m_TileOffsetX, m_TileOffsetY, background);
 }
 

--- a/src/grandorgue/gui/panels/GOGUIHW1Background.cpp
+++ b/src/grandorgue/gui/panels/GOGUIHW1Background.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -99,8 +99,7 @@ void GOGUIHW1Background::Layout() {
 
 void GOGUIHW1Background::PrepareDraw(double scale, GOBitmap *background) {
   for (unsigned i = 0; i < m_Images.size(); i++)
-    m_Images[i].bmp.PrepareTileBitmap(
-      scale, m_Images[i].rect, 0, 0, background);
+    m_Images[i].bmp.BuildTileBitmap(scale, m_Images[i].rect, 0, 0, background);
 }
 
 void GOGUIHW1Background::Draw(GODC &dc) {

--- a/src/grandorgue/gui/panels/GOGUIImage.cpp
+++ b/src/grandorgue/gui/panels/GOGUIImage.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -51,7 +51,7 @@ void GOGUIImage::Load(GOConfigReader &cfg, wxString group) {
     1,
     m_metrics->GetScreenWidth(),
     false,
-    m_Bitmap.GetWidth());
+    m_Bitmap.GetSourceWidth());
   h = cfg.ReadInteger(
     ODFSetting,
     group,
@@ -59,7 +59,7 @@ void GOGUIImage::Load(GOConfigReader &cfg, wxString group) {
     1,
     m_metrics->GetScreenHeight(),
     false,
-    m_Bitmap.GetHeight());
+    m_Bitmap.GetSourceHeight());
   m_BoundingRect = wxRect(x, y, w, h);
 
   m_TileOffsetX = cfg.ReadInteger(
@@ -67,7 +67,7 @@ void GOGUIImage::Load(GOConfigReader &cfg, wxString group) {
     group,
     wxT("TileOffsetX"),
     0,
-    m_Bitmap.GetWidth() - 1,
+    m_Bitmap.GetSourceWidth() - 1,
     false,
     0);
   m_TileOffsetY = cfg.ReadInteger(
@@ -75,13 +75,13 @@ void GOGUIImage::Load(GOConfigReader &cfg, wxString group) {
     group,
     wxT("TileOffsetY"),
     0,
-    m_Bitmap.GetHeight() - 1,
+    m_Bitmap.GetSourceHeight() - 1,
     false,
     0);
 }
 
 void GOGUIImage::PrepareDraw(double scale, GOBitmap *background) {
-  m_Bitmap.PrepareTileBitmap(
+  m_Bitmap.BuildTileBitmap(
     scale, m_BoundingRect, m_TileOffsetX, m_TileOffsetY, background);
 }
 

--- a/src/grandorgue/gui/panels/GOGUILabel.cpp
+++ b/src/grandorgue/gui/panels/GOGUILabel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -78,9 +78,9 @@ void GOGUILabel::InitBackgroundBitmap(
 
   // take the size from the bitmap if it is not specified
   if (!w)
-    w = m_PBackgroundBitmap ? m_PBackgroundBitmap->GetWidth() : 80;
+    w = m_PBackgroundBitmap ? m_PBackgroundBitmap->GetSourceWidth() : 80;
   if (!h)
-    h = m_PBackgroundBitmap ? m_PBackgroundBitmap->GetHeight() : 25;
+    h = m_PBackgroundBitmap ? m_PBackgroundBitmap->GetSourceHeight() : 25;
   unsigned textX = 1;
   unsigned textY = 1;
   unsigned textWidth = w - textX;
@@ -309,7 +309,7 @@ void GOGUILabel::Layout() {
 
 void GOGUILabel::PrepareDraw(double scale, GOBitmap *background) {
   if (m_PBackgroundBitmap)
-    m_PBackgroundBitmap->PrepareTileBitmap(
+    m_PBackgroundBitmap->BuildTileBitmap(
       scale, m_BoundingRect, m_TileOffsetX, m_TileOffsetY, background);
 }
 

--- a/src/grandorgue/gui/panels/GOGUIManual.cpp
+++ b/src/grandorgue/gui/panels/GOGUIManual.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -104,17 +104,19 @@ void GOGUIManual::Init(GOConfigReader &cfg, wxString group) {
     m_Keys[i].OffBitmap = m_panel->LoadBitmap(off_file, off_mask_file);
 
     if (
-      m_Keys[i].OnBitmap.GetWidth() != m_Keys[i].OffBitmap.GetWidth()
-      || m_Keys[i].OnBitmap.GetHeight() != m_Keys[i].OffBitmap.GetHeight())
+      m_Keys[i].OnBitmap.GetSourceWidth()
+        != m_Keys[i].OffBitmap.GetSourceWidth()
+      || m_Keys[i].OnBitmap.GetSourceHeight()
+        != m_Keys[i].OffBitmap.GetSourceHeight())
       throw wxString::Format(
         _("bitmap size does not match for '%s'"), group.c_str());
 
-    key_width = m_Keys[i].OnBitmap.GetWidth();
+    key_width = m_Keys[i].OnBitmap.GetSourceWidth();
     key_offset = 0;
     key_yoffset = 0;
     if (m_Keys[i].IsSharp && m_ManualNumber) {
       key_width = 0;
-      key_offset = -((int)m_Keys[i].OnBitmap.GetWidth()) / 2;
+      key_offset = -((int)m_Keys[i].OnBitmap.GetSourceWidth()) / 2;
     } else if (!m_ManualNumber && !next_is_sharp && !m_Keys[i].IsSharp) {
       key_width *= 2;
     }
@@ -122,8 +124,8 @@ void GOGUIManual::Init(GOConfigReader &cfg, wxString group) {
     m_Keys[i].Rect = wxRect(
       x + key_offset,
       y + key_yoffset,
-      m_Keys[i].OnBitmap.GetWidth(),
-      m_Keys[i].OnBitmap.GetHeight());
+      m_Keys[i].OnBitmap.GetSourceWidth(),
+      m_Keys[i].OnBitmap.GetSourceHeight());
     if (x + key_offset < 0)
       wxLogWarning(
         _("Manual key %d outside of the bounding box"), m_Keys[i].MidiNumber);
@@ -307,17 +309,19 @@ void GOGUIManual::Load(GOConfigReader &cfg, wxString group) {
     m_Keys[i].OffBitmap = m_panel->LoadBitmap(off_file, off_mask_file);
 
     if (
-      m_Keys[i].OnBitmap.GetWidth() != m_Keys[i].OffBitmap.GetWidth()
-      || m_Keys[i].OnBitmap.GetHeight() != m_Keys[i].OffBitmap.GetHeight())
+      m_Keys[i].OnBitmap.GetSourceWidth()
+        != m_Keys[i].OffBitmap.GetSourceWidth()
+      || m_Keys[i].OnBitmap.GetSourceHeight()
+        != m_Keys[i].OffBitmap.GetSourceHeight())
       throw wxString::Format(
         _("bitmap size does not match for '%s'"), group.c_str());
 
-    key_width = m_Keys[i].OnBitmap.GetWidth();
+    key_width = m_Keys[i].OnBitmap.GetSourceWidth();
     key_offset = 0;
     key_yoffset = 0;
     if (m_Keys[i].IsSharp && m_ManualNumber) {
       key_width = 0;
-      key_offset = -((int)m_Keys[i].OnBitmap.GetWidth()) / 2;
+      key_offset = -((int)m_Keys[i].OnBitmap.GetSourceWidth()) / 2;
     } else if (!m_ManualNumber && !next_is_sharp && !m_Keys[i].IsSharp) {
       key_width *= 2;
     }
@@ -359,8 +363,8 @@ void GOGUIManual::Load(GOConfigReader &cfg, wxString group) {
     keyRect = wxRect(
       x + key_offset,
       y + key_yoffset,
-      m_Keys[i].OnBitmap.GetWidth(),
-      m_Keys[i].OnBitmap.GetHeight());
+      m_Keys[i].OnBitmap.GetSourceWidth(),
+      m_Keys[i].OnBitmap.GetSourceHeight());
 
     unsigned mouse_x = cfg.ReadInteger(
       ODFSetting,
@@ -448,8 +452,8 @@ void GOGUIManual::Layout() {
 
 void GOGUIManual::PrepareDraw(double scale, GOBitmap *background) {
   for (unsigned i = 0; i < m_Keys.size(); i++) {
-    m_Keys[i].OnBitmap.PrepareBitmap(scale, m_Keys[i].Rect, background);
-    m_Keys[i].OffBitmap.PrepareBitmap(scale, m_Keys[i].Rect, background);
+    m_Keys[i].OnBitmap.BuildScaledBitmap(scale, m_Keys[i].Rect, background);
+    m_Keys[i].OffBitmap.BuildScaledBitmap(scale, m_Keys[i].Rect, background);
   }
 }
 

--- a/src/grandorgue/gui/panels/GOGUIManualBackground.cpp
+++ b/src/grandorgue/gui/panels/GOGUIManualBackground.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -45,8 +45,8 @@ void GOGUIManualBackground::Layout() {
 }
 
 void GOGUIManualBackground::PrepareDraw(double scale, GOBitmap *background) {
-  m_VBackground.PrepareTileBitmap(scale, m_VRect, 0, 0, background);
-  m_HBackground.PrepareTileBitmap(scale, m_HRect, 0, 0, background);
+  m_VBackground.BuildTileBitmap(scale, m_VRect, 0, 0, background);
+  m_HBackground.BuildTileBitmap(scale, m_HRect, 0, 0, background);
 }
 
 void GOGUIManualBackground::Draw(GODC &dc) {

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -52,7 +52,7 @@ GOGUIPanelWidget::GOGUIPanelWidget(
   m_panel->PrepareDraw(m_Scale, NULL);
   OnUpdate();
   m_BGImage = m_ClientBitmap.ConvertToImage();
-  m_Background.PrepareBitmap(m_Scale, wxRect(0, 0, 0, 0), NULL);
+  m_Background.BuildScaledBitmap(m_Scale, wxRect(0, 0, 0, 0), NULL);
   m_BGInit = true;
   SetCanFocus(true);
 }

--- a/src/grandorgue/gui/panels/primitives/GOBitmap.cpp
+++ b/src/grandorgue/gui/panels/primitives/GOBitmap.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,30 +12,37 @@
 #include <wx/image.h>
 
 GOBitmap::GOBitmap()
-  : m_img(NULL),
+  : p_SourceImage(nullptr),
     m_Scale(0),
     m_ResultWidth(0),
     m_ResultHeight(0),
     m_ResultXOffset(0),
     m_ResultYOffset(0) {}
 
-GOBitmap::GOBitmap(wxImage *img)
-  : m_img(img),
+GOBitmap::GOBitmap(const wxImage *pSourceImg)
+  : p_SourceImage(pSourceImg),
     m_Scale(0),
     m_ResultWidth(0),
     m_ResultHeight(0),
     m_ResultXOffset(0),
     m_ResultYOffset(0) {}
 
-void GOBitmap::ScaleBMP(
-  wxImage &img, double scale, const wxRect &rect, GOBitmap *background) {
+unsigned GOBitmap::GetSourceWidth() const { return p_SourceImage->GetWidth(); }
+
+unsigned GOBitmap::GetSourceHeight() const {
+  return p_SourceImage->GetHeight();
+}
+
+void GOBitmap::BuildBitmapFrom(
+  const wxImage &img, double scale, const wxRect &rect, GOBitmap *background) {
   if (background && img.HasAlpha()) {
     wxBitmap bmp(img.GetWidth(), img.GetHeight());
     wxBitmap orig(img);
     wxMemoryDC dc;
 
     dc.SelectObject(bmp);
-    dc.DrawBitmap(background->GetBitmap(), -rect.GetX(), -rect.GetY(), false);
+    dc.DrawBitmap(
+      background->GetResultBitmap(), -rect.GetX(), -rect.GetY(), false);
     dc.DrawBitmap(orig, 0, 0, true);
     bmp.SetMask(orig.GetMask());
     wxImage img_result = bmp.ConvertToImage();
@@ -44,24 +51,24 @@ void GOBitmap::ScaleBMP(
     memcpy(
       img_result.GetAlpha(), img.GetAlpha(), img.GetWidth() * img.GetHeight());
 
-    m_bmp = (wxBitmap)img_result.Scale(
+    m_ResultBitmap = (wxBitmap)img_result.Scale(
       img.GetWidth() * scale, img.GetHeight() * scale, wxIMAGE_QUALITY_BICUBIC);
   } else
-    m_bmp = (wxBitmap)img.Scale(
+    m_ResultBitmap = (wxBitmap)img.Scale(
       img.GetWidth() * scale, img.GetHeight() * scale, wxIMAGE_QUALITY_BICUBIC);
   m_Scale = scale;
 }
 
-void GOBitmap::PrepareBitmap(
+void GOBitmap::BuildScaledBitmap(
   double scale, const wxRect &rect, GOBitmap *background) {
   if (scale != m_Scale || m_ResultWidth || m_ResultHeight) {
-    ScaleBMP(*m_img, scale, rect, background);
+    BuildBitmapFrom(*p_SourceImage, scale, rect, background);
     m_ResultWidth = 0;
     m_ResultHeight = 0;
   }
 }
 
-void GOBitmap::PrepareTileBitmap(
+void GOBitmap::BuildTileBitmap(
   double scale,
   const wxRect &rect,
   unsigned xo,
@@ -72,19 +79,14 @@ void GOBitmap::PrepareTileBitmap(
     || m_ResultHeight != rect.GetHeight() || xo != m_ResultXOffset
     || yo != m_ResultYOffset) {
     wxImage img(rect.GetWidth(), rect.GetHeight());
-    for (int y = -yo; y < img.GetHeight(); y += GetHeight())
-      for (int x = -xo; x < img.GetWidth(); x += GetWidth())
-        img.Paste(*m_img, x, y);
-    ScaleBMP(img, scale, rect, background);
+
+    for (int y = -yo; y < img.GetHeight(); y += GetSourceHeight())
+      for (int x = -xo; x < img.GetWidth(); x += GetSourceWidth())
+        img.Paste(*p_SourceImage, x, y);
+    BuildBitmapFrom(img, scale, rect, background);
     m_ResultWidth = rect.GetWidth();
     m_ResultHeight = rect.GetHeight();
     m_ResultXOffset = xo;
     m_ResultYOffset = yo;
   }
 }
-
-const wxBitmap &GOBitmap::GetBitmap() { return m_bmp; }
-
-unsigned GOBitmap::GetWidth() { return m_img->GetWidth(); }
-
-unsigned GOBitmap::GetHeight() { return m_img->GetHeight(); }

--- a/src/grandorgue/gui/panels/primitives/GOBitmap.h
+++ b/src/grandorgue/gui/panels/primitives/GOBitmap.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,36 +11,43 @@
 #include <wx/bitmap.h>
 
 class wxImage;
+class wxRect;
+
+/**
+ * This class is designed for building a result wxBitmap instance from a source
+ * wxImage instance. It supports both scaling and tiling
+ */
 
 class GOBitmap {
 private:
-  wxImage *m_img;
-  wxBitmap m_bmp;
+  const wxImage *p_SourceImage;
+  wxBitmap m_ResultBitmap;
   double m_Scale;
   int m_ResultWidth;
   int m_ResultHeight;
   unsigned m_ResultXOffset;
   unsigned m_ResultYOffset;
 
-  void ScaleBMP(
-    wxImage &img, double scale, const wxRect &rect, GOBitmap *background);
+  void BuildBitmapFrom(
+    const wxImage &img, double scale, const wxRect &rect, GOBitmap *background);
 
 public:
-  GOBitmap();
-  GOBitmap(wxImage *img);
+  GOBitmap(); // Makes a dummy instance
+  GOBitmap(const wxImage *pSourceImg);
 
-  void PrepareBitmap(double scale, const wxRect &rect, GOBitmap *background);
-  void PrepareTileBitmap(
+  unsigned GetSourceWidth() const;
+  unsigned GetSourceHeight() const;
+
+  void BuildScaledBitmap(
+    double scale, const wxRect &rect, GOBitmap *background);
+  void BuildTileBitmap(
     double scale,
     const wxRect &rect,
     unsigned xo,
     unsigned yo,
     GOBitmap *background);
 
-  unsigned GetWidth();
-  unsigned GetHeight();
-
-  const wxBitmap &GetBitmap();
+  const wxBitmap &GetResultBitmap() const { return m_ResultBitmap; }
 };
 
 #endif

--- a/src/grandorgue/gui/panels/primitives/GODC.cpp
+++ b/src/grandorgue/gui/panels/primitives/GODC.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -26,7 +26,7 @@ wxRect GODC::ScaleRect(const wxRect &rect) {
 void GODC::DrawBitmap(GOBitmap &bitmap, const wxRect &target) {
   unsigned xpos = target.GetX() * m_Scale + 0.5;
   unsigned ypos = target.GetY() * m_Scale + 0.5;
-  m_DC->DrawBitmap(bitmap.GetBitmap(), xpos, ypos, true);
+  m_DC->DrawBitmap(bitmap.GetResultBitmap(), xpos, ypos, true);
 }
 
 wxString GODC::WrapText(const wxString &string, unsigned width) {


### PR DESCRIPTION
This PR makes GOBitmap members name more clear.

It is just refactoring. No GO behavior should be changed.