### PR TITLE
Removed GOGUIPanel::LoadImage and GOGUIPanel::GetWoodImage

### DIFF
--- a/src/grandorgue/gui/panels/GOGUIButton.cpp
+++ b/src/grandorgue/gui/panels/GOGUIButton.cpp
@@ -18,6 +18,7 @@
 #include "GOGUILayoutEngine.h"
 #include "GOGUIMouseState.h"
 #include "GOGUIPanel.h"
+#include "GOImageCache.h"
 
 GOGUIButton::GOGUIButton(
   GOGUIPanel *panel, GOButtonControl *control, bool is_piston)
@@ -77,8 +78,10 @@ void GOGUIButton::Init(
   on_mask_file = wxEmptyString;
   off_mask_file = on_mask_file;
 
-  m_OnBitmap.SetSourceImage(m_panel->LoadImage(on_file, on_mask_file));
-  m_OffBitmap.SetSourceImage(m_panel->LoadImage(off_file, off_mask_file));
+  GOImageCache &imageCache = m_panel->GetImageCache();
+
+  m_OnBitmap.SetSourceImage(imageCache.LoadImage(on_file, on_mask_file));
+  m_OffBitmap.SetSourceImage(imageCache.LoadImage(off_file, off_mask_file));
 
   x = -1;
   y = -1;
@@ -207,8 +210,10 @@ void GOGUIButton::Load(GOConfigReader &cfg, wxString group) {
   off_mask_file = cfg.ReadStringTrim(
     ODFSetting, group, wxT("MaskOff"), false, on_mask_file);
 
-  m_OnBitmap.SetSourceImage(m_panel->LoadImage(on_file, on_mask_file));
-  m_OffBitmap.SetSourceImage(m_panel->LoadImage(off_file, off_mask_file));
+  GOImageCache &imageCache = m_panel->GetImageCache();
+
+  m_OnBitmap.SetSourceImage(imageCache.LoadImage(on_file, on_mask_file));
+  m_OffBitmap.SetSourceImage(imageCache.LoadImage(off_file, off_mask_file));
 
   x = cfg.ReadInteger(
     ODFSetting,

--- a/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
+++ b/src/grandorgue/gui/panels/GOGUIEnclosure.cpp
@@ -18,6 +18,7 @@
 #include "GOGUILayoutEngine.h"
 #include "GOGUIMouseState.h"
 #include "GOGUIPanel.h"
+#include "GOImageCache.h"
 
 GOGUIEnclosure::GOGUIEnclosure(GOGUIPanel *panel, GOEnclosure *control)
   : GOGUIMidiControl(panel, control, control),
@@ -45,7 +46,8 @@ void GOGUIEnclosure::Init(GOConfigReader &cfg, wxString group) {
       wxT(GOBitmapPrefix "enclosure%c%02d"), wxT('B'), i - 1);
 
     m_Bitmaps.emplace_back();
-    m_Bitmaps.back().SetSourceImage(m_panel->LoadImage(bitmap, wxEmptyString));
+    m_Bitmaps.back().SetSourceImage(
+      m_panel->GetImageCache().LoadImage(bitmap, wxEmptyString));
   }
 
   for (unsigned i = 1; i < m_Bitmaps.size(); i++)
@@ -121,7 +123,8 @@ void GOGUIEnclosure::Load(GOConfigReader &cfg, wxString group) {
       false,
       wxEmptyString);
     m_Bitmaps.emplace_back();
-    m_Bitmaps.back().SetSourceImage(m_panel->LoadImage(bitmap, mask));
+    m_Bitmaps.back().SetSourceImage(
+      m_panel->GetImageCache().LoadImage(bitmap, mask));
   }
 
   for (unsigned i = 1; i < m_Bitmaps.size(); i++)

--- a/src/grandorgue/gui/panels/GOGUIHW1Background.cpp
+++ b/src/grandorgue/gui/panels/GOGUIHW1Background.cpp
@@ -12,6 +12,7 @@
 #include "GOGUIDisplayMetrics.h"
 #include "GOGUILayoutEngine.h"
 #include "GOGUIPanel.h"
+#include "GOImageCache.h"
 
 GOGUIHW1Background::GOGUIHW1Background(GOGUIPanel *panel)
   : GOGUIControl(panel, NULL), m_Images() {}
@@ -24,12 +25,15 @@ bool is_rect_valid(wxRect &rect) { return rect.width > 0 && rect.height > 0; }
 
 void GOGUIHW1Background::Layout() {
   m_Images.clear();
+
+  GOImageCache &imageCache = m_panel->GetImageCache();
   wxRect rect;
 
   rect = wxRect(0, 0, m_layout->GetCenterX(), m_metrics->GetScreenHeight());
   if (is_rect_valid(rect))
     m_Images.emplace_back(
-      rect, m_panel->GetWoodImage(m_metrics->GetDrawstopBackgroundImageNum()));
+      rect,
+      imageCache.GetWoodImage(m_metrics->GetDrawstopBackgroundImageNum()));
   rect = wxRect(
     m_layout->GetCenterX() + m_layout->GetCenterWidth(),
     0,
@@ -38,7 +42,8 @@ void GOGUIHW1Background::Layout() {
     m_metrics->GetScreenHeight());
   if (is_rect_valid(rect))
     m_Images.emplace_back(
-      rect, m_panel->GetWoodImage(m_metrics->GetDrawstopBackgroundImageNum()));
+      rect,
+      imageCache.GetWoodImage(m_metrics->GetDrawstopBackgroundImageNum()));
   rect = wxRect(
     m_layout->GetCenterX(),
     0,
@@ -46,7 +51,7 @@ void GOGUIHW1Background::Layout() {
     m_metrics->GetScreenHeight());
   if (is_rect_valid(rect))
     m_Images.emplace_back(
-      rect, m_panel->GetWoodImage(m_metrics->GetConsoleBackgroundImageNum()));
+      rect, imageCache.GetWoodImage(m_metrics->GetConsoleBackgroundImageNum()));
 
   if (m_metrics->HasPairDrawstopCols()) {
     for (unsigned i = 0; i < (m_metrics->NumberOfDrawstopColsToDisplay() >> 2);
@@ -60,7 +65,7 @@ void GOGUIHW1Background::Layout() {
       if (is_rect_valid(rect))
         m_Images.emplace_back(
           rect,
-          m_panel->GetWoodImage(
+          imageCache.GetWoodImage(
             m_metrics->GetDrawstopInsetBackgroundImageNum()));
       rect = wxRect(
         i * (2 * m_metrics->GetDrawstopWidth() + 18) + m_layout->GetJambRightX()
@@ -71,7 +76,7 @@ void GOGUIHW1Background::Layout() {
       if (is_rect_valid(rect))
         m_Images.emplace_back(
           rect,
-          m_panel->GetWoodImage(
+          imageCache.GetWoodImage(
             m_metrics->GetDrawstopInsetBackgroundImageNum()));
     }
   }
@@ -84,7 +89,8 @@ void GOGUIHW1Background::Layout() {
       8);
     if (is_rect_valid(rect))
       m_Images.emplace_back(
-        rect, m_panel->GetWoodImage(m_metrics->GetKeyVertBackgroundImageNum()));
+        rect,
+        imageCache.GetWoodImage(m_metrics->GetKeyVertBackgroundImageNum()));
   }
 
   if (m_layout->GetJambTopHeight() + m_layout->GetPistonTopHeight()) {
@@ -96,7 +102,7 @@ void GOGUIHW1Background::Layout() {
     if (is_rect_valid(rect))
       m_Images.emplace_back(
         rect,
-        m_panel->GetWoodImage(m_metrics->GetKeyHorizBackgroundImageNum()));
+        imageCache.GetWoodImage(m_metrics->GetKeyHorizBackgroundImageNum()));
   }
 }
 

--- a/src/grandorgue/gui/panels/GOGUIImage.cpp
+++ b/src/grandorgue/gui/panels/GOGUIImage.cpp
@@ -7,11 +7,12 @@
 
 #include "GOGUIImage.h"
 
+#include "config/GOConfigReader.h"
 #include "primitives/GODC.h"
 
 #include "GOGUIDisplayMetrics.h"
 #include "GOGUIPanel.h"
-#include "config/GOConfigReader.h"
+#include "GOImageCache.h"
 
 GOGUIImage::GOGUIImage(GOGUIPanel *panel)
   : GOGUIControl(panel, NULL), m_TileOffsetX(0), m_TileOffsetY(0) {}
@@ -26,7 +27,8 @@ void GOGUIImage::Load(GOConfigReader &cfg, wxString group) {
   image_mask_file
     = cfg.ReadStringTrim(ODFSetting, group, wxT("Mask"), false, wxEmptyString);
 
-  m_Bitmap.SetSourceImage(m_panel->LoadImage(image_file, image_mask_file));
+  m_Bitmap.SetSourceImage(
+    m_panel->GetImageCache().LoadImage(image_file, image_mask_file));
 
   x = cfg.ReadInteger(
     ODFSetting,

--- a/src/grandorgue/gui/panels/GOGUILabel.cpp
+++ b/src/grandorgue/gui/panels/GOGUILabel.cpp
@@ -75,7 +75,7 @@ void GOGUILabel::InitBackgroundBitmap(
   if (!imageFileName.IsEmpty()) {
     m_PBackgroundBitmap = new GOBitmap();
     m_PBackgroundBitmap->SetSourceImage(
-      m_panel->LoadImage(imageFileName, imageMaskFilename));
+      m_panel->GetImageCache().LoadImage(imageFileName, imageMaskFilename));
   }
 
   // take the size from the bitmap if it is not specified

--- a/src/grandorgue/gui/panels/GOGUIManual.cpp
+++ b/src/grandorgue/gui/panels/GOGUIManual.cpp
@@ -18,6 +18,7 @@
 #include "GOGUILayoutEngine.h"
 #include "GOGUIMouseState.h"
 #include "GOGUIPanel.h"
+#include "GOImageCache.h"
 
 GOGUIManual::GOGUIManual(
   GOGUIPanel *panel, GOManual *manual, unsigned manual_number)
@@ -100,10 +101,12 @@ void GOGUIManual::Init(GOConfigReader &cfg, wxString group) {
     on_mask_file = wxEmptyString;
     off_mask_file = on_mask_file;
 
+    GOImageCache &imageCache = m_panel->GetImageCache();
+
     m_Keys[i].OnBitmap.SetSourceImage(
-      m_panel->LoadImage(on_file, on_mask_file));
+      imageCache.LoadImage(on_file, on_mask_file));
     m_Keys[i].OffBitmap.SetSourceImage(
-      m_panel->LoadImage(off_file, off_mask_file));
+      imageCache.LoadImage(off_file, off_mask_file));
 
     if (
       m_Keys[i].OnBitmap.GetSourceWidth()
@@ -307,10 +310,12 @@ void GOGUIManual::Load(GOConfigReader &cfg, wxString group) {
       false,
       off_mask_file);
 
+    GOImageCache &imageCache = m_panel->GetImageCache();
+
     m_Keys[i].OnBitmap.SetSourceImage(
-      m_panel->LoadImage(on_file, on_mask_file));
+      imageCache.LoadImage(on_file, on_mask_file));
     m_Keys[i].OffBitmap.SetSourceImage(
-      m_panel->LoadImage(off_file, off_mask_file));
+      imageCache.LoadImage(off_file, off_mask_file));
 
     if (
       m_Keys[i].OnBitmap.GetSourceWidth()

--- a/src/grandorgue/gui/panels/GOGUIManualBackground.cpp
+++ b/src/grandorgue/gui/panels/GOGUIManualBackground.cpp
@@ -14,6 +14,7 @@
 #include "GOGUIDisplayMetrics.h"
 #include "GOGUILayoutEngine.h"
 #include "GOGUIPanel.h"
+#include "GOImageCache.h"
 
 GOGUIManualBackground::GOGUIManualBackground(
   GOGUIPanel *panel, unsigned manual_number)
@@ -28,13 +29,15 @@ void GOGUIManualBackground::Load(GOConfigReader &cfg, wxString group) {
 }
 
 void GOGUIManualBackground::Layout() {
+  GOImageCache &imageCache = m_panel->GetImageCache();
   const GOGUILayoutEngine::MANUAL_RENDER_INFO &mri
     = m_layout->GetManualRenderInfo(m_ManualNumber);
+
   m_BoundingRect = wxRect(mri.x, mri.y, mri.width, mri.height);
   m_VRect = wxRect(
     m_layout->GetCenterX(), mri.y, m_layout->GetCenterWidth(), mri.height);
   m_VBackground.SetSourceImage(
-    m_panel->GetWoodImage(m_metrics->GetKeyVertBackgroundImageNum()));
+    imageCache.GetWoodImage(m_metrics->GetKeyVertBackgroundImageNum()));
   m_HRect = wxRect(
     m_layout->GetCenterX(),
     mri.piston_y,
@@ -43,7 +46,7 @@ void GOGUIManualBackground::Layout() {
       ? 2 * m_metrics->GetButtonHeight()
       : m_metrics->GetButtonHeight());
   m_HBackground.SetSourceImage(
-    m_panel->GetWoodImage(m_metrics->GetKeyHorizBackgroundImageNum()));
+    imageCache.GetWoodImage(m_metrics->GetKeyHorizBackgroundImageNum()));
 }
 
 void GOGUIManualBackground::PrepareDraw(double scale, GOBitmap *background) {

--- a/src/grandorgue/gui/panels/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanel.cpp
@@ -40,7 +40,8 @@
 #include "Images.h"
 
 GOGUIPanel::GOGUIPanel(GOOrganController *organController)
-  : m_OrganController(organController),
+  : r_ImageCache(organController->GetImageCache()),
+    m_OrganController(organController),
     m_MouseState(organController->GetMouseState()),
     m_controls(0),
     m_BackgroundControls(0),
@@ -65,11 +66,6 @@ GOOrganController *GOGUIPanel::GetOrganFile() { return m_OrganController; }
 const wxString &GOGUIPanel::GetName() { return m_Name; }
 
 const wxString &GOGUIPanel::GetGroupName() { return m_GroupName; }
-
-const wxImage *GOGUIPanel::LoadImage(
-  const wxString &filename, const wxString &maskname) {
-  return m_OrganController->GetImageCache().LoadImage(filename, maskname);
-}
 
 GODocumentBase *GOGUIPanel::GetDocument() const {
   return m_view ? m_view->GetDocument() : nullptr;
@@ -845,8 +841,4 @@ void GOGUIPanel::HandleMouseScroll(int x, int y, int amount) {
   for (unsigned i = 0; i < m_controls.size(); i++)
     if (m_controls[i]->HandleMouseScroll(x, y, amount))
       return;
-}
-
-const wxImage *GOGUIPanel::GetWoodImage(unsigned woodImageNumber) const {
-  return m_OrganController->GetImageCache().GetWoodImage(woodImageNumber);
 }

--- a/src/grandorgue/gui/panels/GOGUIPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIPanel.h
@@ -27,12 +27,15 @@ class GOGUILayoutEngine;
 class GOGUIMouseState;
 class GOGUIPanelView;
 class GOGUIPanelWidget;
+class GOImageCache;
 class GOOrganController;
 
 #define GOBitmapPrefix "../GO:"
 
 class GOGUIPanel : public GOSizeKeeper {
 private:
+  GOImageCache &r_ImageCache;
+
   void BasicLoad(
     GOConfigReader &cfg, const wxString &group, bool isOpenByDefault);
   void LoadButton(
@@ -73,6 +76,9 @@ protected:
 public:
   GOGUIPanel(GOOrganController *organController);
   virtual ~GOGUIPanel();
+
+  GOImageCache &GetImageCache() const { return r_ImageCache; }
+
   void Init(
     GOConfigReader &cfg,
     GOGUIDisplayMetrics *metrics,
@@ -99,8 +105,6 @@ public:
   GOGUILayoutEngine *GetLayoutEngine();
   void PrepareDraw(double scale, GOBitmap *background);
   void Draw(GODC &dc);
-  const wxImage *GetWoodImage(unsigned woodImageNumber) const;
-  const wxImage *LoadImage(const wxString &filename, const wxString &maskname);
   void HandleKey(int key);
   void HandleMousePress(int x, int y, bool right);
   void HandleMouseRelease(bool right);


### PR DESCRIPTION
Since  last commits, both `LoadImage` and `GetWoodImage` are provided by GOImageCache.

Earlier GOGUIPanel  obtained the GOImageCache instance from the GOOrganController one.

This PR:
- Introduces GOGUIPanel::r_ImageCache and GOGUIPanel::GetImageCache
- Removes GOGUIPanel::LoadImage and GOGUIPanel::GetWoodImage so they can be easy replaced with GOGUIPanel::GetImageCache().LoadImage and GOGUIPanel::GetImageCache().GetWoodImage

It is just refactoring. No GO behavior should be changed.