### PR TITLE
Bugfix/open sound asan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: Build
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      asan:
+        description: 'Build with ASAN'
+        type: boolean
+        default: false
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -33,6 +40,7 @@ jobs:
       release_flag: ${{steps.vers.outputs.release_flag}}
       release_id: ${{ steps.create_release.outputs.id }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
+      asan_flag: ${{steps.vers.outputs.asan_flag}}
 
     steps:
     - name: Checkout
@@ -65,10 +73,17 @@ jobs:
           RELEASE_FLAG=ON
         fi
 
+        if [[ "${{ github.event.inputs.asan }}" == "true" ]]; then
+          ASAN_FLAG=asan
+        else
+          ASAN_FLAG=
+        fi
+
         echo "project_ver=$PROJECT_VERSION" >>$GITHUB_OUTPUT
         echo "build_ver=$BUILD_VERSION" >>$GITHUB_OUTPUT
         echo "full_ver=$PROJECT_VERSION-$BUILD_VERSION" >>$GITHUB_OUTPUT
         echo "release_flag=$RELEASE_FLAG" >>$GITHUB_OUTPUT
+        echo "asan_flag=$ASAN_FLAG" >>$GITHUB_OUTPUT
 
     - name: Display versions
       run: |
@@ -76,6 +91,7 @@ jobs:
         echo "build_ver=${{steps.vers.outputs.build_ver}}"
         echo "full_ver=${{steps.vers.outputs.full_ver}}"
         echo "release_flag=${{steps.vers.outputs.release_flag}}"
+        echo "asan_flag=${{steps.vers.outputs.asan_flag}}"
 
     - name: Create Draft Release
       if: ${{ steps.vers.outputs.release_flag == 'ON' }}
@@ -168,7 +184,15 @@ jobs:
       
     - name: Build
       working-directory: ${{github.workspace}}
-      run: ${{github.workspace}}/build-scripts/for-${{ matrix.for }}/build-on-${{ matrix.build_on }}.sh ${{needs.calc_ver.outputs.project_ver}} ${{needs.calc_ver.outputs.build_ver}} ${{github.workspace}} "${{ matrix.pkg_suffix }}"
+      run: >
+        ${{github.workspace}}/build-scripts/for-${{ matrix.for }}/build-on-${{ matrix.build_on }}.sh
+        ${{needs.calc_ver.outputs.project_ver}}
+        ${{needs.calc_ver.outputs.build_ver}}
+        ${{github.workspace}}
+        "${{ matrix.pkg_suffix }}"
+        ${{needs.calc_ver.outputs.release_flag}}
+        ""
+        ${{needs.calc_ver.outputs.asan_flag}}
 
     - name: Upload result
       uses: nanoufo/action-upload-artifacts-and-release-assets@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,58 @@ project(
 set(NUM_VERSION "${PROJECT_VERSION}")
 string(REPLACE "." "," NUM_WIN_VERSION ${NUM_VERSION})
 
+option(RELEASE_FLAG "Build as a release" OFF)
+
+# GO_SPLIT_DEBUG_SYMBOLS: save debug symbols to separate files (.dbg on Linux, .pdb on Windows).
+# Default: always ON on Windows (PDB is always useful); on Linux equals RELEASE_FLAG.
+#
+# Behavior matrix (BT = CMAKE_BUILD_TYPE, GS = GO_SPLIT_DEBUG_SYMBOLS):
+# BT default: Debug when RELEASE_FLAG=OFF/unset, Release when RELEASE_FLAG=ON
+# GS default: ON on Windows; on Linux = RELEASE_FLAG
+#
+# RELEASE_FLAG | CMAKE_BUILD_TYPE | GO_SPLIT_DEBUG_SYMBOLS || Compiler flags | Result (Linux)  | Result (Windows)
+# -------------|------------------|------------------------||----------------|-----------------|------------------
+# unset        | unset            | unset                  || -g3 -Og        | unstripped      | stripped + .pdb
+# unset        | unset            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# unset        | unset            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# unset        | Debug            | unset                  || -g3 -Og        | unstripped      | stripped + .pdb
+# unset        | Debug            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# unset        | Debug            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# unset        | Release          | unset                  || -O3 -g         | stripped        | stripped + .pdb
+# unset        | Release          | OFF                    || -O3 -g         | stripped        | stripped
+# unset        | Release          | ON                     || -O3 -g         | stripped + .dbg | stripped + .pdb
+# OFF          | unset            | unset                  || -g3 -Og        | unstripped      | stripped + .pdb
+# OFF          | unset            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# OFF          | unset            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# OFF          | Debug            | unset                  || -g3 -Og        | unstripped      | stripped + .pdb
+# OFF          | Debug            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# OFF          | Debug            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# OFF          | Release          | unset                  || -O3 -g         | stripped        | stripped + .pdb
+# OFF          | Release          | OFF                    || -O3 -g         | stripped        | stripped
+# OFF          | Release          | ON                     || -O3 -g         | stripped + .dbg | stripped + .pdb
+# ON           | unset            | unset                  || -O3 -g         | stripped + .dbg | stripped + .pdb
+# ON           | unset            | OFF                    || -O3 -g         | stripped        | stripped
+# ON           | unset            | ON                     || -O3 -g         | stripped + .dbg | stripped + .pdb
+# ON           | Debug            | unset                  || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# ON           | Debug            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# ON           | Debug            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# ON           | Release          | unset                  || -O3 -g         | stripped + .dbg | stripped + .pdb
+# ON           | Release          | OFF                    || -O3 -g         | stripped        | stripped
+# ON           | Release          | ON                     || -O3 -g         | stripped + .dbg | stripped + .pdb
+if(WIN32)
+  option(GO_SPLIT_DEBUG_SYMBOLS "Save debug symbols separately (PDB on Windows, .dbg on Linux)" ON)
+else()
+  option(GO_SPLIT_DEBUG_SYMBOLS "Save debug symbols separately (PDB on Windows, .dbg on Linux)" ${RELEASE_FLAG})
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+  if(RELEASE_FLAG)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+  else()
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
+  endif()
+endif()
+
 if(NOT DEFINED BUILD_VERSION)
   set(BUILD_VERSION "0.local")
 elseif(NOT BUILD_VERSION)
@@ -36,6 +88,10 @@ endif()
 
 if (NOT DEFINED GO_BUILD_COVERAGE OR GO_BUILD_COVERAGE STREQUAL "")
   set(GO_BUILD_COVERAGE OFF)
+endif()
+
+if (NOT DEFINED GO_BUILD_ASAN OR GO_BUILD_ASAN STREQUAL "")
+  set(GO_BUILD_ASAN OFF)
 endif()
 
 set(FULL_VERSION "${PROJECT_VERSION}-${BUILD_VERSION}")
@@ -230,6 +286,20 @@ if (GO_BUILD_COVERAGE)
     message(STATUS "============================================================================")
 endif()
 
+if(GO_BUILD_ASAN)
+  add_option(-fsanitize=address)
+  add_option(-fno-omit-frame-pointer)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
+  if(UNIX AND NOT APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libasan")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libasan")
+  endif()
+  message(STATUS "============================================================================")
+  message(STATUS " AddressSanitizer enabled")
+  message(STATUS "============================================================================")
+endif()
+
 add_subdirectory(src/build)
 add_subdirectory(src/images)
 add_subdirectory(src/core)
@@ -367,6 +437,12 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   else()
     set(CPACK_STRIP_FILES ON)
   endif()
+  if(GO_SPLIT_DEBUG_SYMBOLS)
+    set(CPACK_STRIP_FILES OFF)  # stripped via install(CODE) in BuildExecutable/BuildLibrary
+    # Disable RPM's built-in brp-strip: we handle stripping ourselves, and the host strip may
+    # not recognize the target arch ELF (e.g. x86_64 host strip on aarch64 cross-built binaries)
+    string(APPEND CPACK_RPM_SPEC_MORE_DEFINE "%define __strip /bin/true\n%define __objcopy /bin/true\n")
+  endif()
 
   set(CPACK_SYSTEM_NAME "linux")
   set(CPACK_GENERATOR TGZ RPM DEB)
@@ -395,7 +471,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   # On Ubuntu rpmbuild generates a libcurl.so.4(CURL_OPENSSL_4)(64bit) requirement for libcurl.
   # In Fedora libcurl is based on openssl, but libcurl package does not provide such symbol.
   # As a workaround, we set the right symbol manually.
-  set(CPACK_RPM_SPEC_MORE_DEFINE "%global __requires_exclude libcurl.*")
+  string(APPEND CPACK_RPM_SPEC_MORE_DEFINE "%global __requires_exclude libcurl.*")
   if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     # dnf tries to install the 32-bit package on x86_64 if '()(64bit)' is omitted
     set(CPACK_RPM_PACKAGE_REQUIRES "libcurl.so.4()(64bit)")

--- a/build-scripts/for-appimage-x86_64/build-on-linux.sh
+++ b/build-scripts/for-appimage-x86_64/build-on-linux.sh
@@ -3,11 +3,12 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
+# $4 - release flag (ON/OFF, default: OFF)
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$4"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$(readlink -f $3)
@@ -27,7 +28,7 @@ GO_PRMS="-DCMAKE_INSTALL_PREFIX=/usr \
   -DRTAUDIO_USE_JACK=OFF \
   -DRTMIDI_USE_JACK=OFF \
   -DGO_USE_JACK=OFF \
-  -DCMAKE_BUILD_TYPE=Release \
+  $CMAKE_RELEASE_FLAG_PRM \
   $CMAKE_VERSION_PRMS"
 echo "cmake -G \"Unix Makefiles\" $GO_PRMS . $SRC_DIR"
 cmake -G "Unix Makefiles" $GO_PRMS . $SRC_DIR

--- a/build-scripts/for-linux-aarch64/build-on-linux.sh
+++ b/build-scripts/for-linux-aarch64/build-on-linux.sh
@@ -4,11 +4,12 @@
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
 # $4 - package suffix: empty or wx30
+# $5 - release flag (ON/OFF, default: OFF)
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3
@@ -38,13 +39,15 @@ GO_ARM_PRMS="-DCMAKE_SYSTEM_NAME=Linux \
   -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
   -DCMAKE_C_COMPILER=/usr/bin/aarch64-linux-gnu-gcc \
   -DCMAKE_CXX_COMPILER=/usr/bin/aarch64-linux-gnu-g++ \
+  -DCMAKE_OBJCOPY=/usr/bin/aarch64-linux-gnu-objcopy \
   -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 \
   -DCPACK_RPM_PACKAGE_ARCHITECTURE=aarch64 \
   -DIMPORT_EXECUTABLES=../build-tools/ImportExecutables.cmake"
 
-GO_PRMS="-DCMAKE_BUILD_TYPE=Release \
+GO_PRMS="$CMAKE_RELEASE_FLAG_PRM \
   $CMAKE_VERSION_PRMS \
   -DCMAKE_PACKAGE_SUFFIX=$PACKAGE_SUFFIX \
+  -DGO_SPLIT_DEBUG_SYMBOLS=ON \
   $($DIR/../for-linux/cmake-prm-yaml-cpp.bash arm64)"
 
 echo "cmake -G \"Unix Makefiles\" $GO_PRMS . $SRC_DIR"

--- a/build-scripts/for-linux-armhf/build-on-linux.sh
+++ b/build-scripts/for-linux-armhf/build-on-linux.sh
@@ -4,11 +4,12 @@
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
 # $4 - package suffix: empty or wx30
+# $5 - release flag (ON/OFF, default: OFF)
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3
@@ -42,9 +43,10 @@ GO_ARM_PRMS="-DCMAKE_SYSTEM_NAME=Linux \
   -DCPACK_RPM_PACKAGE_ARCHITECTURE=armhf \
   -DIMPORT_EXECUTABLES=../build-tools/ImportExecutables.cmake"
 
-GO_PRMS="-DCMAKE_BUILD_TYPE=Release \
+GO_PRMS="$CMAKE_RELEASE_FLAG_PRM \
   $CMAKE_VERSION_PRMS \
   -DCMAKE_PACKAGE_SUFFIX=$PACKAGE_SUFFIX \
+  -DGO_SPLIT_DEBUG_SYMBOLS=ON \
   $($DIR/../for-linux/cmake-prm-yaml-cpp.bash armhf)"
 
 echo "cmake -G \"Unix Makefiles\" $GO_PRMS . $SRC_DIR"

--- a/build-scripts/for-linux/build-for-tests.sh
+++ b/build-scripts/for-linux/build-for-tests.sh
@@ -2,6 +2,7 @@
 
 # $1 - target deb architecture. Default - current
 # $2 - build type: Debug or Release. Default - Debug
+# $3 - optional: "asan" to enable AddressSanitizer
 
 set -e
 
@@ -22,8 +23,13 @@ if [ "$BUILD_TYPE" = "Debug" ]; then
     COVERAGE_FLAG="-DGO_BUILD_COVERAGE=ON"
 fi
 
+ASAN_FLAG=""
+if [ "${3:-}" = "asan" ]; then
+    ASAN_FLAG="-DGO_BUILD_ASAN=ON"
+fi
+
 # Define BUILD_TESTING=ON
-GO_PRMS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=ON $COVERAGE_FLAG \
+GO_PRMS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=ON $COVERAGE_FLAG $ASAN_FLAG \
   $CMAKE_VERSION_PRMS \
   $($DIR/cmake-prm-yaml-cpp.bash $TARGET_ARCH)"
 

--- a/build-scripts/for-linux/build-on-linux.sh
+++ b/build-scripts/for-linux/build-on-linux.sh
@@ -4,12 +4,14 @@
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
 # $4 - package suffix: empty or wx30 or wx32
-# $5 - target deb architecture. Default - current
+# $5 - release flag (ON/OFF, default: OFF)
+# $6 - target deb architecture. Default - current
+# $7 - optional: "asan" to enable AddressSanitizer
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3
@@ -18,7 +20,12 @@ else
 fi
 
 PACKAGE_SUFFIX=$4
-TARGET_ARCH=${5:$(dpkg --print-architecture)}
+TARGET_ARCH=${6:$(dpkg --print-architecture)}
+
+ASAN_FLAG=""
+if [ "${7:-}" = "asan" ]; then
+    ASAN_FLAG="-DGO_BUILD_ASAN=ON"
+fi
 
 PARALLEL_PRMS="-j$(nproc)"
 
@@ -28,9 +35,11 @@ pushd build/linux
 rm -rf *
 export LANG=C
 
-GO_PRMS="-DCMAKE_BUILD_TYPE=Release \
+GO_PRMS="$CMAKE_RELEASE_FLAG_PRM \
   $CMAKE_VERSION_PRMS \
   -DCMAKE_PACKAGE_SUFFIX=$PACKAGE_SUFFIX \
+  -DGO_SPLIT_DEBUG_SYMBOLS=ON \
+  $ASAN_FLAG \
   $($DIR/cmake-prm-yaml-cpp.bash $TARGET_ARCH)"
 
 # a workaround of the new dpkg-shlibdeps that prevents cpack from making the DEB package

--- a/build-scripts/for-linux/prepare-debian-based.sh
+++ b/build-scripts/for-linux/prepare-debian-based.sh
@@ -67,6 +67,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 OPTIONAL_PKGS=""
 [[ "$INSTALL_TESTS" == "tests" ]] && OPTIONAL_PKGS="$OPTIONAL_PKGS gcovr"
+# libasan.a (static) is included in the gcc package, no extra install needed for ASAN
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   cmake \

--- a/build-scripts/for-linux/prepare-fedora.sh
+++ b/build-scripts/for-linux/prepare-fedora.sh
@@ -14,6 +14,7 @@ WX_PKG_NAME=wxGTK-devel
 
 OPTIONAL_PKGS=""
 [[ "$INSTALL_TESTS" == "tests" ]] && OPTIONAL_PKGS="$OPTIONAL_PKGS gcovr"
+[[ "$INSTALL_ASAN" == "asan" ]] && OPTIONAL_PKGS="$OPTIONAL_PKGS libasan-static"
 
 sudo dnf install -y \
   cmake gcc-c++ make gettext docbook-style-xsl zip po4a ImageMagick librsvg2-tools rpm-build $OPTIONAL_PKGS \

--- a/build-scripts/for-linux/prepare-parse-prms.bash
+++ b/build-scripts/for-linux/prepare-parse-prms.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 INSTALL_TESTS=notests
+INSTALL_ASAN=noasan
 TARGET_CPU=auto
 WX_VER=auto
 
@@ -14,12 +15,15 @@ while [[ $# -gt 0 ]]; do
       tests | notests)
 	INSTALL_TESTS=$1
 	;;
+      asan | noasan)
+	INSTALL_ASAN=$1
+	;;
       wx30 | wx32)
 	WX_VER=$1
 	;;
       *)
 	echo "Unknown parameter $1" >&2
