### PR TITLE
Fixed compilation warnings.

### DIFF
--- a/src/grandorgue/gui/dialogs/organ-settings/GOOrganSettingsPipesTab.cpp
+++ b/src/grandorgue/gui/dialogs/organ-settings/GOOrganSettingsPipesTab.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -1053,7 +1053,7 @@ void GOOrganSettingsPipesTab::DiscardChanges() {
 void GOOrganSettingsPipesTab::ApplyChanges() {
   double amp, gain, manualTuning, autoTuningCorrection;
   long delay, toneBalance;
-  unsigned releaseLength;
+  unsigned releaseLength = 0;
 
   wxArrayTreeItemIds entries;
   m_Tree->GetSelections(entries);

--- a/src/grandorgue/sound/playing/GOSoundResample.cpp
+++ b/src/grandorgue/sound/playing/GOSoundResample.cpp
@@ -21,6 +21,7 @@
 
 #include "GOSoundResample.h"
 
+#include <cassert>
 #include <math.h>
 #include <stdlib.h>
 
@@ -111,6 +112,13 @@ unsigned GOSoundResample::getVectorLength(
     break;
   case GO_POLYPHASE_INTERPOLATION:
     res = PolyphaseResampler::VECTOR_LENGTH;
+    break;
+
+  /* A compiler cannot guarantee that interpolation has a valid value.
+   * So for avoiding the "res may be used uninitialized" warning */
+  default:
+    assert(false);
+    res = 0;
   }
   return res;
 }


### PR DESCRIPTION
This PR eliminates a compilation warning "releaseLength may be not initialised".

No GO behavior should be changed.