### PR TITLE
Fix -Wreorder warning in GOSoundSystem constructor

### DIFF
--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -35,9 +35,9 @@ GOSoundSystem::GOSoundSystem(GOConfig &settings)
     m_IsRunning(false),
     m_NCallbacksEntered(0),
     m_CallbackCondition(m_CallbackMutex),
+    meter_counter(0),
     m_WaitCount(0),
-    m_CalcCount(0),
-    meter_counter(0) {}
+    m_CalcCount(0) {}
 
 GOSoundSystem::~GOSoundSystem() {
   AssureSoundIsClosed();


### PR DESCRIPTION
## Summary
- Reorder member initializers in `GOSoundSystem::GOSoundSystem` to match the declaration order in the header, eliminating `-Wreorder` compiler warnings.

## Test plan
- [ ] Rebuild `GOSoundSystem.cpp` and confirm no `-Wreorder` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)