### PR TITLE
Renamed file GOSoundCompress.h to GOSoundCompressionCache.h and the struct DecompressionCache to the class GOSoundCompressionCache

### DIFF
--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,7 +13,7 @@
 
 #include "GOBool3.h"
 #include "GOInt.h"
-#include "GOSoundCompress.h"
+#include "GOSoundCompressionCache.h"
 #include "GOSoundResample.h"
 #include "GOWave.h"
 
@@ -34,7 +34,7 @@ public:
     /* Sample offset into entire audio section where data begins. */
     unsigned start_offset;
 
-    DecompressionCache cache;
+    GOSoundCompressionCache cache;
   };
 
   /**
@@ -249,11 +249,11 @@ public:
   inline int GetSample(
     unsigned position,
     unsigned channel,
-    DecompressionCache *cache = nullptr) const {
+    GOSoundCompressionCache *cache = nullptr) const {
     if (!m_IsCompressed) {
       return GetSampleData(m_data, position, channel);
     } else {
-      DecompressionCache tmp;
+      GOSoundCompressionCache tmp;
       if (!cache) {
         cache = &tmp;
         InitDecompressionCache(*cache);
@@ -262,7 +262,7 @@ public:
       assert(m_BitsPerSample >= 12);
       DecompressTo(
         *cache, position, m_data, m_channels, (m_BitsPerSample >= 20));
-      return cache->value[channel];
+      return cache->m_value[channel];
     }
   }
 

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -56,7 +56,7 @@ void GOSoundReleaseAlignTable::ComputeTable(
   int phase_align_max_derivative,
   unsigned int sample_rate,
   unsigned start_position) {
-  DecompressionCache cache;
+  GOSoundCompressionCache cache;
   InitDecompressionCache(cache);
 
   for (unsigned i = 0; i < PHASE_ALIGN_DERIVATIVES; i++)

--- a/src/grandorgue/sound/GOSoundStream.h
+++ b/src/grandorgue/sound/GOSoundStream.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,7 +8,7 @@
 #ifndef GOSOUNDSTREAM_H
 #define GOSOUNDSTREAM_H
 
-#include "GOSoundCompress.h"
+#include "GOSoundCompressionCache.h"
 #include "GOSoundResample.h"
 
 class GOSoundAudioSection;
@@ -59,7 +59,7 @@ private:
   GOSoundResample::ResamplingPosition m_ResamplingPos;
 
   /* for decoding compressed format */
-  DecompressionCache cache;
+  GOSoundCompressionCache cache;
 
   /* A ring buffer for resampling of compressed samples. It has double
    * MAX_WINDOW_LEN length for having a continous memory region of


### PR DESCRIPTION
This PR does some renaming in the file GOSoundCompress.h acording to the GrandOrgue code conventions.

1. Because the class DecompressionCache is used not only for decompression but also for compression, it is renamed to GOSoundCompressionCache
2. All it's members receive the 'm_' prefix.
3. The file is renamed to GOSoundCompressionCache.h for matching with the class name.

It is just renaming. No GrandOrgue behavior should change.