### PR TITLE
Moved the wood image cache from GOGUIPanel to GOImageCache

### DIFF
--- a/src/grandorgue/GOImageCache.h
+++ b/src/grandorgue/GOImageCache.h
@@ -24,12 +24,18 @@ private:
   std::vector<wxString> m_filenames;
   std::vector<wxString> m_masknames;
 
+  const wxImage *FindImage(
+    const wxString &filename, const wxString &maskname) const;
+
   bool LoadImageFromFile(const wxString &filename, wxImage &image);
+
   void RegisterImage(
     const wxString &filename, const wxString &maskname, wxImage *pImage);
 
 public:
   GOImageCache(GOOrganController *organController);
+
+  const wxImage *GetWoodImage(unsigned woodImageNum) const;
 
   void Cleanup() {
     m_images.clear();

--- a/src/grandorgue/gui/panels/GOGUIHW1Background.cpp
+++ b/src/grandorgue/gui/panels/GOGUIHW1Background.cpp
@@ -28,8 +28,8 @@ void GOGUIHW1Background::Layout() {
 
   rect = wxRect(0, 0, m_layout->GetCenterX(), m_metrics->GetScreenHeight());
   if (is_rect_valid(rect))
-    m_Images.push_back(GOBackgroundImage(
-      rect, m_panel->GetWood(m_metrics->GetDrawstopBackgroundImageNum())));
+    m_Images.emplace_back(
+      rect, m_panel->GetWoodImage(m_metrics->GetDrawstopBackgroundImageNum()));
   rect = wxRect(
     m_layout->GetCenterX() + m_layout->GetCenterWidth(),
     0,
@@ -37,16 +37,16 @@ void GOGUIHW1Background::Layout() {
       - (m_layout->GetCenterX() + m_layout->GetCenterWidth()),
     m_metrics->GetScreenHeight());
   if (is_rect_valid(rect))
-    m_Images.push_back(GOBackgroundImage(
-      rect, m_panel->GetWood(m_metrics->GetDrawstopBackgroundImageNum())));
+    m_Images.emplace_back(
+      rect, m_panel->GetWoodImage(m_metrics->GetDrawstopBackgroundImageNum()));
   rect = wxRect(
     m_layout->GetCenterX(),
     0,
     m_layout->GetCenterWidth(),
     m_metrics->GetScreenHeight());
   if (is_rect_valid(rect))
-    m_Images.push_back(GOBackgroundImage(
-      rect, m_panel->GetWood(m_metrics->GetConsoleBackgroundImageNum())));
+    m_Images.emplace_back(
+      rect, m_panel->GetWoodImage(m_metrics->GetConsoleBackgroundImageNum()));
 
   if (m_metrics->HasPairDrawstopCols()) {
     for (unsigned i = 0; i < (m_metrics->NumberOfDrawstopColsToDisplay() >> 2);
@@ -58,9 +58,10 @@ void GOGUIHW1Background::Layout() {
         2 * m_metrics->GetDrawstopWidth() + 10,
         m_layout->GetJambLeftRightHeight());
       if (is_rect_valid(rect))
-        m_Images.push_back(GOBackgroundImage(
+        m_Images.emplace_back(
           rect,
-          m_panel->GetWood(m_metrics->GetDrawstopInsetBackgroundImageNum())));
+          m_panel->GetWoodImage(
+            m_metrics->GetDrawstopInsetBackgroundImageNum()));
       rect = wxRect(
         i * (2 * m_metrics->GetDrawstopWidth() + 18) + m_layout->GetJambRightX()
           - 5,
@@ -68,9 +69,10 @@ void GOGUIHW1Background::Layout() {
         2 * m_metrics->GetDrawstopWidth() + 10,
         m_layout->GetJambLeftRightHeight());
       if (is_rect_valid(rect))
-        m_Images.push_back(GOBackgroundImage(
+        m_Images.emplace_back(
           rect,
-          m_panel->GetWood(m_metrics->GetDrawstopInsetBackgroundImageNum())));
+          m_panel->GetWoodImage(
+            m_metrics->GetDrawstopInsetBackgroundImageNum()));
     }
   }
 
@@ -81,8 +83,8 @@ void GOGUIHW1Background::Layout() {
       m_layout->GetCenterWidth(),
       8);
     if (is_rect_valid(rect))
-      m_Images.push_back(GOBackgroundImage(
-        rect, m_panel->GetWood(m_metrics->GetKeyVertBackgroundImageNum())));
+      m_Images.emplace_back(
+        rect, m_panel->GetWoodImage(m_metrics->GetKeyVertBackgroundImageNum()));
   }
 
   if (m_layout->GetJambTopHeight() + m_layout->GetPistonTopHeight()) {
@@ -92,8 +94,9 @@ void GOGUIHW1Background::Layout() {
       m_layout->GetCenterWidth(),
       m_layout->GetJambTopHeight() + m_layout->GetPistonTopHeight());
     if (is_rect_valid(rect))
-      m_Images.push_back(GOBackgroundImage(
-        rect, m_panel->GetWood(m_metrics->GetKeyHorizBackgroundImageNum())));
+      m_Images.emplace_back(
+        rect,
+        m_panel->GetWoodImage(m_metrics->GetKeyHorizBackgroundImageNum()));
   }
 }
 

--- a/src/grandorgue/gui/panels/GOGUIHW1Background.h
+++ b/src/grandorgue/gui/panels/GOGUIHW1Background.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,14 +14,17 @@
 
 #include "GOGUIControl.h"
 
+class wxImage;
+
 class GOGUIHW1Background : public GOGUIControl {
   class GOBackgroundImage {
   public:
     wxRect rect;
     GOBitmap bmp;
 
-    GOBackgroundImage(wxRect Rect, const GOBitmap &Bmp)
-      : rect(Rect), bmp(Bmp) {}
+    GOBackgroundImage(wxRect Rect, const wxImage *pImage) : rect(Rect) {
+      bmp.SetSourceImage(pImage);
+    }
   };
 
 private:

--- a/src/grandorgue/gui/panels/GOGUIManualBackground.cpp
+++ b/src/grandorgue/gui/panels/GOGUIManualBackground.cpp
@@ -33,7 +33,8 @@ void GOGUIManualBackground::Layout() {
   m_BoundingRect = wxRect(mri.x, mri.y, mri.width, mri.height);
   m_VRect = wxRect(
     m_layout->GetCenterX(), mri.y, m_layout->GetCenterWidth(), mri.height);
-  m_VBackground = m_panel->GetWood(m_metrics->GetKeyVertBackgroundImageNum());
+  m_VBackground.SetSourceImage(
+    m_panel->GetWoodImage(m_metrics->GetKeyVertBackgroundImageNum()));
   m_HRect = wxRect(
     m_layout->GetCenterX(),
     mri.piston_y,
@@ -41,7 +42,8 @@ void GOGUIManualBackground::Layout() {
     (!m_ManualNumber && m_metrics->HasExtraPedalButtonRow())
       ? 2 * m_metrics->GetButtonHeight()
       : m_metrics->GetButtonHeight());
-  m_HBackground = m_panel->GetWood(m_metrics->GetKeyHorizBackgroundImageNum());
+  m_HBackground.SetSourceImage(
+    m_panel->GetWoodImage(m_metrics->GetKeyHorizBackgroundImageNum()));
 }
 
 void GOGUIManualBackground::PrepareDraw(double scale, GOBitmap *background) {

--- a/src/grandorgue/gui/panels/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanel.cpp
@@ -43,20 +43,13 @@ GOGUIPanel::GOGUIPanel(GOOrganController *organController)
   : m_OrganController(organController),
     m_MouseState(organController->GetMouseState()),
     m_controls(0),
-    m_WoodImages(0),
     m_BackgroundControls(0),
     m_Name(),
     m_GroupName(),
     m_metrics(0),
     m_layout(0),
     m_view(0),
-    m_InitialOpenWindow(false) {
-  for (unsigned i = 0; i < 64; i++) {
-    m_WoodImages.emplace_back();
-    m_WoodImages.back().SetSourceImage(LoadImage(
-      wxString::Format(wxT(GOBitmapPrefix "wood%02d"), i + 1), wxEmptyString));
-  }
-}
+    m_InitialOpenWindow(false) {}
 
 GOGUIPanel::~GOGUIPanel() {
   if (m_layout)
@@ -854,6 +847,6 @@ void GOGUIPanel::HandleMouseScroll(int x, int y, int amount) {
       return;
 }
 
-const GOBitmap &GOGUIPanel::GetWood(unsigned index) {
-  return m_WoodImages[index - 1];
+const wxImage *GOGUIPanel::GetWoodImage(unsigned woodImageNumber) const {
+  return m_OrganController->GetImageCache().GetWoodImage(woodImageNumber);
 }

--- a/src/grandorgue/gui/panels/GOGUIPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIPanel.h
@@ -53,7 +53,6 @@ protected:
   GOOrganController *m_OrganController;
   GOGUIMouseState &m_MouseState;
   ptr_vector<GOGUIControl> m_controls;
-  std::vector<GOBitmap> m_WoodImages;
   unsigned m_BackgroundControls;
   wxString m_Name;
   wxString m_GroupName;
@@ -100,7 +99,7 @@ public:
   GOGUILayoutEngine *GetLayoutEngine();
   void PrepareDraw(double scale, GOBitmap *background);
   void Draw(GODC &dc);
-  const GOBitmap &GetWood(unsigned which);
+  const wxImage *GetWoodImage(unsigned woodImageNumber) const;
   const wxImage *LoadImage(const wxString &filename, const wxString &maskname);
   void HandleKey(int key);
   void HandleMousePress(int x, int y, bool right);


### PR DESCRIPTION
Earlier each GOGUIPanel instance contained it's own set of 64 GOBitmap's with wood images, most of them were never used.

This PR moves the wood image cache to GOImageCache, that is shared across all GOGUIPanel instance.

It is just refactoring. No GO behavior should be changed.