### PR TITLE
Separated running functional and performance tests on Github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,24 @@
 name: Build
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - actions: "functional coverage"
+            build_type: Debug
+            coverage: "ON"
+          - actions: "perf"
+            build_type: Debug
+            coverage: "OFF"
+          - actions: "perf"
+            build_type: Release
+            coverage: "OFF"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -14,12 +29,15 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}
-        run: ${{github.workspace}}/build-scripts/for-linux/build-for-tests.sh amd64
-  
+        run: ${{github.workspace}}/build-scripts/for-linux/build-for-tests.sh amd64 ${{ matrix.build_type }} ${{ matrix.coverage }}
+
       - name: Run tests
         working-directory: ${{github.workspace}}
-        run: ${{github.workspace}}/build-scripts/for-linux/do-tests.sh
-      - uses: codecov/codecov-action@v3
+        run: ${{github.workspace}}/build-scripts/for-linux/do-tests.sh ${{ matrix.actions }}
+
+      - name: Upload coverage
+        if: contains(matrix.actions, 'coverage')
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,7 @@ name: pre-commit
 on:
   pull_request:
   push:
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/build-scripts/for-linux/build-for-tests.sh
+++ b/build-scripts/for-linux/build-for-tests.sh
@@ -2,6 +2,7 @@
 
 # $1 - target deb architecture. Default - current
 # $2 - build type: Debug or Release. Default - Debug
+# $3 - enable coverage: ON or OFF. Default - ON for Debug, OFF for Release
 
 set -e
 
@@ -13,12 +14,13 @@ SRC_DIR=$(readlink -f $(dirname $0)/../..)
 
 TARGET_ARCH=${1:-$(dpkg --print-architecture)}
 BUILD_TYPE=${2:-Debug}
+COVERAGE=${3:-$([ "$BUILD_TYPE" = "Debug" ] && echo ON || echo OFF)}
 
 export LANG=C
 
-# Enable coverage only for Debug builds
+# Enable coverage only when explicitly requested (default: ON for Debug)
 COVERAGE_FLAG=""
-if [ "$BUILD_TYPE" = "Debug" ]; then
+if [ "$COVERAGE" = "ON" ]; then
     COVERAGE_FLAG="-DGO_BUILD_COVERAGE=ON"
 fi
 

--- a/build-scripts/for-linux/do-tests.sh
+++ b/build-scripts/for-linux/do-tests.sh
@@ -1,28 +1,122 @@
 #!/bin/bash
 
-# $1 - optional - [test | coverage | gcovr] - If nothing is provided,
-# run all the tests steps.
+# $@ - optional list of actions: functional, perf, tests, coverage, all (default: all)
+# Actions:
+#   functional - run functional tests (-R GOTestFunctional)
+#   perf       - run performance tests (-R GOTestPerf)
+#   tests      - run all tests without filter (no coverage)
+#   coverage   - run coverage steps (ctest -T coverage + gcovr)
+#   all        - run all tests without filter + coverage (default when no args)
 
 set -e
 
-STEP=$1
+if [ "$1" = "--help" ] || [ "$1" = "-?" ]; then
+    echo "Usage: $(basename $0) [action...]"
+    echo ""
+    echo "Actions (can be combined):"
+    echo "  functional  Run functional tests (-R GOTestFunctional)"
+    echo "  perf        Run performance tests (-R GOTestPerf)"
+    echo "  tests       Run all tests without filter (no coverage)"
+    echo "  coverage    Run coverage steps (ctest -T coverage + gcovr)"
+    echo "  all         Run all tests + coverage (default when no args)"
+    exit 0
+fi
 
-TEST_SCRIPT="ctest -T test --verbose"
-COVERAGE_SCRIPT="ctest -T coverage"
-GCOVR_SCRIPT="gcovr -e 'submodules/*|usr/*'"
+ACTIONS="${*:-all}"
+IS_ALL=false
+IS_TESTS=false
+IS_FUNCTIONAL=false
+IS_PERF=false
+IS_COVERAGE=false
 
