### PR TITLE
Added saving debug symbols in tar.gz

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,16 @@ name: Build
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
+    inputs:
+      asan:
+        description: 'Build with ASAN'
+        type: boolean
+        default: false
+permissions:
+  contents: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -51,6 +60,7 @@ jobs:
       release_flag: ${{steps.vers.outputs.release_flag}}
       release_id: ${{ steps.create_release.outputs.id }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
+      asan_flag: ${{steps.vers.outputs.asan_flag}}
 
     steps:
     - name: Checkout
@@ -83,10 +93,17 @@ jobs:
           RELEASE_FLAG=ON
         fi
 
+        if [[ "${{ github.event.inputs.asan }}" == "true" ]]; then
+          ASAN_FLAG=asan
+        else
+          ASAN_FLAG=
+        fi
+
         echo "project_ver=$PROJECT_VERSION" >>$GITHUB_OUTPUT
         echo "build_ver=$BUILD_VERSION" >>$GITHUB_OUTPUT
         echo "full_ver=$PROJECT_VERSION-$BUILD_VERSION" >>$GITHUB_OUTPUT
         echo "release_flag=$RELEASE_FLAG" >>$GITHUB_OUTPUT
+        echo "asan_flag=$ASAN_FLAG" >>$GITHUB_OUTPUT
 
     - name: Display versions
       run: |
@@ -94,6 +111,7 @@ jobs:
         echo "build_ver=${{steps.vers.outputs.build_ver}}"
         echo "full_ver=${{steps.vers.outputs.full_ver}}"
         echo "release_flag=${{steps.vers.outputs.release_flag}}"
+        echo "asan_flag=${{steps.vers.outputs.asan_flag}}"
 
     - name: Create Draft Release
       if: ${{ steps.vers.outputs.release_flag == 'ON' }}
@@ -186,7 +204,15 @@ jobs:
       
     - name: Build
       working-directory: ${{github.workspace}}
-      run: ${{github.workspace}}/build-scripts/for-${{ matrix.for }}/build-on-${{ matrix.build_on }}.sh ${{needs.calc_ver.outputs.project_ver}} ${{needs.calc_ver.outputs.build_ver}} ${{github.workspace}} "${{ matrix.pkg_suffix }}"
+      run: >
+        ${{github.workspace}}/build-scripts/for-${{ matrix.for }}/build-on-${{ matrix.build_on }}.sh
+        ${{needs.calc_ver.outputs.project_ver}}
+        ${{needs.calc_ver.outputs.build_ver}}
+        ${{github.workspace}}
+        "${{ matrix.pkg_suffix }}"
+        ${{needs.calc_ver.outputs.release_flag}}
+        ""
+        ${{needs.calc_ver.outputs.asan_flag}}
 
     - name: Upload result
       uses: nanoufo/action-upload-artifacts-and-release-assets@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,58 @@ project(
 set(NUM_VERSION "${PROJECT_VERSION}")
 string(REPLACE "." "," NUM_WIN_VERSION ${NUM_VERSION})
 
+option(RELEASE_FLAG "Build as a release" OFF)
+
+# GO_SPLIT_DEBUG_SYMBOLS: save debug symbols to separate files (.dbg on Linux, .pdb on Windows).
+# Default: always ON on Windows (PDB is always useful); on Linux equals RELEASE_FLAG.
+#
+# Behavior matrix (BT = CMAKE_BUILD_TYPE, GS = GO_SPLIT_DEBUG_SYMBOLS):
+# BT default: Debug when RELEASE_FLAG=OFF/unset, Release when RELEASE_FLAG=ON
+# GS default: ON on Windows; on Linux = RELEASE_FLAG
+#
+# RELEASE_FLAG | CMAKE_BUILD_TYPE | GO_SPLIT_DEBUG_SYMBOLS || Compiler flags | Result (Linux)  | Result (Windows)
+# -------------|------------------|------------------------||----------------|-----------------|------------------
+# unset        | unset            | unset                  || -g3 -Og        | unstripped      | stripped + .pdb
+# unset        | unset            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# unset        | unset            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# unset        | Debug            | unset                  || -g3 -Og        | unstripped      | stripped + .pdb
+# unset        | Debug            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# unset        | Debug            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# unset        | Release          | unset                  || -O3 -g         | stripped        | stripped + .pdb
+# unset        | Release          | OFF                    || -O3 -g         | stripped        | stripped
+# unset        | Release          | ON                     || -O3 -g         | stripped + .dbg | stripped + .pdb
+# OFF          | unset            | unset                  || -g3 -Og        | unstripped      | stripped + .pdb
+# OFF          | unset            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# OFF          | unset            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# OFF          | Debug            | unset                  || -g3 -Og        | unstripped      | stripped + .pdb
+# OFF          | Debug            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# OFF          | Debug            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# OFF          | Release          | unset                  || -O3 -g         | stripped        | stripped + .pdb
+# OFF          | Release          | OFF                    || -O3 -g         | stripped        | stripped
+# OFF          | Release          | ON                     || -O3 -g         | stripped + .dbg | stripped + .pdb
+# ON           | unset            | unset                  || -O3 -g         | stripped + .dbg | stripped + .pdb
+# ON           | unset            | OFF                    || -O3 -g         | stripped        | stripped
+# ON           | unset            | ON                     || -O3 -g         | stripped + .dbg | stripped + .pdb
+# ON           | Debug            | unset                  || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# ON           | Debug            | OFF                    || -g3 -Og        | unstripped      | unstripped
+# ON           | Debug            | ON                     || -g3 -Og        | stripped + .dbg | stripped + .pdb
+# ON           | Release          | unset                  || -O3 -g         | stripped + .dbg | stripped + .pdb
+# ON           | Release          | OFF                    || -O3 -g         | stripped        | stripped
+# ON           | Release          | ON                     || -O3 -g         | stripped + .dbg | stripped + .pdb
+if(WIN32)
+  option(GO_SPLIT_DEBUG_SYMBOLS "Save debug symbols separately (PDB on Windows, .dbg on Linux)" ON)
+else()
+  option(GO_SPLIT_DEBUG_SYMBOLS "Save debug symbols separately (PDB on Windows, .dbg on Linux)" ${RELEASE_FLAG})
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+  if(RELEASE_FLAG)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+  else()
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
+  endif()
+endif()
+
 if(NOT DEFINED BUILD_VERSION)
   set(BUILD_VERSION "0.local")
 elseif(NOT BUILD_VERSION)
@@ -36,6 +88,10 @@ endif()
 
 if (NOT DEFINED GO_BUILD_COVERAGE OR GO_BUILD_COVERAGE STREQUAL "")
   set(GO_BUILD_COVERAGE OFF)
+endif()
+
+if (NOT DEFINED GO_BUILD_ASAN OR GO_BUILD_ASAN STREQUAL "")
+  set(GO_BUILD_ASAN OFF)
 endif()
 
 set(FULL_VERSION "${PROJECT_VERSION}-${BUILD_VERSION}")
@@ -230,6 +286,20 @@ if (GO_BUILD_COVERAGE)
     message(STATUS "============================================================================")
 endif()
 
+if(GO_BUILD_ASAN)
+  add_option(-fsanitize=address)
+  add_option(-fno-omit-frame-pointer)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
+  if(UNIX AND NOT APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libasan")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libasan")
+  endif()
+  message(STATUS "============================================================================")
+  message(STATUS " AddressSanitizer enabled")
+  message(STATUS "============================================================================")
+endif()
+
 add_subdirectory(src/build)
 add_subdirectory(src/images)
 add_subdirectory(src/core)
@@ -367,6 +437,12 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   else()
     set(CPACK_STRIP_FILES ON)
   endif()
+  if(GO_SPLIT_DEBUG_SYMBOLS)
+    set(CPACK_STRIP_FILES OFF)  # stripped via install(CODE) in BuildExecutable/BuildLibrary
+    # Disable RPM's built-in brp-strip: we handle stripping ourselves, and the host strip may
+    # not recognize the target arch ELF (e.g. x86_64 host strip on aarch64 cross-built binaries)
+    string(APPEND CPACK_RPM_SPEC_MORE_DEFINE "%define __strip /bin/true\n%define __objcopy /bin/true\n")
+  endif()
 
   set(CPACK_SYSTEM_NAME "linux")
   set(CPACK_GENERATOR TGZ RPM DEB)
@@ -395,7 +471,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   # On Ubuntu rpmbuild generates a libcurl.so.4(CURL_OPENSSL_4)(64bit) requirement for libcurl.
   # In Fedora libcurl is based on openssl, but libcurl package does not provide such symbol.
   # As a workaround, we set the right symbol manually.
-  set(CPACK_RPM_SPEC_MORE_DEFINE "%global __requires_exclude libcurl.*")
+  string(APPEND CPACK_RPM_SPEC_MORE_DEFINE "%global __requires_exclude libcurl.*")
   if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     # dnf tries to install the 32-bit package on x86_64 if '()(64bit)' is omitted
     set(CPACK_RPM_PACKAGE_REQUIRES "libcurl.so.4()(64bit)")

--- a/build-scripts/for-appimage-x86_64/build-on-linux.sh
+++ b/build-scripts/for-appimage-x86_64/build-on-linux.sh
@@ -3,11 +3,12 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
+# $4 - release flag (ON/OFF, default: OFF)
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$4"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$(readlink -f $3)
@@ -27,7 +28,7 @@ GO_PRMS="-DCMAKE_INSTALL_PREFIX=/usr \
   -DRTAUDIO_USE_JACK=OFF \
   -DRTMIDI_USE_JACK=OFF \
   -DGO_USE_JACK=OFF \
-  -DCMAKE_BUILD_TYPE=Release \
+  $CMAKE_RELEASE_FLAG_PRM \
   $CMAKE_VERSION_PRMS"
 echo "cmake -G \"Unix Makefiles\" $GO_PRMS . $SRC_DIR"
 cmake -G "Unix Makefiles" $GO_PRMS . $SRC_DIR

--- a/build-scripts/for-linux-aarch64/build-on-linux.sh
+++ b/build-scripts/for-linux-aarch64/build-on-linux.sh
@@ -4,11 +4,12 @@
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
 # $4 - package suffix: empty or wx30
+# $5 - release flag (ON/OFF, default: OFF)
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3
@@ -38,13 +39,15 @@ GO_ARM_PRMS="-DCMAKE_SYSTEM_NAME=Linux \
   -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
   -DCMAKE_C_COMPILER=/usr/bin/aarch64-linux-gnu-gcc \
   -DCMAKE_CXX_COMPILER=/usr/bin/aarch64-linux-gnu-g++ \
+  -DCMAKE_OBJCOPY=/usr/bin/aarch64-linux-gnu-objcopy \
   -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 \
   -DCPACK_RPM_PACKAGE_ARCHITECTURE=aarch64 \
   -DIMPORT_EXECUTABLES=../build-tools/ImportExecutables.cmake"
 
-GO_PRMS="-DCMAKE_BUILD_TYPE=Release \
+GO_PRMS="$CMAKE_RELEASE_FLAG_PRM \
   $CMAKE_VERSION_PRMS \
   -DCMAKE_PACKAGE_SUFFIX=$PACKAGE_SUFFIX \
+  -DGO_SPLIT_DEBUG_SYMBOLS=ON \
   $($DIR/../for-linux/cmake-prm-yaml-cpp.bash arm64)"
 
 echo "cmake -G \"Unix Makefiles\" $GO_PRMS . $SRC_DIR"

--- a/build-scripts/for-linux-armhf/build-on-linux.sh
+++ b/build-scripts/for-linux-armhf/build-on-linux.sh
@@ -4,11 +4,12 @@
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
 # $4 - package suffix: empty or wx30
+# $5 - release flag (ON/OFF, default: OFF)
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3
@@ -42,9 +43,10 @@ GO_ARM_PRMS="-DCMAKE_SYSTEM_NAME=Linux \
   -DCPACK_RPM_PACKAGE_ARCHITECTURE=armhf \
   -DIMPORT_EXECUTABLES=../build-tools/ImportExecutables.cmake"
 
-GO_PRMS="-DCMAKE_BUILD_TYPE=Release \
+GO_PRMS="$CMAKE_RELEASE_FLAG_PRM \
   $CMAKE_VERSION_PRMS \
   -DCMAKE_PACKAGE_SUFFIX=$PACKAGE_SUFFIX \
+  -DGO_SPLIT_DEBUG_SYMBOLS=ON \
   $($DIR/../for-linux/cmake-prm-yaml-cpp.bash armhf)"
 
 echo "cmake -G \"Unix Makefiles\" $GO_PRMS . $SRC_DIR"

--- a/build-scripts/for-linux/build-for-tests.sh
+++ b/build-scripts/for-linux/build-for-tests.sh
@@ -3,6 +3,7 @@
 # $1 - target deb architecture. Default - current
 # $2 - build type: Debug or Release. Default - Debug
 # $3 - enable coverage: ON or OFF. Default - ON for Debug, OFF for Release
+# $4 - optional: "asan" to enable AddressSanitizer
 
 set -e
 
@@ -24,8 +25,13 @@ if [ "$COVERAGE" = "ON" ]; then
     COVERAGE_FLAG="-DGO_BUILD_COVERAGE=ON"
 fi
 
+ASAN_FLAG=""
+if [ "${4:-}" = "asan" ]; then
+    ASAN_FLAG="-DGO_BUILD_ASAN=ON"
+fi
+
 # Define BUILD_TESTING=ON
-GO_PRMS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=ON $COVERAGE_FLAG \
+GO_PRMS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=ON $COVERAGE_FLAG $ASAN_FLAG \
   $CMAKE_VERSION_PRMS \
   $($DIR/cmake-prm-yaml-cpp.bash $TARGET_ARCH)"
 

--- a/build-scripts/for-linux/build-on-linux.sh
+++ b/build-scripts/for-linux/build-on-linux.sh
@@ -4,12 +4,14 @@
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
 # $4 - package suffix: empty or wx30 or wx32
-# $5 - target deb architecture. Default - current
+# $5 - release flag (ON/OFF, default: OFF)
+# $6 - target deb architecture. Default - current
+# $7 - optional: "asan" to enable AddressSanitizer
 
 set -e
 
 DIR=$(readlink -f $(dirname $0))
-source $DIR/../set-ver-prms.sh "$1" "$2"
+source $DIR/../set-ver-prms.sh "$1" "$2" "$5"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3
@@ -18,7 +20,12 @@ else
 fi
 
 PACKAGE_SUFFIX=$4
-TARGET_ARCH=${5:$(dpkg --print-architecture)}
+TARGET_ARCH=${6:$(dpkg --print-architecture)}
+
+ASAN_FLAG=""
+if [ "${7:-}" = "asan" ]; then
+    ASAN_FLAG="-DGO_BUILD_ASAN=ON"
+fi
 
 PARALLEL_PRMS="-j$(nproc)"
 
@@ -28,9 +35,11 @@ pushd build/linux
 rm -rf *
 export LANG=C
 
-GO_PRMS="-DCMAKE_BUILD_TYPE=Release \
+GO_PRMS="$CMAKE_RELEASE_FLAG_PRM \
   $CMAKE_VERSION_PRMS \
   -DCMAKE_PACKAGE_SUFFIX=$PACKAGE_SUFFIX \
+  -DGO_SPLIT_DEBUG_SYMBOLS=ON \
+  $ASAN_FLAG \
   $($DIR/cmake-prm-yaml-cpp.bash $TARGET_ARCH)"
 
 # a workaround of the new dpkg-shlibdeps that prevents cpack from making the DEB package

--- a/build-scripts/for-linux/prepare-debian-based.sh
+++ b/build-scripts/for-linux/prepare-debian-based.sh
@@ -67,6 +67,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 OPTIONAL_PKGS=""
 [[ "$INSTALL_TESTS" == "tests" ]] && OPTIONAL_PKGS="$OPTIONAL_PKGS gcovr"
+# libasan.a (static) is included in the gcc package, no extra install needed for ASAN
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   cmake \

--- a/build-scripts/for-linux/prepare-fedora.sh
+++ b/build-scripts/for-linux/prepare-fedora.sh
@@ -14,6 +14,7 @@ WX_PKG_NAME=wxGTK-devel
 
 OPTIONAL_PKGS=""
 [[ "$INSTALL_TESTS" == "tests" ]] && OPTIONAL_PKGS="$OPTIONAL_PKGS gcovr"
+[[ "$INSTALL_ASAN" == "asan" ]] && OPTIONAL_PKGS="$OPTIONAL_PKGS libasan-static"
 
 sudo dnf install -y \
   cmake gcc-c++ make gettext docbook-style-xsl zip po4a ImageMagick librsvg2-tools rpm-build $OPTIONAL_PKGS \

--- a/build-scripts/for-linux/prepare-parse-prms.bash
+++ b/build-scripts/for-linux/prepare-parse-prms.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 INSTALL_TESTS=notests
+INSTALL_ASAN=noasan
 TARGET_CPU=auto
 WX_VER=auto
 
@@ -14,12 +15,15 @@ while [[ $# -gt 0 ]]; do
       tests | notests)
 	INSTALL_TESTS=$1
 	;;
+      asan | noasan)
+	INSTALL_ASAN=$1
+	;;
       wx30 | wx32)
 	WX_VER=$1
 	;;
       *)
 	echo "Unknown parameter $1" >&2
