### PR TITLE
Fixed on-screen keyboard appearing when tapping organ panels https://github.com/GrandOrgue/grandorgue/issues/2492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
+- Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494
 # 3.17.2 (2026-05-24)
 - Fixed matching MIDI and audio device names containing regex metacharacters (e.g. parentheses) https://github.com/GrandOrgue/grandorgue/issues/2491

--- a/src/grandorgue/combinations/GOSetter.cpp
+++ b/src/grandorgue/combinations/GOSetter.cpp
@@ -828,10 +828,6 @@ void GOSetter::Load(GOConfigReader &cfg) {
   m_buttons[ID_SETTER_PREV]->Init(cfg, wxT("SetterPrev"), _("Previous"));
   m_buttons[ID_SETTER_NEXT]->Init(cfg, wxT("SetterNext"), _("Next"));
   m_buttons[ID_SETTER_SET]->Init(cfg, wxT("SetterSet"), _("Set"));
-  m_buttons[ID_SETTER_PREV]->SetDefaultShortcutKey(37);
-  m_buttons[ID_SETTER_NEXT]->SetDefaultShortcutKey(39);
-  m_buttons[ID_SETTER_CURRENT]->SetDefaultShortcutKey(40);
-
   m_buttons[ID_SETTER_M1]->Init(cfg, wxT("SetterM1"), _("-1"));
   m_buttons[ID_SETTER_M10]->Init(cfg, wxT("SetterM10"), _("-10"));
   m_buttons[ID_SETTER_M100]->Init(cfg, wxT("SetterM100"), _("-100"));

--- a/src/grandorgue/control/GOButtonControl.h
+++ b/src/grandorgue/control/GOButtonControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -59,6 +59,9 @@ public:
   bool IsPiston() const { return m_IsPiston; }
   bool IsEngaged() const { return m_Engaged; }
   bool DisplayInverted() const { return m_DisplayInInvertedState; }
+  bool IsKeyboardInputUsed() const override {
+    return GOMidiObjectWithShortcut::IsKeyboardInputUsed();
+  }
 
   virtual void Push();
   virtual void SetButtonState(bool on) {}

--- a/src/grandorgue/control/GOControl.h
+++ b/src/grandorgue/control/GOControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,6 +13,8 @@
 class GOControl {
 public:
   virtual ~GOControl() {}
+
+  virtual bool IsKeyboardInputUsed() const { return false; }
 };
 
 #endif /* GOCONTROL_H */

--- a/src/grandorgue/gui/panels/GOGUIControl.h
+++ b/src/grandorgue/gui/panels/GOGUIControl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -43,6 +43,8 @@ protected:
 public:
   GOGUIControl(GOGUIPanel *panel, GOControl *pControl);
   virtual ~GOGUIControl();
+
+  GOControl *GetControl() const { return p_control; }
 
   GODocumentBase *GetDocument() const {
     return m_panel ? m_panel->GetDocument() : nullptr;

--- a/src/grandorgue/gui/panels/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanel.cpp
@@ -7,6 +7,8 @@
 
 #include "GOGUIPanel.h"
 
+#include <algorithm>
+
 #include <wx/image.h>
 #include <wx/toplevel.h>
 
@@ -61,6 +63,15 @@ GOGUIPanel::~GOGUIPanel() {
 bool GOGUIPanel::InitialOpenWindow() { return m_InitialOpenWindow; }
 
 GOOrganController *GOGUIPanel::GetOrganFile() { return m_OrganController; }
+
+bool GOGUIPanel::IsKeyboardInputUsed() const {
+  return std::any_of(
+    m_controls.begin(), m_controls.end(), [](const GOGUIControl *pGuiCtrl) {
+      const GOControl *pCtrl = pGuiCtrl->GetControl();
+
+      return pCtrl && pCtrl->IsKeyboardInputUsed();
+    });
+}
 
 const wxString &GOGUIPanel::GetName() { return m_Name; }
 

--- a/src/grandorgue/gui/panels/GOGUIPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIPanel.h
@@ -110,6 +110,7 @@ public:
   unsigned GetWidth();
   unsigned GetHeight();
   bool InitialOpenWindow();
+  bool IsKeyboardInputUsed() const;
 
   void SetInitialOpenWindow(bool open);
 };

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
@@ -54,7 +54,7 @@ GOGUIPanelWidget::GOGUIPanelWidget(
   m_BGImage = m_ClientBitmap.ConvertToImage();
   m_Background.BuildScaledBitmap(m_Scale, wxRect(0, 0, 0, 0), NULL);
   m_BGInit = true;
-  SetCanFocus(true);
+  SetCanFocus(m_panel->IsKeyboardInputUsed());
 }
 
 GOGUIPanelWidget::~GOGUIPanelWidget() {}
@@ -70,7 +70,10 @@ void GOGUIPanelWidget::initFont() {
 }
 
 void GOGUIPanelWidget::Focus() {
-  if (!HasFocus())
+  const bool isKeyboardUsed = m_panel->IsKeyboardInputUsed();
+
+  SetCanFocus(isKeyboardUsed);
+  if (isKeyboardUsed && !HasFocus())
     SetFocus();
 }
 

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -23,9 +23,8 @@ GOMidiObjectWithShortcut::~GOMidiObjectWithShortcut() {
   SetMidiShortcutReceiver(nullptr);
 }
 
-void GOMidiObjectWithShortcut::SetDefaultShortcutKey(unsigned key) {
-  if (!m_ShortcutReceiver.IsMidiConfigured())
-    m_ShortcutReceiver.SetShortcut(key);
+bool GOMidiObjectWithShortcut::IsKeyboardInputUsed() const {
+  return m_ShortcutReceiver.GetShortcut() || m_ShortcutReceiver.GetMinusKey();
 }
 
 void GOMidiObjectWithShortcut::HandleKey(int key) {

--- a/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
+++ b/src/grandorgue/midi/objects/GOMidiObjectWithShortcut.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -33,9 +33,7 @@ protected:
     = 0;
 
 public:
-  // Set the shortcut key if it is not configured
-  // Should be called after Init()
-  void SetDefaultShortcutKey(unsigned key);
+  bool IsKeyboardInputUsed() const;
 };
 
 #endif /* GOMIDIOBJECTWITHSHORTCUT_H */

--- a/src/grandorgue/model/GOEnclosure.h
+++ b/src/grandorgue/model/GOEnclosure.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -73,6 +73,10 @@ public:
   void SetEnclosureValue(uint8_t n);
   int GetEnclosureValue() const { return m_MIDIValue; }
   float GetAttenuation();
+
+  bool IsKeyboardInputUsed() const override {
+    return GOMidiObjectWithShortcut::IsKeyboardInputUsed();
+  }
 
   void Scroll(bool scroll_up);
   bool IsDisplayed(bool new_format);


### PR DESCRIPTION
Resolves: #2492

Earlier all panel widgets grabbed keyboard focus that caused activating the desktop on-screen keyboard on touch-enabled Linux systems (GNOME/Caribou, KDE/Maliit). 

This PR:
- makes GrandOrgue panel to grab keyboard focus only if some element has a keyboard shortcut assigned
- stops assigning keyboard shortcuts to setters elements (Next - Right, Prev - Left, Current - Down) by default. If a user needs the chortcuts, he/she has to assign them manually (with an MIDI event dialog or with the initial MIDI settings)

So no more on-screen keyboard appears until the user assigns a keyboard shortcut for the panel.