### PR TITLE
Changed SoundPort::AudioCallback to use GOSoundBufferMutable

### DIFF
--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -353,21 +353,15 @@ unsigned GOSoundOrganEngine::GetBufferSizeFor(
     * m_AudioOutputTasks[outputIndex + 1]->GetNChannels();
 }
 
-void GOSoundOrganEngine::GetEmptyAudioOutput(
-  unsigned outputIndex, unsigned nFrames, float *pOutputBuffer) {
-  memset(pOutputBuffer, 0, GetBufferSizeFor(outputIndex, nFrames));
-}
-
 void GOSoundOrganEngine::GetAudioOutput(
-  float *output_buffer, unsigned n_frames, unsigned audio_output, bool last) {
+  unsigned outputIndex, bool isLast, GOSoundBufferMutable &outBuffer) {
   if (m_HasBeenSetup.load()) {
-    m_AudioOutputTasks[audio_output + 1]->Finish(last);
-    memcpy(
-      output_buffer,
-      m_AudioOutputTasks[audio_output + 1]->GetData(),
-      GetBufferSizeFor(audio_output, n_frames));
+    GOSoundOutputTask *pOutputTask = m_AudioOutputTasks[outputIndex + 1];
+
+    pOutputTask->Finish(isLast);
+    outBuffer.CopyFrom(*pOutputTask);
   } else
-    GetEmptyAudioOutput(audio_output, n_frames, output_buffer);
+    outBuffer.FillWithSilence();
 }
 
 void GOSoundOrganEngine::NextPeriod() {

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -21,6 +21,7 @@
 class GOConfig;
 class GOMemoryPool;
 class GOOrganModel;
+class GOSoundBufferMutable;
 class GOSoundProvider;
 class GOSoundRecorder;
 class GOSoundGroupTask;
@@ -183,10 +184,8 @@ public:
     GOSoundSampler *handle,
     unsigned velocity) override;
 