-	echo "Usage: $(basename $0) [wx30 | wx32] [tests | notests]"
+	echo "Usage: $(basename $0) [wx30 | wx32] [tests | notests] [asan | noasan]"
 	exit 1
 	;;
     esac

--- a/build-scripts/for-osx/build-on-osx.sh
+++ b/build-scripts/for-osx/build-on-osx.sh
@@ -3,10 +3,11 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
+# $4 - release flag (ON/OFF, default: OFF)
 
 set -e
 
-source $(dirname $0)/../set-ver-prms.sh "$1" "$2"
+source $(dirname $0)/../set-ver-prms.sh "$1" "$2" "$4"
 
 if [[ -n "$3" ]]; then
   SRC_DIR=$3
@@ -30,7 +31,7 @@ case `arch` in
   OS_PRMS="-DDOCBOOK_DIR=/usr/local/opt/docbook-xsl/docbook-xsl -DCMAKE_OSX_DEPLOYMENT_TARGET=12.1"
   ;;
 esac
-GO_PRMS="-DCMAKE_BUILD_TYPE=Release $CMAKE_VERSION_PRMS"
+GO_PRMS="$CMAKE_RELEASE_FLAG_PRM $CMAKE_VERSION_PRMS"
 cmake -G "Unix Makefiles" $OS_PRMS $GO_PRMS . $SRC_DIR
 
 echo "Phase 1"