-	echo "Usage: $(basename $0) [wx30 | wx32] [tests | notests]"
+	echo "Usage: $(basename $0) [wx30 | wx32] [tests | notests] [asan | noasan]"
 	exit 1
 	;;
     esac

--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -3,10 +3,11 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
+# $4 - release flag (ON/OFF, default: OFF)
 
 set -e
 
-source $(dirname $0)/../set-ver-prms.sh "$1" "$2"
+source $(dirname $0)/../set-ver-prms.sh "$1" "$2" "$4"
 
 if [[ -n "$3" ]]; then
   SRC_DIR=$3
@@ -30,7 +31,7 @@ case `arch` in
   OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl -DCMAKE_OSX_DEPLOYMENT_TARGET=12.1"
   ;;
 esac
-GO_PRMS="-DCMAKE_BUILD_TYPE=Release $CMAKE_VERSION_PRMS"
+GO_PRMS="$CMAKE_RELEASE_FLAG_PRM $CMAKE_VERSION_PRMS"
 cmake -G "Unix Makefiles" $OS_PRMS $GO_PRMS . $SRC_DIR
 
 echo "Phase 1"

--- a/build-scripts/for-win64/build-on-linux.sh
+++ b/build-scripts/for-win64/build-on-linux.sh
@@ -3,10 +3,11 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
+# $4 - release flag (ON/OFF, default: OFF)
 
 set -e
 
