### PR TITLE
Fixed expression pedal malfunction when CC value exceeds configured high value #2494

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494
 # 3.17.2 (2026-05-24)
 - Fixed matching MIDI and audio device names containing regex metacharacters (e.g. parentheses) https://github.com/GrandOrgue/grandorgue/issues/2491
 - Fixed installing the .deb package on Ubuntu with PipeWire https://github.com/GrandOrgue/grandorgue/issues/2457

--- a/src/grandorgue/midi/events/GOMidiEventPattern.cpp
+++ b/src/grandorgue/midi/events/GOMidiEventPattern.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -86,16 +86,18 @@ int GOMidiEventPattern::convertValueBetweenRanges(
   int_fast8_t srcHigh,
   int_fast8_t dstLow,
   int_fast8_t dstHigh) {
-  const int_fast8_t dstAbsLow = std::min(dstLow, dstHigh);
-  const int_fast8_t dstAbsHigh = std::max(dstLow, dstHigh);
-  int_fast8_t dstValue = srcValue - srcLow;
+  // Linear interpolation from [srcLow, srcHigh] to [dstLow, dstHigh].
+  // dstValue is int (not int_fast8_t) to avoid overflow when the intermediate
+  // result exceeds 127 (e.g. srcValue > srcHigh maps to dstHigh + epsilon).
+  const int dstValue = srcHigh != srcLow ? dstLow
+      + (int)round((srcValue - srcLow) * (float)(dstHigh - dstLow)
+                   / (srcHigh - srcLow))
+                                         : (int)dstLow;
 
-  if (srcHigh != srcLow)
-    dstValue = dstLow
-      + round(dstValue * (float)(dstHigh - dstLow) / (srcHigh - srcLow));
-  if (dstValue < dstAbsLow)
-    dstValue = dstAbsLow;
-  if (dstValue > dstAbsHigh)
-    dstValue = dstAbsHigh;
-  return dstValue;
+  // Clamp to [min(dstLow,dstHigh), max(dstLow,dstHigh)] to handle both normal
+  // (low < high) and inverted (high < low) destination ranges, and to keep
+  // out-of-range srcValues (srcValue < srcLow or srcValue > srcHigh) within
+  // the destination bounds.
+  return std::clamp(
+    dstValue, (int)std::min(dstLow, dstHigh), (int)std::max(dstLow, dstHigh));
 }


### PR DESCRIPTION
## Summary

- Fixed `int_fast8_t` overflow in `GOMidiEventPattern::convertValueBetweenRanges` that caused enclosures to close completely when a CC value exceeded the configured `high_value`
- Replaced manual clamp logic with `int dstValue` + `std::clamp` to prevent overflow before clamping
- Added changelog entry

## Root cause

Commit bb9b80e1 (#2311) changed the local variable `dstValue` from `int` to `int_fast8_t`. When `srcValue > srcHigh`, the intermediate interpolation result can exceed 127, which overflowed `int_fast8_t` (wrapping to −128) before the clamp could correct it — causing the enclosure to snap fully closed.

## Test plan

- [ ] Configure an enclosure to respond to CC range 0–115
- [ ] Send CC values above 115 — enclosure should remain fully open, not close
- [ ] Send CC values below 0 — enclosure should remain fully closed
- [ ] Verify normal range (0–127) still maps correctly

Fixes https://github.com/GrandOrgue/grandorgue/issues/2494

🤖 Generated with [Claude Code](https://claude.com/claude-code)