### PR TITLE
Fixed wrong initial position of the Combination Setter https://github.com/GrandOrgue/grandorgue/issues/2430

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed wrong initial position of the Combination Setter https://github.com/GrandOrgue/grandorgue/issues/2430
 - Fixed listening a SYSEX Johanus event in the MIDI event editor https://github.com/GrandOrgue/grandorgue/issues/2114
 # 3.17.0 (2026-02-09)
 - Added capability of entering a setter combination number with the new "N" MIDI button https://github.com/GrandOrgue/grandorgue/issues/1237

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -736,6 +736,8 @@ const GOSetter::ButtonDefinitionEntry *const GOSetter::P_BUTTON_DEFS
 GOSetter::GOSetter(GOOrganController *organController)
   : m_OrganController(organController),
     m_pos(0),
+    m_NumericModeDigitsEntered(-1),
+    m_NumericModeAccomulated(0),
     m_bank(0),
     m_crescendopos(0),
     m_crescendobank(0),


### PR DESCRIPTION
Resolves: #2430

The reason of the issue was that some GOSetter were not initialised properly.