### PR TITLE
Fixed data race in GOSoundOrganEngine::GetMeterInfo

### DIFF
--- a/src/grandorgue/gui/frames/GOFrame.cpp
+++ b/src/grandorgue/gui/frames/GOFrame.cpp
@@ -764,7 +764,8 @@ void GOFrame::OnSize(wxSizeEvent &event) {
 
 void GOFrame::OnMeters(wxCommandEvent &event) {
   if (m_isMeterReady) {
-    const std::vector<double> vals = r_SoundSystem.GetEngine().GetMeterInfo();
+    const std::vector<float> vals = r_SoundSystem.GetEngine().GetMeterInfo();
+
     if (vals.size() == m_VolumeGauge.size() + 1) {
       m_SamplerUsage->SetValue(33 * vals[0]);
       for (unsigned i = 1; i < vals.size(); i++)

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -22,6 +22,7 @@
 #include "tasks/GOSoundTouchTask.h"
 #include "tasks/GOSoundTremulantTask.h"
 #include "tasks/GOSoundWindchestTask.h"
+#include "threading/GOMutexLocker.h"
 
 #include "GOEvent.h"
 #include "GOSoundRecorder.h"
@@ -282,7 +283,10 @@ void GOSoundOrganEngine::SetAudioOutput(
     outputs.push_back(m_AudioGroupTasks[i]);
   for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
     m_AudioOutputTasks[i]->SetOutputs(outputs);
-  m_MeterInfo.resize(channels + 1);
+  {
+    GOMutexLocker locker(m_MeterMutex);
+    m_MeterInfo = std::vector<std::atomic<float>>(channels + 1);
+  }
 }
 
 void GOSoundOrganEngine::SetAudioRecorder(
@@ -333,8 +337,25 @@ void GOSoundOrganEngine::NextPeriod() {
 
   m_CurrentTime += m_SamplesPerBuffer;
   unsigned used_samplers = m_SamplerPool.UsedSamplerCount();
+
   if (used_samplers > m_UsedPolyphony.load())
     m_UsedPolyphony.store(used_samplers);
+
+  // publish meter snapshot for the GUI thread
+  for (auto &v : m_MeterInfo)
+    v.store(0.0f);
+  m_MeterInfo[0].store(m_UsedPolyphony.load() / (float)GetHardPolyphony());
+  m_UsedPolyphony.store(0);
+
+  std::atomic<float> *pMeter = m_MeterInfo.data() + 1;
+
+  for (GOSoundOutputTask *pTask : m_AudioOutputTasks) {
+    if (pTask) {
+      for (const float f : pTask->GetMeterInfo())
+        (pMeter++)->store(f);
+      pTask->ResetMeterInfo();
+    }
+  }
 
   m_Scheduler.Reset();
 }
@@ -636,19 +657,11 @@ void GOSoundOrganEngine::UpdateVelocity(
   }
 }
 
-const std::vector<double> &GOSoundOrganEngine::GetMeterInfo() {
-  m_MeterInfo[0] = m_UsedPolyphony.load() / (double)GetHardPolyphony();
-  m_UsedPolyphony.store(0);
+std::vector<float> GOSoundOrganEngine::GetMeterInfo() {
+  GOMutexLocker locker(m_MeterMutex);
+  std::vector<float> result(m_MeterInfo.size());
 
-  for (unsigned i = 1; i < m_MeterInfo.size(); i++)
-    m_MeterInfo[i] = 0;
-  for (unsigned i = 0, nr = 1; i < m_AudioOutputTasks.size(); i++) {
-    if (!m_AudioOutputTasks[i])
-      continue;
-    const std::vector<float> &info = m_AudioOutputTasks[i]->GetMeterInfo();
-    for (unsigned j = 0; j < info.size(); j++)
-      m_MeterInfo[nr++] = info[j];
-    m_AudioOutputTasks[i]->ResetMeterInfo();
-  }
-  return m_MeterInfo;
+  for (unsigned i = 0; i < m_MeterInfo.size(); i++)
+    result[i] = m_MeterInfo[i].load();
+  return result;
 }

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -11,6 +11,8 @@
 #include <atomic>
 #include <vector>
 
+#include "threading/GOMutex.h"
+
 #include "playing/GOSoundResample.h"
 #include "playing/GOSoundSampler.h"
 #include "playing/GOSoundSamplerPool.h"
@@ -63,7 +65,22 @@ private:
   GOSoundSamplerPool m_SamplerPool;
   unsigned m_AudioGroupCount;
   std::atomic_uint m_UsedPolyphony;
-  std::vector<double> m_MeterInfo;
+
+  // protects m_MeterInfo against concurrent resize (SetAudioOutput vs
+  // GetMeterInfo)
+  GOMutex m_MeterMutex;
+
+  // Meter snapshot: [0] = polyphony ratio, [1..N] = per-channel peak levels.
+  // Written atomically by the audio thread in NextPeriod() after each buffer:
+  // polyphony is taken from m_UsedPolyphony, per-channel peaks are collected
+  // from GOSoundOutputTask::GetMeterInfo() and then reset via ResetMeterInfo().
+  // Read by the GUI thread in GetMeterInfo() under m_MeterMutex.
+  // Resized under m_MeterMutex in SetAudioOutput() when audio configuration
+  // changes. float is used instead of double because std::atomic<float> is
+  // lock-free on all supported platforms (x86, ARM), while std::atomic<double>
+  // is not guaranteed to be lock-free
+  std::vector<std::atomic<float>> m_MeterInfo;
+
   ptr_vector<GOSoundTremulantTask> m_TremulantTasks;
   ptr_vector<GOSoundWindchestTask> m_WindchestTasks;
   ptr_vector<GOSoundGroupTask> m_AudioGroupTasks;
@@ -148,7 +165,7 @@ public:
   int GetVolume() const { return m_Volume; }
   void SetScaledReleases(bool enable) { m_ScaledReleases = enable; }
   void SetRandomizeSpeaking(bool enable) { m_RandomizeSpeaking = enable; }
-  const std::vector<double> &GetMeterInfo();
+  std::vector<float> GetMeterInfo();
   void SetAudioRecorder(GOSoundRecorder *recorder, bool downmix);
 
   GOSoundSampler *StartPipeSample(


### PR DESCRIPTION
## Summary

- `GetMeterInfo()` was called from the GUI thread while directly accessing `m_AudioOutputTasks`, which could be concurrently resized or cleared by the control thread in `SetAudioOutput()` / `ClearSetup()` — a data race (UB)
- Meter data is now collected from tasks in `NextPeriod()` (audio thread) and stored atomically into `m_MeterInfo` (`std::vector<std::atomic<float>>`)
- `GetMeterInfo()` only reads `m_MeterInfo` under `m_MeterMutex`, which also protects against concurrent resize in `SetAudioOutput()`
- `float` is used instead of `double` because `std::atomic<float>` is lock-free on all supported platforms (x86, ARM)

## Test plan

- [ ] Build succeeds without errors or new warnings
- [ ] Open an organ — volume and polyphony meters update correctly
- [ ] Reopen audio system via Settings → Audio — no crash
- [ ] Run under ThreadSanitizer (TSan) — no race condition reported on meter data

🤖 Generated with [Claude Code](https://claude.com/claude-code)