### PR TITLE
Fixed github build on macos https://github.com/GrandOrgue/grandorgue/issues/2398

### DIFF
--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -9,6 +9,7 @@ brew link --overwrite pkg-config
 cmake --version || brew install cmake
 
 brew install \
+  docbook \
   docbook-xsl \
   fftw wavpack \
   gettext \

--- a/cmake/BuildHelp.cmake
+++ b/cmake/BuildHelp.cmake
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -26,9 +26,14 @@ function(BUILD_HELPFILE xmlfile VARIANT)
     SET(_ImgList ${_ImgList} ${BUILDDIR}/images/${IMG_NAME})
   ENDFOREACH()
   
-  ADD_CUSTOM_COMMAND(OUTPUT ${BUILDDIR}/GrandOrgue.hhp COMMAND ${XSLTPROC}
-    ARGS --path ${DOCBOOK_PATH}/htmlhelp ${SRCDIR}/grandorgue.xsl ${xmlfile}
-    WORKING_DIRECTORY ${BUILDDIR} DEPENDS ${SRCDIR}/grandorgue.xsl ${xmlfile})
+  if(XML_CATALOG_FILE)
+    set(_CatalogArgs "XML_CATALOG_FILES=${XML_CATALOG_FILE}")
+  endif()
+  ADD_CUSTOM_COMMAND(OUTPUT ${BUILDDIR}/GrandOrgue.hhp
+    COMMAND ${CMAKE_COMMAND} -E env ${_CatalogArgs}
+      ${XSLTPROC} --path ${DOCBOOK_PATH}/htmlhelp ${SRCDIR}/grandorgue.xsl ${xmlfile}
+    WORKING_DIRECTORY ${BUILDDIR}
+    DEPENDS ${SRCDIR}/grandorgue.xsl ${xmlfile})
 
   ADD_CUSTOM_COMMAND(OUTPUT ${HELPDIR}/GrandOrgue${VARIANT}.htb COMMAND ${ZIP} 
     ARGS -r -X --filesync ${HELPDIR}/GrandOrgue${VARIANT}.htb * WORKING_DIRECTORY ${BUILDDIR}

--- a/cmake/FindTools.cmake
+++ b/cmake/FindTools.cmake
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -38,6 +38,17 @@ IF (NOT PO4A_GETTEXT)
 ENDIF()
 IF (NOT PO4A_TRANSLATE)
    MESSAGE(STATUS "po4a-translate not found (package po4a)")
+ENDIF()
+
+FIND_FILE(XML_CATALOG_FILE catalog
+  PATHS
+    /opt/homebrew/etc/xml   # macOS Homebrew arm64
+    /usr/local/etc/xml      # macOS Homebrew x86
+    /etc/xml                # Linux
+  NO_DEFAULT_PATH
+)
+IF (NOT XML_CATALOG_FILE)
+   MESSAGE(STATUS "XML catalog not found - xsltproc may fail to resolve DocBook entities")
 ENDIF()
 
 IF(CMAKE_CROSSCOMPILING)

--- a/help/grandorgue.xml
+++ b/help/grandorgue.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN" "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <book lang="en">
 <!--
 Copyright 2006 Milan Digital Audio LLC


### PR DESCRIPTION
Resolves: #2398.

Earlier GitHub builds for macos often failed because the url "http://www.oasis-open.org" was not always available for macos github runners.

This PR removes necesserity of accessing this url by installing the `docbook` package that contains a cache of this .dtd file.

No GO behavior should be changed.