### PR TITLE
Bumped cpptrace version

### DIFF
--- a/build-scripts/for-linux/prepare-cpptrace.bash
+++ b/build-scripts/for-linux/prepare-cpptrace.bash
@@ -2,7 +2,7 @@
 
 set -e
 
-CPP_TRACE_VERSION="0.4.1"
+CPP_TRACE_VERSION="1.0.4"
 
 # Install cpptrace from sources
 if ! ls /usr/local/lib*/libcpptrace.a &> /dev/null ; then

--- a/src/tests/common/GOTestException.h
+++ b/src/tests/common/GOTestException.h
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2024-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 #ifndef GOTESTEXCEPTION_H
 #define GOTESTEXCEPTION_H
-#include <cpptrace.hpp>
+#include <cpptrace/cpptrace.hpp>
 #include <exception>
 #include <iostream>
 #include <string>

--- a/src/tests/common/GOTestUtils.h
+++ b/src/tests/common/GOTestUtils.h
@@ -2,7 +2,7 @@
 #define GOTESTUTILS_H
 
 #include "GOTestException.h"
-#include <cpptrace.hpp>
+#include <cpptrace/cpptrace.hpp>
 
 class GOTestUtils {
   /*


### PR DESCRIPTION
I switched to the latest avaliable cpp version because the old one cannot be installed on recent systems.

No GO begavior should be changed. Only tests are affected