-source $(dirname $0)/../set-ver-prms.sh "$1" "$2"
+source $(dirname $0)/../set-ver-prms.sh "$1" "$2" "$4"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3
@@ -41,7 +42,7 @@ CMAKE_WIN_PRMS="-DASIO_SDK_DIR=/usr/local/asio-sdk \
   -DRTAUDIO_USE_ASIO=ON \
   -DVC_PATH=/usr/local/share/wine/msvc/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x86"
 
-CMAKE_APP_PRMS="-DGO_USE_JACK=ON $CMAKE_VERSION_PRMS"
+CMAKE_APP_PRMS="-DGO_USE_JACK=ON $CMAKE_VERSION_PRMS $CMAKE_RELEASE_FLAG_PRM"
 
 cmake $CMAKE_MINGW_PRMS $CMAKE_WIN_PRMS $CMAKE_APP_PRMS . $SRC_DIR
 make $PARALLEL_PRMS VERBOSE=1 package

--- a/build-scripts/set-ver-prms.sh
+++ b/build-scripts/set-ver-prms.sh
@@ -2,6 +2,7 @@
 
 # $1 - Project version
 # $2 - Build version
+# $3 - Release flag (ON/OFF, default: OFF)
 
 CMAKE_VERSION_PRMS=
 
@@ -9,4 +10,5 @@ CMAKE_VERSION_PRMS=
 [[ -n "$2" ]] && CMAKE_VERSION_PRMS="$CMAKE_VERSION_PRMS -DBUILD_VERSION=$2"
 
 export CMAKE_VERSION_PRMS
+export CMAKE_RELEASE_FLAG_PRM="-DRELEASE_FLAG=${3:-OFF}"
 

--- a/cmake/BuildExecutable.cmake
+++ b/cmake/BuildExecutable.cmake
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -15,7 +15,24 @@ function(BUILD_EXECUTABLE TARGET)
   endif()
   install(TARGETS ${TARGET} RUNTIME DESTINATION "${BININSTDIR}")
 
