### PR TITLE
Modified the github release creation workflow to be idempotent https://github.com/GrandOrgue/grandorgue/issues/2397

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,8 @@ jobs:
 
     - name: Set git tags and compose RELNOTES.md
       shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ${{github.workspace}}/build-scripts/for-github/autotag.sh
       if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') }}
 
@@ -116,15 +118,15 @@ jobs:
     - name: Create Draft Release
       if: ${{ steps.vers.outputs.release_flag == 'ON' }}
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: ncipollo/release-action@v1
       with:
-        tag_name: "${{ steps.vers.outputs.full_ver }}"
-        release_name:  "v${{ steps.vers.outputs.full_ver }}"
+        tag: "${{ steps.vers.outputs.full_ver }}"
+        name: "v${{ steps.vers.outputs.full_ver }}"
         draft: true
-        prerelease: false
-        body_path: "${{ steps.relnotes.outputs.file }}"
+        bodyFile: "${{ steps.relnotes.outputs.file }}"
+        allowUpdates: true
+        updateOnlyUnreleased: true
+        token: ${{ secrets.GITHUB_TOKEN }}
         
   build:
     needs: [calc_ver]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
     - name: Create Draft Release
       if: ${{ steps.vers.outputs.release_flag == 'ON' }}
       id: create_release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
       with:
         tag: "${{ steps.vers.outputs.full_ver }}"
         name: "v${{ steps.vers.outputs.full_ver }}"

--- a/build-scripts/for-appimage-x86_64/build-on-linux.sh
+++ b/build-scripts/for-appimage-x86_64/build-on-linux.sh
@@ -3,12 +3,13 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
-# $4 - release flag (ON/OFF, default: OFF)
+# $4 - pkg_suffix
+# $5 - release flag (ON/OFF, default: OFF)
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2" "$4"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$(readlink -f $3)

--- a/build-scripts/for-github/autotag.sh
+++ b/build-scripts/for-github/autotag.sh
@@ -26,7 +26,7 @@ if [[ "$(echo $CHANGELOG_HEAD | cut -d\  -f1)" == "#" ]]; then
   # release
   CHANGELOG_TAG=$(assure_full_version $(echo $CHANGELOG_HEAD | cut -d\  -f2) 1)
 fi
-if [[ "$CHANGELOG_TAG" > "$GIT_TAG" ]]; then
+if [[ -n "$CHANGELOG_TAG" ]] && [[ ! "$CHANGELOG_TAG" < "$GIT_TAG" ]]; then
   # a new release. Push the release tag and make the relnotes
   NEW_TAG=$CHANGELOG_TAG
   sed '0,/^#/d;/^#/Q' CHANGELOG.md >$RELEASE_NOTES
@@ -37,7 +37,18 @@ else
 fi
 echo "NEW_TAG=$NEW_TAG"
 if [[ -n "$NEW_TAG" ]]; then
+  # If moving an existing tag, check the release is not already published.
+  # If the release is a draft or does not exist yet, push the tag as usual.
+  if [[ "$NEW_TAG" == "$GIT_TAG" ]] && [[ -n "$GH_TOKEN" ]]; then
+    IS_DRAFT=$(gh release view "$NEW_TAG" --json isDraft --jq '.isDraft' 2>/dev/null || echo "notfound")
+    if [[ "$IS_DRAFT" == "false" ]]; then
+      echo "Release $NEW_TAG is already published, skipping tag push."
+      NEW_TAG=
+    fi
+  fi
+fi
+if [[ -n "$NEW_TAG" ]]; then
   # add and push the new tag
-  git tag $NEW_TAG
-  git push origin $NEW_TAG
+  git tag --force $NEW_TAG
+  git push --force origin $NEW_TAG
 fi

--- a/build-scripts/for-github/autotag.sh
+++ b/build-scripts/for-github/autotag.sh
@@ -15,25 +15,31 @@ assure_full_version()
   echo $TAG
 }
 
