### PR TITLE
Enchanced GOBitmap initialisation

### DIFF
--- a/src/grandorgue/GOBitmapCache.cpp
+++ b/src/grandorgue/GOBitmapCache.cpp
@@ -1,13 +1,12 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
 #include "GOBitmapCache.h"
 
-#include <wx/image.h>
 #include <wx/intl.h>
 #include <wx/mstream.h>
 
@@ -207,10 +206,10 @@ bool GOBitmapCache::loadFile(wxImage &img, const wxString &filename) {
   return result;
 }
 
-GOBitmap GOBitmapCache::GetBitmap(wxString filename, wxString maskName) {
+const wxImage *GOBitmapCache::GetBitmap(wxString filename, wxString maskName) {
   for (unsigned i = 0; i < m_Filenames.size(); i++)
     if (m_Filenames[i] == filename && m_Masknames[i] == maskName)
-      return GOBitmap(m_Bitmaps[i]);
+      return m_Bitmaps[i];
 
   wxImage image, maskimage;
 
@@ -235,8 +234,9 @@ GOBitmap GOBitmapCache::GetBitmap(wxString filename, wxString maskName) {
   }
 
   wxImage *bitmap = new wxImage(image);
+
   if (bitmap->HasMask())
     bitmap->InitAlpha();
   RegisterBitmap(bitmap, filename, maskName);
-  return GOBitmap(bitmap);
+  return bitmap;
 }

--- a/src/grandorgue/GOBitmapCache.h
+++ b/src/grandorgue/GOBitmapCache.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,11 +8,10 @@
 #ifndef GOBITMAPCACHE_H
 #define GOBITMAPCACHE_H
 
+#include <wx/image.h>
 #include <wx/string.h>
 
 #include "ptrvector.h"
-
-#include "gui/panels/primitives/GOBitmap.h"
 
 class GOOrganController;
 
@@ -36,7 +35,8 @@ public:
 
   void RegisterBitmap(
     wxImage *bitmap, wxString filename, wxString maskname = wxEmptyString);
-  GOBitmap GetBitmap(wxString filename, wxString maskName = wxEmptyString);
+  const wxImage *GetBitmap(
+    wxString filename, wxString maskName = wxEmptyString);
 };
 
 #endif

