### PR TITLE
fix: correct spelling typos in CMakeLists.txt and GOTestExe.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ if (USE_INTERNAL_RTAUDIO)
       message(
         FATAL_ERROR 
         "${RTAUDIO_SRC_DIR}/RtAudio.h file does not exist."
-        "Possible the RtAudio submodule has not been updated."
+        "Possibly the RtAudio submodule has not been updated."
         "Try to execute 'git submodule update --init --recursive' in the source directory"
       )
     endif()
@@ -224,7 +224,7 @@ if (USE_INTERNAL_RTAUDIO)
       message(
         FATAL_ERROR 
         "${RTMIDI_SRC_DIR}/RtMidi.h file does not exist."
-        "Possible the RtMidi submodule has not been updated."
+        "Possibly the RtMidi submodule has not been updated."
         "Try to execute 'git submodule update --init --recursive' in the source directory"
       )
     endif()
@@ -257,7 +257,7 @@ else()
   set(ZITACONVOLVER_LIBRARIES zita-convolver)
 endif()
 
-# include libcurl for automatic cheking for updates
+# include libcurl for automatic checking for updates
 # exports CURL::libcurl that can be used in target_link_libraries
 find_package(CURL REQUIRED)
 

--- a/src/core/threading/GOCondition.cpp
+++ b/src/core/threading/GOCondition.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -58,7 +58,7 @@ unsigned GOCondition::WaitOrStop(const char *waiterInfo, GOThread *pThread) {
     if (rc & SIGNAL_RECEIVED)
       break;
 
-    // timeout occured
+    // timeout occurred
     if (isFirstTime && waiterInfo) {
       wxLogWarning(
         "GOCondition::WaitOrStop: timeout while %s waited for condition %p",

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -547,7 +547,7 @@ wxString GOOrganController::Load(
             // show the progress and process possible Cancel
             if (!dlg->Update(objectDistributor.GetPos(), obj->GetLoadTitle()))
               throw GOLoadAborted(); // skip the rest of loading code
-          // rethrow exception if any occured in thisWorker.LoadNextObject
+          // rethrow exception if any occurred in thisWorker.LoadNextObject
           bool wereExceptions = thisWorker.WereExceptions();
 
           for (unsigned i = 0; i < threads.size(); i++)

--- a/src/grandorgue/combinations/model/GODivisionalCombination.cpp
+++ b/src/grandorgue/combinations/model/GODivisionalCombination.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -254,7 +254,7 @@ GODivisionalCombination *GODivisionalCombination::loadFrom(
     pCmb->LoadCombination(cfg);
     if (isCmbOnReadGroup) {  // The combination was loaded from the legacy group
       pCmb->m_group = group; // It will be saved to the normal group
-      if (isCmbOnGroup)      // Load the overriden combination
+      if (isCmbOnGroup)      // Load the overridden combination
         pCmb->LoadCombination(cfg);
     }
   }

--- a/src/grandorgue/loader/GOFileStore.h
+++ b/src/grandorgue/loader/GOFileStore.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -55,8 +55,8 @@ public:
    * @param mainArchivePath - an path to the main archive to load. If empty
    *   then search among organList
    * @param errMsg - an error message that is returned if the operation fails
-   * @return - true if success and false if any error occured (the error message
-   *   is returned in errMsg)
+   * @return - true if success and false if any error occurred (the error
+   * message is returned in errMsg)
    */
   bool LoadArchives(
     GOOrganList &organList,

--- a/src/grandorgue/loader/GOLoadThread.h
+++ b/src/grandorgue/loader/GOLoadThread.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -31,7 +31,7 @@ public:
 
   /**
    * Waits for completions
-   * @return true if any exceptions occured. Otherwise - false
+   * @return true if any exceptions occurred. Otherwise - false
    */
   bool CheckExceptions();
 };

--- a/src/grandorgue/loader/GOLoadWorker.h
+++ b/src/grandorgue/loader/GOLoadWorker.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -44,7 +44,7 @@ public:
     GOCacheObjectDistributor &distributor);
 
   /**
-   * Load the object. If an exception occured then remembers it for
+   * Load the object. If an exception occurred then remembers it for
    *   future calls of AssertNoException(). Only GOOutOfMemory may be thrown,
    *   all other exceptions are catched and remembered  for
    *   future calls of AssertNoException()
@@ -64,7 +64,7 @@ public:
   /**
    * If there was GOOutOfMemory then rethrows it
    * Otherwise does nothing
-   * @return whether any exceptions were occured
+   * @return whether any exceptions were occurred
    */
   bool WereExceptions() const;
 };

--- a/src/grandorgue/loader/GOObjectDistributor.h
+++ b/src/grandorgue/loader/GOObjectDistributor.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -55,7 +55,7 @@ public:
   }
 
   /**
-   * This method is called on any exception occured. It causes that all worker
+   * This method is called on any exception occurred. It causes that all worker
    * threads stop working immediate because they cannot fetch more objects
    */
   void Break() { m_IsBroken.store(true); }


### PR DESCRIPTION
This PR replaces #2459. It adds necessary copyright and formatting changes.