-  if(CV2PDB_EXE)
+  if(UNIX AND NOT APPLE AND GO_SPLIT_DEBUG_SYMBOLS)
+    install(CODE "
+      # \$ENV{DESTDIR} is empty for TGZ (CMAKE_INSTALL_PREFIX is the staging dir),
+      # but set to the staging root for RPM (CMAKE_INSTALL_PREFIX stays /usr).
+      set(_bin \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${BININSTDIR}/${TARGET}\")
+      # Extract debug info into a separate .dbg file alongside the binary.
+      execute_process(COMMAND ${CMAKE_OBJCOPY} --only-keep-debug \"\${_bin}\" \"\${_bin}.dbg\")
+      # objcopy needs to read the .dbg file to compute its CRC for the debuglink section.
+      # It looks for the file by bare name in WORKING_DIRECTORY, so we set that to the
+      # directory containing both the binary and the .dbg file.
+      get_filename_component(_dir \"\${_bin}\" DIRECTORY)
+      execute_process(COMMAND ${CMAKE_OBJCOPY} --strip-debug
+        --add-gnu-debuglink=${TARGET}.dbg \"\${_bin}\"
+        WORKING_DIRECTORY \"\${_dir}\")
+    ")
+  endif()
+
+  if(CV2PDB_EXE AND GO_SPLIT_DEBUG_SYMBOLS)
     add_custom_command(
       OUTPUT "${BINDIR}/${TARGET}.pdb"
       DEPENDS ${TARGET}

--- a/cmake/BuildLibrary.cmake
+++ b/cmake/BuildLibrary.cmake
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -16,7 +16,7 @@ function(BUILD_LIBRARY TARGET)
   endif()
 
   install(
-    TARGETS ${TARGET} 
+    TARGETS ${TARGET}
     RUNTIME DESTINATION ${LIBINSTDIR} LIBRARY DESTINATION ${LIBINSTDIR}
     NAMELINK_SKIP
     # these permissions required for building rmp on debian/ubuntu
@@ -26,7 +26,24 @@ function(BUILD_LIBRARY TARGET)
       WORLD_EXECUTE WORLD_READ
   )
 
-  if(CV2PDB_EXE)
+  if(UNIX AND NOT APPLE AND GO_SPLIT_DEBUG_SYMBOLS)
+    install(CODE "
+      # \$ENV{DESTDIR} is empty for TGZ (CMAKE_INSTALL_PREFIX is the staging dir),
+      # but set to the staging root for RPM (CMAKE_INSTALL_PREFIX stays /usr).
+      set(_lib \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBINSTDIR}/lib${TARGET}.so.${NUM_VERSION}\")
+      # Extract debug info into a separate .dbg file alongside the library.
+      execute_process(COMMAND ${CMAKE_OBJCOPY} --only-keep-debug \"\${_lib}\" \"\${_lib}.dbg\")
+      # objcopy needs to read the .dbg file to compute its CRC for the debuglink section.
+      # It looks for the file by bare name in WORKING_DIRECTORY, so we set that to the
+      # directory containing both the library and the .dbg file.
+      get_filename_component(_dir \"\${_lib}\" DIRECTORY)
+      execute_process(COMMAND ${CMAKE_OBJCOPY} --strip-debug
+        --add-gnu-debuglink=lib${TARGET}.so.${NUM_VERSION}.dbg \"\${_lib}\"
+        WORKING_DIRECTORY \"\${_dir}\")
+    ")
+  endif()
+
+  if(CV2PDB_EXE AND GO_SPLIT_DEBUG_SYMBOLS)
     add_custom_command(
       OUTPUT "${LIBDIR}/lib${TARGET}.pdb"
       DEPENDS ${TARGET}

--- a/src/build/CMakeLists.txt
+++ b/src/build/CMakeLists.txt
@@ -1,11 +1,15 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 cmake_minimum_required(VERSION 3.10)
 
 IF(NOT CMAKE_CROSSCOMPILING)
-   ADD_EXECUTABLE(imageconverter imageconverter.cpp)
+  ADD_EXECUTABLE(imageconverter imageconverter.cpp)
+  # imageconverter is a build-time tool; it must not use ASan because it runs
+  # during the build without the ASan runtime preloaded.
+  target_compile_options(imageconverter PRIVATE -fno-sanitize=address)
+  target_link_options(imageconverter PRIVATE -fno-sanitize=address)
 ENDIF(NOT CMAKE_CROSSCOMPILING)
 
 IF(NOT CMAKE_CROSSCOMPILING) 

--- a/src/core/ptrvector.h
+++ b/src/core/ptrvector.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,6 +8,7 @@
 #ifndef PTRVECTOR_H
 #define PTRVECTOR_H
 
+#include <cstdio>
 #include <vector>
 
 template <class T> class ptr_vector : protected std::vector<T *> {
@@ -20,6 +21,7 @@ private:
     typename T1,
     std::enable_if_t<std::is_array<T1>::value, bool> = true>
   inline static void delete0(T1 *e) {
+    fprintf(stderr, "ptr_vector::delete0 deleting %p\n", (void *)e);
     delete[] e;
   }
 
@@ -27,6 +29,7 @@ private:
     typename T1,
     std::enable_if_t<!std::is_array<T1>::value, bool> = true>
   inline static void delete0(T1 *e) {
+    fprintf(stderr, "ptr_vector::delete0 deleting %p\n", (void *)e);
     delete e;
   }
 
@@ -60,6 +63,12 @@ public:
 
   void resize(unsigned new_size) {
     unsigned oldsize = size();
+    fprintf(
+      stderr,
+      "ptr_vector::resize this=%p, oldsize=%u, new_size=%u\n",
+      (void *)this,
+      oldsize,
+      new_size);
     for (unsigned i = new_size; i < oldsize; i++)
       delete1(at(i));
     std::vector<T *>::resize(new_size);
@@ -67,7 +76,14 @@ public:
       at(i) = nullptr;
   }
 
-  void push_back(T *ptr) { std::vector<T *>::push_back(ptr); }
+  void push_back(T *ptr) {
+    fprintf(
+      stderr,
+      "ptr_vector::push_back this=%p, ptr=%p\n",
+      (void *)this,
+      (void *)ptr);
+    std::vector<T *>::push_back(ptr);
+  }
 
   void insert(unsigned pos, T *ptr) {
     std::vector<T *>::insert(std::vector<T *>::begin() + pos, ptr);

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -782,6 +782,7 @@ void GOSetter::Load(GOConfigReader &cfg) {
 
   wxString buffer;
 
+  fprintf(stderr, "GOSetter::Load clearing m_framegeneral\n");
   m_framegeneral.resize(0);
   for (unsigned i = 0; i < FRAME_GENERALS; i++) {
     m_framegeneral.push_back(
@@ -790,6 +791,7 @@ void GOSetter::Load(GOConfigReader &cfg) {
     m_framegeneral[i]->Load(cfg, buffer);
   }
 
+  fprintf(stderr, "GOSetter::Load clearing m_general\n");
   m_general.resize(0);
   for (unsigned i = 0; i < GENERALS * GENERAL_BANKS; i++) {
     m_general.push_back(new GOGeneralCombination(*m_OrganController, true));
@@ -797,6 +799,7 @@ void GOSetter::Load(GOConfigReader &cfg) {
     m_general[i]->Load(cfg, buffer);
   }
 
+  fprintf(stderr, "GOSetter::Load clearing m_crescendo\n");
   m_crescendo.resize(0);
   for (unsigned i = 0; i < N_CRESCENDOS; i++) {
     buffer.Printf(wxT("SetterCrescendo%d"), i);

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -8,6 +8,7 @@
 #include "GOSetter.h"
 
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <string>
 
@@ -761,7 +762,14 @@ GOSetter::GOSetter(GOOrganController *organController)
   m_OrganController->RegisterControlChangedHandler(this);
 }
 
-GOSetter::~GOSetter() {}
+GOSetter::~GOSetter() {
+  std::cerr << "GOSetter::~GOSetter clearing m_crescendo" << std::endl;
+  m_crescendo.clear();
+  std::cerr << "GOSetter::~GOSetter clearing m_general" << std::endl;
+  m_general.clear();
+  std::cerr << "GOSetter::~GOSetter clearing m_framegeneral" << std::endl;
+  m_framegeneral.clear();
+}
 
 static const wxString WX_OVERRIDE_MODE = wxT("OverrideMode");
 static const wxString WX_EMPTY_STRING = wxEmptyString;

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -47,9 +47,11 @@ GOCombination::GOCombination(
 GOCombination::~GOCombination() {
   fprintf(
     stderr,
-    "GOCombination::~GOCombination this=%p, m_ElementStates.size()=%zu, "
+    "GOCombination::~GOCombination this=%p, m_group=%s, "
+    "m_ElementStates.size()=%zu, "
     "m_ElementStates.data()=%p\n",
     (void *)this,
+    m_group.c_str().AsChar(),
     m_ElementStates.size(),
     (void *)m_ElementStates.data());
 }

--- a/src/grandorgue/combinations/model/GOCombination.cpp
+++ b/src/grandorgue/combinations/model/GOCombination.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,6 +8,7 @@
 #include "GOCombination.h"
 
 #include <algorithm>
+#include <cstdio>
 
 #include <wx/intl.h>
 #include <wx/log.h>
@@ -35,9 +36,23 @@ GOCombination::GOCombination(
     m_IsFull(false),
     m_HasScope(false),
     r_ElementDefinitions(cmbDef.GetElements()),
-    m_Protected(false) {}
+    m_Protected(false) {
+  fprintf(
+    stderr,
+    "GOCombination::GOCombination this=%p, m_ElementStates.size()=%zu\n",
+    (void *)this,
+    m_ElementStates.size());
+}
 
-GOCombination::~GOCombination() {}
+GOCombination::~GOCombination() {
+  fprintf(
+    stderr,
+    "GOCombination::~GOCombination this=%p, m_ElementStates.size()=%zu, "
+    "m_ElementStates.data()=%p\n",
+    (void *)this,
+    m_ElementStates.size(),
+    (void *)m_ElementStates.data());
+}
 
 void GOCombination::Clear() {
   EnsureElementStatesAllocated();
@@ -49,7 +64,21 @@ void GOCombination::Clear() {
 
 void GOCombination::Copy(const GOCombination *combination) {
   assert(&m_Template == &combination->m_Template);
+  fprintf(
+    stderr,
+    "GOCombination::Copy this=%p from=%p, before: m_ElementStates.size()=%zu, "
+    "data=%p\n",
+    (void *)this,
+    (void *)combination,
+    m_ElementStates.size(),
+    (void *)m_ElementStates.data());
   m_ElementStates = combination->m_ElementStates;
+  fprintf(
+    stderr,
+    "GOCombination::Copy this=%p, after: m_ElementStates.size()=%zu, data=%p\n",
+    (void *)this,
+    m_ElementStates.size(),
+    (void *)m_ElementStates.data());
   EnsureElementStatesAllocated();
 }
 
@@ -216,14 +245,46 @@ void GOCombination::SetStatesFromYaml(
 void GOCombination::EnsureElementStatesAllocated() {
   unsigned defSize = r_ElementDefinitions.size();
 
-  if (m_ElementStates.size() > defSize)
+  fprintf(
+    stderr,
+    "GOCombination::EnsureElementStatesAllocated this=%p, current size=%zu, "
+    "defSize=%u, data=%p\n",
+    (void *)this,
+    m_ElementStates.size(),
+    defSize,
+    (void *)m_ElementStates.data());
+
+  if (m_ElementStates.size() > defSize) {
+    fprintf(
+      stderr,
+      "GOCombination::EnsureElementStatesAllocated this=%p, shrinking from %zu "
+      "to "
+      "%u\n",
+      (void *)this,
+      m_ElementStates.size(),
+      defSize);
     m_ElementStates.resize(defSize);
-  else if (m_ElementStates.size() < defSize) {
+  } else if (m_ElementStates.size() < defSize) {
     unsigned current = m_ElementStates.size();
+    fprintf(
+      stderr,
+      "GOCombination::EnsureElementStatesAllocated this=%p, growing from %zu "
+      "to "
+      "%u\n",
+      (void *)this,
+      m_ElementStates.size(),
+      defSize);
     m_ElementStates.resize(defSize);
     while (current < defSize)
       m_ElementStates[current++] = BOOL3_DEFAULT;
   }
+  fprintf(
+    stderr,
+    "GOCombination::EnsureElementStatesAllocated this=%p, after: size=%zu, "
+    "data=%p\n",
+    (void *)this,
+    m_ElementStates.size(),
+    (void *)m_ElementStates.data());
 }
 
 static const wxString WX_NUMBER_OF_STOPS = wxT("NumberOfStops");

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -272,12 +272,13 @@ void GOSoundSystem::StartStreams() {
 }
 
 bool GOSoundSystem::AssureSoundIsOpen() {
-  if (!m_open)
+  if (!m_open) {
     OpenSoundSystem();
-  if (m_open && m_OrganController) {
-    BuildAndStartEngine();
-    StartSoundSystem();
-    NotifySoundIsOpen();
+    if (m_open && m_OrganController) {
+      BuildAndStartEngine();
+      StartSoundSystem();
+      NotifySoundIsOpen();
+    }
   }
   return m_open;
 }

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -14,7 +14,6 @@
 #include "buffer/GOSoundBufferMutable.h"
 #include "config/GOConfig.h"
 #include "config/GOPortsConfig.h"
-#include "ports/GOSoundPort.h"
 #include "ports/GOSoundPortFactory.h"
 #include "scheduler/GOSoundThread.h"
 #include "threading/GOMultiMutexLocker.h"
@@ -25,23 +24,21 @@
 #include "GOSoundDefs.h"
 
 GOSoundSystem::GOSoundSystem(GOConfig &settings)
-  : m_open(false),
+  : m_config(settings),
+    m_midi(settings),
+    m_open(false),
+    logSoundErrors(true),
+    m_SampleRate(0),
+    m_SamplesPerBuffer(0),
+    m_OrganController(0),
+    m_DefaultAudioDevice(GOSoundDevInfo::getInvalideDeviceInfo()),
     m_IsRunning(false),
     m_NCallbacksEntered(0),
     m_CallbackCondition(m_CallbackMutex),
-    logSoundErrors(true),
-    m_AudioOutputs(),
-    m_WaitCount(),
-    m_CalcCount(),
-    m_SamplesPerBuffer(0),
-    meter_counter(0),
-    m_DefaultAudioDevice(GOSoundDevInfo::getInvalideDeviceInfo()),
-    m_OrganController(0),
-    m_config(settings),
-    m_midi(settings) {}
+    meter_counter(0) {}
 
 GOSoundSystem::~GOSoundSystem() {
-  CloseSound();
+  AssureSoundIsClosed();
 
   GOMidiPortFactory::terminate();
   GOSoundPortFactory::terminate();
@@ -68,83 +65,26 @@ void GOSoundSystem::StopThreads() {
   m_Threads.resize(0);
 }
 
-void GOSoundSystem::OpenMidi() { m_midi.Open(); }
-
-void GOSoundSystem::OpenSound() {
-  m_LastErrorMessage = wxEmptyString;
+void GOSoundSystem::OpenSoundSystem() {
   assert(!m_open);
   assert(m_AudioOutputs.size() == 0);
 
-  const unsigned audio_group_count = m_config.GetAudioGroups().size();
   std::vector<GOAudioDeviceConfig> &audio_config
     = m_config.GetAudioDeviceConfig();
-  const unsigned audioDeviceCount = audio_config.size();
-  std::vector<GOAudioOutputConfiguration> engine_config;
+
+  m_LastErrorMessage = wxEmptyString;
+  m_SampleRate = m_config.SampleRate();
+  m_SamplesPerBuffer = m_config.SamplesPerBuffer();
+  m_AudioRecorder.SetBytesPerSample(m_config.WaveFormatBytesPerSample());
 
   m_AudioOutputs.resize(audio_config.size());
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
-    m_AudioOutputs[i].port = NULL;
-  engine_config.resize(audioDeviceCount);
-  for (unsigned i = 0; i < audioDeviceCount; i++) {
-    const GOAudioDeviceConfig &deviceConfig = audio_config[i];
-    const auto &deviceOutputs = deviceConfig.GetChannelOututs();
-    GOAudioOutputConfiguration &engineConfig = engine_config[i];
-
-    engineConfig.channels = deviceConfig.GetChannels();
-    engineConfig.scale_factors.resize(engineConfig.channels);
-    for (unsigned j = 0; j < engineConfig.channels; j++) {
-      std::vector<float> &scaleFactors = engineConfig.scale_factors[j];
-
-      scaleFactors.resize(audio_group_count * 2);
-      std::fill(
-        scaleFactors.begin(),
-        scaleFactors.end(),
-        GOAudioDeviceConfig::MUTE_VOLUME);
-
-      if (j >= deviceOutputs.size())
-        continue;
-
-      const auto &channelOutputs = deviceOutputs[j];
-
-      for (unsigned k = 0; k < channelOutputs.size(); k++) {
-        const auto &groupOutput = channelOutputs[k];
-        int id = m_config.GetStrictAudioGroupId(groupOutput.GetName());
-
-        if (id >= 0) {
-          scaleFactors[id * 2] = groupOutput.GetLeft();
-          scaleFactors[id * 2 + 1] = groupOutput.GetRight();
-        }
-      }
-    }
-  }
-  m_SamplesPerBuffer = m_config.SamplesPerBuffer();
-  m_SoundEngine.SetSamplesPerBuffer(m_SamplesPerBuffer);
-  m_SoundEngine.SetPolyphonyLimiting(m_config.ManagePolyphony());
-  m_SoundEngine.SetHardPolyphony(m_config.PolyphonyLimit());
-  m_SoundEngine.SetScaledReleases(m_config.ScaleRelease());
-  m_SoundEngine.SetRandomizeSpeaking(m_config.RandomizeSpeaking());
-  m_SoundEngine.SetInterpolationType(m_config.m_InterpolationType());
-  m_SoundEngine.SetAudioGroupCount(audio_group_count);
-  unsigned sample_rate = m_config.SampleRate();
-  m_AudioRecorder.SetBytesPerSample(m_config.WaveFormatBytesPerSample());
-  GetEngine().SetSampleRate(sample_rate);
-  m_AudioRecorder.SetSampleRate(sample_rate);
-  m_SoundEngine.SetAudioOutput(engine_config);
-  m_SoundEngine.SetupReverb(m_config);
-  m_SoundEngine.SetAudioRecorder(&m_AudioRecorder, m_config.RecordDownmix());
-
-  if (m_OrganController)
-    m_SoundEngine.Setup(
-      *m_OrganController,
-      m_OrganController->GetMemoryPool(),
-      m_config.ReleaseConcurrency());
-  else
-    m_SoundEngine.ClearSetup();
+  for (GOSoundOutput &output : m_AudioOutputs)
+    output.port = NULL;
 
   const GOPortsConfig &portsConfig(m_config.GetSoundPortsConfig());
 
   try {
-    for (unsigned l = m_AudioOutputs.size(), i = 0; i < l; i++) {
+    for (unsigned n = m_AudioOutputs.size(), i = 0; i < n; i++) {
       GOAudioDeviceConfig &deviceConfig = audio_config[i];
       GODeviceNamePattern *pNamePattern = &deviceConfig;
       GODeviceNamePattern defaultDevicePattern;
@@ -165,56 +105,103 @@ void GOSoundSystem::OpenSound() {
       m_AudioOutputs[i].port = pPort;
       pPort->Init(
         deviceConfig.GetChannels(),
-        GetEngine().GetSampleRate(),
+        m_SampleRate,
         m_SamplesPerBuffer,
         deviceConfig.GetDesiredLatency(),
         i);
     }
-
-    OpenMidi();
-    m_NCallbacksEntered.store(0);
     StartStreams();
-    StartThreads();
+    OpenMidi();
+    m_AudioRecorder.SetSampleRate(m_SampleRate);
     m_open = true;
-    m_IsRunning.store(true);
-
-    if (m_OrganController)
-      m_OrganController->PreparePlayback(
-        &GetEngine(), &GetMidi(), &m_AudioRecorder);
   } catch (wxString &msg) {
     if (logSoundErrors)
       GOMessageBox(msg, _("Error"), wxOK | wxICON_ERROR, NULL);
     else
       m_LastErrorMessage = msg;
-  }
 
-  if (!m_open)
-    CloseSound();
+    CloseSoundSystem();
+  }
 }
 
-void GOSoundSystem::StartStreams() {
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
-    m_AudioOutputs[i].port->Open();
+void GOSoundSystem::BuildAndStartEngine() {
+  const unsigned audio_group_count = m_config.GetAudioGroups().size();
+  std::vector<GOAudioDeviceConfig> &audio_config
+    = m_config.GetAudioDeviceConfig();
+  const unsigned audioDeviceCount = audio_config.size();
+  std::vector<GOAudioOutputConfiguration> engine_config;
 
-  if (m_SamplesPerBuffer > MAX_FRAME_SIZE)
-    throw wxString::Format(
-      _("Cannot use buffer size above %d samples; "
-        "unacceptable quantization would occur."),
-      MAX_FRAME_SIZE);
+  engine_config.resize(audioDeviceCount);
+  for (unsigned deviceI = 0; deviceI < audioDeviceCount; deviceI++) {
+    const GOAudioDeviceConfig &deviceConfig = audio_config[deviceI];
+    const auto &deviceOutputs = deviceConfig.GetChannelOututs();
+    GOAudioOutputConfiguration &engineConfig = engine_config[deviceI];
 
-  m_WaitCount.exchange(0);
-  m_CalcCount.exchange(0);
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++) {
-    GOMutexLocker dev_lock(m_AudioOutputs[i].mutex);
-    m_AudioOutputs[i].wait = false;
-    m_AudioOutputs[i].waiting = true;
+    engineConfig.channels = deviceConfig.GetChannels();
+    engineConfig.scale_factors.resize(engineConfig.channels);
+    for (unsigned channelI = 0; channelI < engineConfig.channels; channelI++) {
+      std::vector<float> &scaleFactors = engineConfig.scale_factors[channelI];
+
+      scaleFactors.resize(audio_group_count * 2);
+      std::fill(
+        scaleFactors.begin(),
+        scaleFactors.end(),
+        GOAudioDeviceConfig::MUTE_VOLUME);
+
+      if (channelI < deviceOutputs.size()) {
+        for (const auto &groupOutput : deviceOutputs[channelI]) {
+          int id = m_config.GetStrictAudioGroupId(groupOutput.GetName());
+
+          if (id >= 0) {
+            scaleFactors[id * 2] = groupOutput.GetLeft();
+            scaleFactors[id * 2 + 1] = groupOutput.GetRight();
+          }
+        }
+      }
+    }
   }
 
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
-    m_AudioOutputs[i].port->StartStream();
+  m_SoundEngine.SetSamplesPerBuffer(m_SamplesPerBuffer);
+  m_SoundEngine.SetPolyphonyLimiting(m_config.ManagePolyphony());
+  m_SoundEngine.SetHardPolyphony(m_config.PolyphonyLimit());
+  m_SoundEngine.SetScaledReleases(m_config.ScaleRelease());
+  m_SoundEngine.SetRandomizeSpeaking(m_config.RandomizeSpeaking());
+  m_SoundEngine.SetInterpolationType(m_config.m_InterpolationType());
+  m_SoundEngine.SetAudioGroupCount(audio_group_count);
+  m_SoundEngine.SetSampleRate(m_SampleRate);
+  m_SoundEngine.SetAudioOutput(engine_config);
+  m_SoundEngine.SetupReverb(m_config);
+  m_SoundEngine.SetAudioRecorder(&m_AudioRecorder, m_config.RecordDownmix());
+  m_SoundEngine.Setup(
+    *m_OrganController,
+    m_OrganController->GetMemoryPool(),
+    m_config.ReleaseConcurrency());
+  StartThreads();
+  m_SoundEngine.GetScheduler().ResumeGivingWork();
 }
 
-void GOSoundSystem::CloseSound() {
+void GOSoundSystem::StartSoundSystem() {
+  // Enable all outputs
+  for (GOSoundOutput &output : m_AudioOutputs) {
+    GOMutexLocker dev_lock(output.mutex);
+
+    output.wait = false;
+    output.waiting = true;
+  }
+  m_WaitCount.store(0);
+  m_CalcCount.store(0);
+  m_NCallbacksEntered.store(0);
+  m_IsRunning.store(true);
+}
+
+void GOSoundSystem::NotifySoundIsOpen() {
+  m_OrganController->PreparePlayback(
+    &GetEngine(), &GetMidi(), &m_AudioRecorder);
+}
+
+void GOSoundSystem::NotifySoundIsClosing() { m_OrganController->Abort(); }
+
+void GOSoundSystem::StopSoundSystem() {
   m_IsRunning.store(false);
 
   // wait for all started callbacks to finish
@@ -223,22 +210,39 @@ void GOSoundSystem::CloseSound() {
 
     while (m_NCallbacksEntered.load() > 0)
       m_CallbackCondition.WaitOrStop(
-        "GOSoundSystem::CloseSound waits for all callbacks to finish", nullptr);
+        "GOSoundSystem::StopSoundSystem waits for all callbacks to finish",
+        nullptr);
   }
 
+  // Disable all outputs
+  {
+    GOMultiMutexLocker multi;
+
+    for (GOSoundOutput &output : m_AudioOutputs)
+      multi.Add(output.mutex);
+
+    for (GOSoundOutput &output : m_AudioOutputs) {
+      output.waiting = false;
+      output.wait = false;
+      output.condition.Broadcast();
+    }
+
+    for (unsigned n = m_AudioOutputs.size(), i = 1; i < n; i++) {
+      GOMutexLocker dev_lock(m_AudioOutputs[i].mutex);
+      m_AudioOutputs[i].condition.Broadcast();
+    }
+  }
+}
+
+void GOSoundSystem::StopAndDestroyEngine() {
+  m_SoundEngine.GetScheduler().PauseGivingWork();
+  for (GOSoundThread *pThread : m_Threads)
+    pThread->WaitForIdle();
   StopThreads();
+  m_SoundEngine.ClearSetup();
+}
 
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++) {
-    m_AudioOutputs[i].waiting = false;
-    m_AudioOutputs[i].wait = false;
-    m_AudioOutputs[i].condition.Broadcast();
-  }
-
-  for (unsigned i = 1; i < m_AudioOutputs.size(); i++) {
-    GOMutexLocker dev_lock(m_AudioOutputs[i].mutex);
-    m_AudioOutputs[i].condition.Broadcast();
-  }
-
+void GOSoundSystem::CloseSoundSystem() {
   for (int i = m_AudioOutputs.size() - 1; i >= 0; i--) {
     if (m_AudioOutputs[i].port) {
       GOSoundPort *const port = m_AudioOutputs[i].port;
@@ -249,65 +253,64 @@ void GOSoundSystem::CloseSound() {
     }
   }
 
-  if (m_OrganController)
-    m_OrganController->Abort();
   ResetMeters();
   m_AudioOutputs.clear();
   m_open = false;
 }
 
+void GOSoundSystem::StartStreams() {
+  for (GOSoundOutput &output : m_AudioOutputs)
+    output.port->Open();
+
+  if (m_SamplesPerBuffer > MAX_FRAME_SIZE)
+    throw wxString::Format(
+      _("Cannot use buffer size above %d samples; "
+        "unacceptable quantization would occur."),
+      MAX_FRAME_SIZE);
+  for (GOSoundOutput &output : m_AudioOutputs)
+    output.port->StartStream();
+}
+
 bool GOSoundSystem::AssureSoundIsOpen() {
   if (!m_open)
-    OpenSound();
+    OpenSoundSystem();
+  if (m_open && m_OrganController) {
+    BuildAndStartEngine();
+    StartSoundSystem();
+    NotifySoundIsOpen();
+  }
   return m_open;
 }
 
 void GOSoundSystem::AssureSoundIsClosed() {
-  if (m_open)
-    CloseSound();
-}
-
-void GOSoundSystem::AssignOrganFile(GOOrganController *organController) {
-  if (organController == m_OrganController)
-    return;
-
-  GOMutexLocker locker(m_lock);
-  GOMultiMutexLocker multi;
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
-    multi.Add(m_AudioOutputs[i].mutex);
-
-  if (m_OrganController) {
-    // ensure pointers to work items are not held by threads
-    m_SoundEngine.GetScheduler().PauseGivingWork();
-    for (GOSoundThread *thread : m_Threads)
-      thread->WaitForIdle();
-
-    m_OrganController->Abort();
-    // now work items are safe to be deleted
-    m_SoundEngine.ClearSetup();
-
-    // resume processing of work items
-    m_SoundEngine.GetScheduler().ResumeGivingWork();
-  }
-
-  m_OrganController = organController;
-
-  if (m_OrganController && m_AudioOutputs.size()) {
-    m_SoundEngine.Setup(
-      *organController,
-      m_OrganController->GetMemoryPool(),
-      m_config.ReleaseConcurrency());
-    m_OrganController->PreparePlayback(
-      &GetEngine(), &GetMidi(), &m_AudioRecorder);
+  if (m_open) {
+    if (m_OrganController) {
+      NotifySoundIsClosing();
+      StopSoundSystem();
+      StopAndDestroyEngine();
+    }
+    CloseSoundSystem();
   }
 }
 
-GOConfig &GOSoundSystem::GetSettings() { return m_config; }
+void GOSoundSystem::AssignOrganFile(GOOrganController *pNewOrganController) {
+  if (pNewOrganController != m_OrganController) {
+    GOMutexLocker locker(m_lock);
 
-GOOrganController *GOSoundSystem::GetOrganFile() { return m_OrganController; }
+    if (m_open && m_OrganController) {
+      NotifySoundIsClosing();
+      StopSoundSystem();
+      StopAndDestroyEngine();
+    }
 
-void GOSoundSystem::SetLogSoundErrorMessages(bool settingsDialogVisible) {
-  logSoundErrors = settingsDialogVisible;
+    m_OrganController = pNewOrganController;
+
+    if (m_open && m_OrganController) {
+      BuildAndStartEngine();
+      StartSoundSystem();
+      NotifySoundIsOpen();
+    }
+  }
 }
 
 std::vector<GOSoundDevInfo> GOSoundSystem::GetAudioDevices(
@@ -344,8 +347,6 @@ void GOSoundSystem::FillDeviceNamePattern(
   pattern.SetApiName(deviceInfo.GetApiName());
   pattern.SetPhysicalName(deviceInfo.GetFullName());
 }
-
-GOMidiSystem &GOSoundSystem::GetMidi() { return m_midi; }
 
 void GOSoundSystem::ResetMeters() {
   wxWindow *const topWindow = wxTheApp ? wxTheApp->GetTopWindow() : nullptr;
@@ -432,8 +433,6 @@ bool GOSoundSystem::AudioCallback(
   }
   return true;
 }
-
-GOSoundOrganEngine &GOSoundSystem::GetEngine() { return m_SoundEngine; }
 
 wxString GOSoundSystem::getState() {
   if (!m_AudioOutputs.size())

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -8,14 +8,11 @@
 #ifndef GOSOUNDSYSTEM_H
 #define GOSOUNDSYSTEM_H
 
-#include <map>
 #include <vector>
 
 #include <wx/string.h>
 
-#include "config/GOPortsConfig.h"
 #include "midi/GOMidiSystem.h"
-#include "ports/GOSoundPortFactory.h"
 #include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
 
@@ -25,14 +22,13 @@
 #include "GOSoundOrganEngine.h"
 #include "GOSoundRecorder.h"
 
+class GOConfig;
 class GODeviceNamePattern;
 class GOOrganController;
-class GOMidiSystem;
-class GOSoundThread;
+class GOPortsConfig;
+class GOSoundBufferMutable;
 class GOSoundPort;
-class GOSoundRtPort;
-class GOSoundPortaudioPort;
-class GOConfig;
+class GOSoundThread;
 
 /**
  * This class represents a GrandOrgue-wide sound system. It may be used even
@@ -69,9 +65,26 @@ class GOSoundSystem {
   };
 
 private:
-  bool m_open;
-  std::atomic_bool m_IsRunning;
+  GOConfig &m_config;
 
+  GOMidiSystem m_midi;
+  GOSoundRecorder m_AudioRecorder;
+  GOSoundOrganEngine m_SoundEngine;
+  ptr_vector<GOSoundThread> m_Threads;
+
+  bool m_open;
+  bool logSoundErrors;
+  unsigned m_SampleRate;
+  unsigned m_SamplesPerBuffer;
+  std::vector<GOSoundOutput> m_AudioOutputs;
+
+  wxString m_LastErrorMessage;
+
+  GOOrganController *m_OrganController;
+
+  GOSoundDevInfo m_DefaultAudioDevice;
+
+  std::atomic_bool m_IsRunning;
   // counter of audio callbacks that have been entered but have not yet been
   // exited
   std::atomic_uint m_NCallbacksEntered;
@@ -83,69 +96,62 @@ private:
   GOMutex m_lock;
   GOMutex m_thread_lock;
 
-  bool logSoundErrors;
+  unsigned meter_counter;
 
-  std::vector<GOSoundOutput> m_AudioOutputs;
   std::atomic_uint m_WaitCount;
   std::atomic_uint m_CalcCount;
 
-  unsigned m_SamplesPerBuffer;
+  void StartStreams();
+  void OpenMidi() { m_midi.Open(); }
 
-  unsigned meter_counter;
-
-  GOSoundDevInfo m_DefaultAudioDevice;
-
-  GOOrganController *m_OrganController;
-  GOSoundRecorder m_AudioRecorder;
-
-  GOSoundOrganEngine m_SoundEngine;
-  ptr_vector<GOSoundThread> m_Threads;
-
-  GOConfig &m_config;
-
-  GOMidiSystem m_midi;
-
-  wxString m_LastErrorMessage;
-
-  void StopThreads();
   void StartThreads();
+  void StopThreads();
 
+  void UpdateMeter();
   void ResetMeters();
 
-  void OpenMidi();
+  /** Open audio ports and configure the sound engine (without organ setup) */
+  void OpenSoundSystem();
+  /** Set up the sound engine for the current organ and start worker threads */
+  void BuildAndStartEngine();
+  /** Start audio streams and mark system as running */
+  void StartSoundSystem();
+  /** Notify the organ controller that sound is open and begin playback */
+  void NotifySoundIsOpen();
 
-  void OpenSound();
-  void CloseSound();
-
-  void StartStreams();
-  void UpdateMeter();
+  /** Notify the organ controller that sound is about to close */
+  void NotifySoundIsClosing();
+  /** Stop audio streams and wait for all callbacks to finish */
+  void StopSoundSystem();
+  /** Stop sound engine worker threads and tear down the organ setup */
+  void StopAndDestroyEngine();
+  /** Close and delete audio ports, reset meters, mark system as closed */
+  void CloseSoundSystem();
 
 public:
-  GOSoundSystem(GOConfig &settings);
-  ~GOSoundSystem();
-
-  bool AssureSoundIsOpen();
-  void AssureSoundIsClosed();
-
-  wxString getLastErrorMessage() const { return m_LastErrorMessage; }
-  wxString getState();
-
-  GOConfig &GetSettings();
-
-  void AssignOrganFile(GOOrganController *organController);
-  GOOrganController *GetOrganFile();
-
-  void SetLogSoundErrorMessages(bool settingsDialogVisible);
-
-  std::vector<GOSoundDevInfo> GetAudioDevices(const GOPortsConfig &portsConfig);
-  const GOSoundDevInfo &GetDefaultAudioDevice(const GOPortsConfig &portsConfig);
-
   static void FillDeviceNamePattern(
     const GOSoundDevInfo &deviceInfo, GODeviceNamePattern &pattern);
 
-  GOMidiSystem &GetMidi();
+  GOSoundSystem(GOConfig &settings);
+  ~GOSoundSystem();
 
-  GOSoundOrganEngine &GetEngine();
+  GOConfig &GetSettings() { return m_config; }
+  GOMidiSystem &GetMidi() { return m_midi; }
+  GOSoundOrganEngine &GetEngine() { return m_SoundEngine; }
+
+  std::vector<GOSoundDevInfo> GetAudioDevices(const GOPortsConfig &portsConfig);
+  const GOSoundDevInfo &GetDefaultAudioDevice(const GOPortsConfig &portsConfig);
+  wxString getLastErrorMessage() const { return m_LastErrorMessage; }
+  GOOrganController *GetOrganFile() { return m_OrganController; }
+  unsigned GetSampleRate() const { return m_SampleRate; }
+  unsigned GetSamplesPerBuffer() const { return m_SamplesPerBuffer; }
+  wxString getState();
+
+  void SetLogSoundErrorMessages(bool isVisible) { logSoundErrors = isVisible; }
+
+  bool AssureSoundIsOpen();
+  void AssureSoundIsClosed();
+  void AssignOrganFile(GOOrganController *pNewOrganController);
 
   bool AudioCallback(unsigned devIndex, GOSoundBufferMutable &outBuffer);
 };


### PR DESCRIPTION
Earlier:
 - Debug symbols on Linux were never shipped with GitHub build artifacts, making it impossible to diagnose crash backtraces
 - Windows PDB generation (cv2pdb) was unconditional — no way to disable it
 - All GitHub builds (release and intermediate) used the `Release` build type
 - ASAN was not supported in CI or build scripts

 This PR does:
 - Adds `RELEASE_FLAG` CMake option — unifies release/debug build type selection across all platform build scripts
 - Adds `GO_SPLIT_DEBUG_SYMBOLS` CMake option (default: ON on Windows always; on Linux = RELEASE_FLAG) — extracts `.dbg` via `objcopy --only-keep-debug` on Linux, gates PDB generation on Windows
 - Now all intermediate GitHub builds use the `Debug` build type; release builds use the `Release` build type
 - Adds `GO_BUILD_ASAN` CMake option with `-fsanitize=address -fno-omit-frame-pointer -static-libasan`, wired through build scripts and CI via `workflow_dispatch` `asan` boolean input
 - Adds capability of triggering ASAN builds from the GitHub Actions UI

This is a GitHub CI/build-only change. GO runtime behavior is unchanged. Intermediate builds now use the `Debug` build type, but the performance impact is negligible thanks to [c4ec548f](https://github.com/GrandOrgue/grandorgue/commit/c4ec548f).
