### PR TITLE
Reimplemented GOSoundBufferTaskBase with GOSoundBufferMutable

### DIFF
--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -349,7 +349,7 @@ void GOSoundOrganEngine::SetupReverb(GOConfig &settings) {
 unsigned GOSoundOrganEngine::GetBufferSizeFor(
   unsigned outputIndex, unsigned nFrames) {
   return sizeof(float) * nFrames
-    * m_AudioOutputTasks[outputIndex + 1]->GetChannels();
+    * m_AudioOutputTasks[outputIndex + 1]->GetNChannels();
 }
 
 void GOSoundOrganEngine::GetEmptyAudioOutput(
@@ -363,7 +363,7 @@ void GOSoundOrganEngine::GetAudioOutput(
     m_AudioOutputTasks[audio_output + 1]->Finish(last);
     memcpy(
       output_buffer,
-      m_AudioOutputTasks[audio_output + 1]->m_Buffer,
+      m_AudioOutputTasks[audio_output + 1]->GetData(),
       GetBufferSizeFor(audio_output, n_frames));
   } else
     GetEmptyAudioOutput(audio_output, n_frames, output_buffer);

--- a/src/grandorgue/sound/scheduler/GOSoundBufferTaskBase.h
+++ b/src/grandorgue/sound/scheduler/GOSoundBufferTaskBase.h
@@ -8,27 +8,18 @@
 #ifndef GOSOUNDBUFFERTASKBASE_H
 #define GOSOUNDBUFFERTASKBASE_H
 
+#include "sound/buffer/GOSoundBufferManaged.h"
+
+#include "GOSoundTask.h"
+
 class GOSoundThread;
 
-class GOSoundBufferTaskBase {
-protected:
-  unsigned m_SamplesPerBuffer;
-  unsigned m_Channels;
-
+class GOSoundBufferTaskBase : public GOSoundTask, public GOSoundBufferManaged {
 public:
-  GOSoundBufferTaskBase(unsigned samples_per_buffer, unsigned channels)
-    : m_SamplesPerBuffer(samples_per_buffer), m_Channels(channels) {
-    m_Buffer = new float[m_SamplesPerBuffer * m_Channels];
-  }
-  virtual ~GOSoundBufferTaskBase() { delete[] m_Buffer; }
+  GOSoundBufferTaskBase(unsigned nChannels, unsigned nFrames)
+    : GOSoundBufferManaged(nChannels, nFrames) {}
 
   virtual void Finish(bool stop, GOSoundThread *pThread = nullptr) = 0;
-
-  float *m_Buffer;
-
-  unsigned GetSamplesPerBuffer() { return m_SamplesPerBuffer; }
-
-  unsigned GetChannels() { return m_Channels; }
 };
 
 #endif /* GOSOUNDBUFFERTASKBASE_H */

--- a/src/grandorgue/sound/scheduler/GOSoundGroupTask.h
+++ b/src/grandorgue/sound/scheduler/GOSoundGroupTask.h
@@ -20,7 +20,7 @@
 
 class GOSoundOrganEngine;
 
-class GOSoundGroupTask : public GOSoundTask, public GOSoundBufferTaskBase {
+class GOSoundGroupTask : public GOSoundBufferTaskBase {
 private:
   GOSoundOrganEngine &m_engine;
   GOSoundSamplerList m_Active;

--- a/src/grandorgue/sound/scheduler/GOSoundOutputTask.h
+++ b/src/grandorgue/sound/scheduler/GOSoundOutputTask.h
@@ -17,10 +17,7 @@
 
 #include "GOSoundBufferTaskBase.h"
 
-class GOSoundReverb;
-class GOConfig;
-
-class GOSoundOutputTask : public GOSoundTask, public GOSoundBufferTaskBase {
+class GOSoundOutputTask : public GOSoundBufferTaskBase {
 private:
   std::vector<float> m_ScaleFactors;
   std::vector<GOSoundBufferTaskBase *> m_Outputs;


### PR DESCRIPTION
This is a first usage of GOSoundBuffer classes.

Earlier GOSoundBufferTaskBase had it's own code for managing sound data memory.

This PR implements GOSoundBufferTaskBase on top of GOSoundBufferManaged.

It is just refactoring. No GO behavior should be changed.