### PR TITLE
Fixed win64 parallel build race in FixupBundle post-build step

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -20,6 +20,8 @@ endif ()
 BUILD_EXECUTABLE(GrandOrgueTool)
 target_link_libraries(GrandOrgueTool GrandOrgueCore)
 if (INSTALL_DEPEND STREQUAL "ON")
+  # fixup_bundle scans all executables in bin/; ensure GrandOrgue.exe is fully written first
+  add_dependencies(GrandOrgueTool GrandOrgue)
   CopyDependencies(GrandOrgueTool "${BININSTDIR}/GrandOrgueTool${CMAKE_EXECUTABLE_SUFFIX}" GrandOrgueCore)
 endif()
 
@@ -28,6 +30,8 @@ BUILD_EXECUTABLE(GrandOrguePerfTest)
 target_include_directories(GrandOrguePerfTest PUBLIC ${CMAKE_SOURCE_DIR}/src/grandorgue)
 target_link_libraries(GrandOrguePerfTest golib)
 if (INSTALL_DEPEND STREQUAL "ON")
+  # fixup_bundle scans all executables in bin/; ensure they are all fully written first
+  add_dependencies(GrandOrguePerfTest GrandOrgue GrandOrgueTool)
   CopyDependencies(GrandOrguePerfTest "${BININSTDIR}/GrandOrguePerfTest${CMAKE_EXECUTABLE_SUFFIX}" golib)
 endif()
 


### PR DESCRIPTION
## Summary

- `fixup_bundle` (CMake BundleUtilities) scans **all executables in `bin/`** when processing any one of them
- On a parallel `-j` build, `GrandOrgue.exe` may still be partially written when `GrandOrguePerfTest`'s POST_BUILD FixupBundle step fires — `objdump` fails with `file format not recognized`
- This regression was introduced in #2455 which added `CopyDependencies` for the tool executables
- Fix: add `add_dependencies` so `GrandOrgueTool` and `GrandOrguePerfTest` link **after** `GrandOrgue` (and PerfTest after Tool) when `INSTALL_DEPEND` is ON

## Test plan

- [ ] CI job `build (ubuntu-latest, win64, debian-based, linux)` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)