### PR TITLE
Moved some classes to gui/, renamed classes

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -104,7 +104,7 @@ gui/dialogs/GOSplash.cpp
 gui/dialogs/go-message-boxes.cpp
 gui/document-base/GODocumentBase.cpp
 gui/document-base/GODocumentView.cpp
-gui/frames/GOToolbarWindow.cpp
+gui/frames/GOAppWindow.cpp
 gui/frames/GOLogWindow.cpp
 gui/frames/GOMainWindowData.cpp
 gui/frames/GOStopsWindow.cpp

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -65,8 +65,9 @@ control/GOElementCreator.cpp
 control/GOEventDistributor.cpp
 control/GOLabelControl.cpp
 control/GOPistonControl.cpp
-document-base/GODocumentBase.cpp
-document-base/GOView.cpp
+gui/GOGuiImageCache.cpp
+gui/GOGuiLog.cpp
+gui/GOGuiOrgan.cpp
 gui/dialogs/common/GODialogCloser.cpp
 gui/dialogs/common/GODialogSizeSet.cpp
 gui/dialogs/common/GODialogTab.cpp
@@ -101,7 +102,9 @@ gui/dialogs/GOPropertiesDialog.cpp
 gui/dialogs/GOSelectOrganDialog.cpp
 gui/dialogs/GOSplash.cpp
 gui/dialogs/go-message-boxes.cpp
-gui/frames/GOFrame.cpp
+gui/document-base/GODocumentBase.cpp
+gui/document-base/GODocumentView.cpp
+gui/frames/GOToolbarWindow.cpp
 gui/frames/GOLogWindow.cpp
 gui/frames/GOMainWindowData.cpp
 gui/frames/GOStopsWindow.cpp
@@ -239,11 +242,8 @@ yaml/GOSaveableToYaml.cpp
 yaml/GOYamlModel.cpp
 yaml/go-wx-yaml.cpp
 GOAudioRecorder.cpp
-GOImageCache.cpp
-GODocument.cpp
 GOEvent.cpp
 GOKeyConvert.cpp
-GOLog.cpp
 GOMetronome.cpp
 GOOrganController.cpp
 GOVirtualCouplerController.cpp
@@ -262,11 +262,11 @@ link_directories(${go_libdir})
 
 if (WIN32)
   set_source_files_properties("${RESOURCEDIR}/GrandOrgue.rc" PROPERTIES GENERATED "YES")
-  add_executable(GrandOrgue WIN32 GOApp.cpp "${RESOURCEDIR}/GrandOrgue.rc")
+  add_executable(GrandOrgue WIN32 gui/GOGuiApp.cpp "${RESOURCEDIR}/GrandOrgue.rc")
   add_dependencies(GrandOrgue resources) # GrandOrgue.rc and GrandOrgue.manifest & GOIcon.ico referenced from GrandOrgue.rc
   add_linker_option(GrandOrgue large-address-aware)
 else ()
-   add_executable(GrandOrgue GOApp.cpp)
+   add_executable(GrandOrgue gui/GOGuiApp.cpp)
 endif ()
 
 BUILD_EXECUTABLE(GrandOrgue)

--- a/src/grandorgue/GOAudioRecorder.cpp
+++ b/src/grandorgue/GOAudioRecorder.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -17,6 +17,7 @@
 
 #include "GOEvent.h"
 #include "GOOrganController.h"
