### PR TITLE
Moved sound/GOSoundBufferWorkItem to sound/scheduler/GOSoundBufferTaskBase

### DIFF
--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -314,7 +314,7 @@ void GOSoundOrganEngine::SetAudioOutput(
       audio_outputs[i].channels, scale_factors, m_SamplesPerBuffer));
     channels += audio_outputs[i].channels;
   }
-  std::vector<GOSoundBufferItem *> outputs;
+  std::vector<GOSoundBufferTaskBase *> outputs;
   for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
     outputs.push_back(m_AudioGroupTasks[i]);
   for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
@@ -325,7 +325,7 @@ void GOSoundOrganEngine::SetAudioOutput(
 void GOSoundOrganEngine::SetAudioRecorder(
   GOSoundRecorder *recorder, bool downmix) {
   m_AudioRecorder = recorder;
-  std::vector<GOSoundBufferItem *> outputs;
+  std::vector<GOSoundBufferTaskBase *> outputs;
   if (downmix)
     outputs.push_back(m_AudioOutputTasks[0]);
   else {

--- a/src/grandorgue/sound/GOSoundRecorder.cpp
+++ b/src/grandorgue/sound/GOSoundRecorder.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,9 +10,10 @@
 #include <wx/intl.h>
 #include <wx/log.h>
 
-#include "GOSoundBufferItem.h"
-#include "GOWaveTypes.h"
+#include "scheduler/GOSoundBufferTaskBase.h"
 #include "threading/GOMutexLocker.h"
+
+#include "GOWaveTypes.h"
 
 #pragma pack(push, 1)
 
@@ -109,7 +110,7 @@ void GOSoundRecorder::SetBytesPerSample(unsigned value) {
 }
 
 void GOSoundRecorder::SetOutputs(
-  std::vector<GOSoundBufferItem *> outputs, unsigned samples_per_buffer) {
+  std::vector<GOSoundBufferTaskBase *> outputs, unsigned samples_per_buffer) {
   m_Outputs = outputs;
   m_SamplesPerBuffer = samples_per_buffer;
   SetupBuffer();

--- a/src/grandorgue/sound/GOSoundRecorder.h
+++ b/src/grandorgue/sound/GOSoundRecorder.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -17,7 +17,7 @@
 #include "sound/scheduler/GOSoundTask.h"
 #include "threading/GOMutex.h"
 
-class GOSoundBufferItem;
+class GOSoundBufferTaskBase;
 struct struct_WAVE;
 
 class GOSoundRecorder : public GOSoundTask {
@@ -34,7 +34,7 @@ private:
   bool m_Recording;
   bool m_Done;
   std::atomic_bool m_Stop;
-  std::vector<GOSoundBufferItem *> m_Outputs;
+  std::vector<GOSoundBufferTaskBase *> m_Outputs;
   char *m_Buffer;
 
   void SetupBuffer();
@@ -52,7 +52,7 @@ public:
   /* 1 = 8 bit, 2 = 16 bit, 3 = 24 bit, 4 = float */
   void SetBytesPerSample(unsigned value);
   void SetOutputs(
-    std::vector<GOSoundBufferItem *> outputs, unsigned samples_per_buffer);
+    std::vector<GOSoundBufferTaskBase *> outputs, unsigned samples_per_buffer);
 
   unsigned GetGroup();
   unsigned GetCost();

--- a/src/grandorgue/sound/scheduler/GOSoundBufferTaskBase.h
+++ b/src/grandorgue/sound/scheduler/GOSoundBufferTaskBase.h
@@ -1,26 +1,26 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GOSOUNDBUFFERITEM_H
-#define GOSOUNDBUFFERITEM_H
+#ifndef GOSOUNDBUFFERTASKBASE_H
+#define GOSOUNDBUFFERTASKBASE_H
 
 class GOSoundThread;
 
-class GOSoundBufferItem {
+class GOSoundBufferTaskBase {
 protected:
   unsigned m_SamplesPerBuffer;
   unsigned m_Channels;
 
 public:
-  GOSoundBufferItem(unsigned samples_per_buffer, unsigned channels)
+  GOSoundBufferTaskBase(unsigned samples_per_buffer, unsigned channels)
     : m_SamplesPerBuffer(samples_per_buffer), m_Channels(channels) {
     m_Buffer = new float[m_SamplesPerBuffer * m_Channels];
   }
-  virtual ~GOSoundBufferItem() { delete[] m_Buffer; }
+  virtual ~GOSoundBufferTaskBase() { delete[] m_Buffer; }
 
   virtual void Finish(bool stop, GOSoundThread *pThread = nullptr) = 0;
 
@@ -31,4 +31,4 @@ public:
   unsigned GetChannels() { return m_Channels; }
 };
 
-#endif
+#endif /* GOSOUNDBUFFERTASKBASE_H */

--- a/src/grandorgue/sound/scheduler/GOSoundGroupTask.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundGroupTask.cpp
@@ -13,7 +13,7 @@
 
 GOSoundGroupTask::GOSoundGroupTask(
   GOSoundOrganEngine &sound_engine, unsigned samples_per_buffer)
-  : GOSoundBufferItem(samples_per_buffer, 2),
+  : GOSoundBufferTaskBase(samples_per_buffer, 2),
     m_engine(sound_engine),
     m_Condition(m_Mutex),
     m_ActiveCount(0),

--- a/src/grandorgue/sound/scheduler/GOSoundGroupTask.h
+++ b/src/grandorgue/sound/scheduler/GOSoundGroupTask.h
@@ -11,15 +11,16 @@
 #include <atomic>
 
 #include "GOSoundThread.h"
-#include "sound/GOSoundBufferItem.h"
 #include "sound/GOSoundSamplerList.h"
-#include "sound/scheduler/GOSoundTask.h"
 #include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
 
+#include "GOSoundBufferTaskBase.h"
+#include "GOSoundTask.h"
+
 class GOSoundOrganEngine;
 
-class GOSoundGroupTask : public GOSoundTask, public GOSoundBufferItem {
+class GOSoundGroupTask : public GOSoundTask, public GOSoundBufferTaskBase {
 private:
   GOSoundOrganEngine &m_engine;
   GOSoundSamplerList m_Active;

--- a/src/grandorgue/sound/scheduler/GOSoundOutputTask.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundOutputTask.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -15,7 +15,7 @@ GOSoundOutputTask::GOSoundOutputTask(
   unsigned channels,
   std::vector<float> scale_factors,
   unsigned samples_per_buffer)
-  : GOSoundBufferItem(samples_per_buffer, channels),
+  : GOSoundBufferTaskBase(samples_per_buffer, channels),
     m_ScaleFactors(scale_factors),
     m_Outputs(),
     m_OutputCount(0),
@@ -30,7 +30,8 @@ GOSoundOutputTask::~GOSoundOutputTask() {
     delete m_Reverb;
 }
 
-void GOSoundOutputTask::SetOutputs(std::vector<GOSoundBufferItem *> outputs) {
+void GOSoundOutputTask::SetOutputs(
+  std::vector<GOSoundBufferTaskBase *> outputs) {
   m_Outputs = outputs;
   m_OutputCount = m_Outputs.size() * 2;
 }

--- a/src/grandorgue/sound/scheduler/GOSoundOutputTask.h
+++ b/src/grandorgue/sound/scheduler/GOSoundOutputTask.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,17 +11,18 @@
 #include <atomic>
 #include <vector>
 
-#include "sound/GOSoundBufferItem.h"
 #include "sound/scheduler/GOSoundTask.h"
 #include "threading/GOMutex.h"
+
+#include "GOSoundBufferTaskBase.h"
 
 class GOSoundReverb;
 class GOConfig;
 
-class GOSoundOutputTask : public GOSoundTask, public GOSoundBufferItem {
+class GOSoundOutputTask : public GOSoundTask, public GOSoundBufferTaskBase {
 private:
   std::vector<float> m_ScaleFactors;
-  std::vector<GOSoundBufferItem *> m_Outputs;
+  std::vector<GOSoundBufferTaskBase *> m_Outputs;
   unsigned m_OutputCount;
   std::vector<float> m_MeterInfo;
   GOSoundReverb *m_Reverb;
@@ -36,7 +37,7 @@ public:
     unsigned samples_per_buffer);
   ~GOSoundOutputTask();
 
-  void SetOutputs(std::vector<GOSoundBufferItem *> outputs);
+  void SetOutputs(std::vector<GOSoundBufferTaskBase *> outputs);
 
   unsigned GetGroup();
   unsigned GetCost();


### PR DESCRIPTION
This PR renames the class `sound/GOSoundBufferWorkItem` to `GOSoundBufferTaskBase` and moves it to the sound/scheduler directory.

 It is just moving/renaming. No GO behavior should be changed.