### PR TITLE
Introduced GOProgressMonitor interface to decouple loading from GUI

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -30,7 +30,6 @@
 #include "files/GOOpenedFile.h"
 #include "files/GOStdFileName.h"
 #include "gui/GOGuiImageCache.h"
-#include "gui/dialogs/GOProgressDialog.h"
 #include "gui/dialogs/go-message-boxes.h"
 #include "gui/panels/GOGUIBankedGeneralsPanel.h"
 #include "gui/panels/GOGUICouplerManualsAndVolumePanel.h"
@@ -45,6 +44,7 @@
 #include "gui/panels/GOGUISequencerPanel.h"
 #include "loader/GOLoadThread.h"
 #include "loader/GOLoaderFilename.h"
+#include "loader/GOProgressMonitor.h"
 #include "loader/cache/GOCache.h"
 #include "loader/cache/GOCacheWriter.h"
 #include "midi/GOMidiPlayer.h"
@@ -331,10 +331,10 @@ wxString GOOrganController::GenerateCacheFileName() {
 class GOLoadAborted : public std::exception {};
 
 wxString GOOrganController::Load(
-  GOProgressDialog *dlg,
   const GOOrgan &organ,
   const wxString &file2,
-  bool isGuiOnly) {
+  bool isGuiOnly,
+  GOProgressMonitor &monitor) {
   GOBuffer<char> dummy;
   wxString errMsg;
 
@@ -343,7 +343,7 @@ wxString GOOrganController::Load(
 
     m_ArchiveID = organ.GetArchiveID();
     if (m_ArchiveID != wxEmptyString) {
-      dlg->Setup(1, _("Loading sample set"), _("Parsing organ packages"));
+      monitor.Setup(1, _("Loading sample set"), _("Parsing organ packages"));
 
       wxString errMsg1;
 
@@ -364,7 +364,7 @@ wxString GOOrganController::Load(
       m_FileStore.SetDirectory(go_get_path(m_odf));
     }
     m_hash = organ.GetOrganHash();
-    dlg->Setup(
+    monitor.Setup(
       1, _("Loading sample set"), _("Parsing sample set definition file"));
     m_SettingFilename = GenerateSettingFileName();
     m_CacheFilename = GenerateCacheFileName();
@@ -475,7 +475,7 @@ wxString GOOrganController::Load(
         /* Figure out list of pipes to load */
         GOCacheObjectDistributor objectDistributor(GetCacheObjects());
 
-        dlg->Reset(objectDistributor.GetNObjects());
+        monitor.Reset(objectDistributor.GetNObjects());
 
         GOCacheObject *obj = nullptr;
 
@@ -509,7 +509,8 @@ wxString GOOrganController::Load(
                 wxLogWarning(_("Cache load failure: %s"), obj->GetLoadError());
                 break;
               }
-              if (!dlg->Update(objectDistributor.GetPos(), obj->GetLoadTitle()))
+              if (!monitor.Update(
+                    objectDistributor.GetPos(), obj->GetLoadTitle()))
                 throw GOLoadAborted(); // Skip the rest of the loading code
             }
             if (!obj)
@@ -545,7 +546,8 @@ wxString GOOrganController::Load(
 
           while (thisWorker.LoadNextObject(obj))
             // show the progress and process possible Cancel
-            if (!dlg->Update(objectDistributor.GetPos(), obj->GetLoadTitle()))
+            if (!monitor.Update(
+                  objectDistributor.GetPos(), obj->GetLoadTitle()))
               throw GOLoadAborted(); // skip the rest of loading code
           // rethrow exception if any occured in thisWorker.LoadNextObject
           bool wereExceptions = thisWorker.WereExceptions();
@@ -566,7 +568,7 @@ wxString GOOrganController::Load(
             if (objectDistributor.IsComplete())
               m_Cacheable = true;
             if (m_config.ManageCache() && m_Cacheable)
-              UpdateCache(dlg, m_config.CompressCache());
+              UpdateCache(m_config.CompressCache(), monitor);
           }
 
           // Despite a possible exception automatic calling ~GOLoadThread from
@@ -678,7 +680,7 @@ void GOOrganController::LoadCombination(const wxString &file) {
   }
 }
 
-bool GOOrganController::UpdateCache(GOProgressDialog *dlg, bool compress) {
+bool GOOrganController::UpdateCache(bool compress, GOProgressMonitor &monitor) {
   bool isOk = false;
 
   DeleteCache();
@@ -686,7 +688,7 @@ bool GOOrganController::UpdateCache(GOProgressDialog *dlg, bool compress) {
   /* Figure out the list of pipes to save */
   GOCacheObjectDistributor objectDistributor(GetCacheObjects());
 
-  dlg->Setup(objectDistributor.GetNObjects(), _("Creating sample cache"));
+  monitor.Setup(objectDistributor.GetNObjects(), _("Creating sample cache"));
 
   wxFileOutputStream file(m_CacheFilename);
 
@@ -710,7 +712,7 @@ bool GOOrganController::UpdateCache(GOProgressDialog *dlg, bool compress) {
         wxLogError(
           _("Save of %s to the cache failed"), obj->GetLoadTitle().c_str());
       }
-      if (!dlg->Update(objectDistributor.GetPos(), obj->GetLoadTitle())) {
+      if (!monitor.Update(objectDistributor.GetPos(), obj->GetLoadTitle())) {
         writer.Close();
         DeleteCache();
         isOk = false;

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -21,6 +21,7 @@
 #include "gui/frames/GOMainWindowData.h"
 #include "gui/panels/GOGUIMouseState.h"
 #include "loader/GOFileStore.h"
+#include "loader/GOProgressMonitor.h"
 #include "model/GOOrganModel.h"
 #include "modification/GOModificationProxy.h"
 
@@ -46,7 +47,6 @@ class GOMidiPlayer;
 class GOMidiRecorder;
 class GOMidiSystem;
 class GOOrgan;
-class GOProgressDialog;
 class GOSetter;
 class GOSoundProvider;
 class GOSoundRecorder;
@@ -151,10 +151,10 @@ public:
   }
 
   wxString Load(
-    GOProgressDialog *dlg,
     const GOOrgan &organ,
     const wxString &cmb,
-    bool isGuiOnly);
+    bool isGuiOnly,
+    GOProgressMonitor &monitor);
   /**
    * Exports organ combinations in the yaml file
    * @param fileName - the path to the yaml file to export
@@ -166,7 +166,7 @@ public:
   bool Export(const wxString &cmb);
   bool CachePresent() const { return wxFileExists(m_CacheFilename); }
   bool IsCacheable() const { return m_Cacheable; }
-  bool UpdateCache(GOProgressDialog *dlg, bool compress);
+  bool UpdateCache(bool compress, GOProgressMonitor &monitor);
   void DeleteCache();
   void DeleteSettings();
   void Abort();

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -19,6 +19,7 @@
 #include "gui/panels/GOGUIPanel.h"
 #include "gui/panels/GOGUIPanelView.h"
 #include "gui/size/GOResizable.h"
+#include "loader/GOProgressMonitor.h"
 #include "midi/events/GOMidiEvent.h"
 #include "sound/GOSoundSystem.h"
 #include "threading/GOMutexLocker.h"
@@ -47,16 +48,16 @@ bool GOGuiOrgan::IsModified() const {
 }
 
 GOOrganController *GOGuiOrgan::LoadOrgan(
-  GOProgressDialog *dlg,
   const GOOrgan &organ,
   const wxString &cmb,
-  bool isGuiOnly) {
+  bool isGuiOnly,
+  GOProgressMonitor &monitor) {
   wxBusyCursor busy;
   GOConfig &cfg = m_sound.GetSettings();
 
   CloseOrgan();
   m_OrganController = new GOOrganController(cfg, true);
-  wxString error = m_OrganController->Load(dlg, organ, cmb, isGuiOnly);
+  wxString error = m_OrganController->Load(organ, cmb, isGuiOnly, monitor);
 
   if (error.IsEmpty()) {
     cfg.AddOrgan(m_OrganController->GetOrganInfo());
@@ -98,10 +99,10 @@ GOOrganController *GOGuiOrgan::LoadOrgan(
   return m_OrganController;
 }
 
-bool GOGuiOrgan::UpdateCache(GOProgressDialog *dlg, bool compress) {
+bool GOGuiOrgan::UpdateCache(bool compress, GOProgressMonitor &monitor) {
   if (!m_OrganController)
     return false;
-  return m_OrganController->UpdateCache(dlg, compress);
+  return m_OrganController->UpdateCache(compress, monitor);
 }
 
 void GOGuiOrgan::ShowPanel(unsigned id) {

--- a/src/grandorgue/gui/GOGuiOrgan.h
+++ b/src/grandorgue/gui/GOGuiOrgan.h
@@ -19,7 +19,7 @@ class GOMidiDialogListener;
 class GOMidiObject;
 class GOOrganController;
 class GOOrgan;
-class GOProgressDialog;
+class GOProgressMonitor;
 class GOResizable;
 class GOSoundSystem;
 
@@ -57,11 +57,11 @@ public:
   // Note: on failure CloseOrgan() is called, which also clears
   // m_OrganController.
   GOOrganController *LoadOrgan(
-    GOProgressDialog *dlg,
     const GOOrgan &organ,
     const wxString &cmb,
-    bool isGuiOnly);
-  bool UpdateCache(GOProgressDialog *dlg, bool compress);
+    bool isGuiOnly,
+    GOProgressMonitor &monitor);
+  bool UpdateCache(bool compress, GOProgressMonitor &monitor);
 
   void ShowMIDIEventDialog(
     GOMidiObject &obj, GOMidiDialogListener *pDialogListener = nullptr);

--- a/src/grandorgue/gui/dialogs/GOProgressDialog.h
+++ b/src/grandorgue/gui/dialogs/GOProgressDialog.h
@@ -2,7 +2,7 @@
  * GrandOrgue - a free pipe organ simulator
  *
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -24,9 +24,11 @@
 
 #include <wx/string.h>
 
+#include "loader/GOProgressMonitor.h"
+
 class wxProgressDialog;
 
-class GOProgressDialog {
+class GOProgressDialog : public GOProgressMonitor {
 private:
   wxProgressDialog *m_dlg;
   long m_last;
@@ -39,10 +41,12 @@ public:
   ~GOProgressDialog();
 
   void Setup(
-    long max, const wxString &title, const wxString &msg = wxEmptyString);
-  void Reset(long max, const wxString &msg = wxEmptyString);
+    long max,
+    const wxString &title,
+    const wxString &msg = wxEmptyString) override;
+  void Reset(long max, const wxString &msg = wxEmptyString) override;
 
-  bool Update(unsigned value, const wxString &msg);
+  bool Update(unsigned value, const wxString &msg) override;
 };
 
 #endif

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -617,7 +617,7 @@ void GOAppWindow::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
   if (mp_organ) {
     GOProgressDialog dlg;
 
-    p_OrganController = mp_organ->LoadOrgan(&dlg, organ, cmb, m_IsGuiOnly);
+    p_OrganController = mp_organ->LoadOrgan(organ, cmb, m_IsGuiOnly, dlg);
     OnIsModifiedChanged(false);
 
     // for reflecting model changes
@@ -1024,7 +1024,7 @@ void GOAppWindow::OnCache(wxCommandEvent &event) {
   GOProgressDialog dlg;
 
   if (p_OrganController)
-    res = p_OrganController->UpdateCache(&dlg, r_config.CompressCache());
+    res = p_OrganController->UpdateCache(r_config.CompressCache(), dlg);
   if (!res) {
     wxLogError(_("Creating the cache failed"));
     GOMessageBox(

--- a/src/grandorgue/loader/GOProgressMonitor.h
+++ b/src/grandorgue/loader/GOProgressMonitor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOPROGRESSMONITOR_H
+#define GOPROGRESSMONITOR_H
+
+#include <wx/string.h>
+
+/**
+ * Abstract interface for reporting loading progress.
+ * Decouples model-layer loading code from GUI dialogs.
+ */
+class GOProgressMonitor {
+public:
+  virtual ~GOProgressMonitor() = default;
+
+  virtual void Setup(
+    long max, const wxString &title, const wxString &msg = wxEmptyString)
+    = 0;
+  virtual void Reset(long max, const wxString &msg = wxEmptyString) = 0;
+  virtual bool Update(unsigned value, const wxString &msg) = 0;
+};
+
+#endif


### PR DESCRIPTION
This PR Replaces GOProgressDialog* parameters in GOOrganController::Load() and UpdateCache() with GOProgressMonitor& so model-layer code no longer depends on a GUI dialog class. GOProgressDialog now inherits from GOProgressMonitor and overrides all three methods.

This is just refactoring. No GO behavior should be changed.