+#include "GOTimer.h"
 #include "go_path.h"
 
 enum {

--- a/src/grandorgue/GOMetronome.cpp
+++ b/src/grandorgue/GOMetronome.cpp
@@ -19,6 +19,7 @@
 #include "model/GOWindchest.h"
 
 #include "GOOrganController.h"
+#include "GOTimer.h"
 
 static const GOMidiObjectContext MIDI_CONTEXT(wxT("Metronome"), _("Metronome"));
 

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -8,7 +8,6 @@
 #include "GOOrganController.h"
 
 #include <algorithm>
-#include <math.h>
 
 #include <wx/filename.h>
 #include <wx/log.h>
@@ -27,11 +26,10 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigReaderDB.h"
 #include "config/GOConfigWriter.h"
-#include "contrib/sha1.h"
 #include "control/GOElementCreator.h"
-#include "control/GOPushbuttonControl.h"
 #include "files/GOOpenedFile.h"
 #include "files/GOStdFileName.h"
+#include "gui/GOGuiImageCache.h"
 #include "gui/dialogs/GOProgressDialog.h"
 #include "gui/dialogs/go-message-boxes.h"
 #include "gui/panels/GOGUIBankedGeneralsPanel.h"
@@ -53,7 +51,6 @@
 #include "midi/GOMidiRecorder.h"
 #include "midi/GOMidiSystem.h"
 #include "midi/events/GOMidiEvent.h"
-#include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
 #include "model/GOEnclosure.h"
 #include "model/GOManual.h"
@@ -70,11 +67,11 @@
 
 #include "GOAudioRecorder.h"
 #include "GOBuffer.h"
-#include "GODocument.h"
 #include "GOEvent.h"
 #include "GOHash.h"
 #include "GOMetronome.h"
 #include "GOOrgan.h"
+#include "GOTimer.h"
 #include "go_path.h"
 
 static const wxString WX_ORGAN = wxT("Organ");
@@ -84,13 +81,7 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
   : GOEventDistributor(this),
     GOOrganModel(config),
     m_config(config),
-    m_odf(),
-    m_ArchiveID(),
-    m_hash(),
     m_FileStore(config),
-    m_CacheFilename(),
-    m_SettingFilename(),
-    m_ODFHash(),
     m_Cacheable(false),
     m_setter(0),
     m_AudioRecorder(NULL),
@@ -102,18 +93,7 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
     m_b_customized(false),
     m_CurrentPitch(999999.0), // for enforcing updating the label first time
     m_OrganModified(false),
-    m_ChurchAddress(),
-    m_OrganBuilder(),
-    m_OrganBuildDate(),
-    m_OrganComments(),
-    m_RecordingDetails(),
-    m_InfoFilename(),
-    m_panels(),
-    m_panelcreators(),
-    m_elementcreators(),
-    m_soundengine(0),
     m_midi(0),
-    m_MidiSamplesetMatch(),
     m_SampleSetId1(0),
     m_SampleSetId2(0),
     mp_ImageCache(nullptr),
@@ -123,7 +103,7 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
   if (isAppInitialized) {
     // Load here objects that needs App (wx) to be loaded
     m_timer = new GOTimer();
-    mp_ImageCache = new GOImageCache(m_FileStore);
+    mp_ImageCache = new GOGuiImageCache(m_FileStore);
   }
   GOOrganModel::SetModelModificationListener(this);
   m_setter = new GOSetter(this);

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+#include <wx/filefn.h>
 #include <wx/string.h>
 
 #include "ptrvector.h"
@@ -23,14 +24,11 @@
 #include "model/GOOrganModel.h"
 #include "modification/GOModificationProxy.h"
 
-#include "GOImageCache.h"
+#include "sound/GOSoundOrganEngine.h"
+
 #include "GOMemoryPool.h"
-#include "GOTimer.h"
 #include "GOVirtualCouplerController.h"
 
-class GOGUIPanel;
-class GOGUIPanelCreator;
-class GOGUICouplerPanel;
 class GOArchive;
 class GOAudioRecorder;
 class GOButtonControl;
@@ -38,19 +36,23 @@ class GOCache;
 class GODialogSizeSet;
 class GODivisionalSetter;
 class GOElementCreator;
-class GOMidiSystem;
+class GOGUICouplerPanel;
+class GOGuiImageCache;
+class GOGuiOrgan;
+class GOGUIPanel;
+class GOGUIPanelCreator;
 class GOMidiEvent;
 class GOMidiPlayer;
 class GOMidiRecorder;
+class GOMidiSystem;
 class GOOrgan;
 class GOProgressDialog;
 class GOSetter;
-class GOConfig;
-class GOTemperament;
-class GODocument;
-class GOSoundOrganEngine;
 class GOSoundProvider;
 class GOSoundRecorder;
+class GOSoundSystem;
+class GOTemperament;
+class GOTimer;
 typedef struct _GOHashType GOHashType;
 
 class GOOrganController : public GOEventDistributor,
@@ -102,7 +104,8 @@ private:
   GOGUIMouseState m_MouseState;
 
   GOMemoryPool m_pool;
-  GOImageCache *mp_ImageCache;
+  GOSoundOrganEngine m_SoundEngine;
+  GOGuiImageCache *mp_ImageCache;
   GOLabelControl m_PitchLabel;
   GOLabelControl m_TemperamentLabel;
   GOMainWindowData m_MainWindowData;
@@ -183,7 +186,7 @@ public:
   void AddPanel(GOGUIPanel *panel) { m_panels.push_back(panel); }
   GOMemoryPool &GetMemoryPool() { return m_pool; }
   GOConfig &GetSettings() { return m_config; }
-  GOImageCache &GetImageCache() const { return *mp_ImageCache; }
+  GOGuiImageCache &GetImageCache() const { return *mp_ImageCache; }
   void SetTemperament(const wxString &name);
   const wxString &GetTemperament() const { return m_Temperament; }
 

--- a/src/grandorgue/control/GOButtonControl.cpp
+++ b/src/grandorgue/control/GOButtonControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,9 +10,8 @@
 #include <wx/intl.h>
 
 #include "config/GOConfigReader.h"
+#include "gui/GOGuiOrgan.h"
 #include "model/GOOrganModel.h"
-
-#include "GODocument.h"
 
 GOButtonControl::GOButtonControl(
   GOOrganModel &organModel,

--- a/src/grandorgue/gui/GOGuiApp.cpp
+++ b/src/grandorgue/gui/GOGuiApp.cpp
@@ -5,7 +5,7 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOApp.h"
+#include "GOGuiApp.h"
 
 #include <wx/cmdline.h>
 #include <wx/filesys.h>
@@ -13,10 +13,10 @@
 #include <wx/regex.h>
 
 #include "config/GOConfig.h"
-#include "gui/frames/GOFrame.h"
+#include "frames/GOToolbarWindow.h"
 #include "sound/GOSoundSystem.h"
 
-#include "GOLog.h"
+#include "GOGuiLog.h"
 #include "GOStdPath.h"
 #include "go_defs.h"
 
@@ -28,11 +28,11 @@
 #include <windows.h>
 #endif
 
-IMPLEMENT_APP(GOApp)
+IMPLEMENT_APP(GOGuiApp)
 
-GOApp::~GOApp() = default;
+GOGuiApp::~GOGuiApp() = default;
 
-void GOApp::TemporaryLog::DoLogTextAtLevel(
+void GOGuiApp::TemporaryLog::DoLogTextAtLevel(
   wxLogLevel level, const wxString &msg) {
   FILE *output = (level <= wxLOG_Warning) ? stderr : stdout;
 
@@ -85,13 +85,13 @@ static const wxCmdLineEntryDesc cmd_line_desc[] = {
    wxCMD_LINE_PARAM_OPTIONAL},
   {wxCMD_LINE_NONE}};
 
-void GOApp::OnInitCmdLine(wxCmdLineParser &parser) {
+void GOGuiApp::OnInitCmdLine(wxCmdLineParser &parser) {
   parser.SetLogo(wxString::Format(
     _("GrandOrgue %s - Virtual Pipe Organ Software"), wxT(APP_VERSION)));
   parser.SetDesc(cmd_line_desc);
 }
 
-bool GOApp::OnCmdLineParsed(wxCmdLineParser &parser) {
+bool GOGuiApp::OnCmdLineParsed(wxCmdLineParser &parser) {
   bool res = wxApp::OnCmdLineParsed(parser);
   wxString str;
 
@@ -115,7 +115,7 @@ bool GOApp::OnCmdLineParsed(wxCmdLineParser &parser) {
   return res;
 }
 
-bool GOApp::OnInit() {
+bool GOGuiApp::OnInit() {
   wxLog::SetActiveTarget(mp_TemporaryLog.get());
 
 #ifdef __WXMAC__
@@ -158,7 +158,7 @@ bool GOApp::OnInit() {
 
   mp_SoundSystem = std::make_unique<GOSoundSystem>(*mp_config);
 
-  p_frame = new GOFrame(
+  p_ToolbarWindow = new GOToolbarWindow(
     *this,
     NULL,
     wxID_ANY,
@@ -168,24 +168,24 @@ bool GOApp::OnInit() {
     wxMINIMIZE_BOX | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX
       | wxCLIP_CHILDREN | wxFULL_REPAINT_ON_RESIZE,
     *mp_SoundSystem);
-  SetTopWindow(p_frame);
-  mp_log = std::make_unique<GOLog>(p_frame);
+  SetTopWindow(p_ToolbarWindow);
+  mp_log = std::make_unique<GOGuiLog>(p_ToolbarWindow);
   wxLog::SetActiveTarget(mp_log.get());
-  p_frame->Init(m_FileName, m_IsGuiOnly);
+  p_ToolbarWindow->Init(m_FileName, m_IsGuiOnly);
 
   return true;
 }
 
 #ifdef __WXMAC__
-void GOApp::MacOpenFile(const wxString &filename) {
-  if (p_frame)
-    p_frame->SendLoadFile(filename);
+void GOGuiApp::MacOpenFile(const wxString &filename) {
+  if (p_ToolbarWindow)
+    p_ToolbarWindow->SendLoadFile(filename);
 }
 #endif
 
-int GOApp::OnRun() { return wxApp::OnRun(); }
+int GOGuiApp::OnRun() { return wxApp::OnRun(); }
 
-int GOApp::OnExit() {
+int GOGuiApp::OnExit() {
   wxLog::FlushActive();
   wxLog::SetActiveTarget(nullptr);
 
@@ -199,8 +199,8 @@ int GOApp::OnExit() {
   return rc;
 }
 
-void GOApp::CleanUp() {
-  // Ensure that GOFrame and other objects are destroyed before deleting
+void GOGuiApp::CleanUp() {
+  // Ensure that GOToolbarWindow and other objects are destroyed before deleting
   wxApp::CleanUp();
   // CleanUp() may be called even if OnInit() has not succeed, so unique_ptr
   // reset() is safe to call even if the objects were never created

--- a/src/grandorgue/gui/GOGuiApp.cpp
+++ b/src/grandorgue/gui/GOGuiApp.cpp
@@ -13,7 +13,7 @@
 #include <wx/regex.h>
 
 #include "config/GOConfig.h"
-#include "frames/GOToolbarWindow.h"
+#include "frames/GOAppWindow.h"
 #include "sound/GOSoundSystem.h"
 
 #include "GOGuiLog.h"
@@ -158,7 +158,7 @@ bool GOGuiApp::OnInit() {
 
   mp_SoundSystem = std::make_unique<GOSoundSystem>(*mp_config);
 
-  p_ToolbarWindow = new GOToolbarWindow(
+  p_AppWindow = new GOAppWindow(
     *this,
     NULL,
     wxID_ANY,
@@ -168,18 +168,18 @@ bool GOGuiApp::OnInit() {
     wxMINIMIZE_BOX | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX
       | wxCLIP_CHILDREN | wxFULL_REPAINT_ON_RESIZE,
     *mp_SoundSystem);
-  SetTopWindow(p_ToolbarWindow);
-  mp_log = std::make_unique<GOGuiLog>(p_ToolbarWindow);
+  SetTopWindow(p_AppWindow);
+  mp_log = std::make_unique<GOGuiLog>(p_AppWindow);
   wxLog::SetActiveTarget(mp_log.get());
-  p_ToolbarWindow->Init(m_FileName, m_IsGuiOnly);
+  p_AppWindow->Init(m_FileName, m_IsGuiOnly);
 
   return true;
 }
 
 #ifdef __WXMAC__
 void GOGuiApp::MacOpenFile(const wxString &filename) {
-  if (p_ToolbarWindow)
-    p_ToolbarWindow->SendLoadFile(filename);
+  if (p_AppWindow)
+    p_AppWindow->SendLoadFile(filename);
 }
 #endif
 
@@ -200,7 +200,7 @@ int GOGuiApp::OnExit() {
 }
 
 void GOGuiApp::CleanUp() {
-  // Ensure that GOToolbarWindow and other objects are destroyed before deleting
+  // Ensure that GOAppWindow and other objects are destroyed before deleting
   wxApp::CleanUp();
   // CleanUp() may be called even if OnInit() has not succeed, so unique_ptr
   // reset() is safe to call even if the objects were never created

--- a/src/grandorgue/gui/GOGuiApp.h
+++ b/src/grandorgue/gui/GOGuiApp.h
@@ -19,25 +19,25 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef GOAPP_H
-#define GOAPP_H
+#ifndef GOGUIAPP_H
+#define GOGUIAPP_H
 
 #include <memory>
 
 #include <wx/app.h>
 
 class GOConfig;
-class GOFrame;
-class GOLog;
+class GOToolbarWindow;
+class GOGuiLog;
 class GOSoundSystem;
 
-class GOApp : public wxApp {
+class GOGuiApp : public wxApp {
 private:
   /**
    * A temporary logging class.
    * It logs all Warning and Error log messages to stderr, all other messages to
    * stdout. It alse displays all Error messages to a modal message box.
-   * It is used only before initialising the GOLog instance, including during
+   * It is used only before initialising the GOGuiLog instance, including during
    * reading the GrandOrgueConfig
    */
   class TemporaryLog : public wxLog {
@@ -61,23 +61,23 @@ private:
   virtual void CleanUp() override;
 
 protected:
-  GOFrame *p_frame = nullptr;
+  GOToolbarWindow *p_ToolbarWindow = nullptr;
   wxLocale m_locale;
   std::unique_ptr<GOConfig> mp_config;
   std::unique_ptr<GOSoundSystem> mp_SoundSystem;
-  std::unique_ptr<GOLog> mp_log;
+  std::unique_ptr<GOGuiLog> mp_log;
   wxString m_FileName;
   std::string m_InstanceName;
   std::string m_ConfigFilePath;
   bool m_IsGuiOnly = false;
 
 public:
-  ~GOApp();
+  ~GOGuiApp();
 
   bool IsToRestartAfterExit() const { return m_IsToRestartAfterExit; }
   void SetToRestartAfterExit() { m_IsToRestartAfterExit = true; }
 };
 
-DECLARE_APP(GOApp)
+DECLARE_APP(GOGuiApp)
 
 #endif

--- a/src/grandorgue/gui/GOGuiApp.h
+++ b/src/grandorgue/gui/GOGuiApp.h
@@ -27,7 +27,7 @@
 #include <wx/app.h>
 
 class GOConfig;
-class GOToolbarWindow;
+class GOAppWindow;
 class GOGuiLog;
 class GOSoundSystem;
 
@@ -61,7 +61,7 @@ private:
   virtual void CleanUp() override;
 
 protected:
-  GOToolbarWindow *p_ToolbarWindow = nullptr;
+  GOAppWindow *p_AppWindow = nullptr;
   wxLocale m_locale;
   std::unique_ptr<GOConfig> mp_config;
   std::unique_ptr<GOSoundSystem> mp_SoundSystem;

--- a/src/grandorgue/gui/GOGuiImageCache.cpp
+++ b/src/grandorgue/gui/GOGuiImageCache.cpp
@@ -5,7 +5,7 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOImageCache.h"
+#include "GOGuiImageCache.h"
 
 #include <wx/intl.h>
 #include <wx/mstream.h>
@@ -14,7 +14,7 @@
 #include "loader/GOLoaderFilename.h"
 
 #include "GOBuffer.h"
-#include "GOLog.h"
+#include "GOGuiLog.h"
 #include "Images.h"
 
 #define BITMAP_LIST                                                            \
@@ -155,9 +155,9 @@ BITMAP_LIST
   static wxImage A##_r(GetImage_##A().Rotate90());                             \
   RegisterImage(wxT(GOBitmapPrefix B), WX_EMPTY_STRING, new wxImage(A##_r));
 
-const wxString GOImageCache::WX_EMPTY_STRING = wxEmptyString;
+const wxString GOGuiImageCache::WX_EMPTY_STRING = wxEmptyString;
 
-const wxImage *GOImageCache::FindImage(
+const wxImage *GOGuiImageCache::FindImage(
   const wxString &filename, const wxString &maskname) const {
   const wxImage *pImage = nullptr;
 
@@ -169,27 +169,28 @@ const wxImage *GOImageCache::FindImage(
   return pImage;
 }
 
-void GOImageCache::RegisterImage(
+void GOGuiImageCache::RegisterImage(
   const wxString &filename, const wxString &maskname, wxImage *pImage) {
   m_images.push_back(pImage);
   m_filenames.push_back(filename);
   m_masknames.push_back(maskname);
 }
 
-GOImageCache::GOImageCache(const GOFileStore &fileStore)
+GOGuiImageCache::GOGuiImageCache(const GOFileStore &fileStore)
   : r_FileStore(fileStore) {
   BITMAP_LIST;
 }
 
-const wxImage *GOImageCache::GetWoodImage(unsigned woodImageNum) const {
+const wxImage *GOGuiImageCache::GetWoodImage(unsigned woodImageNum) const {
   return FindImage(
     wxString::Format(wxT(GOBitmapPrefix "wood%02d"), woodImageNum),
     wxEmptyString);
 }
 
-bool GOImageCache::LoadImageFromFile(const wxString &filename, wxImage &image) {
+bool GOGuiImageCache::LoadImageFromFile(
+  const wxString &filename, wxImage &image) {
   bool result;
-  GOLog *const log = dynamic_cast<GOLog *>(wxLog::GetActiveTarget());
+  GOGuiLog *const log = dynamic_cast<GOGuiLog *>(wxLog::GetActiveTarget());
 
   if (log)
     log->SetCurrentFileName(filename);
@@ -218,7 +219,7 @@ bool GOImageCache::LoadImageFromFile(const wxString &filename, wxImage &image) {
   return result;
 }
 
-const wxImage *GOImageCache::LoadImage(
+const wxImage *GOGuiImageCache::LoadImage(
   const wxString &filename, const wxString &maskName) {
   const wxImage *pImage = FindImage(filename, maskName);
 

--- a/src/grandorgue/gui/GOGuiImageCache.h
+++ b/src/grandorgue/gui/GOGuiImageCache.h
@@ -5,8 +5,8 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GOIMAGECACHE_H
-#define GOIMAGECACHE_H
+#ifndef GOGUIIMAGECACHE_H
+#define GOGUIIMAGECACHE_H
 
 #include <wx/image.h>
 #include <wx/string.h>
@@ -15,7 +15,7 @@
 
 class GOFileStore;
 
-class GOImageCache {
+class GOGuiImageCache {
 private:
   static const wxString WX_EMPTY_STRING;
 
@@ -33,7 +33,7 @@ private:
     const wxString &filename, const wxString &maskname, wxImage *pImage);
 
 public:
-  GOImageCache(const GOFileStore &fileStore);
+  GOGuiImageCache(const GOFileStore &fileStore);
 
   const wxImage *GetWoodImage(unsigned woodImageNum) const;
 

--- a/src/grandorgue/gui/GOGuiLog.cpp
+++ b/src/grandorgue/gui/GOGuiLog.cpp
@@ -1,25 +1,25 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOLog.h"
+#include "GOGuiLog.h"
 
-#include "gui/frames/GOLogWindow.h"
+#include "frames/GOLogWindow.h"
 
-GOLog::GOLog(wxWindow *parent) : m_LogWindow(NULL) {
+GOGuiLog::GOGuiLog(wxWindow *parent) : m_LogWindow(NULL) {
   m_LogWindow = new GOLogWindow(parent, wxID_ANY, _("Log messages"));
 }
 
-GOLog::~GOLog() {
+GOGuiLog::~GOGuiLog() {
   if (m_LogWindow) {
     m_LogWindow = NULL;
   }
 }
 
-void GOLog::DoLogTextAtLevel(wxLogLevel level, const wxString &msg) {
+void GOGuiLog::DoLogTextAtLevel(wxLogLevel level, const wxString &msg) {
   if (m_LogWindow) {
     wxString resultMsg = msg;
 

--- a/src/grandorgue/gui/GOGuiLog.h
+++ b/src/grandorgue/gui/GOGuiLog.h
@@ -1,18 +1,18 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GOLOG_H
-#define GOLOG_H
+#ifndef GOBUILOG_H
+#define GOBUILOG_H
 
 #include <wx/log.h>
 
 class GOLogWindow;
 
-class GOLog : public wxLog {
+class GOGuiLog : public wxLog {
 private:
   GOLogWindow *m_LogWindow;
 
@@ -22,8 +22,8 @@ protected:
   void DoLogTextAtLevel(wxLogLevel level, const wxString &msg);
 
 public:
-  GOLog(wxWindow *parent);
-  virtual ~GOLog();
+  GOGuiLog(wxWindow *parent);
+  virtual ~GOGuiLog();
 
   const wxString &GetCurrentFileName() const { return m_CurrentFileName; }
   void SetCurrentFileName(const wxString &fileName) {

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -5,16 +5,16 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GODocument.h"
+#include "GOGuiOrgan.h"
 
 #include <wx/app.h>
 
 #include "config/GOConfig.h"
-#include "document-base/GOView.h"
+#include "document-base/GODocumentView.h"
+#include "frames/GOToolbarWindow.h"
 #include "gui/dialogs/GOMidiObjectstDialog.h"
 #include "gui/dialogs/midi-event/GOMidiEventDialog.h"
 #include "gui/dialogs/organ-settings/GOOrganSettingsDialog.h"
-#include "gui/frames/GOFrame.h"
 #include "gui/frames/GOStopsWindow.h"
 #include "gui/panels/GOGUIPanel.h"
 #include "gui/panels/GOGUIPanelView.h"
@@ -28,7 +28,7 @@
 #include "GOOrganController.h"
 #include "go_ids.h"
 
-GODocument::GODocument(GOResizable *pMainWindow, GOSoundSystem *sound)
+GOGuiOrgan::GOGuiOrgan(GOResizable *pMainWindow, GOSoundSystem *sound)
   : p_MainWindow(pMainWindow),
     m_sound(*sound),
     m_OrganFileReady(false),
@@ -37,16 +37,16 @@ GODocument::GODocument(GOResizable *pMainWindow, GOSoundSystem *sound)
   m_listener.Register(&m_sound.GetMidi());
 }
 
-GODocument::~GODocument() {
+GOGuiOrgan::~GOGuiOrgan() {
   m_listener.SetCallback(NULL);
   CloseOrgan();
 }
 
-bool GODocument::IsModified() const {
+bool GOGuiOrgan::IsModified() const {
   return m_OrganController && m_OrganController->IsOrganModified();
 }
 
-GOOrganController *GODocument::LoadOrgan(
+GOOrganController *GOGuiOrgan::LoadOrgan(
   GOProgressDialog *dlg,
   const GOOrgan &organ,
   const wxString &cmb,
@@ -98,23 +98,22 @@ GOOrganController *GODocument::LoadOrgan(
   return m_OrganController;
 }
 
-bool GODocument::UpdateCache(GOProgressDialog *dlg, bool compress) {
+bool GOGuiOrgan::UpdateCache(GOProgressDialog *dlg, bool compress) {
   if (!m_OrganController)
     return false;
   return m_OrganController->UpdateCache(dlg, compress);
 }
 
-void GODocument::ShowPanel(unsigned id) {
+void GOGuiOrgan::ShowPanel(unsigned id) {
   GOGUIPanel *panel = m_OrganController->GetPanel(id);
 
-  if (!showWindow(GODocument::PANEL, panel)) {
+  if (!showWindow(GOGuiOrgan::PANEL, panel)) {
     registerWindow(
-      GODocument::PANEL, panel, GOGUIPanelView::createWithFrame(this, panel));
+      GOGuiOrgan::PANEL, panel, GOGUIPanelView::createWithFrame(this, panel));
   }
 }
 
-void GODocument::SyncState() {
-  m_OrganController->SetVolume(m_sound.GetEngine().GetVolume());
+void GOGuiOrgan::SyncState() {
   if (p_MainWindow)
     m_OrganController->GetMainWindowData()->SetWindowRect(
       p_MainWindow->GetPosSize());
@@ -123,17 +122,17 @@ void GODocument::SyncState() {
   GODocumentBase::SyncState();
 }
 
-bool GODocument::Save() {
+bool GOGuiOrgan::Save() {
   SyncState();
   return m_OrganController->Save();
 }
 
-bool GODocument::Export(const wxString &cmb) {
+bool GOGuiOrgan::Export(const wxString &cmb) {
   SyncState();
   return m_OrganController->Export(cmb);
 }
 
-void GODocument::CloseOrgan() {
+void GOGuiOrgan::CloseOrgan() {
   m_listener.SetCallback(NULL);
   m_sound.AssignOrganFile(NULL);
   // m_sound.CloseSound();
@@ -152,7 +151,7 @@ void GODocument::CloseOrgan() {
   wxTheApp->GetTopWindow()->GetEventHandler()->AddPendingEvent(event);
 }
 
-void GODocument::OnMidiEvent(const GOMidiEvent &event) {
+void GOGuiOrgan::OnMidiEvent(const GOMidiEvent &event) {
   GOMutexLocker locker(m_lock);
 
   if (!m_OrganFileReady)
@@ -162,26 +161,26 @@ void GODocument::OnMidiEvent(const GOMidiEvent &event) {
     m_OrganController->ProcessMidi(event);
 }
 
-void GODocument::ShowOrganSettingsDialog() {
-  if (!showWindow(GODocument::ORGAN_DIALOG, NULL) && m_OrganController) {
+void GOGuiOrgan::ShowOrganSettingsDialog() {
+  if (!showWindow(GOGuiOrgan::ORGAN_DIALOG, NULL) && m_OrganController) {
     registerWindow(
-      GODocument::ORGAN_DIALOG,
+      GOGuiOrgan::ORGAN_DIALOG,
       NULL,
       new GOOrganSettingsDialog(*m_OrganController, this, nullptr));
   }
 }
 
-void GODocument::ShowMidiList() {
-  if (!showWindow(GODocument::MIDI_LIST, NULL) && m_OrganController) {
+void GOGuiOrgan::ShowMidiList() {
+  if (!showWindow(GOGuiOrgan::MIDI_LIST, NULL) && m_OrganController) {
     registerWindow(
-      GODocument::MIDI_LIST,
+      GOGuiOrgan::MIDI_LIST,
       nullptr,
       new GOMidiObjectsDialog(this, nullptr, *m_OrganController));
   }
 }
 
-void GODocument::ShowStops() {
-  if (!showWindow(GODocument::STOPS, NULL) && m_OrganController) {
+void GOGuiOrgan::ShowStops() {
+  if (!showWindow(GOGuiOrgan::STOPS, NULL) && m_OrganController) {
     auto stopsWindow = new GOStopsWindow(
       this,
       nullptr,
@@ -189,15 +188,15 @@ void GODocument::ShowStops() {
       *m_OrganController);
 
     registerWindow(
-      GODocument::STOPS,
+      GOGuiOrgan::STOPS,
       stopsWindow, // Otherwise GOStopsWindow::SyncState() wont be called
       stopsWindow);
   }
 }
 
-void GODocument::ShowMIDIEventDialog(
+void GOGuiOrgan::ShowMIDIEventDialog(
   GOMidiObject &obj, GOMidiDialogListener *pDialogListener) {
-  if (!showWindow(GODocument::MIDI_EVENT, &obj) && m_OrganController) {
+  if (!showWindow(GOGuiOrgan::MIDI_EVENT, &obj) && m_OrganController) {
     const wxString title = wxString::Format(
       _("MIDI-Settings for %s - %s"), obj.GetMidiTypeName(), obj.GetName());
     const wxString dialogSelector
@@ -214,6 +213,6 @@ void GODocument::ShowMIDIEventDialog(
       pDialogListener);
     dlg->RegisterMIDIListener(m_OrganController->GetMidi());
     dlg->SetModificationListener(m_OrganController);
-    registerWindow(GODocument::MIDI_EVENT, &obj, dlg);
+    registerWindow(GOGuiOrgan::MIDI_EVENT, &obj, dlg);
   }
 }

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -11,7 +11,7 @@
 
 #include "config/GOConfig.h"
 #include "document-base/GODocumentView.h"
-#include "frames/GOToolbarWindow.h"
+#include "frames/GOAppWindow.h"
 #include "gui/dialogs/GOMidiObjectstDialog.h"
 #include "gui/dialogs/midi-event/GOMidiEventDialog.h"
 #include "gui/dialogs/organ-settings/GOOrganSettingsDialog.h"

--- a/src/grandorgue/gui/GOGuiOrgan.h
+++ b/src/grandorgue/gui/GOGuiOrgan.h
@@ -5,8 +5,8 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GODOCUMENT_H
-#define GODOCUMENT_H
+#ifndef GOGUIORGAN_H
+#define GOGUIORGAN_H
 
 #include <wx/string.h>
 
@@ -23,7 +23,7 @@ class GOProgressDialog;
 class GOResizable;
 class GOSoundSystem;
 
-class GODocument : public GODocumentBase, protected GOMidiCallback {
+class GOGuiOrgan : public GODocumentBase, protected GOMidiCallback {
 private:
   GOResizable *p_MainWindow;
   GOSoundSystem &m_sound;
@@ -40,8 +40,8 @@ private:
   void CloseOrgan();
 
 public:
-  GODocument(GOResizable *pMainWindow, GOSoundSystem *sound);
-  ~GODocument();
+  GOGuiOrgan(GOResizable *pMainWindow, GOSoundSystem *sound);
+  ~GOGuiOrgan();
 
   GOOrganController *GetOrganController() const { return m_OrganController; }
   bool IsModified() const;

--- a/src/grandorgue/gui/dialogs/GOMidiObjectsDialog.cpp
+++ b/src/grandorgue/gui/dialogs/GOMidiObjectsDialog.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -19,6 +19,7 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigReaderDB.h"
 #include "config/GOConfigWriter.h"
+#include "gui/GOGuiOrgan.h"
 #include "gui/size/GOAdditionalSizeKeeperProxy.h"
 #include "gui/wxcontrols/GOGrid.h"
 #include "midi/objects/GOMidiObjectContext.h"
@@ -27,7 +28,6 @@
 #include "yaml/GOYamlModel.h"
 #include "yaml/go-wx-yaml.h"
 
-#include "GODocument.h"
 #include "GOEvent.h"
 #include "go-message-boxes.h"
 
@@ -115,7 +115,7 @@ GOMidiObjectsDialog::GOMidiObjectsDialog(
     wxEmptyString,
     0,
     wxCLOSE | wxHELP),
-    GOView(doc, this),
+    GODocumentView(doc, this),
     r_config(organModel.GetConfig()),
     m_ExportImportDir(r_config.ExportImportPath()),
     m_OrganName(organModel.GetOrganName()),
@@ -232,12 +232,12 @@ GOMidiPlayingObject *GOMidiObjectsDialog::GetSelectedObject() const {
 
 void GOMidiObjectsDialog::ConfigureSelectedObject() {
   int row = m_ObjectsGrid->GetGridCursorRow();
-  GODocument *pDoc = dynamic_cast<GODocument *>(GetDocument());
+  GOGuiOrgan *pOrgan = dynamic_cast<GOGuiOrgan *>(GetDocument());
 
   if (row >= 0) {
     GOMidiPlayingObject *pObj = r_MidiObjects[row];
 
-    pDoc->ShowMIDIEventDialog(*pObj, pObj);
+    pOrgan->ShowMIDIEventDialog(*pObj, pObj);
   }
 }
 

--- a/src/grandorgue/gui/dialogs/GOMidiObjectstDialog.h
+++ b/src/grandorgue/gui/dialogs/GOMidiObjectstDialog.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "common/GOSimpleDialog.h"
-#include "document-base/GOView.h"
+#include "gui/document-base/GODocumentView.h"
 #include "midi/dialog-creator/GOMidiDialogListener.h"
 
 class wxButton;
@@ -23,7 +23,7 @@ class GOGrid;
 class GOMidiPlayingObject;
 class GOOrganModel;
 
-class GOMidiObjectsDialog : public GOSimpleDialog, public GOView {
+class GOMidiObjectsDialog : public GOSimpleDialog, public GODocumentView {
 private:
   GOConfig &r_config;
 

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.cpp
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.cpp
@@ -42,7 +42,7 @@ GOMidiEventDialog::GOMidiEventDialog(
   GOMidiDialogListener *pDialogListener)
   : GOTabbedDialog(
     parent, "MidiEvent", title, settings.m_DialogSizes, dialogSelector),
-    GOView(doc, this),
+    GODocumentView(doc, this),
     r_config(settings),
     p_DialogListener(pDialogListener),
     p_object(pMidiObject),

--- a/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.h
+++ b/src/grandorgue/gui/dialogs/midi-event/GOMidiEventDialog.h
@@ -8,10 +8,8 @@
 #ifndef GOMIDIEVENTDIALOG_H
 #define GOMIDIEVENTDIALOG_H
 
-#include <wx/propdlg.h>
-
-#include "document-base/GOView.h"
 #include "gui/dialogs/common/GOTabbedDialog.h"
+#include "gui/document-base/GODocumentView.h"
 #include "modification/GOModificationProxy.h"
 
 class wxButton;
@@ -29,7 +27,7 @@ class GOMidiSender;
 class GOMidiShortcutReceiver;
 
 class GOMidiEventDialog : public GOTabbedDialog,
-                          public GOView,
+                          public GODocumentView,
                           public GOModificationProxy {
 private:
   GOConfig &r_config;

--- a/src/grandorgue/gui/dialogs/organ-settings/GOOrganSettingsDialog.cpp
+++ b/src/grandorgue/gui/dialogs/organ-settings/GOOrganSettingsDialog.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -44,7 +44,7 @@ GOOrganSettingsDialog::GOOrganSettingsDialog(
     wxEmptyString,
     0,
     wxHELP | wxCLOSE),
-    GOView(doc, this) {
+    GODocumentView(doc, this) {
   // add a custom button 'Reason into the space of the standard dialog button
   wxSizer *const pButtonSizer = GetButtonSizer();
 

--- a/src/grandorgue/gui/dialogs/organ-settings/GOOrganSettingsDialog.h
+++ b/src/grandorgue/gui/dialogs/organ-settings/GOOrganSettingsDialog.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,7 +10,7 @@
 
 #include <wx/event.h>
 
-#include "document-base/GOView.h"
+#include "gui/document-base/GODocumentView.h"
 
 #include "GOOrganSettingsDialogBase.h"
 #include "GOOrganSettingsTab.h"
@@ -22,7 +22,8 @@ class GOOrganModel;
 class GOOrganSettingsEnclosuresTab;
 class GOOrganSettingsPipesTab;
 
-class GOOrganSettingsDialog : public GOOrganSettingsDialogBase, public GOView {
+class GOOrganSettingsDialog : public GOOrganSettingsDialogBase,
+                              public GODocumentView {
 private:
   wxButton *m_AudioGroupAssistant;
   wxButton *m_Default;

--- a/src/grandorgue/gui/document-base/GODocumentBase.cpp
+++ b/src/grandorgue/gui/document-base/GODocumentBase.cpp
@@ -1,13 +1,13 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
 #include "GODocumentBase.h"
 
-#include "GOView.h"
+#include "GODocumentView.h"
 
 GODocumentBase::GODocumentBase() : m_Windows() {}
 
@@ -30,7 +30,7 @@ bool GODocumentBase::showWindow(WindowType type, void *data) {
 }
 
 void GODocumentBase::registerWindow(
-  WindowType type, void *data, GOView *window) {
+  WindowType type, void *data, GODocumentView *window) {
   WindowInfo info;
   info.type = type;
   info.data = data;
@@ -39,7 +39,7 @@ void GODocumentBase::registerWindow(
   window->ShowView();
 }
 
-void GODocumentBase::unregisterWindow(GOView *window) {
+void GODocumentBase::unregisterWindow(GODocumentView *window) {
   for (unsigned i = 0; i < m_Windows.size(); i++)
     if (m_Windows[i].window == window) {
       m_Windows.erase(m_Windows.begin() + i);
@@ -55,7 +55,7 @@ void GODocumentBase::SyncState() {
 
 void GODocumentBase::CloseWindows() {
   while (m_Windows.size() > 0) {
-    GOView *wnd = m_Windows[0].window;
+    GODocumentView *wnd = m_Windows[0].window;
     m_Windows.erase(m_Windows.begin());
     wnd->RemoveView();
   }

--- a/src/grandorgue/gui/document-base/GODocumentBase.h
+++ b/src/grandorgue/gui/document-base/GODocumentBase.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,7 +10,7 @@
 
 #include <vector>
 
-class GOView;
+class GODocumentView;
 
 class GODocumentBase {
 public:
@@ -20,7 +20,7 @@ private:
   typedef struct {
     WindowType type;
     void *data;
-    GOView *window;
+    GODocumentView *window;
   } WindowInfo;
 
   std::vector<WindowInfo> m_Windows;
@@ -35,8 +35,8 @@ public:
 
   bool WindowExists(WindowType type, void *data);
   bool showWindow(WindowType type, void *data);
-  void registerWindow(WindowType type, void *data, GOView *window);
-  void unregisterWindow(GOView *window);
+  void registerWindow(WindowType type, void *data, GODocumentView *window);
+  void unregisterWindow(GODocumentView *window);
 };
 
 #endif

--- a/src/grandorgue/gui/document-base/GODocumentView.cpp
+++ b/src/grandorgue/gui/document-base/GODocumentView.cpp
@@ -1,25 +1,26 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOView.h"
+#include "GODocumentView.h"
 
 #include "gui/dialogs/common/GODialogCloser.h"
 
 #include "GODocumentBase.h"
 
-GOView::GOView(GODocumentBase *doc, wxWindow *wnd) : m_doc(doc), m_wnd(wnd) {}
+GODocumentView::GODocumentView(GODocumentBase *doc, wxWindow *wnd)
+  : m_doc(doc), m_wnd(wnd) {}
 
-GOView::~GOView() {
+GODocumentView::~GODocumentView() {
   if (m_doc)
     m_doc->unregisterWindow(this);
   m_doc = NULL;
 }
 
-void GOView::RemoveView() {
+void GODocumentView::RemoveView() {
   m_doc = NULL;
 
   const bool isAutoDestroyed = dynamic_cast<GODialogCloser *>(m_wnd);
@@ -30,7 +31,7 @@ void GOView::RemoveView() {
     m_wnd->Destroy();
 }
 
-void GOView::ShowView() {
+void GODocumentView::ShowView() {
   if (GODialogCloser *pDialog = dynamic_cast<GODialogCloser *>(m_wnd))
     pDialog->ShowAdvanced(true);
   else {
@@ -39,4 +40,4 @@ void GOView::ShowView() {
   }
 }
 
-void GOView::SyncState() {}
+void GODocumentView::SyncState() {}

--- a/src/grandorgue/gui/document-base/GODocumentView.h
+++ b/src/grandorgue/gui/document-base/GODocumentView.h
@@ -1,25 +1,25 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GODIALOGVIEW_H
-#define GODIALOGVIEW_H
+#ifndef GODOCUMENTVIEW_H
+#define GODOCUMENTVIEW_H
 
 #include <wx/window.h>
 
 class GODocumentBase;
 
-class GOView {
+class GODocumentView {
 private:
   GODocumentBase *m_doc;
   wxWindow *m_wnd;
 
 public:
-  GOView(GODocumentBase *doc, wxWindow *wnd);
-  virtual ~GOView();
+  GODocumentView(GODocumentBase *doc, wxWindow *wnd);
+  virtual ~GODocumentView();
 
   bool HasDocument() const { return m_doc != NULL; }
 

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -5,7 +5,7 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOToolbarWindow.h"
+#include "GOAppWindow.h"
 
 #include <algorithm>
 
@@ -55,82 +55,77 @@
 #include "go_limits.h"
 #include "go_path.h"
 
-BEGIN_EVENT_TABLE(GOToolbarWindow, wxFrame)
-EVT_MSGBOX(GOToolbarWindow::OnMsgBox)
-EVT_RENAMEFILE(GOToolbarWindow::OnRenameFile)
-EVT_CLOSE(GOToolbarWindow::OnCloseWindow)
-EVT_CHAR_HOOK(GOToolbarWindow::OnKeyCommand)
-EVT_COMMAND(0, wxEVT_METERS, GOToolbarWindow::OnMeters)
-EVT_COMMAND(0, wxEVT_LOADFILE, GOToolbarWindow::OnLoadFile)
-EVT_MENU_OPEN(GOToolbarWindow::OnMenuOpen)
-EVT_MENU(ID_FILE_OPEN, GOToolbarWindow::OnOpen)
-EVT_MENU(ID_FILE_LOAD, GOToolbarWindow::OnLoad)
-EVT_MENU(ID_FILE_INSTALL, GOToolbarWindow::OnInstall)
+BEGIN_EVENT_TABLE(GOAppWindow, wxFrame)
+EVT_MSGBOX(GOAppWindow::OnMsgBox)
+EVT_RENAMEFILE(GOAppWindow::OnRenameFile)
+EVT_CLOSE(GOAppWindow::OnCloseWindow)
+EVT_CHAR_HOOK(GOAppWindow::OnKeyCommand)
+EVT_COMMAND(0, wxEVT_METERS, GOAppWindow::OnMeters)
+EVT_COMMAND(0, wxEVT_LOADFILE, GOAppWindow::OnLoadFile)
+EVT_MENU_OPEN(GOAppWindow::OnMenuOpen)
+EVT_MENU(ID_FILE_OPEN, GOAppWindow::OnOpen)
+EVT_MENU(ID_FILE_LOAD, GOAppWindow::OnLoad)
+EVT_MENU(ID_FILE_INSTALL, GOAppWindow::OnInstall)
+EVT_MENU_RANGE(ID_LOAD_FAV_FIRST, ID_LOAD_FAV_LAST, GOAppWindow::OnLoadFavorite)
+EVT_MENU_RANGE(ID_LOAD_LRU_FIRST, ID_LOAD_LRU_LAST, GOAppWindow::OnLoadRecent)
+EVT_MENU(ID_FILE_SAVE, GOAppWindow::OnSave)
+EVT_MENU(ID_FILE_CLOSE, GOAppWindow::OnMenuClose)
+EVT_MENU(ID_FILE_EXIT, GOAppWindow::OnExit)
+EVT_MENU(ID_FILE_RELOAD, GOAppWindow::OnReload)
+EVT_MENU(ID_FILE_REVERT, GOAppWindow::OnRevert)
+EVT_MENU(ID_FILE_PROPERTIES, GOAppWindow::OnProperties)
+EVT_MENU(ID_FILE_IMPORT_COMBINATIONS, GOAppWindow::OnImportCombinations)
+EVT_MENU(ID_FILE_EXPORT_COMBINATIONS, GOAppWindow::OnExportCombinations)
+EVT_MENU(ID_FILE_IMPORT_SETTINGS, GOAppWindow::OnImportSettings)
+EVT_MENU(ID_FILE_EXPORT, GOAppWindow::OnExport)
+EVT_MENU(ID_FILE_CACHE, GOAppWindow::OnCache)
+EVT_MENU(ID_FILE_CACHE_DELETE, GOAppWindow::OnCacheDelete)
+EVT_MENU(ID_ORGAN_EDIT, GOAppWindow::OnOrganSettings)
+EVT_MENU(ID_MIDI_LIST, GOAppWindow::OnMidiList)
+EVT_MENU(ID_STOPS, GOAppWindow::OnStops)
+EVT_MENU(ID_MIDI_MONITOR, GOAppWindow::OnMidiMonitor)
+EVT_MENU(ID_AUDIO_PANIC, GOAppWindow::OnAudioPanic)
+EVT_MENU(ID_AUDIO_MEMSET, GOAppWindow::OnAudioMemset)
+EVT_MENU(ID_AUDIO_STATE, GOAppWindow::OnAudioState)
+EVT_MENU(ID_SETTINGS, GOAppWindow::OnSettings)
+EVT_MENU(ID_MIDI_LOAD, GOAppWindow::OnMidiLoad)
+EVT_MENU(wxID_HELP, GOAppWindow::OnHelp)
+EVT_MENU(wxID_ABOUT, GOAppWindow::OnHelpAbout)
+EVT_COMMAND(0, wxEVT_WINTITLE, GOAppWindow::OnSetTitle)
+EVT_MENU(ID_VOLUME, GOAppWindow::OnSettingsVolume)
+EVT_MENU(ID_POLYPHONY, GOAppWindow::OnSettingsPolyphony)
+EVT_MENU(ID_MEMORY, GOAppWindow::OnSettingsMemoryEnter)
+EVT_MENU(ID_TRANSPOSE, GOAppWindow::OnSettingsTranspose)
+EVT_MENU(ID_RELEASELENGTH, GOAppWindow::OnSettingsReleaseLength)
+EVT_MENU_RANGE(ID_PANEL_FIRST, ID_PANEL_LAST, GOAppWindow::OnPanel)
+EVT_MENU_RANGE(ID_PRESET_0, ID_PRESET_LAST, GOAppWindow::OnPreset)
 EVT_MENU_RANGE(
-  ID_LOAD_FAV_FIRST, ID_LOAD_FAV_LAST, GOToolbarWindow::OnLoadFavorite)
-EVT_MENU_RANGE(
-  ID_LOAD_LRU_FIRST, ID_LOAD_LRU_LAST, GOToolbarWindow::OnLoadRecent)
-EVT_MENU(ID_FILE_SAVE, GOToolbarWindow::OnSave)
-EVT_MENU(ID_FILE_CLOSE, GOToolbarWindow::OnMenuClose)
-EVT_MENU(ID_FILE_EXIT, GOToolbarWindow::OnExit)
-EVT_MENU(ID_FILE_RELOAD, GOToolbarWindow::OnReload)
-EVT_MENU(ID_FILE_REVERT, GOToolbarWindow::OnRevert)
-EVT_MENU(ID_FILE_PROPERTIES, GOToolbarWindow::OnProperties)
-EVT_MENU(ID_FILE_IMPORT_COMBINATIONS, GOToolbarWindow::OnImportCombinations)
-EVT_MENU(ID_FILE_EXPORT_COMBINATIONS, GOToolbarWindow::OnExportCombinations)
-EVT_MENU(ID_FILE_IMPORT_SETTINGS, GOToolbarWindow::OnImportSettings)
-EVT_MENU(ID_FILE_EXPORT, GOToolbarWindow::OnExport)
-EVT_MENU(ID_FILE_CACHE, GOToolbarWindow::OnCache)
-EVT_MENU(ID_FILE_CACHE_DELETE, GOToolbarWindow::OnCacheDelete)
-EVT_MENU(ID_ORGAN_EDIT, GOToolbarWindow::OnOrganSettings)
-EVT_MENU(ID_MIDI_LIST, GOToolbarWindow::OnMidiList)
-EVT_MENU(ID_STOPS, GOToolbarWindow::OnStops)
-EVT_MENU(ID_MIDI_MONITOR, GOToolbarWindow::OnMidiMonitor)
-EVT_MENU(ID_AUDIO_PANIC, GOToolbarWindow::OnAudioPanic)
-EVT_MENU(ID_AUDIO_MEMSET, GOToolbarWindow::OnAudioMemset)
-EVT_MENU(ID_AUDIO_STATE, GOToolbarWindow::OnAudioState)
-EVT_MENU(ID_SETTINGS, GOToolbarWindow::OnSettings)
-EVT_MENU(ID_MIDI_LOAD, GOToolbarWindow::OnMidiLoad)
-EVT_MENU(wxID_HELP, GOToolbarWindow::OnHelp)
-EVT_MENU(wxID_ABOUT, GOToolbarWindow::OnHelpAbout)
-EVT_COMMAND(0, wxEVT_WINTITLE, GOToolbarWindow::OnSetTitle)
-EVT_MENU(ID_VOLUME, GOToolbarWindow::OnSettingsVolume)
-EVT_MENU(ID_POLYPHONY, GOToolbarWindow::OnSettingsPolyphony)
-EVT_MENU(ID_MEMORY, GOToolbarWindow::OnSettingsMemoryEnter)
-EVT_MENU(ID_TRANSPOSE, GOToolbarWindow::OnSettingsTranspose)
-EVT_MENU(ID_RELEASELENGTH, GOToolbarWindow::OnSettingsReleaseLength)
-EVT_MENU_RANGE(ID_PANEL_FIRST, ID_PANEL_LAST, GOToolbarWindow::OnPanel)
-EVT_MENU_RANGE(ID_PRESET_0, ID_PRESET_LAST, GOToolbarWindow::OnPreset)
-EVT_MENU_RANGE(
-  ID_TEMPERAMENT_0, ID_TEMPERAMENT_LAST, GOToolbarWindow::OnTemperament)
-EVT_SIZE(GOToolbarWindow::OnSize)
-EVT_TEXT(ID_METER_TRANSPOSE_SPIN, GOToolbarWindow::OnSettingsTranspose)
-EVT_TEXT_ENTER(ID_METER_TRANSPOSE_SPIN, GOToolbarWindow::OnSettingsTranspose)
+  ID_TEMPERAMENT_0, ID_TEMPERAMENT_LAST, GOAppWindow::OnTemperament)
+EVT_SIZE(GOAppWindow::OnSize)
+EVT_TEXT(ID_METER_TRANSPOSE_SPIN, GOAppWindow::OnSettingsTranspose)
+EVT_TEXT_ENTER(ID_METER_TRANSPOSE_SPIN, GOAppWindow::OnSettingsTranspose)
 EVT_COMMAND(
-  ID_METER_TRANSPOSE_SPIN, wxEVT_SETVALUE, GOToolbarWindow::OnChangeTranspose)
-EVT_CHOICE(ID_RELEASELENGTH_SELECT, GOToolbarWindow::OnSettingsReleaseLength)
-EVT_TEXT(ID_METER_POLY_SPIN, GOToolbarWindow::OnSettingsPolyphony)
-EVT_TEXT_ENTER(ID_METER_POLY_SPIN, GOToolbarWindow::OnSettingsPolyphony)
-EVT_TEXT(ID_METER_FRAME_SPIN, GOToolbarWindow::OnSettingsMemory)
-EVT_TEXT_ENTER(ID_METER_FRAME_SPIN, GOToolbarWindow::OnSettingsMemoryEnter)
-EVT_COMMAND(
-  ID_METER_FRAME_SPIN, wxEVT_SETVALUE, GOToolbarWindow::OnChangeSetter)
-EVT_SLIDER(ID_METER_FRAME_SPIN, GOToolbarWindow::OnChangeSetter)
-EVT_TEXT(ID_METER_AUDIO_SPIN, GOToolbarWindow::OnSettingsVolume)
-EVT_TEXT_ENTER(ID_METER_AUDIO_SPIN, GOToolbarWindow::OnSettingsVolume)
-EVT_COMMAND(
-  ID_METER_AUDIO_SPIN, wxEVT_SETVALUE, GOToolbarWindow::OnChangeVolume)
-EVT_MENU(ID_CHECK_FOR_UPDATES, GOToolbarWindow::OnUpdateCheckingRequested)
-EVT_MENU(ID_SHOW_RELEASE_CHANGELOG, GOToolbarWindow::OnNewReleaseInfoRequested)
-EVT_MENU(ID_DOWNLOAD_NEW_RELEASE, GOToolbarWindow::OnNewReleaseDownload)
-EVT_UPDATE_CHECKING_COMPLETION(GOToolbarWindow::OnUpdateCheckingCompletion)
+  ID_METER_TRANSPOSE_SPIN, wxEVT_SETVALUE, GOAppWindow::OnChangeTranspose)
+EVT_CHOICE(ID_RELEASELENGTH_SELECT, GOAppWindow::OnSettingsReleaseLength)
+EVT_TEXT(ID_METER_POLY_SPIN, GOAppWindow::OnSettingsPolyphony)
+EVT_TEXT_ENTER(ID_METER_POLY_SPIN, GOAppWindow::OnSettingsPolyphony)
+EVT_TEXT(ID_METER_FRAME_SPIN, GOAppWindow::OnSettingsMemory)
+EVT_TEXT_ENTER(ID_METER_FRAME_SPIN, GOAppWindow::OnSettingsMemoryEnter)
+EVT_COMMAND(ID_METER_FRAME_SPIN, wxEVT_SETVALUE, GOAppWindow::OnChangeSetter)
+EVT_SLIDER(ID_METER_FRAME_SPIN, GOAppWindow::OnChangeSetter)
+EVT_TEXT(ID_METER_AUDIO_SPIN, GOAppWindow::OnSettingsVolume)
+EVT_TEXT_ENTER(ID_METER_AUDIO_SPIN, GOAppWindow::OnSettingsVolume)
+EVT_COMMAND(ID_METER_AUDIO_SPIN, wxEVT_SETVALUE, GOAppWindow::OnChangeVolume)
+EVT_MENU(ID_CHECK_FOR_UPDATES, GOAppWindow::OnUpdateCheckingRequested)
+EVT_MENU(ID_SHOW_RELEASE_CHANGELOG, GOAppWindow::OnNewReleaseInfoRequested)
+EVT_MENU(ID_DOWNLOAD_NEW_RELEASE, GOAppWindow::OnNewReleaseDownload)
+EVT_UPDATE_CHECKING_COMPLETION(GOAppWindow::OnUpdateCheckingCompletion)
 EVT_UPDATE_UI_RANGE(
-  ID_FILE_RELOAD, ID_AUDIO_MEMSET, GOToolbarWindow::OnUpdateLoaded)
-EVT_UPDATE_UI_RANGE(
-  ID_PRESET_0, ID_PRESET_LAST, GOToolbarWindow::OnUpdateLoaded)
+  ID_FILE_RELOAD, ID_AUDIO_MEMSET, GOAppWindow::OnUpdateLoaded)
+EVT_UPDATE_UI_RANGE(ID_PRESET_0, ID_PRESET_LAST, GOAppWindow::OnUpdateLoaded)
 END_EVENT_TABLE()
 
-GOToolbarWindow::GOToolbarWindow(
+GOAppWindow::GOAppWindow(
   GOGuiApp &app,
   wxFrame *pParentFrame,
   wxWindowID id,
@@ -397,12 +392,12 @@ GOToolbarWindow::GOToolbarWindow(
   m_isMeterReady = true;
 }
 
-GOToolbarWindow::~GOToolbarWindow() {
+GOAppWindow::~GOAppWindow() {
   m_isMeterReady = false;
   m_listener.SetCallback(NULL);
 }
 
-bool GOToolbarWindow::AdjustVolumeControlWithSettings() {
+bool GOAppWindow::AdjustVolumeControlWithSettings() {
   const unsigned count = r_config.GetTotalAudioChannels();
   bool rc = false;
 
@@ -446,7 +441,7 @@ bool GOToolbarWindow::AdjustVolumeControlWithSettings() {
   return rc;
 }
 
-void GOToolbarWindow::UpdateSize() {
+void GOAppWindow::UpdateSize() {
   wxToolBar *tb = GetToolBar();
 
   tb->Realize();
@@ -462,7 +457,7 @@ void GOToolbarWindow::UpdateSize() {
   SetMaxSize(wxSize(frameSize.GetWidth() * 4, frameSize.GetHeight()));
 }
 
-GOLogicalRect GOToolbarWindow::GetPosSize() const {
+GOLogicalRect GOAppWindow::GetPosSize() const {
   GOLogicalRect lRect;
   const wxRect gRect(GetRect());
 
@@ -473,7 +468,7 @@ GOLogicalRect GOToolbarWindow::GetPosSize() const {
   return lRect;
 }
 
-void GOToolbarWindow::SetPosSize(const GOLogicalRect &lRect) {
+void GOAppWindow::SetPosSize(const GOLogicalRect &lRect) {
   if (lRect.width && lRect.height) { // settings are valid
     wxRect rect(lRect.x, lRect.y, lRect.width, lRect.height);
     const wxRect minSize(GetMinSize());
@@ -491,7 +486,7 @@ void GOToolbarWindow::SetPosSize(const GOLogicalRect &lRect) {
   }
 }
 
-void GOToolbarWindow::UpdateReleaseLength(unsigned releaseLength) {
+void GOAppWindow::UpdateReleaseLength(unsigned releaseLength) {
   int releaseLengthIndex = releaseLength / 50;
 
   if (p_OrganController && p_OrganController->GetReleaseTail() != releaseLength)
@@ -500,14 +495,14 @@ void GOToolbarWindow::UpdateReleaseLength(unsigned releaseLength) {
     m_ReleaseLength->SetSelection(releaseLengthIndex);
 }
 
-void GOToolbarWindow::UpdateVolumeControlWithSettings() {
+void GOAppWindow::UpdateVolumeControlWithSettings() {
   m_isMeterReady = false;
   if (AdjustVolumeControlWithSettings())
     UpdateSize();
   m_isMeterReady = true;
 }
 
-void GOToolbarWindow::Init(const wxString &filename, bool isGuiOnly) {
+void GOAppWindow::Init(const wxString &filename, bool isGuiOnly) {
   if (r_config.CheckForUpdatesAtStartup()) {
     // Start update checker thread that will fire events to this frame
     m_UpdateCheckerThread = GOUpdateChecker::StartThread(
@@ -575,12 +570,12 @@ void GOToolbarWindow::Init(const wxString &filename, bool isGuiOnly) {
   clean.Cleanup();
 }
 
-void GOToolbarWindow::AttachDetachOrganController(bool isToAttach) {
+void GOAppWindow::AttachDetachOrganController(bool isToAttach) {
   if (p_OrganController)
     p_OrganController->SetModificationListener(isToAttach ? this : nullptr);
 }
 
-bool GOToolbarWindow::CloseOrgan(bool isForce) {
+bool GOAppWindow::CloseOrgan(bool isForce) {
   bool isClosed = true;
 
   if (mp_organ) {
@@ -618,7 +613,7 @@ bool GOToolbarWindow::CloseOrgan(bool isForce) {
   return isClosed;
 }
 
-void GOToolbarWindow::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
+void GOAppWindow::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
   if (mp_organ) {
     GOProgressDialog dlg;
 
@@ -630,7 +625,7 @@ void GOToolbarWindow::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
   }
 }
 
-void GOToolbarWindow::Open(const GOOrgan &organ) {
+void GOAppWindow::Open(const GOOrgan &organ) {
   if (CloseOrgan(false)) {
     GOMutexLocker m_locker(m_mutex, true);
 
@@ -641,20 +636,20 @@ void GOToolbarWindow::Open(const GOOrgan &organ) {
   }
 }
 
-void GOToolbarWindow::OnPanel(wxCommandEvent &event) {
+void GOAppWindow::OnPanel(wxCommandEvent &event) {
   unsigned no = event.GetId() - ID_PANEL_FIRST;
 
   if (p_OrganController && no < p_OrganController->GetPanelCount())
     mp_organ->ShowPanel(no);
 }
 
-void GOToolbarWindow::OnIsModifiedChanged(bool modified) {
+void GOAppWindow::OnIsModifiedChanged(bool modified) {
   if (p_OrganController)
     UpdateReleaseLength(p_OrganController->GetReleaseTail());
   UpdatePanelMenu();
 }
 
-void GOToolbarWindow::UpdatePanelMenu() {
+void GOAppWindow::UpdatePanelMenu() {
   unsigned panelcount
     = (p_OrganController && p_OrganController->GetPanelCount())
     ? p_OrganController->GetPanelCount()
@@ -688,7 +683,7 @@ void GOToolbarWindow::UpdatePanelMenu() {
   }
 }
 
-void GOToolbarWindow::UpdateFavoritesMenu() {
+void GOAppWindow::UpdateFavoritesMenu() {
   while (m_favorites_menu->GetMenuItemCount() > 0)
     m_favorites_menu->Destroy(m_favorites_menu->FindItemByPosition(
       m_favorites_menu->GetMenuItemCount() - 1));
@@ -704,7 +699,7 @@ void GOToolbarWindow::UpdateFavoritesMenu() {
   }
 }
 
-void GOToolbarWindow::UpdateRecentMenu() {
+void GOAppWindow::UpdateRecentMenu() {
   while (m_recent_menu->GetMenuItemCount() > 0)
     m_recent_menu->Destroy(
       m_recent_menu->FindItemByPosition(m_recent_menu->GetMenuItemCount() - 1));
@@ -720,7 +715,7 @@ void GOToolbarWindow::UpdateRecentMenu() {
   }
 }
 
-void GOToolbarWindow::UpdateTemperamentMenu() {
+void GOAppWindow::UpdateTemperamentMenu() {
   wxString temperament = wxEmptyString;
   if (p_OrganController)
     temperament = p_OrganController->GetTemperament();
@@ -756,7 +751,7 @@ void GOToolbarWindow::UpdateTemperamentMenu() {
   }
 }
 
-void GOToolbarWindow::OnSize(wxSizeEvent &event) {
+void GOAppWindow::OnSize(wxSizeEvent &event) {
   wxWindow *child = (wxWindow *)NULL;
   for (wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
        node;
@@ -771,7 +766,7 @@ void GOToolbarWindow::OnSize(wxSizeEvent &event) {
       0, 0, GetClientSize().GetWidth(), GetClientSize().GetHeight());
 }
 
-void GOToolbarWindow::OnMeters(wxCommandEvent &event) {
+void GOAppWindow::OnMeters(wxCommandEvent &event) {
   if (m_isMeterReady) {
     const std::vector<float> vals = r_SoundSystem.GetEngine().GetMeterInfo();
 
@@ -788,7 +783,7 @@ void GOToolbarWindow::OnMeters(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnUpdateLoaded(wxUpdateUIEvent &event) {
+void GOAppWindow::OnUpdateLoaded(wxUpdateUIEvent &event) {
   if (ID_PRESET_0 <= event.GetId() && event.GetId() <= ID_PRESET_LAST) {
     event.Check(r_config.Preset() == (unsigned)(event.GetId() - ID_PRESET_0));
     return;
@@ -821,7 +816,7 @@ void GOToolbarWindow::OnUpdateLoaded(wxUpdateUIEvent &event) {
       && (event.GetId() == ID_FILE_REVERT ? p_OrganController->IsCustomized() : true));
 }
 
-void GOToolbarWindow::OnPreset(wxCommandEvent &event) {
+void GOAppWindow::OnPreset(wxCommandEvent &event) {
   unsigned id = event.GetId() - ID_PRESET_0;
   if (id == r_config.Preset())
     return;
@@ -830,7 +825,7 @@ void GOToolbarWindow::OnPreset(wxCommandEvent &event) {
     ProcessCommand(ID_FILE_RELOAD);
 }
 
-void GOToolbarWindow::OnTemperament(wxCommandEvent &event) {
+void GOAppWindow::OnTemperament(wxCommandEvent &event) {
   unsigned id = event.GetId() - ID_TEMPERAMENT_0;
 
   if (
@@ -839,7 +834,7 @@ void GOToolbarWindow::OnTemperament(wxCommandEvent &event) {
       r_config.GetTemperaments().GetTemperament(id).GetName());
 }
 
-void GOToolbarWindow::OnLoadFile(wxCommandEvent &event) {
+void GOAppWindow::OnLoadFile(wxCommandEvent &event) {
   GOOrgan *pOrgan = (GOOrgan *)event.GetClientData();
 
   if (!m_InSettings) {
@@ -849,26 +844,26 @@ void GOToolbarWindow::OnLoadFile(wxCommandEvent &event) {
     SetEventAfterSettings(event.GetEventType(), event.GetId(), pOrgan);
 }
 
-void GOToolbarWindow::OnLoadFavorite(wxCommandEvent &event) {
+void GOAppWindow::OnLoadFavorite(wxCommandEvent &event) {
   unsigned id = event.GetId() - ID_LOAD_FAV_FIRST;
   const GOOrgan &organ = *r_config.GetOrganList()[id];
   Open(organ);
 }
 
-void GOToolbarWindow::OnLoadRecent(wxCommandEvent &event) {
+void GOAppWindow::OnLoadRecent(wxCommandEvent &event) {
   unsigned id = event.GetId() - ID_LOAD_LRU_FIRST;
   const GOOrgan &organ = *r_config.GetLRUOrganList()[id];
   Open(organ);
 }
 
-void GOToolbarWindow::OnLoad(wxCommandEvent &event) {
+void GOAppWindow::OnLoad(wxCommandEvent &event) {
   GOSelectOrganDialog dlg(this, r_config);
 
   if (dlg.ShowModal() == wxID_OK)
     Open(*dlg.GetSelection());
 }
 
-void GOToolbarWindow::OnOpen(wxCommandEvent &event) {
+void GOAppWindow::OnOpen(wxCommandEvent &event) {
   wxFileDialog dlg(
     this,
     _("Open organ"),
@@ -881,7 +876,7 @@ void GOToolbarWindow::OnOpen(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnInstall(wxCommandEvent &event) {
+void GOAppWindow::OnInstall(wxCommandEvent &event) {
   wxFileDialog dlg(
     this,
     _("Install organ package"),
@@ -900,7 +895,7 @@ void GOToolbarWindow::OnInstall(wxCommandEvent &event) {
     }
 }
 
-void GOToolbarWindow::OnImportCombinations(wxCommandEvent &event) {
+void GOAppWindow::OnImportCombinations(wxCommandEvent &event) {
   if (p_OrganController) {
     wxFileDialog dlg(
       this,
@@ -915,7 +910,7 @@ void GOToolbarWindow::OnImportCombinations(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnExportCombinations(wxCommandEvent &event) {
+void GOAppWindow::OnExportCombinations(wxCommandEvent &event) {
   if (p_OrganController) {
     const wxString organCmbDir = p_OrganController->GetCombinationsDir();
 
@@ -950,7 +945,7 @@ void GOToolbarWindow::OnExportCombinations(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnImportSettings(wxCommandEvent &event) {
+void GOAppWindow::OnImportSettings(wxCommandEvent &event) {
   if (p_OrganController) {
     wxFileDialog dlg(
       this,
@@ -971,7 +966,7 @@ void GOToolbarWindow::OnImportSettings(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnExport(wxCommandEvent &event) {
+void GOAppWindow::OnExport(wxCommandEvent &event) {
   if (p_OrganController) {
     wxFileDialog dlg(
       this,
@@ -996,7 +991,7 @@ void GOToolbarWindow::OnExport(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnSave(wxCommandEvent &event) {
+void GOAppWindow::OnSave(wxCommandEvent &event) {
   if (p_OrganController && !mp_organ->Save())
     GOMessageBox(
       _("Failed to save the organ setting"),
@@ -1019,7 +1014,7 @@ wxString formatSize(wxLongLong &size) {
   return wxString::Format(wxT("%.2f %s"), n, wxGetTranslation(sizes[i]));
 }
 
-void GOToolbarWindow::OnCache(wxCommandEvent &event) {
+void GOAppWindow::OnCache(wxCommandEvent &event) {
   bool res = true;
   GOMutexLocker m_locker(m_mutex, true);
 
@@ -1037,12 +1032,12 @@ void GOToolbarWindow::OnCache(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnCacheDelete(wxCommandEvent &event) {
+void GOAppWindow::OnCacheDelete(wxCommandEvent &event) {
   if (p_OrganController)
     p_OrganController->DeleteCache();
 }
 
-void GOToolbarWindow::OnReload(wxCommandEvent &event) {
+void GOAppWindow::OnReload(wxCommandEvent &event) {
   if (p_OrganController) {
     GOOrgan organ = p_OrganController->GetOrganInfo();
 
@@ -1051,12 +1046,12 @@ void GOToolbarWindow::OnReload(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnMenuClose(wxCommandEvent &event) {
+void GOAppWindow::OnMenuClose(wxCommandEvent &event) {
   if (mp_organ)
     CloseOrgan(false);
 }
 
-bool GOToolbarWindow::CloseProgram(bool isForce) {
+bool GOAppWindow::CloseProgram(bool isForce) {
   if (m_UpdateCheckerThread) {
     // Stop update checking so that we can safely destruct the thread
     m_UpdateCheckerThread->Stop();
@@ -1069,13 +1064,13 @@ bool GOToolbarWindow::CloseProgram(bool isForce) {
   return isClosed;
 }
 
-void GOToolbarWindow::OnExit(wxCommandEvent &event) { CloseProgram(); }
+void GOAppWindow::OnExit(wxCommandEvent &event) { CloseProgram(); }
 
-void GOToolbarWindow::OnCloseWindow(wxCloseEvent &event) {
+void GOAppWindow::OnCloseWindow(wxCloseEvent &event) {
   CloseProgram(!event.CanVeto());
 }
 
-void GOToolbarWindow::OnRevert(wxCommandEvent &event) {
+void GOAppWindow::OnRevert(wxCommandEvent &event) {
   if (
     wxMessageBox(
       _("Any customizations you have saved to this\norgan definition file "
@@ -1091,23 +1086,23 @@ void GOToolbarWindow::OnRevert(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnProperties(wxCommandEvent &event) {
+void GOAppWindow::OnProperties(wxCommandEvent &event) {
   if (p_OrganController) {
     GOPropertiesDialog dlg(p_OrganController, this);
     dlg.ShowModal();
   }
 }
 
-void GOToolbarWindow::OnAudioPanic(wxCommandEvent &WXUNUSED(event)) {
+void GOAppWindow::OnAudioPanic(wxCommandEvent &WXUNUSED(event)) {
   r_SoundSystem.AssureSoundIsClosed();
   r_SoundSystem.AssureSoundIsOpen();
 }
 
-void GOToolbarWindow::OnMidiMonitor(wxCommandEvent &WXUNUSED(event)) {
+void GOAppWindow::OnMidiMonitor(wxCommandEvent &WXUNUSED(event)) {
   m_MidiMonitor = !m_MidiMonitor;
 }
 
-void GOToolbarWindow::OnMidiLoad(wxCommandEvent &WXUNUSED(event)) {
+void GOAppWindow::OnMidiLoad(wxCommandEvent &WXUNUSED(event)) {
   wxFileDialog dlg(
     this,
     _("Load MIDI file"),
@@ -1121,12 +1116,12 @@ void GOToolbarWindow::OnMidiLoad(wxCommandEvent &WXUNUSED(event)) {
   }
 }
 
-void GOToolbarWindow::OnAudioMemset(wxCommandEvent &WXUNUSED(event)) {
+void GOAppWindow::OnAudioMemset(wxCommandEvent &WXUNUSED(event)) {
   if (p_OrganController)
     p_OrganController->GetSetter()->ToggleSetter();
 }
 
-void GOToolbarWindow::SetEventAfterSettings(
+void GOAppWindow::SetEventAfterSettings(
   wxEventType eventType, int eventId, GOOrgan *pOrganFile) {
   if (p_AfterSettingsEventOrgan)
     delete p_AfterSettingsEventOrgan;
@@ -1135,7 +1130,7 @@ void GOToolbarWindow::SetEventAfterSettings(
   p_AfterSettingsEventOrgan = pOrganFile;
 }
 
-void GOToolbarWindow::OnSettings(wxCommandEvent &event) {
+void GOAppWindow::OnSettings(wxCommandEvent &event) {
   m_InSettings = true;
 
   bool isToContinue = true; // will GO continue running? Otherwise it will exit
@@ -1200,30 +1195,30 @@ void GOToolbarWindow::OnSettings(wxCommandEvent &event) {
   m_InSettings = false;
 }
 
-void GOToolbarWindow::OnAudioState(wxCommandEvent &WXUNUSED(event)) {
+void GOAppWindow::OnAudioState(wxCommandEvent &WXUNUSED(event)) {
   GOMessageBox(r_SoundSystem.getState(), _("Sound output"), wxOK, this);
 }
 
-void GOToolbarWindow::OnOrganSettings(wxCommandEvent &event) {
+void GOAppWindow::OnOrganSettings(wxCommandEvent &event) {
   if (mp_organ)
     mp_organ->ShowOrganSettingsDialog();
 }
 
-void GOToolbarWindow::OnMidiList(wxCommandEvent &event) {
+void GOAppWindow::OnMidiList(wxCommandEvent &event) {
   if (mp_organ)
     mp_organ->ShowMidiList();
 }
 
-void GOToolbarWindow::OnStops(wxCommandEvent &event) {
+void GOAppWindow::OnStops(wxCommandEvent &event) {
   if (mp_organ)
     mp_organ->ShowStops();
 }
 
-void GOToolbarWindow::OnHelp(wxCommandEvent &event) {
+void GOAppWindow::OnHelp(wxCommandEvent &event) {
   GOHelpRequestor::DisplayHelp(_("User Interface"), false);
 }
 
-void GOToolbarWindow::OnSettingsVolume(wxCommandEvent &event) {
+void GOAppWindow::OnSettingsVolume(wxCommandEvent &event) {
   long n = m_Volume->GetValue();
 
   r_SoundSystem.GetEngine().SetVolume(n);
@@ -1231,7 +1226,7 @@ void GOToolbarWindow::OnSettingsVolume(wxCommandEvent &event) {
     m_VolumeGauge[i]->ResetClip();
 }
 
-void GOToolbarWindow::OnSettingsPolyphony(wxCommandEvent &event) {
+void GOAppWindow::OnSettingsPolyphony(wxCommandEvent &event) {
   long n = m_Polyphony->GetValue();
 
   r_config.PolyphonyLimit(n);
@@ -1239,21 +1234,21 @@ void GOToolbarWindow::OnSettingsPolyphony(wxCommandEvent &event) {
   m_SamplerUsage->ResetClip();
 }
 
-void GOToolbarWindow::OnSettingsMemoryEnter(wxCommandEvent &event) {
+void GOAppWindow::OnSettingsMemoryEnter(wxCommandEvent &event) {
   long n = m_SetterPosition->GetValue();
 
   if (p_OrganController)
     p_OrganController->GetSetter()->SetPosition(n);
 }
 
-void GOToolbarWindow::OnSettingsMemory(wxCommandEvent &event) {
+void GOAppWindow::OnSettingsMemory(wxCommandEvent &event) {
   long n = m_SetterPosition->GetValue();
 
   if (p_OrganController)
     p_OrganController->GetSetter()->UpdatePosition(n);
 }
 
-void GOToolbarWindow::OnSettingsTranspose(wxCommandEvent &event) {
+void GOAppWindow::OnSettingsTranspose(wxCommandEvent &event) {
   if (p_OrganController) {
     long n = m_Transpose->GetValue();
 
@@ -1262,17 +1257,15 @@ void GOToolbarWindow::OnSettingsTranspose(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnSettingsReleaseLength(wxCommandEvent &event) {
+void GOAppWindow::OnSettingsReleaseLength(wxCommandEvent &event) {
   UpdateReleaseLength(m_ReleaseLength->GetSelection() * 50);
 }
 
-void GOToolbarWindow::OnHelpAbout(wxCommandEvent &event) { DoSplash(false); }
+void GOAppWindow::OnHelpAbout(wxCommandEvent &event) { DoSplash(false); }
 
-void GOToolbarWindow::DoSplash(bool timeout) {
-  GOSplash::DoSplash(timeout, this);
-}
+void GOAppWindow::DoSplash(bool timeout) { GOSplash::DoSplash(timeout, this); }
 
-void GOToolbarWindow::OnMenuOpen(wxMenuEvent &event) {
+void GOAppWindow::OnMenuOpen(wxMenuEvent &event) {
   DoMenuUpdates(event.GetMenu());
   if (event.GetMenu() == m_panel_menu)
     UpdatePanelMenu();
@@ -1285,19 +1278,19 @@ void GOToolbarWindow::OnMenuOpen(wxMenuEvent &event) {
   event.Skip();
 }
 
-void GOToolbarWindow::OnChangeTranspose(wxCommandEvent &event) {
+void GOAppWindow::OnChangeTranspose(wxCommandEvent &event) {
   m_Transpose->SetValue(event.GetInt());
 }
 
-void GOToolbarWindow::OnChangeSetter(wxCommandEvent &event) {
+void GOAppWindow::OnChangeSetter(wxCommandEvent &event) {
   m_SetterPosition->SetValue(event.GetInt());
 }
 
-void GOToolbarWindow::OnChangeVolume(wxCommandEvent &event) {
+void GOAppWindow::OnChangeVolume(wxCommandEvent &event) {
   m_Volume->SetValue(event.GetInt());
 }
 
-void GOToolbarWindow::OnKeyCommand(wxKeyEvent &event) {
+void GOAppWindow::OnKeyCommand(wxKeyEvent &event) {
   int k = event.GetKeyCode();
   if (!event.AltDown()) {
     switch (k) {
@@ -1310,7 +1303,7 @@ void GOToolbarWindow::OnKeyCommand(wxKeyEvent &event) {
   event.Skip();
 }
 
-void GOToolbarWindow::OnMidiEvent(const GOMidiEvent &event) {
+void GOAppWindow::OnMidiEvent(const GOMidiEvent &event) {
   if (m_MidiMonitor) {
     wxLogWarning(_("MIDI event: ") + event.ToString(r_MidiSystem.GetMidiMap()));
   }
@@ -1328,7 +1321,7 @@ void GOToolbarWindow::OnMidiEvent(const GOMidiEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnSetTitle(wxCommandEvent &event) {
+void GOAppWindow::OnSetTitle(wxCommandEvent &event) {
   m_Label = event.GetString();
   if (m_Label == wxEmptyString)
     SetTitle(m_Title);
@@ -1336,11 +1329,11 @@ void GOToolbarWindow::OnSetTitle(wxCommandEvent &event) {
     SetTitle(m_Title + _(" - ") + m_Label);
 }
 
-void GOToolbarWindow::OnMsgBox(wxMsgBoxEvent &event) {
+void GOAppWindow::OnMsgBox(wxMsgBoxEvent &event) {
   wxMessageBox(event.getText(), event.getTitle(), event.getStyle(), this);
 }
 
-void GOToolbarWindow::OnRenameFile(wxRenameFileEvent &event) {
+void GOAppWindow::OnRenameFile(wxRenameFileEvent &event) {
   wxFileName filepath = event.getFilename();
 
   wxFileDialog dlg(
@@ -1359,7 +1352,7 @@ void GOToolbarWindow::OnRenameFile(wxRenameFileEvent &event) {
   go_sync_directory(filepath.GetPath());
 }
 
-void GOToolbarWindow::OnUpdateCheckingRequested(wxCommandEvent &event) {
+void GOAppWindow::OnUpdateCheckingRequested(wxCommandEvent &event) {
   if (m_UpdateCheckerThread) {
     // Update checking is already in progress, ignore request
     return;
@@ -1369,7 +1362,7 @@ void GOToolbarWindow::OnUpdateCheckingRequested(wxCommandEvent &event) {
     GOUpdateChecker::CheckReason::USER_REQUEST, this);
 }
 
-void GOToolbarWindow::OnUpdateCheckingCompletion(
+void GOAppWindow::OnUpdateCheckingCompletion(
   GOUpdateChecker::CompletionEvent &event) {
   // Remove update checker thread
   m_UpdateCheckerThread->Wait();
@@ -1411,7 +1404,7 @@ void GOToolbarWindow::OnUpdateCheckingCompletion(
   }
 }
 
-void GOToolbarWindow::OnNewReleaseInfoRequested(wxCommandEvent &event) {
+void GOAppWindow::OnNewReleaseInfoRequested(wxCommandEvent &event) {
   GONewReleaseDialog dialog(
     this, r_config, m_StartupUpdateCheckerResult.latestRelease);
   if (dialog.ShowModal() == wxID_OK) {
@@ -1419,11 +1412,11 @@ void GOToolbarWindow::OnNewReleaseInfoRequested(wxCommandEvent &event) {
   }
 }
 
-void GOToolbarWindow::OnNewReleaseDownload(wxCommandEvent &event) {
+void GOAppWindow::OnNewReleaseDownload(wxCommandEvent &event) {
   GOUpdateChecker::OpenDownloadPageInBrowser();
 }
 
-bool GOToolbarWindow::InstallOrganPackage(wxString name) {
+bool GOAppWindow::InstallOrganPackage(wxString name) {
   GOArchiveManager manager(r_config, r_config.OrganCachePath());
   wxString result = manager.InstallPackage(name);
   if (result != wxEmptyString) {
@@ -1433,19 +1426,19 @@ bool GOToolbarWindow::InstallOrganPackage(wxString name) {
     return true;
 }
 
-void GOToolbarWindow::LoadLastOrgan() {
+void GOAppWindow::LoadLastOrgan() {
   std::vector<const GOOrgan *> list = r_config.GetLRUOrganList();
   if (list.size() > 0)
     SendLoadOrgan(*list[0]);
 }
 
-void GOToolbarWindow::LoadFirstOrgan() {
+void GOAppWindow::LoadFirstOrgan() {
   ptr_vector<GOOrgan> &list = r_config.GetOrganList();
   if (list.size() > 0)
     SendLoadOrgan(*list[0]);
 }
 
-void GOToolbarWindow::SendLoadFile(wxString filename) {
+void GOAppWindow::SendLoadFile(wxString filename) {
   wxFileName name = filename;
   if (name.GetExt() == wxT("orgue")) {
     if (InstallOrganPackage(filename))
@@ -1454,7 +1447,7 @@ void GOToolbarWindow::SendLoadFile(wxString filename) {
     SendLoadOrgan(GOOrgan(filename));
 }
 
-void GOToolbarWindow::SendLoadOrgan(const GOOrgan &organ) {
+void GOAppWindow::SendLoadOrgan(const GOOrgan &organ) {
   wxCommandEvent evt(wxEVT_LOADFILE, 0);
   evt.SetClientData(new GOOrgan(organ));
   GetEventHandler()->AddPendingEvent(evt);

--- a/src/grandorgue/gui/frames/GOAppWindow.h
+++ b/src/grandorgue/gui/frames/GOAppWindow.h
@@ -5,8 +5,8 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GOTOOLBARWINDOW_H
-#define GOTOOLBARWINDOW_H
+#ifndef GOAPPWINDOW_H
+#define GOAPPWINDOW_H
 
 #include <memory>
 #include <vector>
@@ -37,11 +37,11 @@ class wxSpinCtrl;
 class wxToolBar;
 class wxToolBarToolBase;
 
-class GOToolbarWindow : public wxFrame,
-                        private GOHelpRequestor,
-                        public GOResizable,
-                        protected GOMidiCallback,
-                        private GOModificationListener {
+class GOAppWindow : public wxFrame,
+                    private GOHelpRequestor,
+                    public GOResizable,
+                    protected GOMidiCallback,
+                    private GOModificationListener {
 private:
   GOGuiApp &r_app;
   GOConfig &r_config;
@@ -182,7 +182,7 @@ private:
   void SendLoadOrgan(const GOOrgan &organ);
 
 public:
-  GOToolbarWindow(
+  GOAppWindow(
     GOGuiApp &app,
     wxFrame *pParentFrame,
     wxWindowID id,
@@ -191,7 +191,7 @@ public:
     const wxSize &size,
     const long type,
     GOSoundSystem &sound);
-  virtual ~GOToolbarWindow(void);
+  virtual ~GOAppWindow(void);
 
   void Init(const wxString &filename, bool isGuiOnly);
 

--- a/src/grandorgue/gui/frames/GOStopsWindow.cpp
+++ b/src/grandorgue/gui/frames/GOStopsWindow.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -38,7 +38,7 @@ GOStopsWindow::GOStopsWindow(
   GOSizeKeeper &sizeKeeper,
   GOOrganModel &model)
   : wxFrame(parent, wxID_ANY, _("Stops")),
-    GOView(doc, this),
+    GODocumentView(doc, this),
     r_SizeKeeper(sizeKeeper),
     r_model(model) {
   SetIcon(get_go_icon());

--- a/src/grandorgue/gui/frames/GOStopsWindow.h
+++ b/src/grandorgue/gui/frames/GOStopsWindow.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,7 +13,7 @@
 #include <wx/frame.h>
 
 #include "control/GOControlChangedHandler.h"
-#include "document-base/GOView.h"
+#include "gui/document-base/GODocumentView.h"
 
 class wxCheckBox;
 
@@ -22,7 +22,7 @@ class GOOrganModel;
 class GOSizeKeeper;
 
 class GOStopsWindow : public wxFrame,
-                      public GOView,
+                      public GODocumentView,
                       private GOControlChangedHandler {
 private:
   GOSizeKeeper &r_SizeKeeper;

--- a/src/grandorgue/gui/frames/GOToolbarWindow.cpp
+++ b/src/grandorgue/gui/frames/GOToolbarWindow.cpp
@@ -5,7 +5,7 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOFrame.h"
+#include "GOToolbarWindow.h"
 
 #include <algorithm>
 
@@ -28,6 +28,8 @@
 #include "config/GOConfig.h"
 #include "config/GORegisteredOrgan.h"
 #include "files/GOStdFileName.h"
+#include "gui/GOGuiApp.h"
+#include "gui/GOGuiOrgan.h"
 #include "gui/dialogs/GONewReleaseDialog.h"
 #include "gui/dialogs/GOProgressDialog.h"
 #include "gui/dialogs/GOPropertiesDialog.h"
@@ -45,8 +47,6 @@
 #include "temperaments/GOTemperament.h"
 #include "threading/GOMutexLocker.h"
 
-#include "GOApp.h"
-#include "GODocument.h"
 #include "GOEvent.h"
 #include "GOOrganController.h"
 #include "Images.h"
@@ -55,83 +55,91 @@
 #include "go_limits.h"
 #include "go_path.h"
 
-BEGIN_EVENT_TABLE(GOFrame, wxFrame)
-EVT_MSGBOX(GOFrame::OnMsgBox)
-EVT_RENAMEFILE(GOFrame::OnRenameFile)
-EVT_CLOSE(GOFrame::OnCloseWindow)
-EVT_CHAR_HOOK(GOFrame::OnKeyCommand)
-EVT_COMMAND(0, wxEVT_METERS, GOFrame::OnMeters)
-EVT_COMMAND(0, wxEVT_LOADFILE, GOFrame::OnLoadFile)
-EVT_MENU_OPEN(GOFrame::OnMenuOpen)
-EVT_MENU(ID_FILE_OPEN, GOFrame::OnOpen)
-EVT_MENU(ID_FILE_LOAD, GOFrame::OnLoad)
-EVT_MENU(ID_FILE_INSTALL, GOFrame::OnInstall)
-EVT_MENU_RANGE(ID_LOAD_FAV_FIRST, ID_LOAD_FAV_LAST, GOFrame::OnLoadFavorite)
-EVT_MENU_RANGE(ID_LOAD_LRU_FIRST, ID_LOAD_LRU_LAST, GOFrame::OnLoadRecent)
-EVT_MENU(ID_FILE_SAVE, GOFrame::OnSave)
-EVT_MENU(ID_FILE_CLOSE, GOFrame::OnMenuClose)
-EVT_MENU(ID_FILE_EXIT, GOFrame::OnExit)
-EVT_MENU(ID_FILE_RELOAD, GOFrame::OnReload)
-EVT_MENU(ID_FILE_REVERT, GOFrame::OnRevert)
-EVT_MENU(ID_FILE_PROPERTIES, GOFrame::OnProperties)
-EVT_MENU(ID_FILE_IMPORT_COMBINATIONS, GOFrame::OnImportCombinations)
-EVT_MENU(ID_FILE_EXPORT_COMBINATIONS, GOFrame::OnExportCombinations)
-EVT_MENU(ID_FILE_IMPORT_SETTINGS, GOFrame::OnImportSettings)
-EVT_MENU(ID_FILE_EXPORT, GOFrame::OnExport)
-EVT_MENU(ID_FILE_CACHE, GOFrame::OnCache)
-EVT_MENU(ID_FILE_CACHE_DELETE, GOFrame::OnCacheDelete)
-EVT_MENU(ID_ORGAN_EDIT, GOFrame::OnOrganSettings)
-EVT_MENU(ID_MIDI_LIST, GOFrame::OnMidiList)
-EVT_MENU(ID_STOPS, GOFrame::OnStops)
-EVT_MENU(ID_MIDI_MONITOR, GOFrame::OnMidiMonitor)
-EVT_MENU(ID_AUDIO_PANIC, GOFrame::OnAudioPanic)
-EVT_MENU(ID_AUDIO_MEMSET, GOFrame::OnAudioMemset)
-EVT_MENU(ID_AUDIO_STATE, GOFrame::OnAudioState)
-EVT_MENU(ID_SETTINGS, GOFrame::OnSettings)
-EVT_MENU(ID_MIDI_LOAD, GOFrame::OnMidiLoad)
-EVT_MENU(wxID_HELP, GOFrame::OnHelp)
-EVT_MENU(wxID_ABOUT, GOFrame::OnHelpAbout)
-EVT_COMMAND(0, wxEVT_WINTITLE, GOFrame::OnSetTitle)
-EVT_MENU(ID_VOLUME, GOFrame::OnSettingsVolume)
-EVT_MENU(ID_POLYPHONY, GOFrame::OnSettingsPolyphony)
-EVT_MENU(ID_MEMORY, GOFrame::OnSettingsMemoryEnter)
-EVT_MENU(ID_TRANSPOSE, GOFrame::OnSettingsTranspose)
-EVT_MENU(ID_RELEASELENGTH, GOFrame::OnSettingsReleaseLength)
-EVT_MENU_RANGE(ID_PANEL_FIRST, ID_PANEL_LAST, GOFrame::OnPanel)
-EVT_MENU_RANGE(ID_PRESET_0, ID_PRESET_LAST, GOFrame::OnPreset)
-EVT_MENU_RANGE(ID_TEMPERAMENT_0, ID_TEMPERAMENT_LAST, GOFrame::OnTemperament)
-EVT_SIZE(GOFrame::OnSize)
-EVT_TEXT(ID_METER_TRANSPOSE_SPIN, GOFrame::OnSettingsTranspose)
-EVT_TEXT_ENTER(ID_METER_TRANSPOSE_SPIN, GOFrame::OnSettingsTranspose)
-EVT_COMMAND(ID_METER_TRANSPOSE_SPIN, wxEVT_SETVALUE, GOFrame::OnChangeTranspose)
-EVT_CHOICE(ID_RELEASELENGTH_SELECT, GOFrame::OnSettingsReleaseLength)
-EVT_TEXT(ID_METER_POLY_SPIN, GOFrame::OnSettingsPolyphony)
-EVT_TEXT_ENTER(ID_METER_POLY_SPIN, GOFrame::OnSettingsPolyphony)
-EVT_TEXT(ID_METER_FRAME_SPIN, GOFrame::OnSettingsMemory)
-EVT_TEXT_ENTER(ID_METER_FRAME_SPIN, GOFrame::OnSettingsMemoryEnter)
-EVT_COMMAND(ID_METER_FRAME_SPIN, wxEVT_SETVALUE, GOFrame::OnChangeSetter)
-EVT_SLIDER(ID_METER_FRAME_SPIN, GOFrame::OnChangeSetter)
-EVT_TEXT(ID_METER_AUDIO_SPIN, GOFrame::OnSettingsVolume)
-EVT_TEXT_ENTER(ID_METER_AUDIO_SPIN, GOFrame::OnSettingsVolume)
-EVT_COMMAND(ID_METER_AUDIO_SPIN, wxEVT_SETVALUE, GOFrame::OnChangeVolume)
-EVT_MENU(ID_CHECK_FOR_UPDATES, GOFrame::OnUpdateCheckingRequested)
-EVT_MENU(ID_SHOW_RELEASE_CHANGELOG, GOFrame::OnNewReleaseInfoRequested)
-EVT_MENU(ID_DOWNLOAD_NEW_RELEASE, GOFrame::OnNewReleaseDownload)
-EVT_UPDATE_CHECKING_COMPLETION(GOFrame::OnUpdateCheckingCompletion)
-EVT_UPDATE_UI_RANGE(ID_FILE_RELOAD, ID_AUDIO_MEMSET, GOFrame::OnUpdateLoaded)
-EVT_UPDATE_UI_RANGE(ID_PRESET_0, ID_PRESET_LAST, GOFrame::OnUpdateLoaded)
+BEGIN_EVENT_TABLE(GOToolbarWindow, wxFrame)
+EVT_MSGBOX(GOToolbarWindow::OnMsgBox)
+EVT_RENAMEFILE(GOToolbarWindow::OnRenameFile)
+EVT_CLOSE(GOToolbarWindow::OnCloseWindow)
+EVT_CHAR_HOOK(GOToolbarWindow::OnKeyCommand)
+EVT_COMMAND(0, wxEVT_METERS, GOToolbarWindow::OnMeters)
+EVT_COMMAND(0, wxEVT_LOADFILE, GOToolbarWindow::OnLoadFile)
+EVT_MENU_OPEN(GOToolbarWindow::OnMenuOpen)
+EVT_MENU(ID_FILE_OPEN, GOToolbarWindow::OnOpen)
+EVT_MENU(ID_FILE_LOAD, GOToolbarWindow::OnLoad)
+EVT_MENU(ID_FILE_INSTALL, GOToolbarWindow::OnInstall)
+EVT_MENU_RANGE(
+  ID_LOAD_FAV_FIRST, ID_LOAD_FAV_LAST, GOToolbarWindow::OnLoadFavorite)
+EVT_MENU_RANGE(
+  ID_LOAD_LRU_FIRST, ID_LOAD_LRU_LAST, GOToolbarWindow::OnLoadRecent)
+EVT_MENU(ID_FILE_SAVE, GOToolbarWindow::OnSave)
+EVT_MENU(ID_FILE_CLOSE, GOToolbarWindow::OnMenuClose)
+EVT_MENU(ID_FILE_EXIT, GOToolbarWindow::OnExit)
+EVT_MENU(ID_FILE_RELOAD, GOToolbarWindow::OnReload)
+EVT_MENU(ID_FILE_REVERT, GOToolbarWindow::OnRevert)
+EVT_MENU(ID_FILE_PROPERTIES, GOToolbarWindow::OnProperties)
+EVT_MENU(ID_FILE_IMPORT_COMBINATIONS, GOToolbarWindow::OnImportCombinations)
+EVT_MENU(ID_FILE_EXPORT_COMBINATIONS, GOToolbarWindow::OnExportCombinations)
+EVT_MENU(ID_FILE_IMPORT_SETTINGS, GOToolbarWindow::OnImportSettings)
+EVT_MENU(ID_FILE_EXPORT, GOToolbarWindow::OnExport)
+EVT_MENU(ID_FILE_CACHE, GOToolbarWindow::OnCache)
+EVT_MENU(ID_FILE_CACHE_DELETE, GOToolbarWindow::OnCacheDelete)
+EVT_MENU(ID_ORGAN_EDIT, GOToolbarWindow::OnOrganSettings)
+EVT_MENU(ID_MIDI_LIST, GOToolbarWindow::OnMidiList)
+EVT_MENU(ID_STOPS, GOToolbarWindow::OnStops)
+EVT_MENU(ID_MIDI_MONITOR, GOToolbarWindow::OnMidiMonitor)
+EVT_MENU(ID_AUDIO_PANIC, GOToolbarWindow::OnAudioPanic)
+EVT_MENU(ID_AUDIO_MEMSET, GOToolbarWindow::OnAudioMemset)
+EVT_MENU(ID_AUDIO_STATE, GOToolbarWindow::OnAudioState)
+EVT_MENU(ID_SETTINGS, GOToolbarWindow::OnSettings)
+EVT_MENU(ID_MIDI_LOAD, GOToolbarWindow::OnMidiLoad)
+EVT_MENU(wxID_HELP, GOToolbarWindow::OnHelp)
+EVT_MENU(wxID_ABOUT, GOToolbarWindow::OnHelpAbout)
+EVT_COMMAND(0, wxEVT_WINTITLE, GOToolbarWindow::OnSetTitle)
+EVT_MENU(ID_VOLUME, GOToolbarWindow::OnSettingsVolume)
+EVT_MENU(ID_POLYPHONY, GOToolbarWindow::OnSettingsPolyphony)
+EVT_MENU(ID_MEMORY, GOToolbarWindow::OnSettingsMemoryEnter)
+EVT_MENU(ID_TRANSPOSE, GOToolbarWindow::OnSettingsTranspose)
+EVT_MENU(ID_RELEASELENGTH, GOToolbarWindow::OnSettingsReleaseLength)
+EVT_MENU_RANGE(ID_PANEL_FIRST, ID_PANEL_LAST, GOToolbarWindow::OnPanel)
+EVT_MENU_RANGE(ID_PRESET_0, ID_PRESET_LAST, GOToolbarWindow::OnPreset)
+EVT_MENU_RANGE(
+  ID_TEMPERAMENT_0, ID_TEMPERAMENT_LAST, GOToolbarWindow::OnTemperament)
+EVT_SIZE(GOToolbarWindow::OnSize)
+EVT_TEXT(ID_METER_TRANSPOSE_SPIN, GOToolbarWindow::OnSettingsTranspose)
+EVT_TEXT_ENTER(ID_METER_TRANSPOSE_SPIN, GOToolbarWindow::OnSettingsTranspose)
+EVT_COMMAND(
+  ID_METER_TRANSPOSE_SPIN, wxEVT_SETVALUE, GOToolbarWindow::OnChangeTranspose)
+EVT_CHOICE(ID_RELEASELENGTH_SELECT, GOToolbarWindow::OnSettingsReleaseLength)
+EVT_TEXT(ID_METER_POLY_SPIN, GOToolbarWindow::OnSettingsPolyphony)
+EVT_TEXT_ENTER(ID_METER_POLY_SPIN, GOToolbarWindow::OnSettingsPolyphony)
+EVT_TEXT(ID_METER_FRAME_SPIN, GOToolbarWindow::OnSettingsMemory)
+EVT_TEXT_ENTER(ID_METER_FRAME_SPIN, GOToolbarWindow::OnSettingsMemoryEnter)
+EVT_COMMAND(
+  ID_METER_FRAME_SPIN, wxEVT_SETVALUE, GOToolbarWindow::OnChangeSetter)
+EVT_SLIDER(ID_METER_FRAME_SPIN, GOToolbarWindow::OnChangeSetter)
+EVT_TEXT(ID_METER_AUDIO_SPIN, GOToolbarWindow::OnSettingsVolume)
+EVT_TEXT_ENTER(ID_METER_AUDIO_SPIN, GOToolbarWindow::OnSettingsVolume)
+EVT_COMMAND(
+  ID_METER_AUDIO_SPIN, wxEVT_SETVALUE, GOToolbarWindow::OnChangeVolume)
+EVT_MENU(ID_CHECK_FOR_UPDATES, GOToolbarWindow::OnUpdateCheckingRequested)
+EVT_MENU(ID_SHOW_RELEASE_CHANGELOG, GOToolbarWindow::OnNewReleaseInfoRequested)
+EVT_MENU(ID_DOWNLOAD_NEW_RELEASE, GOToolbarWindow::OnNewReleaseDownload)
+EVT_UPDATE_CHECKING_COMPLETION(GOToolbarWindow::OnUpdateCheckingCompletion)
+EVT_UPDATE_UI_RANGE(
+  ID_FILE_RELOAD, ID_AUDIO_MEMSET, GOToolbarWindow::OnUpdateLoaded)
+EVT_UPDATE_UI_RANGE(
+  ID_PRESET_0, ID_PRESET_LAST, GOToolbarWindow::OnUpdateLoaded)
 END_EVENT_TABLE()
 
-GOFrame::GOFrame(
-  GOApp &app,
-  wxFrame *frame,
+GOToolbarWindow::GOToolbarWindow(
+  GOGuiApp &app,
+  wxFrame *pParentFrame,
   wxWindowID id,
   const wxString &title,
   const wxPoint &pos,
   const wxSize &size,
   const long type,
   GOSoundSystem &sound)
-  : wxFrame(frame, id, title, pos, size, type),
+  : wxFrame(pParentFrame, id, title, pos, size, type),
     GOHelpRequestor(this),
     r_app(app),
     r_config(sound.GetSettings()),
@@ -389,12 +397,12 @@ GOFrame::GOFrame(
   m_isMeterReady = true;
 }
 
-GOFrame::~GOFrame() {
+GOToolbarWindow::~GOToolbarWindow() {
   m_isMeterReady = false;
   m_listener.SetCallback(NULL);
 }
 
-bool GOFrame::AdjustVolumeControlWithSettings() {
+bool GOToolbarWindow::AdjustVolumeControlWithSettings() {
   const unsigned count = r_config.GetTotalAudioChannels();
   bool rc = false;
 
@@ -438,7 +446,7 @@ bool GOFrame::AdjustVolumeControlWithSettings() {
   return rc;
 }
 
-void GOFrame::UpdateSize() {
+void GOToolbarWindow::UpdateSize() {
   wxToolBar *tb = GetToolBar();
 
   tb->Realize();
@@ -454,7 +462,7 @@ void GOFrame::UpdateSize() {
   SetMaxSize(wxSize(frameSize.GetWidth() * 4, frameSize.GetHeight()));
 }
 
-GOLogicalRect GOFrame::GetPosSize() const {
+GOLogicalRect GOToolbarWindow::GetPosSize() const {
   GOLogicalRect lRect;
   const wxRect gRect(GetRect());
 
@@ -465,7 +473,7 @@ GOLogicalRect GOFrame::GetPosSize() const {
   return lRect;
 }
 
-void GOFrame::SetPosSize(const GOLogicalRect &lRect) {
+void GOToolbarWindow::SetPosSize(const GOLogicalRect &lRect) {
   if (lRect.width && lRect.height) { // settings are valid
     wxRect rect(lRect.x, lRect.y, lRect.width, lRect.height);
     const wxRect minSize(GetMinSize());
@@ -483,7 +491,7 @@ void GOFrame::SetPosSize(const GOLogicalRect &lRect) {
   }
 }
 
-void GOFrame::UpdateReleaseLength(unsigned releaseLength) {
+void GOToolbarWindow::UpdateReleaseLength(unsigned releaseLength) {
   int releaseLengthIndex = releaseLength / 50;
 
   if (p_OrganController && p_OrganController->GetReleaseTail() != releaseLength)
@@ -492,14 +500,14 @@ void GOFrame::UpdateReleaseLength(unsigned releaseLength) {
     m_ReleaseLength->SetSelection(releaseLengthIndex);
 }
 
-void GOFrame::UpdateVolumeControlWithSettings() {
+void GOToolbarWindow::UpdateVolumeControlWithSettings() {
   m_isMeterReady = false;
   if (AdjustVolumeControlWithSettings())
     UpdateSize();
   m_isMeterReady = true;
 }
 
-void GOFrame::Init(const wxString &filename, bool isGuiOnly) {
+void GOToolbarWindow::Init(const wxString &filename, bool isGuiOnly) {
   if (r_config.CheckForUpdatesAtStartup()) {
     // Start update checker thread that will fire events to this frame
     m_UpdateCheckerThread = GOUpdateChecker::StartThread(
@@ -567,16 +575,16 @@ void GOFrame::Init(const wxString &filename, bool isGuiOnly) {
   clean.Cleanup();
 }
 
-void GOFrame::AttachDetachOrganController(bool isToAttach) {
+void GOToolbarWindow::AttachDetachOrganController(bool isToAttach) {
   if (p_OrganController)
     p_OrganController->SetModificationListener(isToAttach ? this : nullptr);
 }
 
-bool GOFrame::CloseOrgan(bool isForce) {
+bool GOToolbarWindow::CloseOrgan(bool isForce) {
   bool isClosed = true;
 
-  if (mp_doc) {
-    if (mp_doc->IsModified()) {
+  if (mp_organ) {
+    if (mp_organ->IsModified()) {
       int choice = isForce ? wxYES
                            : wxMessageBox(
                              _("The organ settings have been modified\n"
@@ -587,7 +595,7 @@ bool GOFrame::CloseOrgan(bool isForce) {
 
       switch (choice) {
       case wxYES:
-        isClosed = mp_doc->Save();
+        isClosed = mp_organ->Save();
         break;
       case wxCANCEL:
         isClosed = false;
@@ -601,7 +609,7 @@ bool GOFrame::CloseOrgan(bool isForce) {
       if (m_locker.IsLocked()) {
         AttachDetachOrganController(false);
         p_OrganController = nullptr;
-        mp_doc.reset();
+        mp_organ.reset();
         UpdatePanelMenu();
       } else
         isClosed = false;
@@ -610,11 +618,11 @@ bool GOFrame::CloseOrgan(bool isForce) {
   return isClosed;
 }
 
-void GOFrame::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
-  if (mp_doc) {
+void GOToolbarWindow::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
+  if (mp_organ) {
     GOProgressDialog dlg;
 
-    p_OrganController = mp_doc->LoadOrgan(&dlg, organ, cmb, m_IsGuiOnly);
+    p_OrganController = mp_organ->LoadOrgan(&dlg, organ, cmb, m_IsGuiOnly);
     OnIsModifiedChanged(false);
 
     // for reflecting model changes
@@ -622,31 +630,31 @@ void GOFrame::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
   }
 }
 
-void GOFrame::Open(const GOOrgan &organ) {
+void GOToolbarWindow::Open(const GOOrgan &organ) {
   if (CloseOrgan(false)) {
     GOMutexLocker m_locker(m_mutex, true);
 
     if (m_locker.IsLocked()) {
-      mp_doc = std::make_unique<GODocument>(this, &r_SoundSystem);
+      mp_organ = std::make_unique<GOGuiOrgan>(this, &r_SoundSystem);
       LoadOrgan(organ);
     }
   }
 }
 
-void GOFrame::OnPanel(wxCommandEvent &event) {
+void GOToolbarWindow::OnPanel(wxCommandEvent &event) {
   unsigned no = event.GetId() - ID_PANEL_FIRST;
 
   if (p_OrganController && no < p_OrganController->GetPanelCount())
-    mp_doc->ShowPanel(no);
+    mp_organ->ShowPanel(no);
 }
 
-void GOFrame::OnIsModifiedChanged(bool modified) {
+void GOToolbarWindow::OnIsModifiedChanged(bool modified) {
   if (p_OrganController)
     UpdateReleaseLength(p_OrganController->GetReleaseTail());
   UpdatePanelMenu();
 }
 
-void GOFrame::UpdatePanelMenu() {
+void GOToolbarWindow::UpdatePanelMenu() {
   unsigned panelcount
     = (p_OrganController && p_OrganController->GetPanelCount())
     ? p_OrganController->GetPanelCount()
@@ -675,11 +683,12 @@ void GOFrame::UpdatePanelMenu() {
     }
     wxMenuItem *item = menu->AppendCheckItem(ID_PANEL_FIRST + i, wxT("_"));
     item->SetItemLabel(panel->GetName());
-    item->Check(mp_doc->WindowExists(GODocument::PANEL, panel) ? true : false);
+    item->Check(
+      mp_organ->WindowExists(GOGuiOrgan::PANEL, panel) ? true : false);
   }
 }
 
-void GOFrame::UpdateFavoritesMenu() {
+void GOToolbarWindow::UpdateFavoritesMenu() {
   while (m_favorites_menu->GetMenuItemCount() > 0)
     m_favorites_menu->Destroy(m_favorites_menu->FindItemByPosition(
       m_favorites_menu->GetMenuItemCount() - 1));
@@ -695,7 +704,7 @@ void GOFrame::UpdateFavoritesMenu() {
   }
 }
 
-void GOFrame::UpdateRecentMenu() {
+void GOToolbarWindow::UpdateRecentMenu() {
   while (m_recent_menu->GetMenuItemCount() > 0)
     m_recent_menu->Destroy(
       m_recent_menu->FindItemByPosition(m_recent_menu->GetMenuItemCount() - 1));
@@ -711,7 +720,7 @@ void GOFrame::UpdateRecentMenu() {
   }
 }
 
-void GOFrame::UpdateTemperamentMenu() {
+void GOToolbarWindow::UpdateTemperamentMenu() {
   wxString temperament = wxEmptyString;
   if (p_OrganController)
     temperament = p_OrganController->GetTemperament();
@@ -747,7 +756,7 @@ void GOFrame::UpdateTemperamentMenu() {
   }
 }
 
-void GOFrame::OnSize(wxSizeEvent &event) {
+void GOToolbarWindow::OnSize(wxSizeEvent &event) {
   wxWindow *child = (wxWindow *)NULL;
   for (wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
        node;
@@ -762,7 +771,7 @@ void GOFrame::OnSize(wxSizeEvent &event) {
       0, 0, GetClientSize().GetWidth(), GetClientSize().GetHeight());
 }
 
-void GOFrame::OnMeters(wxCommandEvent &event) {
+void GOToolbarWindow::OnMeters(wxCommandEvent &event) {
   if (m_isMeterReady) {
     const std::vector<float> vals = r_SoundSystem.GetEngine().GetMeterInfo();
 
@@ -779,7 +788,7 @@ void GOFrame::OnMeters(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnUpdateLoaded(wxUpdateUIEvent &event) {
+void GOToolbarWindow::OnUpdateLoaded(wxUpdateUIEvent &event) {
   if (ID_PRESET_0 <= event.GetId() && event.GetId() <= ID_PRESET_LAST) {
     event.Check(r_config.Preset() == (unsigned)(event.GetId() - ID_PRESET_0));
     return;
@@ -790,11 +799,13 @@ void GOFrame::OnUpdateLoaded(wxUpdateUIEvent &event) {
       p_OrganController && p_OrganController->GetSetter()
       && p_OrganController->GetSetter()->GetState().m_IsActive);
   else if (event.GetId() == ID_ORGAN_EDIT)
-    event.Check(mp_doc && mp_doc->WindowExists(GODocument::ORGAN_DIALOG, NULL));
+    event.Check(
+      mp_organ && mp_organ->WindowExists(GOGuiOrgan::ORGAN_DIALOG, NULL));
   else if (event.GetId() == ID_MIDI_LIST)
-    event.Check(mp_doc && mp_doc->WindowExists(GODocument::MIDI_LIST, NULL));
+    event.Check(
+      mp_organ && mp_organ->WindowExists(GOGuiOrgan::MIDI_LIST, NULL));
   else if (event.GetId() == ID_STOPS)
-    event.Check(mp_doc && mp_doc->WindowExists(GODocument::STOPS, NULL));
+    event.Check(mp_organ && mp_organ->WindowExists(GOGuiOrgan::STOPS, NULL));
   else if (event.GetId() == ID_MIDI_LIST)
     event.Check(m_MidiMonitor);
 
@@ -810,16 +821,16 @@ void GOFrame::OnUpdateLoaded(wxUpdateUIEvent &event) {
       && (event.GetId() == ID_FILE_REVERT ? p_OrganController->IsCustomized() : true));
 }
 
-void GOFrame::OnPreset(wxCommandEvent &event) {
+void GOToolbarWindow::OnPreset(wxCommandEvent &event) {
   unsigned id = event.GetId() - ID_PRESET_0;
   if (id == r_config.Preset())
     return;
   r_config.Preset(id);
-  if (mp_doc)
+  if (mp_organ)
     ProcessCommand(ID_FILE_RELOAD);
 }
 
-void GOFrame::OnTemperament(wxCommandEvent &event) {
+void GOToolbarWindow::OnTemperament(wxCommandEvent &event) {
   unsigned id = event.GetId() - ID_TEMPERAMENT_0;
 
   if (
@@ -828,7 +839,7 @@ void GOFrame::OnTemperament(wxCommandEvent &event) {
       r_config.GetTemperaments().GetTemperament(id).GetName());
 }
 
-void GOFrame::OnLoadFile(wxCommandEvent &event) {
+void GOToolbarWindow::OnLoadFile(wxCommandEvent &event) {
   GOOrgan *pOrgan = (GOOrgan *)event.GetClientData();
 
   if (!m_InSettings) {
@@ -838,26 +849,26 @@ void GOFrame::OnLoadFile(wxCommandEvent &event) {
     SetEventAfterSettings(event.GetEventType(), event.GetId(), pOrgan);
 }
 
-void GOFrame::OnLoadFavorite(wxCommandEvent &event) {
+void GOToolbarWindow::OnLoadFavorite(wxCommandEvent &event) {
   unsigned id = event.GetId() - ID_LOAD_FAV_FIRST;
   const GOOrgan &organ = *r_config.GetOrganList()[id];
   Open(organ);
 }
 
-void GOFrame::OnLoadRecent(wxCommandEvent &event) {
+void GOToolbarWindow::OnLoadRecent(wxCommandEvent &event) {
   unsigned id = event.GetId() - ID_LOAD_LRU_FIRST;
   const GOOrgan &organ = *r_config.GetLRUOrganList()[id];
   Open(organ);
 }
 
-void GOFrame::OnLoad(wxCommandEvent &event) {
+void GOToolbarWindow::OnLoad(wxCommandEvent &event) {
   GOSelectOrganDialog dlg(this, r_config);
 
   if (dlg.ShowModal() == wxID_OK)
     Open(*dlg.GetSelection());
 }
 
-void GOFrame::OnOpen(wxCommandEvent &event) {
+void GOToolbarWindow::OnOpen(wxCommandEvent &event) {
   wxFileDialog dlg(
     this,
     _("Open organ"),
@@ -870,7 +881,7 @@ void GOFrame::OnOpen(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnInstall(wxCommandEvent &event) {
+void GOToolbarWindow::OnInstall(wxCommandEvent &event) {
   wxFileDialog dlg(
     this,
     _("Install organ package"),
@@ -889,7 +900,7 @@ void GOFrame::OnInstall(wxCommandEvent &event) {
     }
 }
 
-void GOFrame::OnImportCombinations(wxCommandEvent &event) {
+void GOToolbarWindow::OnImportCombinations(wxCommandEvent &event) {
   if (p_OrganController) {
     wxFileDialog dlg(
       this,
@@ -904,7 +915,7 @@ void GOFrame::OnImportCombinations(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnExportCombinations(wxCommandEvent &event) {
+void GOToolbarWindow::OnExportCombinations(wxCommandEvent &event) {
   if (p_OrganController) {
     const wxString organCmbDir = p_OrganController->GetCombinationsDir();
 
@@ -939,7 +950,7 @@ void GOFrame::OnExportCombinations(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnImportSettings(wxCommandEvent &event) {
+void GOToolbarWindow::OnImportSettings(wxCommandEvent &event) {
   if (p_OrganController) {
     wxFileDialog dlg(
       this,
@@ -960,7 +971,7 @@ void GOFrame::OnImportSettings(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnExport(wxCommandEvent &event) {
+void GOToolbarWindow::OnExport(wxCommandEvent &event) {
   if (p_OrganController) {
     wxFileDialog dlg(
       this,
@@ -974,7 +985,7 @@ void GOFrame::OnExport(wxCommandEvent &event) {
       wxString exportedFilePath = dlg.GetPath();
       if (!exportedFilePath.EndsWith(wxT(".cmb"), NULL))
         exportedFilePath += wxT(".cmb");
-      if (!mp_doc->Export(exportedFilePath))
+      if (!mp_organ->Export(exportedFilePath))
         GOMessageBox(
           wxString::Format(
             _("Failed to export settings to '%s'"), exportedFilePath.c_str()),
@@ -985,8 +996,8 @@ void GOFrame::OnExport(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnSave(wxCommandEvent &event) {
-  if (p_OrganController && !mp_doc->Save())
+void GOToolbarWindow::OnSave(wxCommandEvent &event) {
+  if (p_OrganController && !mp_organ->Save())
     GOMessageBox(
       _("Failed to save the organ setting"),
       _("Error"),
@@ -1008,7 +1019,7 @@ wxString formatSize(wxLongLong &size) {
   return wxString::Format(wxT("%.2f %s"), n, wxGetTranslation(sizes[i]));
 }
 
-void GOFrame::OnCache(wxCommandEvent &event) {
+void GOToolbarWindow::OnCache(wxCommandEvent &event) {
   bool res = true;
   GOMutexLocker m_locker(m_mutex, true);
 
@@ -1026,12 +1037,12 @@ void GOFrame::OnCache(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnCacheDelete(wxCommandEvent &event) {
+void GOToolbarWindow::OnCacheDelete(wxCommandEvent &event) {
   if (p_OrganController)
     p_OrganController->DeleteCache();
 }
 
-void GOFrame::OnReload(wxCommandEvent &event) {
+void GOToolbarWindow::OnReload(wxCommandEvent &event) {
   if (p_OrganController) {
     GOOrgan organ = p_OrganController->GetOrganInfo();
 
@@ -1040,12 +1051,12 @@ void GOFrame::OnReload(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnMenuClose(wxCommandEvent &event) {
-  if (mp_doc)
+void GOToolbarWindow::OnMenuClose(wxCommandEvent &event) {
+  if (mp_organ)
     CloseOrgan(false);
 }
 
-bool GOFrame::CloseProgram(bool isForce) {
+bool GOToolbarWindow::CloseProgram(bool isForce) {
   if (m_UpdateCheckerThread) {
     // Stop update checking so that we can safely destruct the thread
     m_UpdateCheckerThread->Stop();
@@ -1058,13 +1069,13 @@ bool GOFrame::CloseProgram(bool isForce) {
   return isClosed;
 }
 
-void GOFrame::OnExit(wxCommandEvent &event) { CloseProgram(); }
+void GOToolbarWindow::OnExit(wxCommandEvent &event) { CloseProgram(); }
 
-void GOFrame::OnCloseWindow(wxCloseEvent &event) {
+void GOToolbarWindow::OnCloseWindow(wxCloseEvent &event) {
   CloseProgram(!event.CanVeto());
 }
 
-void GOFrame::OnRevert(wxCommandEvent &event) {
+void GOToolbarWindow::OnRevert(wxCommandEvent &event) {
   if (
     wxMessageBox(
       _("Any customizations you have saved to this\norgan definition file "
@@ -1080,23 +1091,23 @@ void GOFrame::OnRevert(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnProperties(wxCommandEvent &event) {
+void GOToolbarWindow::OnProperties(wxCommandEvent &event) {
   if (p_OrganController) {
     GOPropertiesDialog dlg(p_OrganController, this);
     dlg.ShowModal();
   }
 }
 
-void GOFrame::OnAudioPanic(wxCommandEvent &WXUNUSED(event)) {
+void GOToolbarWindow::OnAudioPanic(wxCommandEvent &WXUNUSED(event)) {
   r_SoundSystem.AssureSoundIsClosed();
   r_SoundSystem.AssureSoundIsOpen();
 }
 
-void GOFrame::OnMidiMonitor(wxCommandEvent &WXUNUSED(event)) {
+void GOToolbarWindow::OnMidiMonitor(wxCommandEvent &WXUNUSED(event)) {
   m_MidiMonitor = !m_MidiMonitor;
 }
 
-void GOFrame::OnMidiLoad(wxCommandEvent &WXUNUSED(event)) {
+void GOToolbarWindow::OnMidiLoad(wxCommandEvent &WXUNUSED(event)) {
   wxFileDialog dlg(
     this,
     _("Load MIDI file"),
@@ -1110,12 +1121,12 @@ void GOFrame::OnMidiLoad(wxCommandEvent &WXUNUSED(event)) {
   }
 }
 
-void GOFrame::OnAudioMemset(wxCommandEvent &WXUNUSED(event)) {
+void GOToolbarWindow::OnAudioMemset(wxCommandEvent &WXUNUSED(event)) {
   if (p_OrganController)
     p_OrganController->GetSetter()->ToggleSetter();
 }
 
-void GOFrame::SetEventAfterSettings(
+void GOToolbarWindow::SetEventAfterSettings(
   wxEventType eventType, int eventId, GOOrgan *pOrganFile) {
   if (p_AfterSettingsEventOrgan)
     delete p_AfterSettingsEventOrgan;
@@ -1124,7 +1135,7 @@ void GOFrame::SetEventAfterSettings(
   p_AfterSettingsEventOrgan = pOrganFile;
 }
 
-void GOFrame::OnSettings(wxCommandEvent &event) {
+void GOToolbarWindow::OnSettings(wxCommandEvent &event) {
   m_InSettings = true;
 
   bool isToContinue = true; // will GO continue running? Otherwise it will exit
@@ -1189,30 +1200,30 @@ void GOFrame::OnSettings(wxCommandEvent &event) {
   m_InSettings = false;
 }
 
-void GOFrame::OnAudioState(wxCommandEvent &WXUNUSED(event)) {
+void GOToolbarWindow::OnAudioState(wxCommandEvent &WXUNUSED(event)) {
   GOMessageBox(r_SoundSystem.getState(), _("Sound output"), wxOK, this);
 }
 
-void GOFrame::OnOrganSettings(wxCommandEvent &event) {
-  if (mp_doc)
-    mp_doc->ShowOrganSettingsDialog();
+void GOToolbarWindow::OnOrganSettings(wxCommandEvent &event) {
+  if (mp_organ)
+    mp_organ->ShowOrganSettingsDialog();
 }
 
-void GOFrame::OnMidiList(wxCommandEvent &event) {
-  if (mp_doc)
-    mp_doc->ShowMidiList();
+void GOToolbarWindow::OnMidiList(wxCommandEvent &event) {
+  if (mp_organ)
+    mp_organ->ShowMidiList();
 }
 
-void GOFrame::OnStops(wxCommandEvent &event) {
-  if (mp_doc)
-    mp_doc->ShowStops();
+void GOToolbarWindow::OnStops(wxCommandEvent &event) {
+  if (mp_organ)
+    mp_organ->ShowStops();
 }
 
-void GOFrame::OnHelp(wxCommandEvent &event) {
+void GOToolbarWindow::OnHelp(wxCommandEvent &event) {
   GOHelpRequestor::DisplayHelp(_("User Interface"), false);
 }
 
-void GOFrame::OnSettingsVolume(wxCommandEvent &event) {
+void GOToolbarWindow::OnSettingsVolume(wxCommandEvent &event) {
   long n = m_Volume->GetValue();
 
   r_SoundSystem.GetEngine().SetVolume(n);
@@ -1220,7 +1231,7 @@ void GOFrame::OnSettingsVolume(wxCommandEvent &event) {
     m_VolumeGauge[i]->ResetClip();
 }
 
-void GOFrame::OnSettingsPolyphony(wxCommandEvent &event) {
+void GOToolbarWindow::OnSettingsPolyphony(wxCommandEvent &event) {
   long n = m_Polyphony->GetValue();
 
   r_config.PolyphonyLimit(n);
@@ -1228,21 +1239,21 @@ void GOFrame::OnSettingsPolyphony(wxCommandEvent &event) {
   m_SamplerUsage->ResetClip();
 }
 
-void GOFrame::OnSettingsMemoryEnter(wxCommandEvent &event) {
+void GOToolbarWindow::OnSettingsMemoryEnter(wxCommandEvent &event) {
   long n = m_SetterPosition->GetValue();
 
   if (p_OrganController)
     p_OrganController->GetSetter()->SetPosition(n);
 }
 
-void GOFrame::OnSettingsMemory(wxCommandEvent &event) {
+void GOToolbarWindow::OnSettingsMemory(wxCommandEvent &event) {
   long n = m_SetterPosition->GetValue();
 
   if (p_OrganController)
     p_OrganController->GetSetter()->UpdatePosition(n);
 }
 
-void GOFrame::OnSettingsTranspose(wxCommandEvent &event) {
+void GOToolbarWindow::OnSettingsTranspose(wxCommandEvent &event) {
   if (p_OrganController) {
     long n = m_Transpose->GetValue();
 
@@ -1251,15 +1262,17 @@ void GOFrame::OnSettingsTranspose(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnSettingsReleaseLength(wxCommandEvent &event) {
+void GOToolbarWindow::OnSettingsReleaseLength(wxCommandEvent &event) {
   UpdateReleaseLength(m_ReleaseLength->GetSelection() * 50);
 }
 
-void GOFrame::OnHelpAbout(wxCommandEvent &event) { DoSplash(false); }
+void GOToolbarWindow::OnHelpAbout(wxCommandEvent &event) { DoSplash(false); }
 
-void GOFrame::DoSplash(bool timeout) { GOSplash::DoSplash(timeout, this); }
+void GOToolbarWindow::DoSplash(bool timeout) {
+  GOSplash::DoSplash(timeout, this);
+}
 
-void GOFrame::OnMenuOpen(wxMenuEvent &event) {
+void GOToolbarWindow::OnMenuOpen(wxMenuEvent &event) {
   DoMenuUpdates(event.GetMenu());
   if (event.GetMenu() == m_panel_menu)
     UpdatePanelMenu();
@@ -1272,19 +1285,19 @@ void GOFrame::OnMenuOpen(wxMenuEvent &event) {
   event.Skip();
 }
 
-void GOFrame::OnChangeTranspose(wxCommandEvent &event) {
+void GOToolbarWindow::OnChangeTranspose(wxCommandEvent &event) {
   m_Transpose->SetValue(event.GetInt());
 }
 
-void GOFrame::OnChangeSetter(wxCommandEvent &event) {
+void GOToolbarWindow::OnChangeSetter(wxCommandEvent &event) {
   m_SetterPosition->SetValue(event.GetInt());
 }
 
-void GOFrame::OnChangeVolume(wxCommandEvent &event) {
+void GOToolbarWindow::OnChangeVolume(wxCommandEvent &event) {
   m_Volume->SetValue(event.GetInt());
 }
 
-void GOFrame::OnKeyCommand(wxKeyEvent &event) {
+void GOToolbarWindow::OnKeyCommand(wxKeyEvent &event) {
   int k = event.GetKeyCode();
   if (!event.AltDown()) {
     switch (k) {
@@ -1297,7 +1310,7 @@ void GOFrame::OnKeyCommand(wxKeyEvent &event) {
   event.Skip();
 }
 
-void GOFrame::OnMidiEvent(const GOMidiEvent &event) {
+void GOToolbarWindow::OnMidiEvent(const GOMidiEvent &event) {
   if (m_MidiMonitor) {
     wxLogWarning(_("MIDI event: ") + event.ToString(r_MidiSystem.GetMidiMap()));
   }
@@ -1315,7 +1328,7 @@ void GOFrame::OnMidiEvent(const GOMidiEvent &event) {
   }
 }
 
-void GOFrame::OnSetTitle(wxCommandEvent &event) {
+void GOToolbarWindow::OnSetTitle(wxCommandEvent &event) {
   m_Label = event.GetString();
   if (m_Label == wxEmptyString)
     SetTitle(m_Title);
@@ -1323,11 +1336,11 @@ void GOFrame::OnSetTitle(wxCommandEvent &event) {
     SetTitle(m_Title + _(" - ") + m_Label);
 }
 
-void GOFrame::OnMsgBox(wxMsgBoxEvent &event) {
+void GOToolbarWindow::OnMsgBox(wxMsgBoxEvent &event) {
   wxMessageBox(event.getText(), event.getTitle(), event.getStyle(), this);
 }
 
-void GOFrame::OnRenameFile(wxRenameFileEvent &event) {
+void GOToolbarWindow::OnRenameFile(wxRenameFileEvent &event) {
   wxFileName filepath = event.getFilename();
 
   wxFileDialog dlg(
@@ -1346,7 +1359,7 @@ void GOFrame::OnRenameFile(wxRenameFileEvent &event) {
   go_sync_directory(filepath.GetPath());
 }
 
-void GOFrame::OnUpdateCheckingRequested(wxCommandEvent &event) {
+void GOToolbarWindow::OnUpdateCheckingRequested(wxCommandEvent &event) {
   if (m_UpdateCheckerThread) {
     // Update checking is already in progress, ignore request
     return;
@@ -1356,7 +1369,7 @@ void GOFrame::OnUpdateCheckingRequested(wxCommandEvent &event) {
     GOUpdateChecker::CheckReason::USER_REQUEST, this);
 }
 
-void GOFrame::OnUpdateCheckingCompletion(
+void GOToolbarWindow::OnUpdateCheckingCompletion(
   GOUpdateChecker::CompletionEvent &event) {
   // Remove update checker thread
   m_UpdateCheckerThread->Wait();
@@ -1398,7 +1411,7 @@ void GOFrame::OnUpdateCheckingCompletion(
   }
 }
 
-void GOFrame::OnNewReleaseInfoRequested(wxCommandEvent &event) {
+void GOToolbarWindow::OnNewReleaseInfoRequested(wxCommandEvent &event) {
   GONewReleaseDialog dialog(
     this, r_config, m_StartupUpdateCheckerResult.latestRelease);
   if (dialog.ShowModal() == wxID_OK) {
@@ -1406,11 +1419,11 @@ void GOFrame::OnNewReleaseInfoRequested(wxCommandEvent &event) {
   }
 }
 
-void GOFrame::OnNewReleaseDownload(wxCommandEvent &event) {
+void GOToolbarWindow::OnNewReleaseDownload(wxCommandEvent &event) {
   GOUpdateChecker::OpenDownloadPageInBrowser();
 }
 
-bool GOFrame::InstallOrganPackage(wxString name) {
+bool GOToolbarWindow::InstallOrganPackage(wxString name) {
   GOArchiveManager manager(r_config, r_config.OrganCachePath());
   wxString result = manager.InstallPackage(name);
   if (result != wxEmptyString) {
@@ -1420,19 +1433,19 @@ bool GOFrame::InstallOrganPackage(wxString name) {
     return true;
 }
 
-void GOFrame::LoadLastOrgan() {
+void GOToolbarWindow::LoadLastOrgan() {
   std::vector<const GOOrgan *> list = r_config.GetLRUOrganList();
   if (list.size() > 0)
     SendLoadOrgan(*list[0]);
 }
 
-void GOFrame::LoadFirstOrgan() {
+void GOToolbarWindow::LoadFirstOrgan() {
   ptr_vector<GOOrgan> &list = r_config.GetOrganList();
   if (list.size() > 0)
     SendLoadOrgan(*list[0]);
 }
 
-void GOFrame::SendLoadFile(wxString filename) {
+void GOToolbarWindow::SendLoadFile(wxString filename) {
   wxFileName name = filename;
   if (name.GetExt() == wxT("orgue")) {
     if (InstallOrganPackage(filename))
@@ -1441,7 +1454,7 @@ void GOFrame::SendLoadFile(wxString filename) {
     SendLoadOrgan(GOOrgan(filename));
 }
 
-void GOFrame::SendLoadOrgan(const GOOrgan &organ) {
+void GOToolbarWindow::SendLoadOrgan(const GOOrgan &organ) {
   wxCommandEvent evt(wxEVT_LOADFILE, 0);
   evt.SetClientData(new GOOrgan(organ));
   GetEventHandler()->AddPendingEvent(evt);

--- a/src/grandorgue/gui/frames/GOToolbarWindow.h
+++ b/src/grandorgue/gui/frames/GOToolbarWindow.h
@@ -5,8 +5,8 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GOFRAME_H
-#define GOFRAME_H
+#ifndef GOTOOLBARWINDOW_H
+#define GOTOOLBARWINDOW_H
 
 #include <memory>
 #include <vector>
@@ -21,10 +21,10 @@
 #include "threading/GOMutex.h"
 #include "updater/GOUpdateChecker.h"
 
-class GOApp;
 class GOAudioGauge;
 class GOConfig;
-class GODocument;
+class GOGuiApp;
+class GOGuiOrgan;
 class GOMidiEvent;
 class GOOrgan;
 class GOOrganController;
@@ -37,13 +37,13 @@ class wxSpinCtrl;
 class wxToolBar;
 class wxToolBarToolBase;
 
-class GOFrame : public wxFrame,
-                private GOHelpRequestor,
-                public GOResizable,
-                protected GOMidiCallback,
-                private GOModificationListener {
+class GOToolbarWindow : public wxFrame,
+                        private GOHelpRequestor,
+                        public GOResizable,
+                        protected GOMidiCallback,
+                        private GOModificationListener {
 private:
-  GOApp &r_app;
+  GOGuiApp &r_app;
   GOConfig &r_config;
   GOSoundSystem &r_SoundSystem;
   GOMidiSystem &r_MidiSystem;
@@ -57,7 +57,7 @@ private:
   wxMenu *m_recent_menu;
   wxMenu *m_temperament_menu;
 
-  std::unique_ptr<GODocument> mp_doc;
+  std::unique_ptr<GOGuiOrgan> mp_organ;
   GOOrganController *p_OrganController;
   wxToolBar *m_ToolBar;
   GOAudioGauge *m_SamplerUsage;
@@ -182,16 +182,16 @@ private:
   void SendLoadOrgan(const GOOrgan &organ);
 
 public:
-  GOFrame(
-    GOApp &app,
-    wxFrame *frame,
+  GOToolbarWindow(
+    GOGuiApp &app,
+    wxFrame *pParentFrame,
     wxWindowID id,
     const wxString &title,
     const wxPoint &pos,
     const wxSize &size,
     const long type,
     GOSoundSystem &sound);
-  virtual ~GOFrame(void);
+  virtual ~GOToolbarWindow(void);
 
   void Init(const wxString &filename, bool isGuiOnly);
 

--- a/src/grandorgue/gui/panels/GOGUIMidiControl.cpp
+++ b/src/grandorgue/gui/panels/GOGUIMidiControl.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -9,17 +9,16 @@
 
 #include <wx/intl.h>
 
+#include "gui/GOGuiOrgan.h"
 #include "midi/objects/GOMidiPlayingObject.h"
-
-#include "GODocument.h"
 
 bool GOGUIMidiControl::HandleMidiConfig(bool isRightClick) {
 
   if (isRightClick && p_MidiObject) {
-    GODocument *pDoc = dynamic_cast<GODocument *>(GetDocument());
+    GOGuiOrgan *pOrgan = dynamic_cast<GOGuiOrgan *>(GetDocument());
 
-    if (pDoc)
-      pDoc->ShowMIDIEventDialog(*p_MidiObject, p_MidiObject);
+    if (pOrgan)
+      pOrgan->ShowMIDIEventDialog(*p_MidiObject, p_MidiObject);
   }
   return isRightClick;
 }

--- a/src/grandorgue/gui/panels/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanel.cpp
@@ -8,6 +8,7 @@
 #include "GOGUIPanel.h"
 
 #include <wx/image.h>
+#include <wx/toplevel.h>
 
 #include "combinations/GOSetter.h"
 #include "combinations/control/GODivisionalButtonControl.h"
@@ -15,13 +16,13 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 #include "control/GOPistonControl.h"
+#include "gui/GOGuiImageCache.h"
 #include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
 #include "model/GOManual.h"
 #include "model/GOStop.h"
 #include "model/GOSwitch.h"
 #include "model/GOTremulant.h"
-#include "primitives/GODC.h"
 
 #include "GOGUIButton.h"
 #include "GOGUIControl.h"
@@ -37,7 +38,6 @@
 #include "GOGUIPanelView.h"
 #include "GOGUIPanelWidget.h"
 #include "GOOrganController.h"
-#include "Images.h"
 
 GOGUIPanel::GOGUIPanel(GOOrganController *organController)
   : m_OrganController(organController),

--- a/src/grandorgue/gui/panels/GOGUIPanelView.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelView.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,6 +10,7 @@
 #include <wx/display.h>
 #include <wx/frame.h>
 #include <wx/image.h>
+#include <wx/toplevel.h>
 
 #include "gui/wxcontrols/go_gui_utils.h"
 
@@ -42,7 +43,7 @@ GOGUIPanelView *GOGUIPanelView::createWithFrame(
 GOGUIPanelView::GOGUIPanelView(
   GODocumentBase *doc, GOGUIPanel *panel, wxTopLevelWindow *topWindow)
   : wxScrolledWindow(topWindow),
-    GOView(doc, topWindow),
+    GODocumentView(doc, topWindow),
     m_panelwidget(new GOGUIPanelWidget(panel, this)),
     m_panel(panel),
     m_TopWindow(topWindow) {
@@ -98,7 +99,7 @@ void GOGUIPanelView::RemoveView() {
   if (m_panel)
     m_panel->SetView(NULL);
   m_panel = NULL;
-  GOView::RemoveView();
+  GODocumentView::RemoveView();
 }
 
 void GOGUIPanelView::AddEvent(GOGUIControl *control) {

--- a/src/grandorgue/gui/panels/GOGUIPanelView.h
+++ b/src/grandorgue/gui/panels/GOGUIPanelView.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -9,15 +9,16 @@
 #define GOGUIPANELVIEW_H
 
 #include <wx/scrolwin.h>
-#include <wx/toplevel.h>
 
-#include "document-base/GOView.h"
+#include "gui/document-base/GODocumentView.h"
+
+class wxTopLevelWindow;
 
 class GOGUIControl;
 class GOGUIPanel;
 class GOGUIPanelWidget;
 
-class GOGUIPanelView : public wxScrolledWindow, public GOView {
+class GOGUIPanelView : public wxScrolledWindow, public GODocumentView {
 private:
   GOGUIPanelWidget *m_panelwidget;
   GOGUIPanel *m_panel;

--- a/src/grandorgue/midi/GOMidiPlayer.cpp
+++ b/src/grandorgue/midi/GOMidiPlayer.cpp
@@ -19,6 +19,7 @@
 #include "GOMidiMap.h"
 #include "GOMidiSystem.h"
 #include "GOOrganController.h"
+#include "GOTimer.h"
 
 enum {
   ID_MIDI_PLAYER_PLAY = 0,

--- a/src/grandorgue/midi/GOMidiRecorder.cpp
+++ b/src/grandorgue/midi/GOMidiRecorder.cpp
@@ -21,6 +21,7 @@
 #include "GOEvent.h"
 #include "GOMidiSystem.h"
 #include "GOOrganController.h"
+#include "GOTimer.h"
 #include "go_path.h"
 
 enum {

--- a/src/grandorgue/model/GOManual.cpp
+++ b/src/grandorgue/model/GOManual.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,9 +12,9 @@
 #include "combinations/control/GODivisionalButtonControl.h"
 #include "config/GOConfig.h"
 #include "config/GOConfigReader.h"
+#include "gui/GOGuiOrgan.h"
 
 #include "GOCoupler.h"
-#include "GODocument.h"
 #include "GOOrganModel.h"
 #include "GOStop.h"
 #include "GOSwitch.h"


### PR DESCRIPTION
- GODocument → GOGuiOrgan (src/grandorgue/gui/GOGuiOrgan.h/cpp)
- GOApp → GOGuiApp (src/grandorgue/gui/GOGuiApp.h/cpp)
- GOView → GODocumentView (src/grandorgue/gui/document-base/GODocumentView.h/cpp)
- document-base/ → gui/document-base/
- Renamed GOFrame::mp_doc → mp_organ, GOFrame::r_app type updated.
- GOLog to gui/, renamed to GOGuiLog
- GOImageCache to gui/, renamed to GOGuiImageCache
- Renamed GOFrame to GOToolbarWindow

It is just moving and renaming. No GO behavior should be changed.