### PR TITLE
Renamed GOApp members and replaced with unique_ptr

### DIFF
--- a/src/grandorgue/GOApp.h
+++ b/src/grandorgue/GOApp.h
@@ -46,9 +46,9 @@ private:
   };
 
   // A temporary logging instance
-  std::unique_ptr<TemporaryLog> m_TemporaryLog
+  std::unique_ptr<TemporaryLog> mp_TemporaryLog
     = std::make_unique<TemporaryLog>();
-  bool m_Restart = false;
+  bool m_IsToRestartAfterExit = false;
 
 #ifdef __WXMAC__
   virtual void MacOpenFile(const wxString &fileName) override;
@@ -61,18 +61,21 @@ private:
   virtual void CleanUp() override;
 
 protected:
-  GOFrame *m_Frame = nullptr;
+  GOFrame *p_frame = nullptr;
   wxLocale m_locale;
-  GOConfig *m_config = nullptr;
-  GOSoundSystem *m_soundSystem = nullptr;
-  GOLog *m_Log = nullptr;
+  std::unique_ptr<GOConfig> mp_config;
+  std::unique_ptr<GOSoundSystem> mp_SoundSystem;
+  std::unique_ptr<GOLog> mp_log;
   wxString m_FileName;
   std::string m_InstanceName;
   std::string m_ConfigFilePath;
   bool m_IsGuiOnly = false;
 
 public:
-  void SetRestart() { m_Restart = true; }
+  ~GOApp();
+
+  bool IsToRestartAfterExit() const { return m_IsToRestartAfterExit; }
+  void SetToRestartAfterExit() { m_IsToRestartAfterExit = true; }
 };
 
 DECLARE_APP(GOApp)

--- a/src/grandorgue/gui/frames/GOFrame.cpp
+++ b/src/grandorgue/gui/frames/GOFrame.cpp
@@ -1158,7 +1158,7 @@ void GOFrame::OnSettings(wxCommandEvent &event) {
            wxYES_NO | wxICON_QUESTION,
            this)
         == wxYES) {
-      m_App.SetRestart();
+      m_App.SetToRestartAfterExit();
       SetEventAfterSettings(wxEVT_COMMAND_MENU_SELECTED, ID_FILE_EXIT);
       isToContinue = false;
     } else if (


### PR DESCRIPTION
This PR rewrites the GOApp class: it replaces row pointers with unique_ptr and renames it's members according to GO naming conventions.

It is a refactoring. No GO behavior should be changed.