### PR TITLE
GOSoundStream: extracted common code to helpers

### DIFF
--- a/src/grandorgue/sound/playing/GOSoundStream.cpp
+++ b/src/grandorgue/sound/playing/GOSoundStream.cpp
@@ -127,7 +127,7 @@ void GOSoundStream::DecodeBlock(float *pOut, unsigned nOutSamples) {
 
 GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
   uint8_t nChannels,
-  uint8_t nBitsPerSample,
+  uint8_t nBitsPerSoundItem,
   bool isCompressed,
   GOSoundResample::InterpolationType interpolationType) {
 
@@ -135,7 +135,7 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
     if (isCompressed) {
       // Polyphase interpolation + compressed audio
       if (nChannels == 1) {
-        if (nBitsPerSample >= 20)
+        if (nBitsPerSoundItem >= 20)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::PolyphaseResampler,
             StreamCacheReadAheadWindow<
@@ -143,7 +143,7 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
               GOSoundResample::PolyphaseResampler::VECTOR_LENGTH,
               1>>;
 
-        assert(nBitsPerSample >= 12);
+        assert(nBitsPerSoundItem >= 12);
         return &GOSoundStream::DecodeBlock<
           GOSoundResample::PolyphaseResampler,
           StreamCacheReadAheadWindow<
@@ -151,7 +151,7 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
             GOSoundResample::PolyphaseResampler::VECTOR_LENGTH,
             1>>;
       } else if (nChannels == 2) {
-        if (nBitsPerSample >= 20)
+        if (nBitsPerSoundItem >= 20)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::PolyphaseResampler,
             StreamCacheReadAheadWindow<
@@ -159,7 +159,7 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
               GOSoundResample::PolyphaseResampler::VECTOR_LENGTH,
               2>>;
 
-        assert(nBitsPerSample >= 12);
+        assert(nBitsPerSoundItem >= 12);
         return &GOSoundStream::DecodeBlock<
           GOSoundResample::PolyphaseResampler,
           StreamCacheReadAheadWindow<
@@ -170,28 +170,28 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
     } else {
       // Polyphase interpolation + uncompressed audio
       if (nChannels == 1) {
-        if (nBitsPerSample <= 8)
+        if (nBitsPerSoundItem <= 8)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::PolyphaseResampler,
             StreamPtrWindow<GOInt8, 1>>;
-        if (nBitsPerSample <= 16)
+        if (nBitsPerSoundItem <= 16)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::PolyphaseResampler,
             StreamPtrWindow<GOInt16, 1>>;
-        if (nBitsPerSample <= 24)
+        if (nBitsPerSoundItem <= 24)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::PolyphaseResampler,
             StreamPtrWindow<GOInt24, 1>>;
       } else if (nChannels == 2) {
-        if (nBitsPerSample <= 8)
+        if (nBitsPerSoundItem <= 8)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::PolyphaseResampler,
             StreamPtrWindow<GOInt8, 2>>;
-        if (nBitsPerSample <= 16)
+        if (nBitsPerSoundItem <= 16)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::PolyphaseResampler,
             StreamPtrWindow<GOInt16, 2>>;
-        if (nBitsPerSample <= 24)
+        if (nBitsPerSoundItem <= 24)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::PolyphaseResampler,
             StreamPtrWindow<GOInt24, 2>>;
@@ -202,22 +202,22 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
     if (isCompressed) {
       // Linear interpolation + compressed audio
       if (nChannels == 1) {
-        if (nBitsPerSample >= 20)
+        if (nBitsPerSoundItem >= 20)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::LinearResampler,
             StreamCacheWindow<true, 1>>;
 
-        assert(nBitsPerSample >= 12);
+        assert(nBitsPerSoundItem >= 12);
         return &GOSoundStream::DecodeBlock<
           GOSoundResample::LinearResampler,
           StreamCacheWindow<false, 1>>;
       } else if (nChannels == 2) {
-        if (nBitsPerSample >= 20)
+        if (nBitsPerSoundItem >= 20)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::LinearResampler,
             StreamCacheWindow<true, 2>>;
 
-        assert(nBitsPerSample >= 12);
+        assert(nBitsPerSoundItem >= 12);
         return &GOSoundStream::DecodeBlock<
           GOSoundResample::LinearResampler,
           StreamCacheWindow<false, 2>>;
@@ -225,28 +225,28 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
     } else {
       // Linear interpolation + uncompressed audio
       if (nChannels == 1) {
-        if (nBitsPerSample <= 8)
+        if (nBitsPerSoundItem <= 8)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::LinearResampler,
             StreamPtrWindow<GOInt8, 1>>;
-        if (nBitsPerSample <= 16)
+        if (nBitsPerSoundItem <= 16)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::LinearResampler,
             StreamPtrWindow<GOInt16, 1>>;
-        if (nBitsPerSample <= 24)
+        if (nBitsPerSoundItem <= 24)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::LinearResampler,
             StreamPtrWindow<GOInt24, 1>>;
       } else if (nChannels == 2) {
-        if (nBitsPerSample <= 8)
+        if (nBitsPerSoundItem <= 8)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::LinearResampler,
             StreamPtrWindow<GOInt8, 2>>;
-        if (nBitsPerSample <= 16)
+        if (nBitsPerSoundItem <= 16)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::LinearResampler,
             StreamPtrWindow<GOInt16, 2>>;
-        if (nBitsPerSample <= 24)
+        if (nBitsPerSoundItem <= 24)
           return &GOSoundStream::DecodeBlock<
             GOSoundResample::LinearResampler,
             StreamPtrWindow<GOInt24, 2>>;
@@ -258,98 +258,103 @@ GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunction(
   return NULL;
 }
 
+GOSoundStream::DecodeBlockFunction GOSoundStream::getDecodeBlockFunctionFor(
+  const GOSoundAudioSection *pSection,
+  bool isCompressed,
+  GOSoundResample::InterpolationType interpolationType) {
+  return getDecodeBlockFunction(
+    pSection->GetChannels(),
+    pSection->GetBitsPerSample(),
+    isCompressed,
+    interpolationType);
+}
+
+unsigned GOSoundStream::GoToStartSegment(unsigned startSegmentIndex) {
+  const GOSoundAudioSection::StartSegment &startSegment
+    = audio_section->GetStartSegment(startSegmentIndex);
+  const GOSoundAudioSection::EndSegment &endSegment
+    = audio_section->GetEndSegment(
+      audio_section->PickEndSegment(startSegmentIndex));
+  const unsigned char *pData = audio_section->GetData();
+
+  // start segment
+  ptr = pData;
+  cache = startSegment.cache;
+  cache.m_ptr = pData + (intptr_t)cache.m_ptr;
+
+  // end segment
+  transition_position = endSegment.transition_offset;
+  end_ptr = endSegment.end_ptr;
+  end_pos = endSegment.end_pos;
+
+  // next start segment
+  m_NextStartSegmentIndex = endSegment.next_start_segment_index;
+
+  return startSegment.start_offset;
+}
+
+unsigned GOSoundStream::InitFromSection(
+  const GOSoundAudioSection *pSection,
+  unsigned startSegmentIndex,
+  GOSoundResample::InterpolationType interpolationType) {
+  audio_section = pSection;
+
+  decode_call = getDecodeBlockFunctionFor(
+    pSection, pSection->IsCompressed(), interpolationType);
+  // End segments are never compressed
+  end_decode_call
+    = getDecodeBlockFunctionFor(pSection, false, interpolationType);
+
+  return GoToStartSegment(startSegmentIndex);
+}
+
 void GOSoundStream::InitStream(
   const GOSoundResample *pResample,
   const GOSoundAudioSection *pSection,
-  GOSoundResample::InterpolationType interpolation,
-  float sample_rate_adjustment) {
-  audio_section = pSection;
-
-  const GOSoundAudioSection::StartSegment &start = pSection->GetStartSegment(0);
-  const GOSoundAudioSection::EndSegment &end
-    = pSection->GetEndSegment(pSection->PickEndSegment(0));
-
-  assert(end.transition_offset >= start.start_offset);
+  GOSoundResample::InterpolationType interpolationType,
+  float sampleRateAdjustment) {
   resample = pResample;
-  ptr = audio_section->GetData();
-  transition_position = end.transition_offset;
-  m_NextStartSegmentIndex = end.next_start_segment_index;
-  end_ptr = end.end_ptr;
+
+  const unsigned startOffset = InitFromSection(pSection, 0, interpolationType);
+
   m_ResamplingPos.Init(
-    sample_rate_adjustment * pSection->GetSampleRate(), start.start_offset);
-  decode_call = getDecodeBlockFunction(
-    pSection->GetChannels(),
-    pSection->GetBitsPerSample(),
-    pSection->IsCompressed(),
-    interpolation);
-  end_decode_call = getDecodeBlockFunction(
-    pSection->GetChannels(),
-    pSection->GetBitsPerSample(),
-    false,
-    interpolation);
-  end_pos = end.end_pos;
-  cache = start.cache;
-  cache.m_ptr = audio_section->GetData() + (intptr_t)cache.m_ptr;
+    sampleRateAdjustment * pSection->GetSampleRate(), startOffset);
 }
 
 void GOSoundStream::InitAlignedStream(
   const GOSoundAudioSection *pSection,
-  GOSoundResample::InterpolationType interpolation,
-  const GOSoundStream *existing_stream) {
-  const unsigned releaseStartSegment = pSection->GetReleaseStartSegment();
-  const GOSoundAudioSection::StartSegment &start
-    = pSection->GetStartSegment(releaseStartSegment);
-  const GOSoundAudioSection::EndSegment &end
-    = pSection->GetEndSegment(pSection->PickEndSegment(releaseStartSegment));
+  GOSoundResample::InterpolationType interpolationType,
+  const GOSoundStream *pExistingStream) {
+  // Release section
   GOSoundReleaseAlignTable *releaseAligner = pSection->GetReleaseAligner();
-  unsigned startIndex;
+
+  resample = pExistingStream->resample;
+
+  unsigned startOffset = InitFromSection(
+    pSection, pSection->GetReleaseStartSegment(), interpolationType);
 
   if (releaseAligner) {
     int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS];
 
-    existing_stream->GetHistory(history);
-    startIndex = releaseAligner->GetPositionFor(history);
-  } else
-    startIndex = start.start_offset;
-
-  assert(end.transition_offset >= start.start_offset);
-
-  audio_section = pSection;
-  ptr = audio_section->GetData();
-  transition_position = end.transition_offset;
-  m_NextStartSegmentIndex = end.next_start_segment_index;
-  end_ptr = end.end_ptr;
-  /* Translate increment in case of differing sample rates */
-  resample = existing_stream->resample;
+    pExistingStream->GetHistory(history);
+    startOffset = releaseAligner->GetPositionFor(history);
+  }
   m_ResamplingPos.Init(
     (float)pSection->GetSampleRate()
-      / existing_stream->audio_section->GetSampleRate(),
-    startIndex,
-    &existing_stream->m_ResamplingPos);
-  decode_call = getDecodeBlockFunction(
-    pSection->GetChannels(),
-    pSection->GetBitsPerSample(),
-    pSection->IsCompressed(),
-    interpolation);
-  end_decode_call = getDecodeBlockFunction(
-    pSection->GetChannels(),
-    pSection->GetBitsPerSample(),
-    false, // End segments are never compressed
-    interpolation);
-  end_pos = end.end_pos;
-  cache = start.cache;
-  cache.m_ptr = audio_section->GetData() + (intptr_t)cache.m_ptr;
+      / pExistingStream->audio_section->GetSampleRate(),
+    startOffset,
+    &pExistingStream->m_ResamplingPos);
 }
 
 bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
   bool res = true;
 
   while (n_blocks > 0) {
-    unsigned pos = m_ResamplingPos.GetIndex();
+    unsigned currSrcOffset = m_ResamplingPos.GetIndex();
 
-    if (pos < end_pos) { // the loop has not yet fully played
+    if (currSrcOffset < end_pos) { // the loop has not yet fully played
       // whether we are playing the start or the end segment
-      bool isToPlayMain = pos < transition_position;
+      bool isToPlayMain = currSrcOffset < transition_position;
       unsigned finishPos = isToPlayMain ? transition_position : end_pos;
       unsigned targetSamples
         = std::min(m_ResamplingPos.AvailableTargetSamples(finishPos), n_blocks);
@@ -362,7 +367,7 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
         assert(end_decode_call);
 
         // Setup ptr and position required by the end-block
-        ptr = end_ptr;
+        GoToEndSegment();
         // we continue to use the same position as before because end_ptr is a
         // "virtual" pointer: end_data - transition_offset
         (this->*end_decode_call)(buffer, targetSamples);
@@ -372,37 +377,20 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
       assert(!n_blocks || m_ResamplingPos.GetIndex() >= finishPos);
     } else if (m_NextStartSegmentIndex >= 0) {
       // switch to the start of the loop
-      const GOSoundAudioSection::StartSegment *next
-        = &audio_section->GetStartSegment(m_NextStartSegmentIndex);
-      unsigned newPos = next->start_offset + (pos - end_pos);
+      const unsigned startOffset = GoToStartSegment(m_NextStartSegmentIndex);
+      const unsigned newSrcOffset = startOffset + (currSrcOffset - end_pos);
 
-      // switch to the start of the loop
-      ptr = audio_section->GetData();
+      assert(end_pos >= startOffset);
 
-      /* Find a suitable end segment */
-      const unsigned next_end_segment_index
-        = audio_section->PickEndSegment(m_NextStartSegmentIndex);
-      const GOSoundAudioSection::EndSegment *next_end
-        = &audio_section->GetEndSegment(next_end_segment_index);
-
-      assert(next_end->end_pos >= next->start_offset);
-
-      cache = next->cache;
-      cache.m_ptr = audio_section->GetData() + (intptr_t)cache.m_ptr;
-      transition_position = next_end->transition_offset;
-      end_pos = next_end->end_pos;
-      end_ptr = next_end->end_ptr;
-
-      m_ResamplingPos.SetIndex(newPos);
-      if (newPos < end_pos) // valid loop
-        m_NextStartSegmentIndex = next_end->next_start_segment_index;
-      else { // invalid loop. Using it might cause infinite iterations here
+      m_ResamplingPos.SetIndex(newSrcOffset);
+      if (newSrcOffset >= end_pos) { // invalid loop. Using it might cause
+                                     // infinite iterations here
         wxLogError(
           "GOSoundStream::ReadBlock: Breaking invalid loop: start_offset=%d, "
           "end_pos=%d, new_pos=%d",
-          next_end->end_pos,
-          next->start_offset,
-          newPos);
+          startOffset,
+          end_pos,
+          newSrcOffset);
         // force exit at the next iteration
         m_NextStartSegmentIndex = -1;
       }

--- a/src/grandorgue/sound/playing/GOSoundStream.cpp
+++ b/src/grandorgue/sound/playing/GOSoundStream.cpp
@@ -290,6 +290,8 @@ unsigned GOSoundStream::GoToStartSegment(unsigned startSegmentIndex) {
   // next start segment
   m_NextStartSegmentIndex = endSegment.next_start_segment_index;
 
+  assert(end_pos >= startSegment.start_offset);
+
   return startSegment.start_offset;
 }
 
@@ -376,11 +378,12 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
       n_blocks -= targetSamples;
       assert(!n_blocks || m_ResamplingPos.GetIndex() >= finishPos);
     } else if (m_NextStartSegmentIndex >= 0) {
-      // switch to the start of the loop
+      // switch to the start of the loop.
+      // overflowOffset must be computed BEFORE GoToStartSegment(): it
+      // overwrites end_pos with the new segment's end position.
+      const unsigned overflowOffset = currSrcOffset - end_pos;
       const unsigned startOffset = GoToStartSegment(m_NextStartSegmentIndex);
-      const unsigned newSrcOffset = startOffset + (currSrcOffset - end_pos);
-
-      assert(end_pos >= startOffset);
+      const unsigned newSrcOffset = startOffset + overflowOffset;
 
       m_ResamplingPos.SetIndex(newSrcOffset);
       if (newSrcOffset >= end_pos) { // invalid loop. Using it might cause

--- a/src/grandorgue/sound/playing/GOSoundStream.h
+++ b/src/grandorgue/sound/playing/GOSoundStream.h
@@ -72,28 +72,63 @@ private:
   template <class ResamplerT, class WindowT>
   void DecodeBlock(float *pOut, unsigned nOutSamples);
 
+  /* These functions must be static class members rather than file-scope
+   * functions because they reference the private typedef DecodeBlockFunction
+   * and the private nested window classes (StreamPtrWindow, StreamCacheWindow,
+   * StreamCacheReadAheadWindow). */
   static DecodeBlockFunction getDecodeBlockFunction(
     uint8_t nChannels,
-    uint8_t nBitsPerSample,
+    uint8_t nBitsPerSoundItem,
+    bool isCompressed,
+    GOSoundResample::InterpolationType interpolationType);
+
+  /**
+   * Returns a decode block function for the given audio section,
+   * compression flag and interpolation type.
+   */
+  static DecodeBlockFunction getDecodeBlockFunctionFor(
+    const GOSoundAudioSection *pSection,
     bool isCompressed,
     GOSoundResample::InterpolationType interpolationType);
 
   void GetHistory(int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]) const;
+
+  /**
+   * Switches the stream to the start segment with the given index.
+   * Sets up ptr, cache, end segment fields and next segment index.
+   * Returns start_offset of the start segment.
+   */
+  unsigned GoToStartSegment(unsigned startSegmentIndex);
+
+  /** Switches the stream to the end segment. */
+  void GoToEndSegment() { ptr = end_ptr; }
+
+  /**
+   * Initializes audio_section, sets up decode functions and switches
+   * to the start segment with the given index.
+   * Returns start_offset of the start segment.
+   */
+  unsigned InitFromSection(
+    const GOSoundAudioSection *pSection,
+    unsigned startSegmentIndex,
+    GOSoundResample::InterpolationType interpolationType);
 
 public:
   /* Initialize a stream to play this audio section */
   void InitStream(
     const GOSoundResample *pResample,
     const GOSoundAudioSection *pSection,
-    GOSoundResample::InterpolationType interpolation,
-    float sample_rate_adjustment);
+    GOSoundResample::InterpolationType interpolationType,
+    float sampleRateAdjustment);
 
-  /* Initialize a stream to play this audio section and seek into it using
-   * release alignment if available. */
+  /**
+   * Initializes a release stream aligned to the existing attack stream.
+   * Uses release alignment table if available.
+   */
   void InitAlignedStream(
     const GOSoundAudioSection *pSection,
-    GOSoundResample::InterpolationType interpolation,
-    const GOSoundStream *existing_stream);
+    GOSoundResample::InterpolationType interpolationType,
+    const GOSoundStream *pExistingStream);
 
   /* Read an audio buffer from an audio section stream */
   bool ReadBlock(float *buffer, unsigned int n_blocks);

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -20,6 +20,7 @@
 #include "testing/sound/buffer/GOTestSoundBufferManaged.h"
 #include "testing/sound/buffer/GOTestSoundBufferMutable.h"
 #include "testing/sound/buffer/GOTestSoundBufferMutableMono.h"
+#include "testing/sound/playing/GOTestSoundStream.h"
 
 int main(int argc, char *argv[]) {
   /*
@@ -54,6 +55,7 @@ int main(int argc, char *argv[]) {
   GOTestSoundBufferMutable testSoundBufferMutable;
   GOTestSoundBufferMutableMono testSoundBufferMutableMono;
   GOTestPerfSoundBufferMutable testPerfSoundBufferMutable;
+  GOTestSoundStream testSoundStream;
   /* end of instanciation */
   GOTestResultCollection test_result_collection;
   test_result_collection = GOTestCollection::Instance()->Run(categoryFilter);

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -10,6 +10,7 @@ set(go_tests
     sound/buffer/GOTestSoundBufferManaged.cpp
     sound/buffer/GOTestSoundBufferMutable.cpp
     sound/buffer/GOTestSoundBufferMutableMono.cpp
+    sound/playing/GOTestSoundStream.cpp
     GOTestNameMap.cpp
 )
 add_library(GOTests STATIC ${go_tests})

--- a/src/tests/testing/sound/playing/GOTestSoundStream.cpp
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundStream.h"
+
+#include <format>
+#include <vector>
+
+#include "sound/playing/GOSoundAudioSection.h"
+#include "sound/playing/GOSoundStream.h"
+
+#include "GOInt.h"
+#include "GOWave.h"
+#include "GOWaveLoop.h"
+
+const std::string GOTestSoundStream::TEST_NAME = "GOTestSoundStream";
+
+static constexpr unsigned SECTION_RATE = 48000;
+static constexpr float SAMPLE_RATE_ADJUSTMENT = 1.0f / SECTION_RATE;
+static constexpr unsigned N_FRAMES = 500;
+static constexpr unsigned N_ATTACK_FRAMES = 100;
+static constexpr unsigned N_FRAMES_PER_BLOCK = 50;
+static constexpr unsigned N_BUFFER_ITEMS = N_FRAMES_PER_BLOCK * 2;
+
+std::unique_ptr<GOSoundAudioSection> GOTestSoundStream::CreateAudioSection(
+  unsigned nChannels,
+  unsigned nFrames,
+  bool isCompressed,
+  const GOWaveLoop *pLoop) {
+  const unsigned nSamples = nChannels * nFrames;
+  std::vector<GOInt24> pcmData(nSamples);
+  std::vector<GOWaveLoop> loops;
+
+  for (unsigned i = 0; i < nSamples; i++)
+    pcmData[i] = (i % 100) * 30000 - 1500000;
+
+  if (pLoop)
+    loops.push_back(*pLoop);
+
+  auto pSection = std::make_unique<GOSoundAudioSection>(m_pool);
+
+  pSection->Setup(
+    nullptr,
+    nullptr,
+    pcmData.data(),
+    GOWave::SF_SIGNEDINT24_24,
+    nChannels,
+    SECTION_RATE,
+    nFrames,
+    &loops,
+    BOOL3_DEFAULT,
+    isCompressed,
+    0,
+    0);
+  return pSection;
+}
+
+void GOTestSoundStream::TestReadBlock(
+  GOSoundResample::InterpolationType interpolationType,
+  bool isCompressed,
+  unsigned nChannels) {
+  const std::string label = std::format(
+    "interpolation={} compressed={} channels={}",
+    interpolationType == GOSoundResample::GO_LINEAR_INTERPOLATION ? "linear"
+                                                                  : "polyphase",
+    isCompressed,
+    nChannels);
+  const auto pSection = CreateAudioSection(nChannels, N_FRAMES, isCompressed);
+  GOSoundResample resample;
+  GOSoundStream stream;
+
+  stream.InitStream(
+    &resample, pSection.get(), interpolationType, SAMPLE_RATE_ADJUSTMENT);
+
+  float buffer[N_BUFFER_ITEMS];
+
+  for (unsigned frameI = 0; frameI < N_FRAMES; frameI += N_FRAMES_PER_BLOCK) {
+    const bool result = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+
+    GOAssert(
+      result,
+      std::format(
+        "ReadBlock should return true while frames available ({})", label));
+  }
+
+  // ReadBlock should return false after exhaustion
+  const bool resultAfterEnd = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+
+  GOAssert(
+    !resultAfterEnd,
+    std::format("ReadBlock should return false after exhaustion ({})", label));
+
+  // Buffer should be filled with zeros after end
+  for (unsigned i = 0; i < N_BUFFER_ITEMS; i++)
+    GOAssert(
+      buffer[i] == 0.0f,
+      std::format(
+        "Buffer[{}] should be 0.0f after end ({}, got: {})",
+        i,
+        label,
+        buffer[i]));
+
+  // TODO: verify decoded frame values
+}
+
+void GOTestSoundStream::TestLoopedStreamAlwaysReturnsTrue() {
+  constexpr unsigned N_ITERATIONS = 100;
+  const GOWaveLoop loop = {100, 499};
+  const auto pSection = CreateAudioSection(1, N_FRAMES, false, &loop);
+  GOSoundResample resample;
+  GOSoundStream stream;
+
+  stream.InitStream(
+    &resample,
+    pSection.get(),
+    GOSoundResample::GO_LINEAR_INTERPOLATION,
+    SAMPLE_RATE_ADJUSTMENT);
+
+  float buffer[N_BUFFER_ITEMS];
+
+  for (unsigned iterI = 0; iterI < N_ITERATIONS; iterI++) {
+    const bool result = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+
+    GOAssert(
+      result,
+      std::format(
+        "ReadBlock should always return true for looped stream (iteration {})",
+        iterI));
+  }
+}
+
+void GOTestSoundStream::TestInitAlignedStream() {
+  const auto pAttack = CreateAudioSection(1, N_FRAMES, false);
+  const auto pRelease = CreateAudioSection(1, N_FRAMES, false);
+
+  pRelease->SetupStreamAlignment({pAttack.get()}, 0);
+
+  GOSoundResample resample;
+  GOSoundStream attackStream;
+
+  attackStream.InitStream(
+    &resample,
+    pAttack.get(),
+    GOSoundResample::GO_LINEAR_INTERPOLATION,
+    SAMPLE_RATE_ADJUSTMENT);
+
+  float buffer[N_BUFFER_ITEMS];
+
+  for (unsigned frameI = 0; frameI < N_ATTACK_FRAMES;
+       frameI += N_FRAMES_PER_BLOCK)
+    attackStream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+
+  GOSoundStream releaseStream;
+
+  releaseStream.InitAlignedStream(
+    pRelease.get(), GOSoundResample::GO_LINEAR_INTERPOLATION, &attackStream);
+
+  const bool result = releaseStream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+
+  GOAssert(result, "ReadBlock should return true after InitAlignedStream");
+}
+
+void GOTestSoundStream::run() {
+  for (unsigned nChannels : {1u, 2u}) {
+    for (bool isCompressed : {false, true}) {
+      TestReadBlock(
+        GOSoundResample::GO_LINEAR_INTERPOLATION, isCompressed, nChannels);
+      TestReadBlock(
+        GOSoundResample::GO_POLYPHASE_INTERPOLATION, isCompressed, nChannels);
+    }
+  }
+  TestLoopedStreamAlwaysReturnsTrue();
+  TestInitAlignedStream();
+}

--- a/src/tests/testing/sound/playing/GOTestSoundStream.cpp
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.cpp
@@ -6,6 +6,7 @@
 
 #include "GOTestSoundStream.h"
 
+#include <cstdlib>
 #include <format>
 #include <vector>
 
@@ -163,6 +164,73 @@ void GOTestSoundStream::TestInitAlignedStream() {
   GOAssert(result, "ReadBlock should return true after InitAlignedStream");
 }
 
+void GOTestSoundStream::TestLoopTransitionAcrossDifferentEndPos() {
+  // Two loops with different end_pos: a long loop and a short loop placed
+  // so PickEndSegment can pick either for some start segments. With the
+  // regression in ReadBlock (using the new segment's end_pos when computing
+  // the post-wrap position), wrap-around between segments with different
+  // end_pos breaks the source position and eventually triggers the
+  // "invalid loop" path, after which ReadBlock returns false.
+  constexpr unsigned N_TOTAL_FRAMES = 1100;
+  constexpr unsigned N_ITERATIONS = 500;
+  // Two long loops with very different end_pos. start_offsets are chosen
+  // such that an unsigned underflow in the buggy expression
+  //   startOffset + (currSrcOffset - end_pos_new)
+  // does NOT happen to wrap back into a valid (< end_pos_new) range — it
+  // stays huge, so the broken code reliably enters the "Breaking invalid
+  // loop" branch and ReadBlock subsequently returns false.
+  const std::vector<GOWaveLoop> loops = {
+    {500, 999}, // long loop, start_offset=500, end_pos=1000
+    {200, 599}, // long loop, start_offset=200, end_pos=600
+  };
+  const unsigned nChannels = 1;
+  const unsigned nSamples = nChannels * N_TOTAL_FRAMES;
+  std::vector<GOInt24> pcmData(nSamples);
+
+  for (unsigned i = 0; i < nSamples; i++)
+    pcmData[i] = (i % 100) * 30000 - 1500000;
+
+  auto pSection = std::make_unique<GOSoundAudioSection>(m_pool);
+
+  pSection->Setup(
+    nullptr,
+    nullptr,
+    pcmData.data(),
+    GOWave::SF_SIGNEDINT24_24,
+    nChannels,
+    SECTION_RATE,
+    N_TOTAL_FRAMES,
+    &loops,
+    BOOL3_DEFAULT,
+    false,
+    0,
+    0);
+
+  GOSoundResample resample;
+  GOSoundStream stream;
+
+  // PickEndSegment uses rand(); seed for reproducibility of the test path.
+  std::srand(0);
+  stream.InitStream(
+    &resample,
+    pSection.get(),
+    GOSoundResample::GO_LINEAR_INTERPOLATION,
+    SAMPLE_RATE_ADJUSTMENT);
+
+  float buffer[N_BUFFER_ITEMS];
+
+  for (unsigned iterI = 0; iterI < N_ITERATIONS; iterI++) {
+    const bool result = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+
+    GOAssert(
+      result,
+      std::format(
+        "ReadBlock should always return true across loop-segment "
+        "transitions with different end_pos (iteration {})",
+        iterI));
+  }
+}
+
 void GOTestSoundStream::run() {
   for (unsigned nChannels : {1u, 2u}) {
     for (bool isCompressed : {false, true}) {
@@ -173,5 +241,6 @@ void GOTestSoundStream::run() {
     }
   }
   TestLoopedStreamAlwaysReturnsTrue();
+  TestLoopTransitionAcrossDifferentEndPos();
   TestInitAlignedStream();
 }

--- a/src/tests/testing/sound/playing/GOTestSoundStream.h
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDSTREAM_H
+#define GOTESTSOUNDSTREAM_H
+
+#include <memory>
+#include <string>
+
+#include "sound/playing/GOSoundResample.h"
+
+#include "GOMemoryPool.h"
+#include "GOTest.h"
+
+class GOSoundAudioSection;
+struct GOWaveLoop;
+
+class GOTestSoundStream : public GOTest {
+private:
+  static const std::string TEST_NAME;
+
+  GOMemoryPool m_pool;
+
+  /**
+   * Creates an audio section with nChannels channels and nFrames frames
+   * of synthetic GOInt24 PCM data at 48000 Hz sample rate.
+   * If isCompressed is true, the data is stored in compressed format.
+   * If pLoop is not null, the section is created with the given loop points.
+   */
+  std::unique_ptr<GOSoundAudioSection> CreateAudioSection(
+    unsigned nChannels,
+    unsigned nFrames,
+    bool isCompressed,
+    const GOWaveLoop *pLoop = nullptr);
+
+  /**
+   * Tests ReadBlock for the given interpolation, compression and channel
+   * combination. Verifies true while frames available, false on exhaustion,
+   * and zeros after end.
+   */
+  void TestReadBlock(
+    GOSoundResample::InterpolationType interpolationType,
+    bool isCompressed,
+    unsigned nChannels);
+
+  /**
+   * Tests that ReadBlock always returns true for a looped stream,
+   * running 100 iterations of 50 frames each.
+   */
+  void TestLoopedStreamAlwaysReturnsTrue();
+
+  /**
+   * Tests InitAlignedStream with real release alignment.
+   * Verifies that ReadBlock returns true after alignment.
+   */
+  void TestInitAlignedStream();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTSOUNDSTREAM_H */

--- a/src/tests/testing/sound/playing/GOTestSoundStream.h
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.h
@@ -53,6 +53,14 @@ private:
   void TestLoopedStreamAlwaysReturnsTrue();
 
   /**
+   * Tests that wrap-around between loop segments with different end_pos
+   * keeps the source position consistent. Catches a regression where
+   * ReadBlock used the new segment's end_pos instead of the previous one
+   * when computing the post-wrap position.
+   */
+  void TestLoopTransitionAcrossDifferentEndPos();
+
+  /**
    * Tests InitAlignedStream with real release alignment.
    * Verifies that ReadBlock returns true after alignment.
    */


### PR DESCRIPTION
This PR introduces the new GOSoundStream functions: getDecodeBlockFunctionFor, GoToStartSegment, InitFromSection. It simplifies the code of InitStream, InitAlignedStream and ReadBlock.

It also adds some unit tests for these functions.

It is just refactoring. No GO behavior should be changed.