-case $STEP in
-    "test") 
-        $TEST_SCRIPT
-    ;;
-    "coverage")
-        $COVERAGE_SCRIPT
-    ;;
-    "gcovr")
-        $GCOVR_SCRIPT
-    ;;
-    "")
-        $TEST_SCRIPT ; $COVERAGE_SCRIPT ; $GCOVR_SCRIPT
-esac;
+for ACTION in $ACTIONS; do
+    case $ACTION in
+        all)        IS_ALL=true ;;
+        tests)      IS_TESTS=true ;;
+        functional) IS_FUNCTIONAL=true ;;
+        perf)       IS_PERF=true ;;
+        coverage)   IS_COVERAGE=true ;;
+    esac
+done
 
+# Print system information for performance test comparison
+echo "=========================================="
+echo "System Information for Performance Tests"
+echo "=========================================="
+echo ""
 
+# CPU Model
+echo "=== CPU Model ==="
+cat /proc/cpuinfo | grep "model name" | head -1 || echo "CPU model: N/A"
+echo ""
+
+# CPU Architecture and Cores
+echo "=== CPU Architecture & Cores ==="
+lscpu | grep -E "Architecture:|CPU\(s\):|Thread\(s\) per core:|Core\(s\) per socket:" || echo "CPU info: N/A"
+echo ""
+
+# CPU Frequency
+echo "=== CPU Frequency ==="
+lscpu | grep -E "MHz|max MHz|min MHz" || echo "CPU frequency: N/A"
+echo ""
+
+# CPU Cache
+echo "=== CPU Cache ==="
+lscpu | grep -E "L1d cache:|L1i cache:|L2 cache:|L3 cache:" || echo "Cache info: N/A"
+echo ""
+
+# CPU Flags (AVX support)
+echo "=== CPU SIMD Support ==="
+grep -o "avx[^ ]*\|sse[^ ]*" /proc/cpuinfo | head -20 | sort -u | tr '\n' ' ' || echo "SIMD flags: N/A"
+echo ""
+echo ""
+
+# GCC Version
+echo "=== GCC Version ==="
+gcc --version | head -1 || echo "GCC: N/A"
+echo ""
+
+# CPU Governor
+echo "=== CPU Governor ==="
+cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor 2>/dev/null | uniq || echo "Governor: N/A (not available)"
+echo ""
+
+# RAM
+echo "=== Memory ==="
+free -h | grep Mem || echo "Memory info: N/A"
+echo ""
+
+# OS Information
+echo "=== Operating System ==="
+if [ -f /etc/os-release ]; then
+    grep -E "PRETTY_NAME|VERSION_ID" /etc/os-release || echo "OS: N/A"
+else
+    echo "OS: N/A"
+fi
+echo ""
+
+# Hostname
+echo "=== Hostname ==="
+hostname || echo "Hostname: N/A"
+echo ""
+
+echo "=========================================="
+echo "Starting Tests"
+echo "=========================================="
+echo ""
+
+if $IS_ALL || $IS_TESTS; then
+    ctest -T test --verbose
+else
+    if $IS_FUNCTIONAL; then
+        ctest -T test --verbose -R GOTestFunctional
+    fi
+    if $IS_PERF; then
+        ctest -T test --verbose -R GOTestPerf
+    fi
+fi
+
+if $IS_ALL || $IS_COVERAGE; then
+    ctest -T coverage
+    gcovr -e 'submodules/*|usr/*'
+fi

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -23,5 +23,6 @@ target_include_directories(GOTestExe PUBLIC ${CMAKE_SOURCE_DIR}/src/tests/testin
 target_include_directories(GOTests PUBLIC ${CMAKE_SOURCE_DIR}/src/tests/common)
 BUILD_EXECUTABLE(GOTestExe)
 
-add_test(NAME GOTestExe COMMAND GOTestExe)
+add_test(NAME GOTestFunctional COMMAND GOTestExe --no-perf)
+add_test(NAME GOTestPerf       COMMAND GOTestExe --perf-only)
 include(CTest)

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -6,6 +6,8 @@
 
 #include <cstdio>
 #include <iostream>
+#include <optional>
+#include <string>
 
 #include "common/GOTestCollection.h"
 #include "testing/GOTestNameMap.h"
@@ -19,13 +21,27 @@
 #include "testing/sound/buffer/GOTestSoundBufferMutable.h"
 #include "testing/sound/buffer/GOTestSoundBufferMutableMono.h"
 
-int main() {
+int main(int argc, char *argv[]) {
   /*
       This is the main function that will collect all tests in the collection,
       then run the whole bunch.
 
-      TODO: It should displays also the tests results
+      Supported arguments:
+        --perf-only   run only performance tests (GOTest::PERF)
+        --no-perf     run only functional tests (GOTest::FUNCTIONAL)
+        (no argument) run all tests
   */
+
+  std::optional<GOTest::Category> categoryFilter;
+
+  for (int argI = 1; argI < argc; ++argI) {
+    const std::string arg = argv[argI];
+
+    if (arg == "--perf-only")
+      categoryFilter = GOTest::PERF;
+    else if (arg == "--no-perf")
+      categoryFilter = GOTest::FUNCTIONAL;
+  }
 
   /* Instantiate all the test classes here */
   GOTestDrawStop testDrawStop;
@@ -40,7 +56,7 @@ int main() {
   GOTestPerfSoundBufferMutable testPerfSoundBufferMutable;
   /* end of instanciation */
   GOTestResultCollection test_result_collection;
-  test_result_collection = GOTestCollection::Instance()->run();
+  test_result_collection = GOTestCollection::Instance()->Run(categoryFilter);
 
   // Display tests results
   int run_number_ = 0;

--- a/src/tests/common/GOTest.cpp
+++ b/src/tests/common/GOTest.cpp
@@ -10,7 +10,7 @@
 #include <cstdio>
 #include <iostream>
 
-GOTest::GOTest() {
+GOTest::GOTest(Category category) : m_Category(category) {
   // This is the magic to auto register tests in TestCollection
   GOTestCollection::Instance()->add_test(this);
 }

--- a/src/tests/common/GOTest.h
+++ b/src/tests/common/GOTest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -18,16 +18,21 @@ class GOTest : public GOTestUtils {
           - A tear down method
   */
 
+public:
+  enum Category { FUNCTIONAL, PERF };
+
 private:
   std::string name = "GOTest";
+  Category m_Category;
 
 public:
-  GOTest();
+  GOTest(Category category = FUNCTIONAL);
   virtual ~GOTest();
   virtual bool setUp();
   virtual void run();
   virtual bool tearDown();
-  virtual std::string GetName() { return name; };
+  virtual std::string GetName() { return name; }
+  Category GetCategory() const { return m_Category; }
 };
 
 class GOCommonControllerTest : public GOTest {

--- a/src/tests/common/GOTestCollection.cpp
+++ b/src/tests/common/GOTestCollection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -34,52 +34,57 @@ int GOTestCollection::get_success_count() {
   return success_count_;
 }
 
-GOTestResultCollection GOTestCollection::run() {
+GOTestResultCollection GOTestCollection::Run(
+  std::optional<GOTest::Category> categoryFilter) {
   /*
       This iterates on tests_ vector, run them one by one, then collects
       the tests results and display them at the end.
   */
   GOTestResultCollection *test_result_collection = new GOTestResultCollection();
+
   run_number_ = 0;
   for (auto current = tests_.begin(); current != tests_.end();
        ++current, ++run_number_) {
     auto test = *current;
-    try {
-      if (test->setUp()) {
-        try {
-          test->run();
-          test_result_collection->add_result(
-            new GOTestResult(test->GetName() + " succeeded"));
-          success_count_++;
-        } catch (GOTestException &e) {
-          fail_count_++;
-          test_result_collection->add_result(
-            new GOTestResult(test->GetName() + " failed: " + e.what(), true));
-          test->tearDown();
-          continue;
-        } catch (std::exception &e) {
-          fail_count_++;
-          test_result_collection->add_result(
-            new GOTestResult(test->GetName() + " failed: " + e.what(), true));
-          test->tearDown();
-          continue;
+
+    if (!categoryFilter.has_value() || test->GetCategory() == *categoryFilter) {
+      try {
+        if (test->setUp()) {
+          bool isRunSucceeded = false;
+
+          try {
+            test->run();
+            isRunSucceeded = true;
+          } catch (GOTestException &e) {
+            fail_count_++;
+            test_result_collection->add_result(
+              new GOTestResult(test->GetName() + " failed: " + e.what(), true));
+            test->tearDown();
+          } catch (std::exception &e) {
+            fail_count_++;
+            test_result_collection->add_result(
+              new GOTestResult(test->GetName() + " failed: " + e.what(), true));
+            test->tearDown();
+          }
+          if (isRunSucceeded) {
+            test_result_collection->add_result(
+              new GOTestResult(test->GetName() + " succeeded"));
+            success_count_++;
+            test->tearDown();
+          }
+        } else {
+          test_result_collection->add_result(new GOTestResult(
+            "The setUp() of test '" + test->GetName() + "' has failed."));
         }
-        if (!test->tearDown()) {
-          continue;
-        }
-      } else {
+      } catch (std::exception &e) {
         test_result_collection->add_result(new GOTestResult(
-          "The setUp() of test '" + test->GetName() + "' has failed."));
+          "An exception occurred during test '" + test->GetName() + "'."));
+      } catch (...) {
+        fail_count_++;
+        test_result_collection->add_result(
+          new GOTestResult("Unknown exception", true));
+        test->tearDown();
       }
-    } catch (std::exception &e) {
-      test_result_collection->add_result(new GOTestResult(
-        "An exception occurred during test '" + test->GetName() + "'."));
-    } catch (...) {
-      fail_count_++;
-      test_result_collection->add_result(
-        new GOTestResult("Unknown exception", true));
-      test->tearDown();
-      continue;
     }
   }
   return *test_result_collection;

--- a/src/tests/common/GOTestCollection.h
+++ b/src/tests/common/GOTestCollection.h
@@ -1,14 +1,16 @@
 /*
- * Copyright 2023-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 #ifndef GOTESTCOLLECTION_H
 #define GOTESTCOLLECTION_H
 
+#include <optional>
+#include <vector>
+
 #include "GOTest.h"
 #include "GOTestResultCollection.h"
-#include <vector>
 
 class GOTestCollection {
   /*
@@ -31,7 +33,8 @@ public:
       go_test_collection = new GOTestCollection;
     return go_test_collection;
   }
-  GOTestResultCollection run();
+  GOTestResultCollection Run(
+    std::optional<GOTest::Category> categoryFilter = std::nullopt);
   void add_test(GOTest *test);
   int get_failed_count();
   int get_success_count();

--- a/src/tests/testing/sound/buffer/GOTestPerfSoundBufferMutable.cpp
+++ b/src/tests/testing/sound/buffer/GOTestPerfSoundBufferMutable.cpp
@@ -38,34 +38,37 @@ struct Baseline {
 // Baselines are set ~10% below the minimum observed value across all CI runs.
 static constexpr Baseline BASELINE_FILL_WITH_SILENCE[] = {
 #ifdef NDEBUG
-  {32, 7500},  // 7500 Mframes/sec (raised for modern hardware)
-  {128, 5900}, // 5900 Mframes/sec (measured: 6636.1, -10% margin)
+  {32, 4690},  // 4690 Mframes/sec (lowered: min observed 5216.9, -10% margin)
+  {128, 7390}, // 7390 Mframes/sec (lowered: min observed 8214.0, -10% margin)
   {512, 5500}, // 5500 Mframes/sec (lowered: min observed 6112.9, -10% margin)
   {2048, 8600} // 8600 Mframes/sec (lowered: min observed 9653.4, -10% margin)
 #else
-  {32, 160},   // 160 Mframes/sec (debug, raised for modern hardware)
-  {128, 600},  // 600 Mframes/sec (debug, raised for modern hardware)
-  {512, 2100}, // 2100 Mframes/sec (debug, raised for modern hardware)
-  {2048, 6000} // 6000 Mframes/sec (debug, raised for modern hardware)
+  {32,
+   2330}, // 2330 Mframes/sec (debug, lowered: min observed 2590.4, -10% margin)
+  {128,
+   5520}, // 5520 Mframes/sec (debug, lowered: min observed 6141.5, -10% margin)
+  {512,
+   5800}, // 5800 Mframes/sec (debug, raised: min observed 6548.4, -10% margin)
+  {2048,
+   8080} // 8080 Mframes/sec (debug, lowered: min observed 8979.2, -10% margin)
 #endif
 };
 
-// Note: Large memcpy operations (512+ frames) show significant overhead
-// in Azure VM environments (~25x slower) due to hypervisor optimizations.
-// Baselines for large buffers are set conservatively to pass on both
-// bare-metal and virtualized environments.
 static constexpr Baseline BASELINE_COPY_FROM[] = {
 #ifdef NDEBUG
-  {32, 3800},  // 3800 Mframes/sec (lowered: min observed 4308.0, -10% margin)
-  {128, 7500}, // 7500 Mframes/sec (lowered: min observed 8511.4, -10% margin)
-  {512, 220},  // 220 Mframes/sec (lowered: min observed 255.5, -10% margin)
-  {2048, 220}  // 220 Mframes/sec (lowered for Azure VM compatibility)
+  {32, 5600},   // 5600 Mframes/sec (lowered: min observed 6222.4, -10% margin)
+  {128, 8300},  // 8300 Mframes/sec (lowered: min observed 9298.1, -10% margin)
+  {512, 7500},  // 7500 Mframes/sec (raised: min observed 8354.3, -10% margin)
+  {2048, 10000} // 10000 Mframes/sec (raised: min observed 11208.8, -10% margin)
 #else
-  {32, 140},   // 140 Mframes/sec (debug, raised for modern hardware)
-  {128, 550},  // 550 Mframes/sec (debug, raised for modern hardware)
+  {32,
+   2150}, // 2150 Mframes/sec (debug, lowered: min observed 2390.4, -10% margin)
+  {128,
+   6600}, // 6600 Mframes/sec (debug, lowered: min observed 7337.8, -10% margin)
   {512,
-   220}, // 220 Mframes/sec (debug, lowered: min observed 255.0, -10% margin)
-  {2048, 220} // 220 Mframes/sec (debug, lowered for Azure VM compatibility)
+   8000}, // 8000 Mframes/sec (debug, raised: min observed 8959.9, -10% margin)
+  {2048, 10000} // 10000 Mframes/sec (debug, raised: min observed 11258.4, -10%
+                // margin)
 #endif
 };
 
@@ -73,27 +76,33 @@ static constexpr Baseline BASELINE_ADD_FROM[] = {
 #ifdef NDEBUG
   {32, 3100},  // 3100 Mframes/sec (measured: 3492.3, with 10% margin)
   {128, 4000}, // 4000 Mframes/sec (lowered: min observed 4485.6, -10% margin)
-  {512, 4000}, // 4000 Mframes/sec (measured: 4476.4, with 10% margin)
-  {2048, 3400} // 3400 Mframes/sec (lowered: min observed 3861.3, -10% margin)
+  {512, 4900}, // 4900 Mframes/sec (raised: min observed 5471.4, -10% margin)
+  {2048, 4900} // 4900 Mframes/sec (raised: min observed 5542.0, -10% margin)
 #else
-  {32, 50},   // 50 Mframes/sec (debug, raised for modern hardware)
-  {128, 70},  // 70 Mframes/sec (debug, raised for modern hardware)
-  {512, 80},  // 80 Mframes/sec (debug, raised for modern hardware)
-  {2048, 80}  // 80 Mframes/sec (debug, raised for modern hardware)
+  {32, 590}, // 590 Mframes/sec (debug, raised: min observed 663.8, -10% margin)
+  {128,
+   660}, // 660 Mframes/sec (debug, raised: min observed 744.1, -10% margin)
+  {512,
+   700}, // 700 Mframes/sec (debug, raised: min observed 786.8, -10% margin)
+  {2048,
+   700}      // 700 Mframes/sec (debug, raised: min observed 791.2, -10% margin)
 #endif
 };
 
 static constexpr Baseline BASELINE_ADD_FROM_COEFF[] = {
 #ifdef NDEBUG
   {32, 2800},  // 2800 Mframes/sec (lowered: min observed 3136.9, -10% margin)
-  {128, 3200}, // 3200 Mframes/sec (lowered: min observed 3654.9, -10% margin)
-  {512, 3500}, // 3500 Mframes/sec (measured: 3890.1, with 10% margin)
-  {2048, 3300} // 3300 Mframes/sec (lowered: min observed 3692.3, -10% margin)
+  {128, 4400}, // 4400 Mframes/sec (raised: min observed 4959.0, -10% margin)
+  {512, 4800}, // 4800 Mframes/sec (raised: min observed 5452.5, -10% margin)
+  {2048, 4800} // 4800 Mframes/sec (raised: min observed 5457.8, -10% margin)
 #else
-  {32, 50},   // 50 Mframes/sec (debug, raised for modern hardware)
-  {128, 70},  // 70 Mframes/sec (debug, raised for modern hardware)
-  {512, 80},  // 80 Mframes/sec (debug, raised for modern hardware)
-  {2048, 80}  // 80 Mframes/sec (debug, raised for modern hardware)
+  {32, 450}, // 450 Mframes/sec (debug, raised: min observed 506.4, -10% margin)
+  {128,
+   470}, // 470 Mframes/sec (debug, raised: min observed 533.3, -10% margin)
+  {512,
+   500}, // 500 Mframes/sec (debug, raised: min observed 557.2, -10% margin)
+  {2048,
+   430} // 430 Mframes/sec (debug, lowered: min observed 478.3, -10% margin)
 #endif
 };
 
@@ -104,10 +113,14 @@ static constexpr Baseline BASELINE_COPY_CHANNEL_FROM[] = {
   {512, 2800}, // 2800 Mframes/sec (raised for modern hardware)
   {2048, 2800} // 2800 Mframes/sec (raised for modern hardware)
 #else
-  {32, 80},   // 80 Mframes/sec (debug, raised for modern hardware)
-  {128, 130}, // 130 Mframes/sec (debug, raised for modern hardware)
-  {512, 150}, // 150 Mframes/sec (debug, raised for modern hardware)
-  {2048, 160} // 160 Mframes/sec (debug, raised for modern hardware)
+  {32,
+   710}, // 710 Mframes/sec (debug, lowered: min observed 790.2, -10% margin)
+  {128,
+   1230}, // 1230 Mframes/sec (debug, lowered: min observed 1365.5, -10% margin)
+  {512,
+   1380}, // 1380 Mframes/sec (debug, lowered: min observed 1537.6, -10% margin)
+  {2048,
+   1420} // 1420 Mframes/sec (debug, lowered: min observed 1582.5, -10% margin)
 #endif
 };
 
@@ -118,10 +131,14 @@ static constexpr Baseline BASELINE_ADD_CHANNEL_FROM[] = {
   {512, 2400}, // 2400 Mframes/sec (measured: 2688.1, with 10% margin)
   {2048, 2700} // 2700 Mframes/sec (raised for modern hardware)
 #else
-  {32, 80},   // 80 Mframes/sec (debug, raised for modern hardware)
-  {128, 130}, // 130 Mframes/sec (debug, raised for modern hardware)
-  {512, 150}, // 150 Mframes/sec (debug, raised for modern hardware)
-  {2048, 160} // 160 Mframes/sec (debug, raised for modern hardware)
+  {32,
+   820}, // 820 Mframes/sec (debug, lowered: min observed 908.9, -10% margin)
+  {128,
+   1160}, // 1160 Mframes/sec (debug, raised: min observed 1295.5, -10% margin)
+  {512,
+   1300}, // 1300 Mframes/sec (debug, raised: min observed 1445.8, -10% margin)
+  {2048,
+   1300} // 1300 Mframes/sec (debug, raised: min observed 1496.9, -10% margin)
 #endif
 };
 
@@ -132,10 +149,14 @@ static constexpr Baseline BASELINE_ADD_CHANNEL_FROM_COEFF[] = {
   {512, 2400}, // 2400 Mframes/sec (raised for modern hardware)
   {2048, 2500} // 2500 Mframes/sec (raised for modern hardware)
 #else
-  {32, 80},   // 80 Mframes/sec (debug, raised for modern hardware)
-  {128, 130}, // 130 Mframes/sec (debug, raised for modern hardware)
-  {512, 150}, // 150 Mframes/sec (debug, raised for modern hardware)
-  {2048, 160} // 160 Mframes/sec (debug, raised for modern hardware)
+  {32,
+   970}, // 970 Mframes/sec (debug, lowered: min observed 1078.6, -10% margin)
+  {128,
+   1200}, // 1200 Mframes/sec (debug, raised: min observed 1352.8, -10% margin)
+  {512,
+   1300}, // 1300 Mframes/sec (debug, raised: min observed 1533.3, -10% margin)
+  {2048,
+   1400} // 1400 Mframes/sec (debug, raised: min observed 1581.0, -10% margin)
 #endif
 };
 
@@ -149,10 +170,13 @@ static constexpr Baseline BASELINE_MONO_COPY_ADD_FROM_COEFF[] = {
   {512, 2100}, // 2100 Mframes/sec (measured: 2434.9, -10% margin)
   {2048, 2100} // 2100 Mframes/sec (measured: 2435.9, -10% margin)
 #else
-  {32, 50},   // 50 Mframes/sec (debug, measured: 57.3, -10% margin)
-  {128, 60},  // 60 Mframes/sec (debug, measured: 74.4, -10% margin)
-  {512, 70},  // 70 Mframes/sec (debug, measured: 79.4, -10% margin)
-  {2048, 70}  // 70 Mframes/sec (debug, measured: 81.7, -10% margin)
+  {32, 520}, // 520 Mframes/sec (debug, raised: min observed 581.6, -10% margin)
+  {128,
+   590}, // 590 Mframes/sec (debug, raised: min observed 659.3, -10% margin)
+  {512,
+   640}, // 640 Mframes/sec (debug, raised: min observed 724.3, -10% margin)
+  {2048,
+   660} // 660 Mframes/sec (debug, raised: min observed 744.4, -10% margin)
 #endif
 };
 

--- a/src/tests/testing/sound/buffer/GOTestPerfSoundBufferMutable.h
+++ b/src/tests/testing/sound/buffer/GOTestPerfSoundBufferMutable.h
@@ -34,6 +34,7 @@ private:
   void TestPerfAddChannelFromMonoRecipient();
 
 public:
+  GOTestPerfSoundBufferMutable() : GOTest(GOTest::PERF) {}
   std::string GetName() override { return TEST_NAME; }
   void run() override;
 };


### PR DESCRIPTION
Earlier performance tests were a part of one test package that was run with coverage enabled. It made the test results too slow.

This PR splits one testing job to three ones:
- Functional tests on Debug build and coverage
- Performance tests on Debug build without coverage
- Performance tests on Release build without coverage

It allows to increase baseline values.

It affects only tests running on GitHub. No GO behavior should be changed.