+# Returns 0 (true) if $1 >= $2 using semantic version ordering
+version_ge() { [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -1)" != "$2" ]] || [[ "$1" == "$2" ]]; }
+
+# Returns 0 (true) if $1 > $2 using semantic version ordering
+version_gt() { [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -1)" != "$1" ]]; }
+
 git fetch --prune --unshallow --tags
 GIT_TAG=`git describe --tags | cut -d- -f1-2`
 NEW_TAG=
 CHANGELOG_HEAD=$(head -n 1 $CHANGELOG)
 CHANGELOG_TAG=
 
-if [[ "$(echo $CHANGELOG_HEAD | cut -d\  -f1)" == "#" ]]; then
+if [[ "$(echo "$CHANGELOG_HEAD" | cut -d\  -f1)" == "#" ]]; then
   echo release
   # release
-  CHANGELOG_TAG=$(assure_full_version $(echo $CHANGELOG_HEAD | cut -d\  -f2) 1)
+  CHANGELOG_TAG=$(assure_full_version "$(echo "$CHANGELOG_HEAD" | cut -d\  -f2)" 1)
 fi
-if [[ -n "$CHANGELOG_TAG" ]] && [[ ! "$CHANGELOG_TAG" < "$GIT_TAG" ]]; then
+if [[ -n "$CHANGELOG_TAG" ]] && version_ge "$CHANGELOG_TAG" "$GIT_TAG"; then
   # a new release. Push the release tag and make the relnotes
   NEW_TAG=$CHANGELOG_TAG
   sed '0,/^#/d;/^#/Q' CHANGELOG.md >$RELEASE_NOTES
 else
   # No release. May be we are preparing for a new release in the future
-  FUTURE_RELEASE_TAG=$(assure_full_version $(cat $VERSION_TXT) 0)
-  [[ "$FUTURE_RELEASE_TAG" > "$GIT_TAG" ]] && NEW_TAG=$FUTURE_RELEASE_TAG
+  FUTURE_RELEASE_TAG=$(assure_full_version "$(cat "$VERSION_TXT")" 0)
+  version_gt "$FUTURE_RELEASE_TAG" "$GIT_TAG" && NEW_TAG=$FUTURE_RELEASE_TAG
 fi
 echo "NEW_TAG=$NEW_TAG"
 if [[ -n "$NEW_TAG" ]]; then
@@ -49,6 +55,6 @@ if [[ -n "$NEW_TAG" ]]; then
 fi
 if [[ -n "$NEW_TAG" ]]; then
   # add and push the new tag
-  git tag --force $NEW_TAG
-  git push --force origin $NEW_TAG
+  git tag --force "$NEW_TAG"
+  git push --force origin "$NEW_TAG"
 fi

--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -3,11 +3,12 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
-# $4 - release flag (ON/OFF, default: OFF)
+# $4 - pkg_suffix
+# $5 - release flag (ON/OFF, default: OFF)
 
 set -e
 
-source $(dirname $0)/../set-ver-prms.sh "$1" "$2" "$4"
+source $(dirname $0)/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
   SRC_DIR=$3

--- a/build-scripts/for-win64/build-on-linux.sh
+++ b/build-scripts/for-win64/build-on-linux.sh
@@ -3,11 +3,12 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
-# $4 - release flag (ON/OFF, default: OFF)
+# $4 - pkg_suffix
+# $5 - release flag (ON/OFF, default: OFF)
 
 set -e
 
-source $(dirname $0)/../set-ver-prms.sh "$1" "$2" "$4"
+source $(dirname $0)/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3


### PR DESCRIPTION
Resolves: #2397
Resolves: #2503

This PR makes the release creation on GitHub more robust. If a release build fails, the second running of workflow (with or without additional commits) will continue the release publication even some artifacts (a git tag or a draft release) remains after the previous build.

Earlier I needed to do some manual cleanup before the second attempt.

Also fixes a bug where win64, osx and appimage build scripts were passing `$4` (pkg_suffix, always empty) instead of `$5` (release_flag) to `set-ver-prms.sh`, causing those builds to always compile as Debug even on release tags.

It affects only the github build workflow. No GO behavior should be changed.