### PR TITLE
Introduced classes GOSoundOrganInterface and GOSoundOrganInterfaceProxy

### DIFF
--- a/src/core/GOInterfaceProxy.h
+++ b/src/core/GOInterfaceProxy.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOINTERFACEPROXY_H
+#define GOINTERFACEPROXY_H
+
+#include <utility> // std::forward
+
+/**
+ * Abstract proxy implementation for any interface.
+ * The instance may be connected or not connected to a target instance of the
+ * same interface. It forwards calls of the interface methods to the target
+ * instance.
+ *
+ * This class template provides two forwarding strategies for derived classes:
+ * 1. ForwardCall() - safe, does nothing if proxy is not connected (void methods
+ * only)
+ * 2. ForwardCall(defaultValue) - safe, returns default value if not connected
+ *
+ * @tparam InterfaceType The interface class to proxy. The proxy inherits from
+ * this interface.
+ */
+template <typename InterfaceType>
+class GOInterfaceProxy : public InterfaceType {
+private:
+  InterfaceType *p_target = nullptr;
+
+public:
+  virtual ~GOInterfaceProxy() = default;
+
+  /**
+   * Connects the proxy to a target object implementing the interface.
+   * @param pTarget Pointer to the target object. Can be nullptr to disconnect.
+   */
+  inline void Connect(InterfaceType *pTarget) noexcept { p_target = pTarget; }
+
+  /**
+   * Disconnects the proxy from the target object.
+   */
+  inline void Disconnect() noexcept { p_target = nullptr; }
+
+  /**
+   * Checks if the proxy is connected to a target.
+   * @return true if connected, false otherwise.
+   */
+  inline constexpr bool IsConnected() const noexcept {
+    return p_target != nullptr;
+  }
+
+protected:
+  // ========== SAFE VERSIONS (always safe) ==========
+
+  /**
+   * Safely forwards a void call to the target object. Does nothing if not
+   * connected. Use for optional operations that can be skipped.
+   *
+   * @param func Pointer-to-member-function to call (must return void)
+   * @param args Arguments to forward to the function
+   *
+   * Example:
+   * \code
+   * ForwardCall(&ISomeInterface::OptionalMethod, arg1, arg2);
+   * \endcode
+   */
+  template <typename Func, typename... Args>
+  void ForwardCall(Func &&func, Args &&...args) const {
+    if (p_target)
+      (p_target->*func)(std::forward<Args>(args)...);
+  }
+
+  /**
+   * Non-const version of ForwardCall for void methods.
+   */
+  template <typename Func, typename... Args>
+  void ForwardCall(Func &&func, Args &&...args) {
+    if (p_target)
+      (p_target->*func)(std::forward<Args>(args)...);
+  }
+
+  /**
+   * Safely forwards a call to the target object with a default return value.
+   * Returns the default value if not connected.
+   * Use for optional operations that need to return a sensible default.
+   *
+   * @param func Pointer-to-member-function to call
+   * @param defaultValue Value to return if proxy is not connected
+   * @param args Arguments to forward to the function
+   * @return The result of the function call, or defaultValue if not connected
+   *
+   * Example:
+   * \code
+   * // Returns 0 if not connected
+   * return ForwardCall(&ISomeInterface::GetValue, 0, arg1, arg2);
+   * \endcode
+   */
+  template <typename Func, typename DefaultType, typename... Args>
+  auto ForwardCall(Func &&func, DefaultType &&defaultValue, Args &&...args)
+    const -> decltype((p_target->*func)(std::forward<Args>(args)...)) {
+    return p_target ? (p_target->*func)(std::forward<Args>(args)...)
+                    : std::forward<DefaultType>(defaultValue);
+  }
+
+  /**
+   * Non-const version of ForwardCall with default value.
+   */
+  template <typename Func, typename DefaultType, typename... Args>
+  auto ForwardCall(Func &&func, DefaultType &&defaultValue, Args &&...args)
+    -> decltype((p_target->*func)(std::forward<Args>(args)...)) {
+    return p_target ? (p_target->*func)(std::forward<Args>(args)...)
+                    : std::forward<DefaultType>(defaultValue);
+  }
+};
+
+#endif /* GOINTERFACEPROXY_H */

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -866,6 +866,7 @@ void GOOrganController::Abort() {
   m_AudioRecorder->SetAudioRecorder(NULL);
   if (p_OnStateButton)
     p_OnStateButton->AbortPlaybackExt();
+  GOOrganModel::GOSoundOrganInterfaceProxy::Disconnect();
   GOOrganModel::SetMidi(nullptr, nullptr);
   m_midi = NULL;
 }
