### PR TITLE
Optimized debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -32,6 +32,10 @@ endif()
 
 if (NOT DEFINED GO_BUILD_TESTING OR GO_BUILD_TESTING STREQUAL "")
   set(GO_BUILD_TESTING ${BUILD_TESTING})
+endif()
+
+if (NOT DEFINED GO_BUILD_COVERAGE OR GO_BUILD_COVERAGE STREQUAL "")
+  set(GO_BUILD_COVERAGE OFF)
 endif()
 
 set(FULL_VERSION "${PROJECT_VERSION}-${BUILD_VERSION}")
@@ -122,6 +126,7 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 add_option(-Wall)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_option(-g3)
+  add_option(-Og)
 else()
   add_option(-O3)
   add_option(-g)
@@ -217,7 +222,7 @@ message(STATUS "  wxWidgets configuration     : ${wxWidgets_CONFIGURATION}")
 message(STATUS "============================================================================")
 
 
-if (GO_BUILD_TESTING)
+if (GO_BUILD_COVERAGE)
     # Add coverage configuration to include project files - Don't put extra libraries here under
     set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
     message(STATUS "============================================================================")

--- a/build-scripts/for-linux/build-for-tests.sh
+++ b/build-scripts/for-linux/build-for-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# $1 - directory
-# $2 - target deb architecture. Default - current
+# $1 - target deb architecture. Default - current
+# $2 - build type: Debug or Release. Default - Debug
 
 set -e
 
@@ -11,12 +11,19 @@ DIR=$(dirname $0)
 
 SRC_DIR=$(readlink -f $(dirname $0)/../..)
 
-TARGET_ARCH=${2:$(dpkg --print-architecture)}
+TARGET_ARCH=${1:-$(dpkg --print-architecture)}
+BUILD_TYPE=${2:-Debug}
 
 export LANG=C
 
+# Enable coverage only for Debug builds
+COVERAGE_FLAG=""
+if [ "$BUILD_TYPE" = "Debug" ]; then
+    COVERAGE_FLAG="-DGO_BUILD_COVERAGE=ON"
+fi
+
 # Define BUILD_TESTING=ON
-GO_PRMS="-DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON \
+GO_PRMS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=ON $COVERAGE_FLAG \
   $CMAKE_VERSION_PRMS \
   $($DIR/cmake-prm-yaml-cpp.bash $TARGET_ARCH)"
 


### PR DESCRIPTION
Earlier GrandOrgue built with a debug build (the cmake flag -DCMAKE_BUILD_TYPE=$BUILD_TYPE) worked very slow. The reason was that Debug builds also enabled coverage instrumentatuib that significally slowed GrandOrgue down.

This PR:

1. Separates GO_BUILD_COVERAGE from GO_BUILD_TESTING — --coverage instrumentation is no longer added globally when testing is enabled; it is only applied when GO_BUILD_COVERAGE=ON (CI Debug builds still use it).
2. Addes -Og optimization flag for Debug builds — GCC's debug-friendly optimization level that enables safe optimizations without impacting debuggability.
3. Sets the GO_BUILD_COVERAGE flag to builts for testing on GitHub.

Some performance tests show that performance of certain operations has been increased up to 15 times.