--- a/build-scripts/for-win64/build-on-linux.sh
+++ b/build-scripts/for-win64/build-on-linux.sh
@@ -3,10 +3,11 @@
 # $1 - Version
 # $2 - Build version
 # $3 - Go source Dir. If not set then relative to the script dir
+# $4 - release flag (ON/OFF, default: OFF)
 
 set -e
 
-source $(dirname $0)/../set-ver-prms.sh "$1" "$2"
+source $(dirname $0)/../set-ver-prms.sh "$1" "$2" "$4"
 
 if [[ -n "$3" ]]; then
 	SRC_DIR=$3
@@ -41,7 +42,7 @@ CMAKE_WIN_PRMS="-DASIO_SDK_DIR=/usr/local/asio-sdk \
   -DRTAUDIO_USE_ASIO=ON \
   -DVC_PATH=/usr/local/share/wine/msvc/VC/Tools/MSVC/14.29.30133/bin/Hostx86/x86"
 
-CMAKE_APP_PRMS="-DGO_USE_JACK=ON $CMAKE_VERSION_PRMS"
+CMAKE_APP_PRMS="-DGO_USE_JACK=ON $CMAKE_VERSION_PRMS $CMAKE_RELEASE_FLAG_PRM"
 
 cmake $CMAKE_MINGW_PRMS $CMAKE_WIN_PRMS $CMAKE_APP_PRMS . $SRC_DIR
 make $PARALLEL_PRMS VERBOSE=1 package

