### PR TITLE
Removed usage of GOOrganController in GOSoundOrganEngine

### DIFF
--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 
+#include "model/GOOrganModel.h"
 #include "model/GOPipe.h"
 #include "model/GOWindchest.h"
 #include "sound/scheduler/GOSoundGroupTask.h"
@@ -19,7 +20,6 @@
 #include "sound/scheduler/GOSoundWindchestTask.h"
 
 #include "GOEvent.h"
-#include "GOOrganController.h"
 #include "GOSoundProvider.h"
 #include "GOSoundRecorder.h"
 #include "GOSoundReleaseAlignTable.h"
@@ -187,23 +187,23 @@ void GOSoundOrganEngine::ClearSetup() {
 }
 
 void GOSoundOrganEngine::Setup(
-  GOOrganController *organController, unsigned release_count) {
+  GOOrganModel &organModel, GOMemoryPool &memoryPool, unsigned releaseCount) {
   m_Scheduler.Clear();
-  if (release_count < 1)
-    release_count = 1;
-  m_Scheduler.SetRepeatCount(release_count);
+  if (releaseCount < 1)
+    releaseCount = 1;
+  m_Scheduler.SetRepeatCount(releaseCount);
   m_TremulantTasks.clear();
-  for (unsigned i = 0; i < organController->GetTremulantCount(); i++)
+  for (unsigned i = 0; i < organModel.GetTremulantCount(); i++)
     m_TremulantTasks.push_back(
       new GOSoundTremulantTask(*this, m_SamplesPerBuffer));
   m_WindchestTasks.clear();
   // a special windchest task for detached releases
   m_WindchestTasks.push_back(new GOSoundWindchestTask(*this, NULL));
-  for (unsigned i = 0; i < organController->GetWindchestCount(); i++)
+  for (unsigned i = 0; i < organModel.GetWindchestCount(); i++)
     m_WindchestTasks.push_back(
-      new GOSoundWindchestTask(*this, organController->GetWindchest(i)));
-  m_TouchTask = std::unique_ptr<GOSoundTouchTask>(
-    new GOSoundTouchTask(organController->GetMemoryPool()));
+      new GOSoundWindchestTask(*this, organModel.GetWindchest(i)));
+  m_TouchTask
+    = std::unique_ptr<GOSoundTouchTask>(new GOSoundTouchTask(memoryPool));
   m_HasBeenSetup.store(true);
   Reset();
 }

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -17,7 +17,9 @@
 #include "GOSoundSampler.h"
 #include "GOSoundSamplerPool.h"
 
-class GOWindchest;
+class GOConfig;
+class GOMemoryPool;
+class GOOrganModel;
 class GOSoundProvider;
 class GOSoundRecorder;
 class GOSoundGroupTask;
@@ -27,8 +29,7 @@ class GOSoundTouchTask;
 class GOSoundTremulantTask;
 class GOSoundWindchestTask;
 class GOSoundTask;
-class GOOrganController;
-class GOConfig;
+class GOWindchest;
 
 typedef struct {
   unsigned channels;
@@ -121,7 +122,10 @@ public:
   GOSoundOrganEngine();
   ~GOSoundOrganEngine();
   void Reset();
-  void Setup(GOOrganController *organController, unsigned release_count = 1);
+  void Setup(
+    GOOrganModel &organModel,
+    GOMemoryPool &memoryPool,
+    unsigned releaseCount = 1);
   void ClearSetup();
   void SetAudioOutput(std::vector<GOAudioOutputConfiguration> audio_outputs);
   void SetupReverb(GOConfig &settings);

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -131,7 +131,10 @@ void GOSoundSystem::OpenSound() {
   m_SoundEngine.SetAudioRecorder(&m_AudioRecorder, m_config.RecordDownmix());
 
   if (m_OrganController)
-    m_SoundEngine.Setup(m_OrganController, m_config.ReleaseConcurrency());
+    m_SoundEngine.Setup(
+      *m_OrganController,
+      m_OrganController->GetMemoryPool(),
+      m_config.ReleaseConcurrency());
   else
     m_SoundEngine.ClearSetup();
 
@@ -287,7 +290,10 @@ void GOSoundSystem::AssignOrganFile(GOOrganController *organController) {
   m_OrganController = organController;
 
   if (m_OrganController && m_AudioOutputs.size()) {
-    m_SoundEngine.Setup(organController, m_config.ReleaseConcurrency());
+    m_SoundEngine.Setup(
+      *organController,
+      m_OrganController->GetMemoryPool(),
+      m_config.ReleaseConcurrency());
     m_OrganController->PreparePlayback(
       &GetEngine(), &GetMidi(), &m_AudioRecorder);
   }

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -140,7 +140,7 @@ void GOPerfTestApp::RunTest(
       engine->SetAudioOutput(engine_config);
       engine->SetAudioRecorder(&recorder, false);
 
-      engine->Setup(organController);
+      engine->Setup(*organController, organController->GetMemoryPool());
 
       std::vector<GOSoundSampler *> handles;
       float output_buffer[samples_per_frame * 2];


### PR DESCRIPTION
This PR removes references to GOOrganController from GOSoundEngine

It is just refactoring. No GO behavior should be changed.