### PR TITLE
Fixed matching device names containing regex metacharacters https://github.com/GrandOrgue/grandorgue/issues/2491

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed matching MIDI and audio device names containing regex metacharacters (e.g. parentheses) https://github.com/GrandOrgue/grandorgue/issues/2491
 - Fixed installing the .deb package on Ubuntu with PipeWire https://github.com/GrandOrgue/grandorgue/issues/2457
 - Fixed running GrandOrgueTool and GrandOrguePerfTest from macOS app bundle https://github.com/GrandOrgue/grandorgue/issues/2400
 - Fixed controlling organ elements when recording or playing MIDI https://github.com/GrandOrgue/grandorgue/issues/2388

--- a/src/grandorgue/config/GOPortFactory.cpp
+++ b/src/grandorgue/config/GOPortFactory.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -37,6 +37,19 @@ void append_name(wxString const &nameComp, wxString &resName) {
       resName.Append(GOPortFactory::c_NameDelim);
     resName.Append(nameComp);
   }
+}
+
+wxString GOPortFactory::escapeRegex(const wxString &s) {
+  static const wxString metaChars = wxT("\\^$.|?*+()[]{}");
+  wxString result;
+
+  result.reserve(s.size() * 2);
+  for (wxUniChar c : s) {
+    if (metaChars.find(c) != wxString::npos)
+      result += wxT('\\');
+    result += c;
+  }
+  return result;
 }
 
 wxString GOPortFactory::ComposeDeviceName(

--- a/src/grandorgue/config/GOPortFactory.h
+++ b/src/grandorgue/config/GOPortFactory.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -46,6 +46,10 @@ public:
 
   wxString ComposeDeviceName(
     wxString const &portName, wxString const &apiName, wxString const &devName);
+
+  // Escapes all regex metacharacters in s so it can be used as a literal
+  // substring pattern.
+  static wxString escapeRegex(const wxString &s);
 };
 
 #endif /* GOPORTFACTORY_H */

--- a/src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp
+++ b/src/grandorgue/midi/ports/GOMidiRtPortFactory.cpp
@@ -229,23 +229,28 @@ wxString GOMidiRtPortFactory::GetDefaultRegEx(
       // Client Name:Port Name
       regEx = wxString::Format(
         wxT("%s:%s"),
-        m_AlsaDevnamePattern.GetMatch(deviceName, 1),
-        m_AlsaDevnamePattern.GetMatch(deviceName, 2));
+        GOPortFactory::escapeRegex(
+          m_AlsaDevnamePattern.GetMatch(deviceName, 1)),
+        GOPortFactory::escapeRegex(
+          m_AlsaDevnamePattern.GetMatch(deviceName, 2)));
     break;
   case RtMidi::Api::UNIX_JACK:
     if (m_JackDevnamePattern.Matches(deviceName))
       // Midi-Bridge:Client Name:(direction_num)) Port Name
       regEx = wxString::Format(
         wxT("Midi-Bridge:%s:(%s_%s) %s"),
-        m_JackDevnamePattern.GetMatch(deviceName, 1),
+        GOPortFactory::escapeRegex(
+          m_JackDevnamePattern.GetMatch(deviceName, 1)),
         m_JackDevnamePattern.GetMatch(deviceName, 2),
         m_JackDevnamePattern.GetMatch(deviceName, 3),
-        m_JackDevnamePattern.GetMatch(deviceName, 4));
+        GOPortFactory::escapeRegex(
+          m_JackDevnamePattern.GetMatch(deviceName, 4)));
     break;
   case RtMidi::Api::WINDOWS_MM:
     if (m_WinMmDevnamePattern.Matches(deviceName))
       // Device Name
-      regEx = m_WinMmDevnamePattern.GetMatch(deviceName, 1);
+      regEx = GOPortFactory::escapeRegex(
+        m_WinMmDevnamePattern.GetMatch(deviceName, 1));
     break;
   default:
     break;

--- a/src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp
@@ -188,7 +188,10 @@ static void fill_logical_name_and_regex(GOSoundDevInfo &info) {
       info.SetDefaultNameRegex(GOSoundPortFactory::getFullDeviceName(
         GOSoundPortaudioPort::PORT_NAME,
         apiName,
-        wxString::Format("%s \\(hw:[0-9]+,%s\\)", devName1, devName3)));
+        wxString::Format(
+          "%s \\(hw:[0-9]+,%s\\)",
+          GOPortFactory::escapeRegex(devName1),
+          devName3)));
       info.SetDefaultLogicalName(GOSoundPortFactory::getFullDeviceName(
         GOSoundPortaudioPort::PORT_NAME,
         apiName,


### PR DESCRIPTION
## Summary

- Added `GOPortFactory::escapeRegex()` static method that escapes POSIX ERE metacharacters in a string so it can be used as a literal pattern
- Applied it in `GOMidiRtPortFactory::GetDefaultRegEx()` for all three APIs (ALSA, JACK, WinMM) when building the default regex from captured device name parts
- Applied it in `GOSoundPortaudioPort::fill_logical_name_and_regex()` for the PortAudio/ALSA device name part

Fixes device names containing parentheses (e.g. `GrOrg (A)`) or other regex metacharacters that previously generated broken regex patterns and failed to match on reconnect.

Fixes https://github.com/GrandOrgue/grandorgue/issues/2491

## Test plan

- [ ] Create virtual MIDI ports with names containing parentheses (e.g. `GrOrg (A)`, `GrOrg (B)`)
- [ ] Open GrandOrgue — ports should appear in MIDI settings and be matchable
- [ ] Disconnect and reconnect the ports — GrandOrgue should re-match them automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)