@@ -891,6 +892,7 @@ void GOOrganController::PreparePlayback(
 
   m_MidiSamplesetMatch.clear();
   GOOrganModel::SetMidi(midi, m_MidiRecorder);
+  GOOrganModel::GOSoundOrganInterfaceProxy::Connect(engine);
   GOEventDistributor::PreparePlayback(engine);
 
   m_setter->UpdateModified(m_OrganModified);

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -19,6 +19,7 @@
 #include "modification/GOModificationProxy.h"
 #include "pipe-config/GOPipeConfigListener.h"
 #include "pipe-config/GOPipeConfigTreeNode.h"
+#include "sound/GOSoundOrganInterfaceProxy.h"
 
 #include "GOEventHandlerList.h"
 
@@ -37,6 +38,7 @@ class GOWindchest;
 class GOOrganModel : private GOCombinationButtonSet,
                      public GOCombinationControllerProxy,
                      public GOEventHandlerList,
+                     public GOSoundOrganInterfaceProxy,
                      public GOMidiSendProxy,
                      public GOPipeConfigListener {
 private:

--- a/src/grandorgue/model/GOTremulant.cpp
+++ b/src/grandorgue/model/GOTremulant.cpp
@@ -11,7 +11,6 @@
 
 #include "config/GOConfigReader.h"
 #include "model/GOOrganModel.h"
-#include "sound/GOSoundOrganEngine.h"
 #include "sound/GOSoundProviderSynthedTrem.h"
 
 #define DELETE_AND_NULL(x)                                                     \
@@ -29,6 +28,7 @@ static const GOConfigEnum TREMULANT_TYPES({
 
 GOTremulant::GOTremulant(GOOrganModel &organModel)
   : GODrawstop(organModel, OBJECT_TYPE_TREMULANT),
+    r_sound(organModel),
     m_TremulantType(GOSynthTrem),
     m_Period(0),
     m_StartRate(0),
@@ -92,23 +92,17 @@ void GOTremulant::InitSoundProvider(GOMemoryPool &pool) {
 
 void GOTremulant::OnDrawstopStateChanged(bool on) {
   if (m_TremulantType == GOSynthTrem) {
-    GOSoundOrganEngine *pSoundEngine = GetSoundEngine();
-
     if (on) {
       assert(m_TremulantN > 0);
-      m_PlaybackHandle = pSoundEngine ? pSoundEngine->StartTremulantSample(
-                           m_TremProvider, m_TremulantN, m_LastStop)
-                                      : nullptr;
+      m_PlaybackHandle = r_OrganModel.StartTremulantSample(
+        m_TremProvider, m_TremulantN, m_LastStop);
     } else if (m_PlaybackHandle) {
-      m_LastStop = pSoundEngine
-        ? pSoundEngine->StopSample(m_TremProvider, m_PlaybackHandle)
-        : 0;
+      m_LastStop = r_OrganModel.StopSample(m_TremProvider, m_PlaybackHandle);
       m_PlaybackHandle = NULL;
     }
   }
-  if (m_TremulantType == GOWavTrem) {
+  if (m_TremulantType == GOWavTrem)
     r_OrganModel.UpdateTremulant(this);
-  }
 }
 
 void GOTremulant::AbortPlayback() {
@@ -121,16 +115,11 @@ void GOTremulant::StartPlayback() {
   GODrawstop::StartPlayback();
 
   if (IsEngaged() && m_TremulantType == GOSynthTrem) {
-    GOSoundOrganEngine *pSoundEngine = GetSoundEngine();
-
     assert(m_TremulantN > 0);
-    m_PlaybackHandle = pSoundEngine
-      ? pSoundEngine->StartTremulantSample(m_TremProvider, m_TremulantN, 0)
-      : nullptr;
+    r_sound.StartTremulantSample(m_TremProvider, m_TremulantN, 0);
   }
-  if (m_TremulantType == GOWavTrem) {
+  if (m_TremulantType == GOWavTrem)
     r_OrganModel.UpdateTremulant(this);
-  }
 }
 
 GOTremulantType GOTremulant::GetTremulantType() { return m_TremulantType; }

--- a/src/grandorgue/model/GOTremulant.h
+++ b/src/grandorgue/model/GOTremulant.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,16 +14,19 @@
 #include "GOCacheObject.h"
 #include "GODrawstop.h"
 
-class GOSoundProvider;
 class GOConfigReader;
 class GOConfigWriter;
 class GOMemoryPool;
+class GOSoundOrganInterface;
+class GOSoundProvider;
 struct GOSoundSampler;
 
 typedef enum { GOSynthTrem, GOWavTrem } GOTremulantType;
 
 class GOTremulant : public GODrawstop, private GOCacheObject {
 private:
+  GOSoundOrganInterface &r_sound;
+
   GOTremulantType m_TremulantType;
   int m_Period;
   int m_StartRate;

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -105,8 +105,6 @@ void GOSoundOrganEngine::SetInterpolationType(unsigned type) {
   m_interpolation = (GOSoundResample::InterpolationType)type;
 }
 
-unsigned GOSoundOrganEngine::GetSampleRate() { return m_SampleRate; }
-
 void GOSoundOrganEngine::SetHardPolyphony(unsigned polyphony) {
   m_SamplerPool.SetUsageLimit(polyphony);
   m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -13,6 +13,7 @@
 
 #include "scheduler/GOSoundScheduler.h"
 
+#include "GOSoundOrganInterface.h"
 #include "GOSoundResample.h"
 #include "GOSoundSampler.h"
 #include "GOSoundSamplerPool.h"
@@ -41,7 +42,7 @@ typedef struct {
  * (WindChests, Tremulants)
  */
 
-class GOSoundOrganEngine {
+class GOSoundOrganEngine : public GOSoundOrganInterface {
 private:
   static constexpr int DETACHED_RELEASE_TASK_ID = 0;
 
@@ -129,7 +130,7 @@ public:
   void SetSampleRate(unsigned sample_rate);
   void SetSamplesPerBuffer(unsigned sample_per_buffer);
   void SetInterpolationType(unsigned type);
-  unsigned GetSampleRate();
+  unsigned GetSampleRate() const override { return m_SampleRate; }
   void SetAudioGroupCount(unsigned groups);
   unsigned GetAudioGroupCount();
   void SetHardPolyphony(unsigned polyphony);
@@ -141,7 +142,7 @@ public:
   const std::vector<double> &GetMeterInfo();
   void SetAudioRecorder(GOSoundRecorder *recorder, bool downmix);
 
-  inline GOSoundSampler *StartPipeSample(
+  GOSoundSampler *StartPipeSample(
     const GOSoundProvider *pipeProvider,
     unsigned windchestN,
     unsigned audioGroup,
@@ -149,7 +150,7 @@ public:
     unsigned delay,
     uint64_t prevEventTime,
     bool isRelease = false,
-    uint64_t *pStartTimeSamples = nullptr) {
+    uint64_t *pStartTimeSamples = nullptr) override {
     return CreateTaskSample(
       pipeProvider,
       windchestN,
@@ -164,15 +165,19 @@ public:
   inline GOSoundSampler *StartTremulantSample(
     const GOSoundProvider *tremProvider,
     unsigned tremulantN,
-    uint64_t prevEventTime) {
+    uint64_t prevEventTime) override {
     return CreateTaskSample(
       tremProvider, -tremulantN, 0, 0x7f, 0, prevEventTime, false, nullptr);
   }
 
-  uint64_t StopSample(const GOSoundProvider *pipe, GOSoundSampler *handle);
-  void SwitchSample(const GOSoundProvider *pipe, GOSoundSampler *handle);
+  uint64_t StopSample(
+    const GOSoundProvider *pipe, GOSoundSampler *handle) override;
+  void SwitchSample(
+    const GOSoundProvider *pipe, GOSoundSampler *handle) override;
   void UpdateVelocity(
-    const GOSoundProvider *pipe, GOSoundSampler *handle, unsigned velocity);
+    const GOSoundProvider *pipe,
+    GOSoundSampler *handle,
+    unsigned velocity) override;
 
   void GetEmptyAudioOutput(
     unsigned outputIndex, unsigned nFrames, float *pOutputBuffer);

--- a/src/grandorgue/sound/GOSoundOrganInterface.h
+++ b/src/grandorgue/sound/GOSoundOrganInterface.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDORGANINTERFACE_H
+#define GOSOUNDORGANINTERFACE_H
+
+#include <cstdint>
+
+/**
+ * This class represents entry points of GOSoundEngine to the organ model.
+ * It is intended that organ model objects would not call GOSoundEngine and
+ * GOSoundSystem directly but would use this interface.
+ */
+
+class GOSoundProvider;
+class GOSoundSampler;
+
+class GOSoundOrganInterface {
+public:
+  virtual ~GOSoundOrganInterface() = default;
+
+  // ProxyDefault: 48000
+  virtual unsigned GetSampleRate() const = 0;
+
+  // ProxyDefault: nullptr
+  virtual GOSoundSampler *StartPipeSample(
+    const GOSoundProvider *pipeProvider,
+    unsigned windchestN,
+    unsigned audioGroup,
+    unsigned velocity,
+    unsigned delay,
+    uint64_t prevEventTime,
+    bool isRelease = false,
+    uint64_t *pStartTimeSamples = nullptr)
+    = 0;
+
+  // ProxyDefault: nullptr
+  virtual GOSoundSampler *StartTremulantSample(
+    const GOSoundProvider *tremProvider,
+    unsigned tremulantN,
+    uint64_t prevEventTime)
+    = 0;
+
+  // ProxyDefault: nothing
+  virtual void UpdateVelocity(
+    const GOSoundProvider *pipe, GOSoundSampler *handle, unsigned velocity)
+    = 0;
+
+  // ProxyDefault: nothing
+  virtual void SwitchSample(const GOSoundProvider *pipe, GOSoundSampler *handle)
+    = 0;
+
+  // ProxyDefault: 0
+  virtual uint64_t StopSample(
+    const GOSoundProvider *pipe, GOSoundSampler *handle)
+    = 0;
+};
+
+#endif /* GOSOUNDORGANINTERFACE_H */

--- a/src/grandorgue/sound/GOSoundOrganInterfaceProxy.h
+++ b/src/grandorgue/sound/GOSoundOrganInterfaceProxy.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDORGANINTERFACEPROXY_H
+#define GOSOUNDORGANINTERFACEPROXY_H
+
+#include "GOInterfaceProxy.h"
+#include "GOSoundOrganInterface.h"
+
+/**
+ * Proxy implementation for GOSoundOrganInterface.
+ * Provides safe default behavior when not connected to a real sound engine.
+ */
+class GOSoundOrganInterfaceProxy
+  : public GOInterfaceProxy<GOSoundOrganInterface> {
+public:
+  /**
+   * Gets the sample rate. Returns 48000 if not connected.
+   */
+  unsigned GetSampleRate() const override {
+    return ForwardCall(&GOSoundOrganInterface::GetSampleRate, 48000u);
+  }
+
+  /**
+   * Starts a pipe sample. Returns nullptr if not connected.
+   */
+  GOSoundSampler *StartPipeSample(
+    const GOSoundProvider *pipeProvider,
+    unsigned windchestN,
+    unsigned audioGroup,
+    unsigned velocity,
+    unsigned delay,
+    uint64_t prevEventTime,
+    bool isRelease = false,
+    uint64_t *pStartTimeSamples = nullptr) override {
+
+    return ForwardCall(
+      &GOSoundOrganInterface::StartPipeSample,
+      nullptr,
+      pipeProvider,
+      windchestN,
+      audioGroup,
+      velocity,
+      delay,
+      prevEventTime,
+      isRelease,
+      pStartTimeSamples);
+  }
+
+  /**
+   * Starts a tremulant sample. Returns nullptr if not connected.
+   */
+  GOSoundSampler *StartTremulantSample(
+    const GOSoundProvider *tremProvider,
+    unsigned tremulantN,
+    uint64_t prevEventTime) override {
+
+    return ForwardCall(
+      &GOSoundOrganInterface::StartTremulantSample,
+      nullptr,
+      tremProvider,
+      tremulantN,
+      prevEventTime);
+  }
+
+  /**
+   * Updates velocity. Does nothing if not connected.
+   */
+  void UpdateVelocity(
+    const GOSoundProvider *pipe,
+    GOSoundSampler *handle,
+    unsigned velocity) override {
+
+    ForwardCall(&GOSoundOrganInterface::UpdateVelocity, pipe, handle, velocity);
+  }
+
+  /**
+   * Switches sample. Does nothing if not connected.
+   */
+  void SwitchSample(
+    const GOSoundProvider *pipe, GOSoundSampler *handle) override {
+
+    ForwardCall(&GOSoundOrganInterface::SwitchSample, pipe, handle);
+  }
+
+  /**
+   * Stops a sample. Returns 0 if not connected.
+   */
+  uint64_t StopSample(
+    const GOSoundProvider *pipe, GOSoundSampler *handle) override {
+
+    return ForwardCall(
+      &GOSoundOrganInterface::StopSample,
+      static_cast<uint64_t>(0),
+      pipe,
+      handle);
+  }
+};
+
+#endif /* GOSOUNDORGANINTERFACEPROXY_H */


### PR DESCRIPTION
This PR introduces the new class GOSoundOrganInterface.

All organ model objects accesses GOSoundEngine only through this interface and it's proxy implementation in GOOrganModel.

It is just refactoring. No GO behavior should be changed.