### PR TITLE
Fixed assertion fail on resizing

### DIFF
--- a/src/grandorgue/gui/panels/primitives/GOBitmap.h
+++ b/src/grandorgue/gui/panels/primitives/GOBitmap.h
@@ -27,6 +27,7 @@ private:
   int m_ResultHeight = 0;
   unsigned m_ResultXOffset = 0;
   unsigned m_ResultYOffset = 0;
+  bool m_ResultValid = false;
 
   void BuildBitmapFrom(
     const wxImage &img, double scale, const wxRect &rect, GOBitmap *background);
@@ -41,12 +42,14 @@ public:
     double scale, const wxRect &rect, GOBitmap *background);
   void BuildTileBitmap(
     double scale,
-    const wxRect &rect,
-    unsigned xo,
-    unsigned yo,
+    const wxRect &newRect,
+    unsigned newXOffset,
+    unsigned newYOffset,
     GOBitmap *background);
 
-  const wxBitmap &GetResultBitmap() const { return m_ResultBitmap; }
+  const wxBitmap *GetResultBitmap() const {
+    return m_ResultValid ? &m_ResultBitmap : nullptr;
+  }
 };
 
 #endif

--- a/src/grandorgue/gui/panels/primitives/GODC.cpp
+++ b/src/grandorgue/gui/panels/primitives/GODC.cpp
@@ -24,9 +24,14 @@ wxRect GODC::ScaleRect(const wxRect &rect) {
 }
 
 void GODC::DrawBitmap(GOBitmap &bitmap, const wxRect &target) {
-  unsigned xpos = target.GetX() * m_Scale + 0.5;
-  unsigned ypos = target.GetY() * m_Scale + 0.5;
-  m_DC->DrawBitmap(bitmap.GetResultBitmap(), xpos, ypos, true);
+  const wxBitmap *pBitmap = bitmap.GetResultBitmap();
+
+  if (pBitmap) {
+    unsigned xpos = target.GetX() * m_Scale + 0.5;
+    unsigned ypos = target.GetY() * m_Scale + 0.5;
+
+    m_DC->DrawBitmap(*pBitmap, xpos, ypos, true);
+  }
 }
 
 wxString GODC::WrapText(const wxString &string, unsigned width) {


### PR DESCRIPTION
Earlier when resising a panel lower it's original size there were assertion failed messages "Image is not valid".

The reason was that some elements had some size equal to 1 pixel. When downscaling the image, the size became 0 that made the bitmap as invalid.

This PR introduces lots of validations when scaling the bitmap. If some size becomes 0, then the GOBitmap instance is marked as invalid, and GetResultBitmap returns nullptr instead of invalid bitmap instance, and GODC::DrawBitmap does not try to draw it.