### PR TITLE
Reordered getters and setters in GOSoundOrganEngine

### DIFF
--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -60,6 +60,134 @@ GOSoundOrganEngine::~GOSoundOrganEngine() {
     delete m_ReleaseProcessor;
 }
 
+void GOSoundOrganEngine::SetVolume(int volume) {
+  m_Volume = volume;
+  m_Gain = powf(10.0f, m_Volume * 0.05f);
+}
+
+void GOSoundOrganEngine::SetHardPolyphony(unsigned polyphony) {
+  m_SamplerPool.SetUsageLimit(polyphony);
+  m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
+}
+
+void GOSoundOrganEngine::SetAudioGroupCount(unsigned groups) {
+  if (groups < 1)
+    groups = 1;
+  m_AudioGroupCount = groups;
+  m_AudioGroupTasks.clear();
+  for (unsigned i = 0; i < m_AudioGroupCount; i++)
+    m_AudioGroupTasks.push_back(
+      new GOSoundGroupTask(*this, m_SamplesPerBuffer));
+}
+
+void GOSoundOrganEngine::SetAudioOutput(
+  std::vector<GOAudioOutputConfiguration> audio_outputs) {
+  m_AudioOutputTasks.clear();
+  {
+    std::vector<float> scale_factors;
+    scale_factors.resize(m_AudioGroupCount * 2 * 2);
+    std::fill(scale_factors.begin(), scale_factors.end(), 0.0f);
+    for (unsigned i = 0; i < m_AudioGroupCount; i++) {
+      scale_factors[i * 4] = 1;
+      scale_factors[i * 4 + 3] = 1;
+    }
+    m_AudioOutputTasks.push_back(
+      new GOSoundOutputTask(2, scale_factors, m_SamplesPerBuffer));
+  }
+  unsigned channels = 0;
+  for (unsigned i = 0; i < audio_outputs.size(); i++) {
+    std::vector<float> scale_factors;
+    scale_factors.resize(m_AudioGroupCount * audio_outputs[i].channels * 2);
+    std::fill(scale_factors.begin(), scale_factors.end(), 0.0f);
+    for (unsigned j = 0; j < audio_outputs[i].channels; j++)
+      for (unsigned k = 0; k < audio_outputs[i].scale_factors[j].size(); k++) {
+        if (k >= m_AudioGroupCount * 2)
+          continue;
+        float factor = audio_outputs[i].scale_factors[j][k];
+        if (factor >= -120 && factor < 40)
+          factor = powf(10.0f, factor * 0.05f);
+        else
+          factor = 0;
+        scale_factors[j * m_AudioGroupCount * 2 + k] = factor;
+      }
+    m_AudioOutputTasks.push_back(new GOSoundOutputTask(
+      audio_outputs[i].channels, scale_factors, m_SamplesPerBuffer));
+    channels += audio_outputs[i].channels;
+  }
+  std::vector<GOSoundBufferTaskBase *> outputs;
+  for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
+    outputs.push_back(m_AudioGroupTasks[i]);
+  for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
+    m_AudioOutputTasks[i]->SetOutputs(outputs);
+  {
+    // Control thread: prevent GetMeterInfo() from reading the buffer while it
+    // is being replaced. SetAudioOutput() is called only when all audio
+    // callbacks are stopped (between StopSoundSystem and StartSoundSystem),
+    // so the audio thread is not accessing p_MeterInfo concurrently.
+    GOMutexLocker locker(m_MeterMutex);
+
+    if (mp_MeterInfo->size() != channels) {
+      auto newInfo
+        = std::make_unique<std::vector<std::atomic<float>>>(channels);
+
+      // Prior to C++20, std::atomic default construction does not
+      // zero-initialize the value; initialize explicitly for safety.
+      for (auto &v : *newInfo)
+        v.store(0.0f, std::memory_order_relaxed);
+
+      // Store the new pointer before destroying the old vector so that
+      // p_MeterInfo always points to a valid object.
+      // release: the audio thread will see the new vector (size + data) via
+      // acquire-load of p_MeterInfo on the next NextPeriod() call.
+      p_MeterInfo.store(newInfo.get(), std::memory_order_release);
+      mp_MeterInfo = std::move(newInfo);
+    }
+  }
+}
+
+void GOSoundOrganEngine::SetupReverb(GOConfig &settings) {
+  const GOSoundReverb::ReverbConfig reverbConfig
+    = GOSoundReverb::createReverbConfig(settings);
+
+  for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
+    if (m_AudioOutputTasks[i])
+      m_AudioOutputTasks[i]->SetupReverb(
+        reverbConfig, settings.SamplesPerBuffer(), settings.SampleRate());
+}
+
+void GOSoundOrganEngine::SetAudioRecorder(
+  GOSoundRecorder *recorder, bool downmix) {
+  m_AudioRecorder = recorder;
+  std::vector<GOSoundBufferTaskBase *> outputs;
+  if (downmix)
+    outputs.push_back(m_AudioOutputTasks[0]);
+  else {
+    m_Scheduler.Remove(m_AudioOutputTasks[0]);
+    delete m_AudioOutputTasks[0];
+    m_AudioOutputTasks[0] = NULL;
+    for (unsigned i = 1; i < m_AudioOutputTasks.size(); i++)
+      outputs.push_back(m_AudioOutputTasks[i]);
+  }
+  m_AudioRecorder->SetOutputs(outputs, m_SamplesPerBuffer);
+}
+
+std::vector<float> GOSoundOrganEngine::GetMeterInfo() {
+  // GUI thread: m_MeterMutex prevents concurrent replacement by SetAudioOutput
+  GOMutexLocker locker(m_MeterMutex);
+  std::vector<std::atomic<float>> &info = *p_MeterInfo.load();
+  const unsigned hardPolyphony = GetHardPolyphony();
+  std::vector<float> result(info.size() + 1);
+  float *pResult = result.data();
+
+  assert(hardPolyphony > 0);
+  // exchange(0) reads accumulated max and resets it for the next poll
+  *(pResult++)
+    = m_UsedPolyphony.exchange(0) / static_cast<float>(hardPolyphony);
+  for (std::atomic<float> &v : info)
+    *(pResult++) = v.exchange(0.0f);
+  return result;
+}
+
 void GOSoundOrganEngine::Reset() {
   if (m_HasBeenSetup.load()) {
     for (unsigned i = 0; i < m_WindchestTasks.size(); i++)
@@ -88,24 +216,41 @@ void GOSoundOrganEngine::Reset() {
   m_Scheduler.Reset();
 }
 
-void GOSoundOrganEngine::SetVolume(int volume) {
-  m_Volume = volume;
-  m_Gain = powf(10.0f, m_Volume * 0.05f);
+void GOSoundOrganEngine::Setup(
+  GOOrganModel &organModel, GOMemoryPool &memoryPool, unsigned releaseCount) {
+  m_Scheduler.Clear();
+  if (releaseCount < 1)
+    releaseCount = 1;
+  m_Scheduler.SetRepeatCount(releaseCount);
+  m_TremulantTasks.clear();
+  for (unsigned i = 0; i < organModel.GetTremulantCount(); i++)
+    m_TremulantTasks.push_back(
+      new GOSoundTremulantTask(*this, m_SamplesPerBuffer));
+  m_WindchestTasks.clear();
+  // a special windchest task for detached releases
+  m_WindchestTasks.push_back(new GOSoundWindchestTask(*this, NULL));
+  for (unsigned i = 0; i < organModel.GetWindchestCount(); i++)
+    m_WindchestTasks.push_back(
+      new GOSoundWindchestTask(*this, organModel.GetWindchest(i)));
+  m_TouchTask
+    = std::unique_ptr<GOSoundTouchTask>(new GOSoundTouchTask(memoryPool));
+  m_HasBeenSetup.store(true);
+  Reset();
 }
 
-void GOSoundOrganEngine::SetHardPolyphony(unsigned polyphony) {
-  m_SamplerPool.SetUsageLimit(polyphony);
-  m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
-}
+void GOSoundOrganEngine::ClearSetup() {
+  m_HasBeenSetup.store(false);
 
-void GOSoundOrganEngine::SetAudioGroupCount(unsigned groups) {
-  if (groups < 1)
-    groups = 1;
-  m_AudioGroupCount = groups;
-  m_AudioGroupTasks.clear();
-  for (unsigned i = 0; i < m_AudioGroupCount; i++)
-    m_AudioGroupTasks.push_back(
-      new GOSoundGroupTask(*this, m_SamplesPerBuffer));
+  // the winchests may be still used from audio callbacks.
+  // clear the pending sound before destroying the windchests
+  for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
+    m_AudioGroupTasks[i]->WaitAndClear();
+
+  m_Scheduler.Clear();
+  m_WindchestTasks.clear();
+  m_TremulantTasks.clear();
+  m_TouchTask = NULL;
+  Reset();
 }
 
 float GOSoundOrganEngine::GetRandomFactor() const {
@@ -135,43 +280,6 @@ void GOSoundOrganEngine::StartSampler(GOSoundSampler *sampler) {
     ? m_WindchestTasks[windchestTaskToIndex(taskId)]
     : nullptr;
   PassSampler(sampler);
-}
-
-void GOSoundOrganEngine::ClearSetup() {
-  m_HasBeenSetup.store(false);
-
-  // the winchests may be still used from audio callbacks.
-  // clear the pending sound before destroying the windchests
-  for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
-    m_AudioGroupTasks[i]->WaitAndClear();
-
-  m_Scheduler.Clear();
-  m_WindchestTasks.clear();
-  m_TremulantTasks.clear();
-  m_TouchTask = NULL;
-  Reset();
-}
-
-void GOSoundOrganEngine::Setup(
-  GOOrganModel &organModel, GOMemoryPool &memoryPool, unsigned releaseCount) {
-  m_Scheduler.Clear();
-  if (releaseCount < 1)
-    releaseCount = 1;
-  m_Scheduler.SetRepeatCount(releaseCount);
-  m_TremulantTasks.clear();
-  for (unsigned i = 0; i < organModel.GetTremulantCount(); i++)
-    m_TremulantTasks.push_back(
-      new GOSoundTremulantTask(*this, m_SamplesPerBuffer));
-  m_WindchestTasks.clear();
-  // a special windchest task for detached releases
-  m_WindchestTasks.push_back(new GOSoundWindchestTask(*this, NULL));
-  for (unsigned i = 0; i < organModel.GetWindchestCount(); i++)
-    m_WindchestTasks.push_back(
-      new GOSoundWindchestTask(*this, organModel.GetWindchest(i)));
-  m_TouchTask
-    = std::unique_ptr<GOSoundTouchTask>(new GOSoundTouchTask(memoryPool));
-  m_HasBeenSetup.store(true);
-  Reset();
 }
 
 bool GOSoundOrganEngine::ProcessSampler(
@@ -242,97 +350,6 @@ void GOSoundOrganEngine::ProcessRelease(GOSoundSampler *sampler) {
 
 void GOSoundOrganEngine::ReturnSampler(GOSoundSampler *sampler) {
   m_SamplerPool.ReturnSampler(sampler);
-}
-
-void GOSoundOrganEngine::SetAudioOutput(
-  std::vector<GOAudioOutputConfiguration> audio_outputs) {
-  m_AudioOutputTasks.clear();
-  {
-    std::vector<float> scale_factors;
-    scale_factors.resize(m_AudioGroupCount * 2 * 2);
-    std::fill(scale_factors.begin(), scale_factors.end(), 0.0f);
-    for (unsigned i = 0; i < m_AudioGroupCount; i++) {
-      scale_factors[i * 4] = 1;
-      scale_factors[i * 4 + 3] = 1;
-    }
-    m_AudioOutputTasks.push_back(
-      new GOSoundOutputTask(2, scale_factors, m_SamplesPerBuffer));
-  }
-  unsigned channels = 0;
-  for (unsigned i = 0; i < audio_outputs.size(); i++) {
-    std::vector<float> scale_factors;
-    scale_factors.resize(m_AudioGroupCount * audio_outputs[i].channels * 2);
-    std::fill(scale_factors.begin(), scale_factors.end(), 0.0f);
-    for (unsigned j = 0; j < audio_outputs[i].channels; j++)
-      for (unsigned k = 0; k < audio_outputs[i].scale_factors[j].size(); k++) {
-        if (k >= m_AudioGroupCount * 2)
-          continue;
-        float factor = audio_outputs[i].scale_factors[j][k];
-        if (factor >= -120 && factor < 40)
-          factor = powf(10.0f, factor * 0.05f);
-        else
-          factor = 0;
-        scale_factors[j * m_AudioGroupCount * 2 + k] = factor;
-      }
-    m_AudioOutputTasks.push_back(new GOSoundOutputTask(
-      audio_outputs[i].channels, scale_factors, m_SamplesPerBuffer));
-    channels += audio_outputs[i].channels;
-  }
-  std::vector<GOSoundBufferTaskBase *> outputs;
-  for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
-    outputs.push_back(m_AudioGroupTasks[i]);
-  for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
-    m_AudioOutputTasks[i]->SetOutputs(outputs);
-  {
-    // Control thread: prevent GetMeterInfo() from reading the buffer while it
-    // is being replaced. SetAudioOutput() is called only when all audio
-    // callbacks are stopped (between StopSoundSystem and StartSoundSystem),
-    // so the audio thread is not accessing p_MeterInfo concurrently.
-    GOMutexLocker locker(m_MeterMutex);
-
-    if (mp_MeterInfo->size() != channels) {
-      auto newInfo
-        = std::make_unique<std::vector<std::atomic<float>>>(channels);
-
-      // Prior to C++20, std::atomic default construction does not
-      // zero-initialize the value; initialize explicitly for safety.
-      for (auto &v : *newInfo)
-        v.store(0.0f, std::memory_order_relaxed);
-
-      // Store the new pointer before destroying the old vector so that
-      // p_MeterInfo always points to a valid object.
-      // release: the audio thread will see the new vector (size + data) via
-      // acquire-load of p_MeterInfo on the next NextPeriod() call.
-      p_MeterInfo.store(newInfo.get(), std::memory_order_release);
-      mp_MeterInfo = std::move(newInfo);
-    }
-  }
-}
-
-void GOSoundOrganEngine::SetAudioRecorder(
-  GOSoundRecorder *recorder, bool downmix) {
-  m_AudioRecorder = recorder;
-  std::vector<GOSoundBufferTaskBase *> outputs;
-  if (downmix)
-    outputs.push_back(m_AudioOutputTasks[0]);
-  else {
-    m_Scheduler.Remove(m_AudioOutputTasks[0]);
-    delete m_AudioOutputTasks[0];
-    m_AudioOutputTasks[0] = NULL;
-    for (unsigned i = 1; i < m_AudioOutputTasks.size(); i++)
-      outputs.push_back(m_AudioOutputTasks[i]);
-  }
-  m_AudioRecorder->SetOutputs(outputs, m_SamplesPerBuffer);
-}
-
-void GOSoundOrganEngine::SetupReverb(GOConfig &settings) {
-  const GOSoundReverb::ReverbConfig reverbConfig
-    = GOSoundReverb::createReverbConfig(settings);
-
-  for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
-    if (m_AudioOutputTasks[i])
-      m_AudioOutputTasks[i]->SetupReverb(
-        reverbConfig, settings.SamplesPerBuffer(), settings.SampleRate());
 }
 
 unsigned GOSoundOrganEngine::GetBufferSizeFor(
@@ -695,21 +712,4 @@ void GOSoundOrganEngine::UpdateVelocity(
     handle->velocity = velocity;
     handle->fader.SetVelocityVolume(pipe->GetVelocityVolume(velocity));
   }
-}
-
-std::vector<float> GOSoundOrganEngine::GetMeterInfo() {
-  // GUI thread: m_MeterMutex prevents concurrent replacement by SetAudioOutput
-  GOMutexLocker locker(m_MeterMutex);
-  std::vector<std::atomic<float>> &info = *p_MeterInfo.load();
-  const unsigned hardPolyphony = GetHardPolyphony();
-  std::vector<float> result(info.size() + 1);
-  float *pResult = result.data();
-
-  assert(hardPolyphony > 0);
-  // exchange(0) reads accumulated max and resets it for the next poll
-  *(pResult++)
-    = m_UsedPolyphony.exchange(0) / static_cast<float>(hardPolyphony);
-  for (std::atomic<float> &v : info)
-    *(pResult++) = v.exchange(0.0f);
-  return result;
 }

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -157,33 +157,48 @@ private:
 public:
   GOSoundOrganEngine();
   ~GOSoundOrganEngine();
+
+  // Group 1: Independent setters (no call-order dependencies)
+  unsigned GetSampleRate() const override { return m_SampleRate; }
+  void SetSampleRate(unsigned sample_rate) { m_SampleRate = sample_rate; }
+  void SetSamplesPerBuffer(unsigned sample_per_buffer) {
+    m_SamplesPerBuffer = sample_per_buffer;
+  }
+  int GetVolume() const { return m_Volume; }
+  void SetVolume(int volume);
+  unsigned GetHardPolyphony() const { return m_SamplerPool.GetUsageLimit(); }
+  void SetHardPolyphony(unsigned polyphony);
+  void SetPolyphonyLimiting(bool limiting) { m_PolyphonyLimiting = limiting; }
+  void SetScaledReleases(bool enable) { m_ScaledReleases = enable; }
+  void SetRandomizeSpeaking(bool enable) { m_RandomizeSpeaking = enable; }
+  void SetInterpolationType(unsigned type) {
+    m_interpolation = (GOSoundResample::InterpolationType)type;
+  }
+
+  // Group 2: Dependent setters (must be called in this order)
+  // Must be called after SetSamplesPerBuffer because uses m_SamplesPerBuffer
+  unsigned GetAudioGroupCount() const { return m_AudioGroupCount; }
+  void SetAudioGroupCount(unsigned groups);
+  // Must be called after SetAudioGroupCount because uses m_AudioGroupCount and
+  // m_SamplesPerBuffer
+  void SetAudioOutput(std::vector<GOAudioOutputConfiguration> audio_outputs);
+  // Must be called after SetAudioOutput because iterates m_AudioOutputTasks
+  void SetupReverb(GOConfig &settings);
+  // Must be called after SetAudioOutput because uses m_AudioOutputTasks
+  void SetAudioRecorder(GOSoundRecorder *recorder, bool downmix);
+
+  // Group 3: Other getters
+  float GetGain() const { return m_Gain; }
+  uint64_t GetTime() const { return m_CurrentTime; }
+  std::vector<float> GetMeterInfo();
+  GOSoundScheduler &GetScheduler() { return m_Scheduler; }
+
   void Reset();
   void Setup(
     GOOrganModel &organModel,
     GOMemoryPool &memoryPool,
     unsigned releaseCount = 1);
   void ClearSetup();
-  void SetAudioOutput(std::vector<GOAudioOutputConfiguration> audio_outputs);
-  void SetupReverb(GOConfig &settings);
-  void SetVolume(int volume);
-  void SetSampleRate(unsigned sample_rate) { m_SampleRate = sample_rate; }
-  void SetSamplesPerBuffer(unsigned sample_per_buffer) {
-    m_SamplesPerBuffer = sample_per_buffer;
-  }
-  void SetInterpolationType(unsigned type) {
-    m_interpolation = (GOSoundResample::InterpolationType)type;
-  }
-  unsigned GetSampleRate() const override { return m_SampleRate; }
-  void SetAudioGroupCount(unsigned groups);
-  unsigned GetAudioGroupCount() const { return m_AudioGroupCount; }
-  void SetHardPolyphony(unsigned polyphony);
-  void SetPolyphonyLimiting(bool limiting) { m_PolyphonyLimiting = limiting; }
-  unsigned GetHardPolyphony() const { return m_SamplerPool.GetUsageLimit(); }
-  int GetVolume() const { return m_Volume; }
-  void SetScaledReleases(bool enable) { m_ScaledReleases = enable; }
-  void SetRandomizeSpeaking(bool enable) { m_RandomizeSpeaking = enable; }
-  std::vector<float> GetMeterInfo();
-  void SetAudioRecorder(GOSoundRecorder *recorder, bool downmix);
 
   GOSoundSampler *StartPipeSample(
     const GOSoundProvider *pipeProvider,
@@ -225,15 +240,12 @@ public:
   void GetAudioOutput(
     unsigned outputIndex, bool isLast, GOSoundBufferMutable &outBuffer);
   void NextPeriod();
-  GOSoundScheduler &GetScheduler() { return m_Scheduler; }
 
   bool ProcessSampler(
     float *buffer, GOSoundSampler *sampler, unsigned n_frames, float volume);
   void ProcessRelease(GOSoundSampler *sampler);
   void PassSampler(GOSoundSampler *sampler);
   void ReturnSampler(GOSoundSampler *sampler);
-  float GetGain() const { return m_Gain; }
-  uint64_t GetTime() const { return m_CurrentTime; }
 };
 
 #endif /* GOSOUNDORGANENGINE_H */


### PR DESCRIPTION
Now GOSoundOrganEngine starting up and shutting down are very fragile: there are lots of setters that affect to the result of other setters. So their calling order is important, and calling setters in a wrong order may cause incorrect operatings or even a crash.

I'm going to make starting/stopping more robust. The first step is documenting existing setters and the required calling order.

This PR splits the setters into three groups: Independent, Dependent and State getters. It also adds comments to setters: what of them depend on other.

It also reorders their declaration and their code in the intended calling order.

No GrandOrgue methods code are changed. So no GO behavior should be changed.