### PR TITLE
Encapsulated methods of GOSoundCompressionCache

### DIFF
--- a/src/grandorgue/sound/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/GOSoundAudioSection.cpp
@@ -257,7 +257,7 @@ static inline void loop_memcpy(
 void GOSoundAudioSection::GetMaxAmplitudeAndDerivative() {
   GOSoundCompressionCache cache;
 
-  InitDecompressionCache(cache);
+  cache.Init();
   m_MaxAmplitude = 0;
   m_MaxAbsAmplitude = 0;
   m_MaxAbsDerivative = 0;
@@ -509,8 +509,8 @@ void GOSoundAudioSection::Compress(bool format16) {
 
   unsigned output_len = 0;
   GOSoundCompressionCache state;
-  InitDecompressionCache(state);
 
+  state.Init();
   for (unsigned i = 0; i < m_SampleCount; i++) {
     state.m_position = i;
     state.m_ptr = (const unsigned char *)(intptr_t)output_len;
@@ -535,9 +535,9 @@ void GOSoundAudioSection::Compress(bool format16) {
         = val - (state.m_prev[j] + (state.m_prev[j] - state.m_last[j]) / 2);
 
       if (format16)
-        AudioWriteCompressed16(data, output_len, encode);
+        GOSoundCompressionCache::writeCompressed16(data, output_len, encode);
       else
-        AudioWriteCompressed8(data, output_len, encode);
+        GOSoundCompressionCache::writeCompressed8(data, output_len, encode);
 
       /* Early abort if the compressed data will be larger than the
        * uncompressed data. */

--- a/src/grandorgue/sound/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/GOSoundAudioSection.h
@@ -256,12 +256,12 @@ public:
       GOSoundCompressionCache tmp;
       if (!cache) {
         cache = &tmp;
-        InitDecompressionCache(*cache);
+        cache->Init();
       }
 
       assert(m_BitsPerSample >= 12);
-      DecompressTo(
-        *cache, position, m_data, m_channels, (m_BitsPerSample >= 20));
+      cache->DecompressTo(
+        position, m_data, m_channels, (m_BitsPerSample >= 20));
       return cache->m_value[channel];
     }
   }

--- a/src/grandorgue/sound/GOSoundCompressionCache.h
+++ b/src/grandorgue/sound/GOSoundCompressionCache.h
@@ -8,83 +8,9 @@
 #ifndef GOSOUNDCOMPRESSIONCACHE_H
 #define GOSOUNDCOMPRESSIONCACHE_H
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstdint>
 
 #include "GOSoundDefs.h"
-
-static inline int AudioReadCompressed8(const unsigned char *&ptr) {
-  int val = *(const int8_t *)ptr;
-  if (val & 0x01) {
-    val >>= 1;
-    ptr++;
-  } else if (val & 0x02) {
-    /* remaining bits are high byte */
-    val = ((val & ~3) << (8 - 2)) | (*(const uint8_t *)(ptr + 1));
-    ptr += 2;
-  } else if (val & 0x04) {
-    val = ((val & ~7) << (16 - 3)) | (*(const uint16_t *)(ptr + 1));
-    ptr += 3;
-  } else {
-    val = ((val & ~7) << (24 - 3)) | ((*(const uint8_t *)(ptr + 1)) << 16)
-      | (*(const uint16_t *)(ptr + 2));
-    ptr += 4;
-  }
-  return val;
-}
-
-static inline int AudioReadCompressed16(const unsigned char *&ptr) {
-  int val = *(const int16_t *)ptr;
-  if (val & 0x01) {
-    val >>= 1;
-    ptr += 2;
-  } else if (val & 0x02) {
-    /* remaining bits are high byte */
-    val = ((val & ~3) << (8 - 2)) | (*(const uint8_t *)(ptr + 2));
-    ptr += 3;
-  } else {
-    val = ((val & ~3) << (16 - 2)) | (*(const uint16_t *)(ptr + 2));
-    ptr += 4;
-  }
-  return val;
-}
-
-static inline void AudioWriteCompressed8(
-  unsigned char *data, unsigned &output_len, int encode) {
-  if (-64 <= encode && encode <= 63) {
-    *((int8_t *)(data + output_len)) = ((encode) << 1) | 0x01;
-    output_len++;
-  } else if (-8192 <= encode && encode <= 8191) {
-    *((int8_t *)(data + output_len)) = ((encode >> 8) << 2) | 0x02;
-    *((uint8_t *)(data + output_len + 1)) = encode & 0xFF;
-    output_len += 2;
-  } else if (-1048576 <= encode && encode <= 1048575) {
-    *((int8_t *)(data + output_len)) = ((encode >> 16) << 3) | 0x04;
-    *((uint16_t *)(data + output_len + 1)) = encode & 0xFFFF;
-    output_len += 3;
-  } else {
-    *((int8_t *)(data + output_len)) = ((encode >> 24) << 3) | 0x00;
-    *((uint8_t *)(data + output_len + 1)) = (encode >> 16) & 0xFF;
-    *((uint16_t *)(data + output_len + 2)) = encode & 0xFFFF;
-    output_len += 4;
-  }
-}
-
-static inline void AudioWriteCompressed16(
-  unsigned char *data, unsigned &output_len, int encode) {
-  if (-16384 <= encode && encode <= 16383) {
-    *((int16_t *)(data + output_len)) = ((encode) << 1) | 0x01;
-    output_len += 2;
-  } else if (-2097152 <= encode && encode <= 2097151) {
-    *((int16_t *)(data + output_len)) = ((encode >> 8) << 2) | 0x02;
-    *((uint8_t *)(data + output_len + 2)) = encode & 0xFF;
-    output_len += 3;
-  } else {
-    *((int16_t *)(data + output_len)) = ((encode >> 16) << 2) | 0x00;
-    *((uint16_t *)(data + output_len + 2)) = encode & 0xFFFF;
-    output_len += 4;
-  }
-}
 
 class GOSoundCompressionCache {
 public:
@@ -93,46 +19,116 @@ public:
   int m_last[MAX_OUTPUT_CHANNELS];
   int m_prev[MAX_OUTPUT_CHANNELS];
   const unsigned char *m_ptr;
+
+  static inline int readCompressed8(const unsigned char *&ptr) {
+    int val = *(const int8_t *)ptr;
+    if (val & 0x01) {
+      val >>= 1;
+      ptr++;
+    } else if (val & 0x02) {
+      /* remaining bits are high byte */
+      val = ((val & ~3) << (8 - 2)) | (*(const uint8_t *)(ptr + 1));
+      ptr += 2;
+    } else if (val & 0x04) {
+      val = ((val & ~7) << (16 - 3)) | (*(const uint16_t *)(ptr + 1));
+      ptr += 3;
+    } else {
+      val = ((val & ~7) << (24 - 3)) | ((*(const uint8_t *)(ptr + 1)) << 16)
+        | (*(const uint16_t *)(ptr + 2));
+      ptr += 4;
+    }
+    return val;
+  }
+
+  static inline int readCompressed16(const unsigned char *&ptr) {
+    int val = *(const int16_t *)ptr;
+    if (val & 0x01) {
+      val >>= 1;
+      ptr += 2;
+    } else if (val & 0x02) {
+      /* remaining bits are high byte */
+      val = ((val & ~3) << (8 - 2)) | (*(const uint8_t *)(ptr + 2));
+      ptr += 3;
+    } else {
+      val = ((val & ~3) << (16 - 2)) | (*(const uint16_t *)(ptr + 2));
+      ptr += 4;
+    }
+    return val;
+  }
+
+  static inline void writeCompressed8(
+    unsigned char *data, unsigned &output_len, int encode) {
+    if (-64 <= encode && encode <= 63) {
+      *((int8_t *)(data + output_len)) = ((encode) << 1) | 0x01;
+      output_len++;
+    } else if (-8192 <= encode && encode <= 8191) {
+      *((int8_t *)(data + output_len)) = ((encode >> 8) << 2) | 0x02;
+      *((uint8_t *)(data + output_len + 1)) = encode & 0xFF;
+      output_len += 2;
+    } else if (-1048576 <= encode && encode <= 1048575) {
+      *((int8_t *)(data + output_len)) = ((encode >> 16) << 3) | 0x04;
+      *((uint16_t *)(data + output_len + 1)) = encode & 0xFFFF;
+      output_len += 3;
+    } else {
+      *((int8_t *)(data + output_len)) = ((encode >> 24) << 3) | 0x00;
+      *((uint8_t *)(data + output_len + 1)) = (encode >> 16) & 0xFF;
+      *((uint16_t *)(data + output_len + 2)) = encode & 0xFFFF;
+      output_len += 4;
+    }
+  }
+
+  static inline void writeCompressed16(
+    unsigned char *data, unsigned &output_len, int encode) {
+    if (-16384 <= encode && encode <= 16383) {
+      *((int16_t *)(data + output_len)) = ((encode) << 1) | 0x01;
+      output_len += 2;
+    } else if (-2097152 <= encode && encode <= 2097151) {
+      *((int16_t *)(data + output_len)) = ((encode >> 8) << 2) | 0x02;
+      *((uint8_t *)(data + output_len + 2)) = encode & 0xFF;
+      output_len += 3;
+    } else {
+      *((int16_t *)(data + output_len)) = ((encode >> 16) << 2) | 0x00;
+      *((uint16_t *)(data + output_len + 2)) = encode & 0xFFFF;
+      output_len += 4;
+    }
+  }
+
+  inline void Init() {
+    m_position = 0;
+    m_ptr = nullptr;
+    for (unsigned j = 0; j < MAX_OUTPUT_CHANNELS; j++) {
+      m_last[j] = 0;
+      m_value[j] = 0;
+      m_prev[j] = 0;
+    }
+  }
+
+  inline void DecompressionStep(unsigned channels, bool format16) {
+    for (unsigned j = 0; j < channels; j++) {
+      int val;
+      if (format16)
+        val = readCompressed16(m_ptr);
+      else
+        val = readCompressed8(m_ptr);
+      m_last[j] = m_prev[j];
+      m_prev[j] = m_value[j];
+      m_value[j] = m_prev[j] + (m_prev[j] - m_last[j]) / 2 + val;
+    }
+    m_position++;
+  }
+
+  inline void DecompressTo(
+    unsigned position,
+    const unsigned char *data,
+    unsigned channels,
+    bool format16) {
+    if (!m_ptr || m_position > position + 1) {
+      Init();
+      m_ptr = data;
+    }
+    while (m_position <= position)
+      DecompressionStep(channels, format16);
+  }
 };
-
-static inline void InitDecompressionCache(GOSoundCompressionCache &cache) {
-  cache.m_position = 0;
-  cache.m_ptr = NULL;
-  for (unsigned j = 0; j < MAX_OUTPUT_CHANNELS; j++) {
-    cache.m_last[j] = 0;
-    cache.m_value[j] = 0;
-    cache.m_prev[j] = 0;
-  }
-}
-
-static inline void DecompressionStep(
-  GOSoundCompressionCache &cache, unsigned channels, bool format16) {
-  for (unsigned j = 0; j < channels; j++) {
-    int val;
-    if (format16)
-      val = AudioReadCompressed16(cache.m_ptr);
-    else
-      val = AudioReadCompressed8(cache.m_ptr);
-    cache.m_last[j] = cache.m_prev[j];
-    cache.m_prev[j] = cache.m_value[j];
-    cache.m_value[j]
-      = cache.m_prev[j] + (cache.m_prev[j] - cache.m_last[j]) / 2 + val;
-  }
-  cache.m_position++;
-}
-
-static inline void DecompressTo(
-  GOSoundCompressionCache &cache,
-  unsigned position,
-  const unsigned char *data,
-  unsigned channels,
-  bool format16) {
-  if (!cache.m_ptr || cache.m_position > position + 1) {
-    InitDecompressionCache(cache);
-    cache.m_ptr = data;
-  }
-  while (cache.m_position <= position)
-    DecompressionStep(cache, channels, format16);
-}
 
 #endif

--- a/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
+++ b/src/grandorgue/sound/GOSoundReleaseAlignTable.cpp
@@ -57,7 +57,8 @@ void GOSoundReleaseAlignTable::ComputeTable(
   unsigned int sample_rate,
   unsigned start_position) {
   GOSoundCompressionCache cache;
-  InitDecompressionCache(cache);
+
+  cache.Init();
 
   for (unsigned i = 0; i < PHASE_ALIGN_DERIVATIVES; i++)
     for (unsigned j = 0; j < PHASE_ALIGN_AMPLITUDES; j++)

--- a/src/grandorgue/sound/GOSoundStream.cpp
+++ b/src/grandorgue/sound/GOSoundStream.cpp
@@ -36,7 +36,7 @@ public:
 
   inline void Seek(unsigned index, uint8_t channelN) {
     while (r_cache.m_position <= index + 1) {
-      DecompressionStep(r_cache, nChannels, format16);
+      r_cache.DecompressionStep(nChannels, format16);
     }
     m_ChannelN = channelN;
     m_curr = PREV;
@@ -87,7 +87,7 @@ public:
       int *pWrite2 = pWrite1 + WINDOW_SAMPLES;
 
       while (r_cache.m_position < readAheadIndexTo) {
-        DecompressionStep(r_cache, nChannels, format16);
+        r_cache.DecompressionStep(nChannels, format16);
 
         /* fill the read ahead buffer. If r_cache.position > index we assume
           that the previous samples already present */
@@ -441,8 +441,8 @@ void GOSoundStream::GetHistory(
     for (unsigned i = 0; i < BLOCK_HISTORY; i++) {
       for (uint8_t j = 0; j < nChannels; j++)
         history[i][j] = tmpCache.m_value[j];
-      DecompressionStep(
-        tmpCache, nChannels, audio_section->GetBitsPerSample() >= 20);
+      tmpCache.DecompressionStep(
+        nChannels, audio_section->GetBitsPerSample() >= 20);
     }
   }
 }


### PR DESCRIPTION
Earlier there were lot of compression-related functions that were defined in GOSoundCompressionCache.h.

This PR move them inside to the GOSoundCompressionCache class and renames according to the GrandOrgue naming convention.

It is just refactoring. No GO behavior should be changed.

