### PR TITLE
Introduced a class GOSoundReverb::ReverbConfig for the future refactoring of GOSoundEngine

### DIFF
--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -337,9 +337,13 @@ void GOSoundOrganEngine::SetAudioRecorder(
 }
 
 void GOSoundOrganEngine::SetupReverb(GOConfig &settings) {
+  const GOSoundReverb::ReverbConfig reverbConfig
+    = GOSoundReverb::createReverbConfig(settings);
+
   for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
     if (m_AudioOutputTasks[i])
-      m_AudioOutputTasks[i]->SetupReverb(settings);
+      m_AudioOutputTasks[i]->SetupReverb(
+        reverbConfig, settings.SamplesPerBuffer(), settings.SampleRate());
 }
 
 unsigned GOSoundOrganEngine::GetBufferSizeFor(

--- a/src/grandorgue/sound/GOSoundReverb.h
+++ b/src/grandorgue/sound/GOSoundReverb.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,11 +8,38 @@
 #ifndef GOSOUNDREVERB_H
 #define GOSOUNDREVERB_H
 
+#include <wx/string.h>
+
 #include "ptrvector.h"
+
 class Convproc;
 class GOConfig;
 
 class GOSoundReverb {
+public:
+  /**
+   * @brief Reverb configuration, independent of engine runtime parameters.
+   *
+   * sampleRate and nSamplesPerBuffer are NOT part of this struct —
+   * they are engine-level parameters passed directly to Setup().
+   */
+  struct ReverbConfig {
+    bool isEnabled;
+    bool isDirect;
+    unsigned channel;
+    unsigned startOffset;
+    unsigned len;
+    unsigned delay;
+    float gain;
+    wxString file;
+  };
+
+  /** Named constant meaning "reverb disabled". Used as default. */
+  static const ReverbConfig CONFIG_REVERB_DISABLED;
+
+  /** Creates a ReverbConfig from GOConfig. */
+  static ReverbConfig createReverbConfig(const GOConfig &config);
+
 private:
   unsigned m_channels;
   ptr_vector<Convproc> m_engine;
@@ -24,7 +51,10 @@ public:
   virtual ~GOSoundReverb();
 
   void Reset();
-  void Setup(GOConfig &settings);
+  void Setup(
+    const ReverbConfig &config,
+    unsigned nSamplesPerBuffer,
+    unsigned sampleRate);
 
   void Process(float *output_buffer, unsigned n_frames);
 };

--- a/src/grandorgue/sound/scheduler/GOSoundOutputTask.cpp
+++ b/src/grandorgue/sound/scheduler/GOSoundOutputTask.cpp
@@ -8,7 +8,6 @@
 #include "GOSoundOutputTask.h"
 
 #include "GOSoundThread.h"
-#include "sound/GOSoundReverb.h"
 #include "threading/GOMutexLocker.h"
 
 GOSoundOutputTask::GOSoundOutputTask(
@@ -115,8 +114,11 @@ unsigned GOSoundOutputTask::GetCost() { return 0; }
 
 bool GOSoundOutputTask::GetRepeat() { return false; }
 
-void GOSoundOutputTask::SetupReverb(GOConfig &settings) {
-  m_Reverb->Setup(settings);
+void GOSoundOutputTask::SetupReverb(
+  const GOSoundReverb::ReverbConfig &config,
+  unsigned nSamplesPerBuffer,
+  unsigned sampleRate) {
+  m_Reverb->Setup(config, nSamplesPerBuffer, sampleRate);
 }
 
 const std::vector<float> &GOSoundOutputTask::GetMeterInfo() {

--- a/src/grandorgue/sound/scheduler/GOSoundOutputTask.h
+++ b/src/grandorgue/sound/scheduler/GOSoundOutputTask.h
@@ -49,7 +49,10 @@ public:
   void Clear();
   void Reset();
 
-  void SetupReverb(GOConfig &settings);
+  void SetupReverb(
+    const GOSoundReverb::ReverbConfig &config,
+    unsigned nSamplesPerBuffer,
+    unsigned sampleRate);
 
   const std::vector<float> &GetMeterInfo();
   void ResetMeterInfo();


### PR DESCRIPTION
Earlier GOSoundReverb was set up only from a GOConfig instance, but I'm planning to make GOSoundOrganEngine to work without a GOConfig instance. So I need a weak configuration of GORewerb.

This PR adds an inner class `GOSoundReverb::ReverbConfig` for storing it's configuration in GOSoundOrganEngine.

it is just a small refactoting. No GO behavior should be changed.