### PR TITLE
Fixed switching the convolution reverb off when the system is overloaded https://github.com/GrandOrgue/grandorgue/issues/2348

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed switching the convolution reverb off when the system is overloaded https://github.com/GrandOrgue/grandorgue/issues/2348
 - Added capability to specify the config file path in the command line with the --config option https://github.com/GrandOrgue/grandorgue/issues/2328
 - Fixed displaying an invalid user-defined temperament name in the Master Control panel https://github.com/GrandOrgue/grandorgue/discussions/2362
 - Fixed saving a SYSEX ID https://github.com/GrandOrgue/grandorgue/issues/2353

--- a/src/grandorgue/sound/GOSoundReverb.cpp
+++ b/src/grandorgue/sound/GOSoundReverb.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -39,8 +39,13 @@ void GOSoundReverb::Setup(GOConfig &settings) {
     return;
 
   m_engine.clear();
-  for (unsigned i = 0; i < m_channels; i++)
-    m_engine.push_back(new Convproc());
+  for (unsigned i = 0; i < m_channels; i++) {
+    Convproc *pConvProc = new Convproc();
+
+    // Disable stopping the reverb engine when the system is overloaded
+    pConvProc->set_options(Convproc::OPT_LATE_CONTIN);
+    m_engine.push_back(pConvProc);
+  }
   unsigned val = settings.SamplesPerBuffer();
   if (val < Convproc::MINPART)
     val = Convproc::MINPART;


### PR DESCRIPTION
#Resolves: #2348

The Zita convolver has a counter of number of times when it was late to process. When it became 5, the convolution stops working.

This PR sets an option of convolver that forces itself to continue even it is late many times.