### PR TITLE
Fixed controlling organ elements when recording or playing MIDI https//github.com/GrandOrgue/grandorgue/issues/2388

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed controlling organ elements when recording or playing MIDI https://github.com/GrandOrgue/grandorgue/issues/2388
 - Fixed Loading organ errors with Tuskish system locale https://github.com/GrandOrgue/grandorgue/issues/2401
 # 3.17.1 (2026-03-31)
 - Fixed wrong .cmb group of division sender MIDI settings https://github.com/GrandOrgue/grandorgue/issues/2409

--- a/src/grandorgue/midi/GOMidiMap.h
+++ b/src/grandorgue/midi/GOMidiMap.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -17,7 +17,7 @@
 class GOMidiMap {
 private:
   GONameMap m_DeviceMap;
-  GONameMap m_ElementMap;
+  GONameMap m_RecorderElementMap;
 
   static uint_fast16_t getIdByName(const GONameMap &map, const wxString &name) {
     return map.GetIdByName(name.utf8_str().data());
@@ -56,12 +56,13 @@ public:
     return getNameById(m_DeviceMap, id);
   }
 
-  uint_fast16_t GetElementByString(const wxString &str) {
-    return getIdByName(m_ElementMap, str);
+  // Recoder element ids start with 0
+  uint_fast16_t EnsureRecorderElementName(const wxString &str) {
+    return ensureName(m_RecorderElementMap, str) - 1;
   }
 
-  wxString GetElementByID(uint_fast16_t id) const {
-    return getNameById(m_ElementMap, id);
+  wxString GetRecorderElementNameById(uint_fast16_t id) const {
+    return getNameById(m_RecorderElementMap, id + 1);
   }
 };
 

--- a/src/grandorgue/midi/GOMidiPlayerContent.cpp
+++ b/src/grandorgue/midi/GOMidiPlayerContent.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -51,7 +51,7 @@ void GOMidiPlayerContent::SetupManual(
   e.SetTime(0);
 
   e.SetMidiType(GOMidiEvent::MIDI_SYSEX_GO_SETUP);
-  e.SetKey(map.GetElementByString(ID));
+  e.SetKey(map.EnsureRecorderElementName(ID));
   e.SetChannel(channel);
   e.SetValue(0);
   m_Events.push_back(e);

--- a/src/grandorgue/midi/GOMidiRecorder.cpp
+++ b/src/grandorgue/midi/GOMidiRecorder.cpp
@@ -133,8 +133,8 @@ void GOMidiRecorder::PreconfigureMapping(const wxString &element, bool isNRPN) {
 
 void GOMidiRecorder::PreconfigureMapping(
   const wxString &element, bool isNRPN, const wxString &reference) {
-  unsigned id = m_Map.GetElementByString(element);
-  unsigned ref = m_Map.GetElementByString(reference);
+  unsigned id = m_Map.EnsureRecorderElementName(element);
+  unsigned ref = m_Map.EnsureRecorderElementName(reference);
   for (unsigned i = 0; i < m_Preconfig.size(); i++)
     if (m_Preconfig[i].elementID == ref) {
       GOMidiEvent e1;

--- a/src/grandorgue/midi/events/GOMidiEvent.cpp
+++ b/src/grandorgue/midi/events/GOMidiEvent.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -150,7 +150,7 @@ void GOMidiEvent::FromMidi(
         SetChannel((msg[4] & 0x0F) + 1);
         SetValue(((msg[5] & 0x7F) << 7) | (msg[6] & 0x7F));
         wxString s = wxString::FromAscii(b);
-        SetKey(map.GetElementByString(s));
+        SetKey(map.EnsureRecorderElementName(s));
         SetMidiType(MIDI_SYSEX_GO_SETUP);
         break;
       }
@@ -317,7 +317,7 @@ void GOMidiEvent::ToMidi(
     return;
 
   case MIDI_SYSEX_GO_SETUP: {
-    const wxString &s = map.GetElementByID(GetKey());
+    const wxString &s = map.GetRecorderElementNameById(GetKey());
     wxCharBuffer b = s.ToAscii();
     unsigned len = s.length();
     m.resize(len + 8);
@@ -478,7 +478,7 @@ wxString GOMidiEvent::ToString(GOMidiMap &map) const {
       _("sysex GrandOrgue setup channel: %d NRPN: %d: name: %s"),
       GetChannel(),
       GetValue(),
-      map.GetElementByID(GetKey()).c_str());
+      map.GetRecorderElementNameById(GetKey()).c_str());
 
   case MIDI_SYSEX_HW_STRING:
     return wxString::Format(

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -57,7 +57,7 @@ GOOrganModel::GOOrganModel(GOConfig &config)
 GOOrganModel::~GOOrganModel() {}
 
 unsigned GOOrganModel::GetRecorderElementID(const wxString &name) {
-  return m_config.GetMidiMap().GetElementByString(name);
+  return m_config.GetMidiMap().EnsureRecorderElementName(name);
 }
 
 static const wxString WX_ORGAN = wxT("Organ");


### PR DESCRIPTION
Resolves: #2388

The reason of the bug was using GOMidiMap::GetElementByString that always returned 0 because nobody inserted any elements.

This PR:

1. Renames GOMidiMap::m_ElementMap to m_RecorderElementMap
2. Renames GOMidiMap::GetElementByString to EnsureRecorderElementName and automatically inserts the name if it does not exist
3. Renames GetElementByID to GetRecorderElementNameById

It also remaps the ids from 0 for compatibility with old MIDI files