--- a/src/grandorgue/gui/panels/GOGUIButton.cpp
+++ b/src/grandorgue/gui/panels/GOGUIButton.cpp
@@ -77,8 +77,8 @@ void GOGUIButton::Init(
   on_mask_file = wxEmptyString;
   off_mask_file = on_mask_file;
 
-  m_OnBitmap = m_panel->LoadBitmap(on_file, on_mask_file);
-  m_OffBitmap = m_panel->LoadBitmap(off_file, off_mask_file);
+  m_OnBitmap.SetSourceImage(m_panel->LoadBitmap(on_file, on_mask_file));
+  m_OffBitmap.SetSourceImage(m_panel->LoadBitmap(off_file, off_mask_file));
 
   x = -1;
   y = -1;
@@ -207,8 +207,8 @@ void GOGUIButton::Load(GOConfigReader &cfg, wxString group) {
   off_mask_file = cfg.ReadStringTrim(
     ODFSetting, group, wxT("MaskOff"), false, on_mask_file);
 
-  m_OnBitmap = m_panel->LoadBitmap(on_file, on_mask_file);
-  m_OffBitmap = m_panel->LoadBitmap(off_file, off_mask_file);
+  m_OnBitmap.SetSourceImage(m_panel->LoadBitmap(on_file, on_mask_file));
+  m_OffBitmap.SetSourceImage(m_panel->LoadBitmap(off_file, off_mask_file));
 
   x = cfg.ReadInteger(
     ODFSetting,

--- a/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
+++ b/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
@@ -43,8 +43,9 @@ void GOGUIEnclosure::Init(GOConfigReader &cfg, wxString group) {
   for (unsigned i = 1; i <= bitmap_count; i++) {
     wxString bitmap = wxString::Format(
       wxT(GOBitmapPrefix "enclosure%c%02d"), wxT('B'), i - 1);
-    wxString mask = wxEmptyString;
-    m_Bitmaps.push_back(m_panel->LoadBitmap(bitmap, mask));
+
+    m_Bitmaps.emplace_back();
+    m_Bitmaps.back().SetSourceImage(m_panel->LoadBitmap(bitmap, wxEmptyString));
   }
 
   for (unsigned i = 1; i < m_Bitmaps.size(); i++)
@@ -119,7 +120,8 @@ void GOGUIEnclosure::Load(GOConfigReader &cfg, wxString group) {
       wxString::Format(wxT("Mask%03d"), i),
       false,
       wxEmptyString);
-    m_Bitmaps.push_back(m_panel->LoadBitmap(bitmap, mask));
+    m_Bitmaps.emplace_back();
+    m_Bitmaps.back().SetSourceImage(m_panel->LoadBitmap(bitmap, mask));
   }
 
   for (unsigned i = 1; i < m_Bitmaps.size(); i++)

--- a/src/grandorgue/gui/panels/GOGUIImage.cpp
+++ b/src/grandorgue/gui/panels/GOGUIImage.cpp
@@ -26,7 +26,7 @@ void GOGUIImage::Load(GOConfigReader &cfg, wxString group) {
   image_mask_file
     = cfg.ReadStringTrim(ODFSetting, group, wxT("Mask"), false, wxEmptyString);
 
-  m_Bitmap = m_panel->LoadBitmap(image_file, image_mask_file);
+  m_Bitmap.SetSourceImage(m_panel->LoadBitmap(image_file, image_mask_file));
 
   x = cfg.ReadInteger(
     ODFSetting,

--- a/src/grandorgue/gui/panels/GOGUILabel.cpp
+++ b/src/grandorgue/gui/panels/GOGUILabel.cpp
@@ -72,9 +72,11 @@ void GOGUILabel::InitBackgroundBitmap(
   if (imageFileName.IsEmpty() && imageNum)
     // Calculate imageFileName from imageNum
     imageFileName.Printf(WX_BITMAP_LABEL_FMT, imageNum);
-  if (!imageFileName.IsEmpty())
-    m_PBackgroundBitmap
-      = new GOBitmap(m_panel->LoadBitmap(imageFileName, imageMaskFilename));
+  if (!imageFileName.IsEmpty()) {
+    m_PBackgroundBitmap = new GOBitmap();
+    m_PBackgroundBitmap->SetSourceImage(
+      m_panel->LoadBitmap(imageFileName, imageMaskFilename));
+  }
 
   // take the size from the bitmap if it is not specified
   if (!w)

--- a/src/grandorgue/gui/panels/GOGUIManual.cpp
+++ b/src/grandorgue/gui/panels/GOGUIManual.cpp
@@ -100,8 +100,10 @@ void GOGUIManual::Init(GOConfigReader &cfg, wxString group) {
     on_mask_file = wxEmptyString;
     off_mask_file = on_mask_file;
 
-    m_Keys[i].OnBitmap = m_panel->LoadBitmap(on_file, on_mask_file);
-    m_Keys[i].OffBitmap = m_panel->LoadBitmap(off_file, off_mask_file);
+    m_Keys[i].OnBitmap.SetSourceImage(
+      m_panel->LoadBitmap(on_file, on_mask_file));
+    m_Keys[i].OffBitmap.SetSourceImage(
+      m_panel->LoadBitmap(off_file, off_mask_file));
 
     if (
       m_Keys[i].OnBitmap.GetSourceWidth()
@@ -305,8 +307,10 @@ void GOGUIManual::Load(GOConfigReader &cfg, wxString group) {
       false,
       off_mask_file);
 
-    m_Keys[i].OnBitmap = m_panel->LoadBitmap(on_file, on_mask_file);
-    m_Keys[i].OffBitmap = m_panel->LoadBitmap(off_file, off_mask_file);
+    m_Keys[i].OnBitmap.SetSourceImage(
+      m_panel->LoadBitmap(on_file, on_mask_file));
+    m_Keys[i].OffBitmap.SetSourceImage(
+      m_panel->LoadBitmap(off_file, off_mask_file));
 
     if (
       m_Keys[i].OnBitmap.GetSourceWidth()

--- a/src/grandorgue/gui/panels/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -51,9 +51,11 @@ GOGUIPanel::GOGUIPanel(GOOrganController *organController)
     m_layout(0),
     m_view(0),
     m_InitialOpenWindow(false) {
-  for (unsigned i = 0; i < 64; i++)
-    m_WoodImages.push_back(LoadBitmap(
+  for (unsigned i = 0; i < 64; i++) {
+    m_WoodImages.emplace_back();
+    m_WoodImages.back().SetSourceImage(LoadBitmap(
       wxString::Format(wxT(GOBitmapPrefix "wood%02d"), i + 1), wxEmptyString));
+  }
 }
 
 GOGUIPanel::~GOGUIPanel() {
@@ -71,7 +73,7 @@ const wxString &GOGUIPanel::GetName() { return m_Name; }
 
 const wxString &GOGUIPanel::GetGroupName() { return m_GroupName; }
 
-GOBitmap GOGUIPanel::LoadBitmap(wxString filename, wxString maskname) {
+const wxImage *GOGUIPanel::LoadBitmap(wxString filename, wxString maskname) {
   return m_OrganController->GetBitmapCache().GetBitmap(filename, maskname);
 }
 

--- a/src/grandorgue/gui/panels/GOGUIPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -101,7 +101,7 @@ public:
   void PrepareDraw(double scale, GOBitmap *background);
   void Draw(GODC &dc);
   const GOBitmap &GetWood(unsigned which);
-  GOBitmap LoadBitmap(wxString filename, wxString maskname);
+  const wxImage *LoadBitmap(wxString filename, wxString maskname);
   void HandleKey(int key);
   void HandleMousePress(int x, int y, bool right);
   void HandleMouseRelease(bool right);

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
@@ -41,10 +41,10 @@ GOGUIPanelWidget::GOGUIPanelWidget(
   : wxPanel(parent, id),
     m_panel(panel),
     m_BGInit(false),
-    m_Background(&m_BGImage),
     m_Scale(1),
     m_FontScale(1),
     m_PressedPoint(default_point) {
+  m_Background.SetSourceImage(&m_BGImage);
   initFont();
   SetLabel(m_panel->GetName());
   m_ClientBitmap.Create(

--- a/src/grandorgue/gui/panels/primitives/GOBitmap.cpp
+++ b/src/grandorgue/gui/panels/primitives/GOBitmap.cpp
@@ -11,26 +11,12 @@
 #include <wx/dcmemory.h>
 #include <wx/image.h>
 
-GOBitmap::GOBitmap()
-  : p_SourceImage(nullptr),
-    m_Scale(0),
-    m_ResultWidth(0),
-    m_ResultHeight(0),
-    m_ResultXOffset(0),
-    m_ResultYOffset(0) {}
-
-GOBitmap::GOBitmap(const wxImage *pSourceImg)
-  : p_SourceImage(pSourceImg),
-    m_Scale(0),
-    m_ResultWidth(0),
-    m_ResultHeight(0),
-    m_ResultXOffset(0),
-    m_ResultYOffset(0) {}
-
-unsigned GOBitmap::GetSourceWidth() const { return p_SourceImage->GetWidth(); }
+unsigned GOBitmap::GetSourceWidth() const {
+  return p_SourceImage ? p_SourceImage->GetWidth() : 0;
+}
 
 unsigned GOBitmap::GetSourceHeight() const {
-  return p_SourceImage->GetHeight();
+  return p_SourceImage ? p_SourceImage->GetHeight() : 0;
 }
 
 void GOBitmap::BuildBitmapFrom(
@@ -61,7 +47,7 @@ void GOBitmap::BuildBitmapFrom(
 
 void GOBitmap::BuildScaledBitmap(
   double scale, const wxRect &rect, GOBitmap *background) {
-  if (scale != m_Scale || m_ResultWidth || m_ResultHeight) {
+  if (p_SourceImage && (scale != m_Scale || m_ResultWidth || m_ResultHeight)) {
     BuildBitmapFrom(*p_SourceImage, scale, rect, background);
     m_ResultWidth = 0;
     m_ResultHeight = 0;
@@ -75,9 +61,12 @@ void GOBitmap::BuildTileBitmap(
   unsigned yo,
   GOBitmap *background) {
   if (
-    scale != m_Scale || m_ResultWidth != rect.GetWidth()
-    || m_ResultHeight != rect.GetHeight() || xo != m_ResultXOffset
-    || yo != m_ResultYOffset) {
+    p_SourceImage
+    && (
+      scale != m_Scale 
+      || m_ResultWidth != rect.GetWidth()
+      || m_ResultHeight != rect.GetHeight() || xo != m_ResultXOffset
+      || yo != m_ResultYOffset)) {
     wxImage img(rect.GetWidth(), rect.GetHeight());
 
     for (int y = -yo; y < img.GetHeight(); y += GetSourceHeight())

--- a/src/grandorgue/gui/panels/primitives/GOBitmap.h
+++ b/src/grandorgue/gui/panels/primitives/GOBitmap.h
@@ -20,20 +20,19 @@ class wxRect;
 
 class GOBitmap {
 private:
-  const wxImage *p_SourceImage;
+  const wxImage *p_SourceImage = nullptr;
   wxBitmap m_ResultBitmap;
-  double m_Scale;
-  int m_ResultWidth;
-  int m_ResultHeight;
-  unsigned m_ResultXOffset;
-  unsigned m_ResultYOffset;
+  double m_Scale = 0.0;
+  int m_ResultWidth = 0;
+  int m_ResultHeight = 0;
+  unsigned m_ResultXOffset = 0;
+  unsigned m_ResultYOffset = 0;
 
   void BuildBitmapFrom(
     const wxImage &img, double scale, const wxRect &rect, GOBitmap *background);
 
 public:
-  GOBitmap(); // Makes a dummy instance
-  GOBitmap(const wxImage *pSourceImg);
+  void SetSourceImage(const wxImage *pSourceImg) { p_SourceImage = pSourceImg; }
 
   unsigned GetSourceWidth() const;
   unsigned GetSourceHeight() const;


### PR DESCRIPTION
GOBitmap is a link between xwImage and wxBitmap. It builds a wxBitmap instance based on the source wxImage.

Earlier there two different types of GOBitMap: a "dummy" one without a valid wxImage and a "normal" one with a valid wxImage. When a conteiner object (ex. GOGUIButten) was created, it received a dummy GOBitMap. Later, when Load() was called, the old dummy GOBitMap was destroyed and was replaced with a normal GOBitMap.

Now "dummy" and "normal" are two states of one GOBitMap. During the Load() the GOBitMap is not destroeyd but becomes "normal" with a SetSourceImage() call.

This PR also changes the GOBitmapCache::GetBitmap() signature. Earlier it was returning a temporary GOBitMap normal instance for replacing a dummy one in a container. Extra creation and destroying of wxBitmap was performed. Now it returns just a pointer to a shared wxImage instance, and the container just calls to SetSourceImage() of the GOBitmap for transfering it to the "normal" state.

It is just refactoring. No GO behavior should be changed except a small performance enchancements when an organ is loaded, but it's not noticeable in comparison with loading time of sound samples.