-  void GetEmptyAudioOutput(
-    unsigned outputIndex, unsigned nFrames, float *pOutputBuffer);
   void GetAudioOutput(
-    float *output_buffer, unsigned n_frames, unsigned audio_output, bool last);
+    unsigned outputIndex, bool isLast, GOSoundBufferMutable &outBuffer);
   void NextPeriod();
   GOSoundScheduler &GetScheduler();
 

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -372,32 +372,33 @@ void GOSoundSystem::UpdateMeter() {
 }
 
 bool GOSoundSystem::AudioCallback(
-  unsigned dev_index, float *output_buffer, unsigned int n_frames) {
+  unsigned devIndex, GOSoundBufferMutable &outBuffer) {
   bool wasEntered = false;
+  const unsigned nSamples = outBuffer.GetNFrames();
 
   if (m_IsRunning.load()) {
-    if (n_frames == m_SamplesPerBuffer) {
+    if (nSamples == m_SamplesPerBuffer) {
       m_NCallbacksEntered.fetch_add(1);
       wasEntered = true;
     } else
       wxLogError(
         _("No sound output will happen. Samples per buffer has been "
           "changed by the sound driver to %d"),
-        n_frames);
+        nSamples);
   }
   // assure that m_IsRunning has not yet been changed after
   // m_NCallbacksEntered.fetch_add, otherwise the control thread may not wait
   if (wasEntered && m_IsRunning.load()) {
-    GOSoundOutput *device = &m_AudioOutputs[dev_index];
-    GOMutexLocker locker(device->mutex);
+    GOSoundOutput &device = m_AudioOutputs[devIndex];
+    GOMutexLocker locker(device.mutex);
 
-    while (device->wait && device->waiting)
-      device->condition.Wait();
+    while (device.wait && device.waiting)
+      device.condition.Wait();
 
     unsigned cnt = m_CalcCount.fetch_add(1);
     m_SoundEngine.GetAudioOutput(
-      output_buffer, n_frames, dev_index, cnt + 1 >= m_AudioOutputs.size());
-    device->wait = true;
+      devIndex, cnt + 1 >= m_AudioOutputs.size(), outBuffer);
+    device.wait = true;
     unsigned count = m_WaitCount.fetch_add(1);
 
     if (count + 1 == m_AudioOutputs.size()) {
@@ -413,13 +414,13 @@ bool GOSoundSystem::AudioCallback(
       m_WaitCount.exchange(0);
 
       for (unsigned i = 0; i < m_AudioOutputs.size(); i++) {
-        GOMutexLocker lock(m_AudioOutputs[i].mutex, i == dev_index);
+        GOMutexLocker lock(m_AudioOutputs[i].mutex, i == devIndex);
         m_AudioOutputs[i].wait = false;
         m_AudioOutputs[i].condition.Signal();
       }
     }
   } else
-    m_SoundEngine.GetEmptyAudioOutput(dev_index, n_frames, output_buffer);
+    outBuffer.FillWithSilence();
   if (
     wasEntered && m_NCallbacksEntered.fetch_sub(1) <= 1
     && !m_IsRunning.load()) {

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -147,8 +147,7 @@ public:
 
   GOSoundOrganEngine &GetEngine();
 
-  bool AudioCallback(
-    unsigned dev_index, float *outputBuffer, unsigned int nFrames);
+  bool AudioCallback(unsigned devIndex, GOSoundBufferMutable &outBuffer);
 };
 
 #endif

--- a/src/grandorgue/sound/ports/GOSoundJackPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundJackPort.cpp
@@ -12,6 +12,7 @@
 #include <wx/log.h>
 
 #include "config/GODeviceNamePattern.h"
+#include "sound/buffer/GOSoundBufferMutable.h"
 
 const wxString GOSoundJackPort::PORT_NAME = wxT("Jack");
 
@@ -46,7 +47,9 @@ void GOSoundJackPort::jackLatencyCallback(
 
 int GOSoundJackPort::jackProcessCallback(jack_nframes_t nFrames, void *pData) {
   GOSoundJackPort *const pPort = (GOSoundJackPort *)pData;
-  const bool isContinue = pPort->AudioCallback(pPort->mp_GoBuffer, nFrames);
+  GOSoundBufferMutable outputBuffer(
+    pPort->mp_GoBuffer, pPort->m_Channels, nFrames);
+  const bool isContinue = pPort->AudioCallback(outputBuffer);
 
   if (isContinue) {
     const unsigned nChannels = pPort->m_Channels;

--- a/src/grandorgue/sound/ports/GOSoundPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundPort.cpp
@@ -11,6 +11,7 @@
 #include <wx/thread.h>
 
 #include "sound/GOSoundSystem.h"
+#include "sound/buffer/GOSoundBufferMutable.h"
 
 GOSoundPort::GOSoundPort(GOSoundSystem *sound, wxString name)
   : m_Sound(sound),
@@ -46,8 +47,8 @@ void GOSoundPort::SetActualLatency(double latency) {
   m_ActualLatency = latency * 1000;
 }
 
-bool GOSoundPort::AudioCallback(float *outputBuffer, unsigned int nFrames) {
-  return m_Sound->AudioCallback(m_Index, outputBuffer, nFrames);
+bool GOSoundPort::AudioCallback(GOSoundBufferMutable &outputBuffer) {
+  return m_Sound->AudioCallback(m_Index, outputBuffer);
 }
 
 const wxString &GOSoundPort::GetName() { return m_Name; }

--- a/src/grandorgue/sound/ports/GOSoundPort.h
+++ b/src/grandorgue/sound/ports/GOSoundPort.h
@@ -14,6 +14,7 @@
 
 #include "config/GOPortsConfig.h"
 
+class GOSoundBufferMutable;
 class GOSoundSystem;
 
 class GOSoundPort {
@@ -29,7 +30,7 @@ protected:
   int m_ActualLatency;
 
   void SetActualLatency(double latency);
-  bool AudioCallback(float *outputBuffer, unsigned int nFrames);
+  bool AudioCallback(GOSoundBufferMutable &outputBuffer);
 
 public:
   GOSoundPort(GOSoundSystem *sound, wxString name);

--- a/src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp
@@ -11,6 +11,7 @@
 #include <wx/regex.h>
 
 #include "config/GODeviceNamePattern.h"
+#include "sound/buffer/GOSoundBufferMutable.h"
 
 const wxString GOSoundPortaudioPort::PORT_NAME = wxT("PortAudio");
 const wxString GOSoundPortaudioPort::PORT_NAME_OLD = wxT("Pa");
@@ -114,10 +115,10 @@ int GOSoundPortaudioPort::Callback(
   PaStreamCallbackFlags statusFlags,
   void *userData) {
   GOSoundPortaudioPort *port = (GOSoundPortaudioPort *)userData;
-  if (port->AudioCallback((float *)output, frameCount))
-    return paContinue;
-  else
-    return paAbort;
+  GOSoundBufferMutable outputBuffer(
+    (float *)output, port->m_Channels, frameCount);
+
+  return port->AudioCallback(outputBuffer) ? paContinue : paAbort;
 }
 
 // for compatibility with old settings

--- a/src/grandorgue/sound/ports/GOSoundRtPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundRtPort.cpp
@@ -12,6 +12,7 @@
 
 #include "GOSoundPortFactory.h"
 #include "config/GODeviceNamePattern.h"
+#include "sound/buffer/GOSoundBufferMutable.h"
 
 const wxString GOSoundRtPort::PORT_NAME = wxT("RtAudio");
 const wxString GOSoundRtPort::PORT_NAME_OLD = wxT("Rt");
@@ -131,10 +132,10 @@ int GOSoundRtPort::Callback(
   RtAudioStreamStatus status,
   void *userData) {
   GOSoundRtPort *port = (GOSoundRtPort *)userData;
-  if (port->AudioCallback((float *)outputBuffer, nFrames))
-    return 0;
-  else
-    return 1;
+  GOSoundBufferMutable outputBufferMutable(
+    (float *)outputBuffer, port->m_Channels, nFrames);
+
+  return port->AudioCallback(outputBufferMutable) ? 0 : 1;
 }
 
 static wxString compose_device_name(

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -157,9 +157,12 @@ void GOPerfTestApp::RunTest(
       wxMilliClock_t diff;
       unsigned batch_size = 1 * engine->GetSampleRate() / samples_per_frame;
       unsigned blocks = 0;
+      GOSoundBufferMutable outputBufferMutable(
+        output_buffer, 2, samples_per_frame);
+
       do {
         for (unsigned i = 0; i < batch_size; i++) {
-          engine->GetAudioOutput(output_buffer, samples_per_frame, 0, false);
+          engine->GetAudioOutput(0, false, outputBufferMutable);
           engine->NextPeriod();
           blocks++;
         }


### PR DESCRIPTION
This is a second PR using GOSoundBuffer classes.

Now GOSoundPort uses GOSoundBufferMutable for audio callbacks.

It is just refactoring. No GO behavior should be changed.