--- a/build-scripts/set-ver-prms.sh
+++ b/build-scripts/set-ver-prms.sh
@@ -2,6 +2,7 @@
 
 # $1 - Project version
 # $2 - Build version
+# $3 - Release flag (ON/OFF, default: OFF)
 
 CMAKE_VERSION_PRMS=
 
@@ -9,4 +10,5 @@ CMAKE_VERSION_PRMS=
 [[ -n "$2" ]] && CMAKE_VERSION_PRMS="$CMAKE_VERSION_PRMS -DBUILD_VERSION=$2"
 
 export CMAKE_VERSION_PRMS
+export CMAKE_RELEASE_FLAG_PRM="-DRELEASE_FLAG=${3:-OFF}"
 

--- a/cmake/BuildExecutable.cmake
+++ b/cmake/BuildExecutable.cmake
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -15,7 +15,24 @@ function(BUILD_EXECUTABLE TARGET)
   endif()
   install(TARGETS ${TARGET} RUNTIME DESTINATION "${BININSTDIR}")
 
-  if(CV2PDB_EXE)
+  if(UNIX AND NOT APPLE AND GO_SPLIT_DEBUG_SYMBOLS)
+    install(CODE "
+      # \$ENV{DESTDIR} is empty for TGZ (CMAKE_INSTALL_PREFIX is the staging dir),
+      # but set to the staging root for RPM (CMAKE_INSTALL_PREFIX stays /usr).
+      set(_bin \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${BININSTDIR}/${TARGET}\")
+      # Extract debug info into a separate .dbg file alongside the binary.
+      execute_process(COMMAND ${CMAKE_OBJCOPY} --only-keep-debug \"\${_bin}\" \"\${_bin}.dbg\")
+      # objcopy needs to read the .dbg file to compute its CRC for the debuglink section.
+      # It looks for the file by bare name in WORKING_DIRECTORY, so we set that to the
+      # directory containing both the binary and the .dbg file.
+      get_filename_component(_dir \"\${_bin}\" DIRECTORY)
+      execute_process(COMMAND ${CMAKE_OBJCOPY} --strip-debug
+        --add-gnu-debuglink=${TARGET}.dbg \"\${_bin}\"
+        WORKING_DIRECTORY \"\${_dir}\")
+    ")
+  endif()
+
+  if(CV2PDB_EXE AND GO_SPLIT_DEBUG_SYMBOLS)
     add_custom_command(
       OUTPUT "${BINDIR}/${TARGET}.pdb"
       DEPENDS ${TARGET}

--- a/cmake/BuildLibrary.cmake
+++ b/cmake/BuildLibrary.cmake
@@ -1,5 +1,5 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later
 # (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
@@ -16,7 +16,7 @@ function(BUILD_LIBRARY TARGET)
   endif()
 
   install(
-    TARGETS ${TARGET} 
+    TARGETS ${TARGET}
     RUNTIME DESTINATION ${LIBINSTDIR} LIBRARY DESTINATION ${LIBINSTDIR}
     NAMELINK_SKIP
     # these permissions required for building rmp on debian/ubuntu
@@ -26,7 +26,24 @@ function(BUILD_LIBRARY TARGET)
       WORLD_EXECUTE WORLD_READ
   )
 
-  if(CV2PDB_EXE)
+  if(UNIX AND NOT APPLE AND GO_SPLIT_DEBUG_SYMBOLS)
+    install(CODE "
+      # \$ENV{DESTDIR} is empty for TGZ (CMAKE_INSTALL_PREFIX is the staging dir),
+      # but set to the staging root for RPM (CMAKE_INSTALL_PREFIX stays /usr).
+      set(_lib \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBINSTDIR}/lib${TARGET}.so.${NUM_VERSION}\")
+      # Extract debug info into a separate .dbg file alongside the library.
+      execute_process(COMMAND ${CMAKE_OBJCOPY} --only-keep-debug \"\${_lib}\" \"\${_lib}.dbg\")
+      # objcopy needs to read the .dbg file to compute its CRC for the debuglink section.
+      # It looks for the file by bare name in WORKING_DIRECTORY, so we set that to the
+      # directory containing both the library and the .dbg file.
+      get_filename_component(_dir \"\${_lib}\" DIRECTORY)
+      execute_process(COMMAND ${CMAKE_OBJCOPY} --strip-debug
+        --add-gnu-debuglink=lib${TARGET}.so.${NUM_VERSION}.dbg \"\${_lib}\"
+        WORKING_DIRECTORY \"\${_dir}\")
+    ")
+  endif()
+
+  if(CV2PDB_EXE AND GO_SPLIT_DEBUG_SYMBOLS)
     add_custom_command(
       OUTPUT "${LIBDIR}/lib${TARGET}.pdb"
       DEPENDS ${TARGET}

--- a/src/build/CMakeLists.txt
+++ b/src/build/CMakeLists.txt
@@ -1,11 +1,15 @@
 # Copyright 2006 Milan Digital Audio LLC
-# Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+# Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
 # License GPL-2.0 or later (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 cmake_minimum_required(VERSION 3.10)
 
 IF(NOT CMAKE_CROSSCOMPILING)
-   ADD_EXECUTABLE(imageconverter imageconverter.cpp)
+  ADD_EXECUTABLE(imageconverter imageconverter.cpp)
+  # imageconverter is a build-time tool; it must not use ASan because it runs
+  # during the build without the ASan runtime preloaded.
+  target_compile_options(imageconverter PRIVATE -fno-sanitize=address)
+  target_link_options(imageconverter PRIVATE -fno-sanitize=address)
 ENDIF(NOT CMAKE_CROSSCOMPILING)
 
 IF(NOT CMAKE_CROSSCOMPILING) 


### PR DESCRIPTION
Earlier:

- Debug symbols on Linux were never shipped with GitHub build artifacts, making it impossible to diagnose crash backtraces
- Windows PDB generation (cv2pdb) was unconditional — no way to disable it
- All GitHub builds (release and intermediate) used the Release build type
- ASAN was not supported in CI or build scripts

This PR does:

- Adds RELEASE_FLAG CMake option — unifies release/debug build type selection across all platform build scripts
- Adds GO_SPLIT_DEBUG_SYMBOLS CMake option (default: ON on Windows always; on Linux = RELEASE_FLAG) — extracts .dbg via objcopy --only-keep-debug on Linux, gates PDB generation on Windows
- Now all intermediate GitHub builds use the Debug build type; release builds use the Release build type
- Adds GO_BUILD_ASAN CMake option with -fsanitize=address -fno-omit-frame-pointer -static-libasan, wired through build scripts and CI via workflow_dispatch asan boolean input
- Adds capability of triggering ASAN builds from the GitHub Actions UI
- Every pull request triggers a build that is visible in the pull request page

This is a GitHub CI/build-only change. GO runtime behavior is unchanged. Intermediate builds now use the Debug build type, but the performance impact is negligible thanks to [c4ec548f](https://github.com/GrandOrgue/grandorgue/commit/c4ec548f).