### PR TITLE
Fixed version_ge in autotag.sh (missed 3.17.2 release)

### DIFF
--- a/build-scripts/for-github/autotag.sh
+++ b/build-scripts/for-github/autotag.sh
@@ -16,7 +16,7 @@ assure_full_version()
 }
 
 # Returns 0 (true) if $1 >= $2 using semantic version ordering
-version_ge() { [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -1)" != "$2" ]] || [[ "$1" == "$2" ]]; }
+version_ge() { [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -1)" != "$1" ]] || [[ "$1" == "$2" ]]; }
 
 # Returns 0 (true) if $1 > $2 using semantic version ordering
 version_gt() { [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -1)" != "$1" ]]; }


### PR DESCRIPTION
## Summary

- Fixed one-character bug in `version_ge` function in `build-scripts/for-github/autotag.sh`: compared `min(A,B) != $2` instead of `!= $1`
- The function returned FALSE when A > B, so it never detected that `3.17.2-1 >= 3.17.2-0` and never pushed the release tag
- As a result, release `v3.17.2` was never published after merging the Release 3.17.2 PR (#2501) or the win64 fix (#2516)
- The bug was introduced in #2446 which replaced lexicographic `[[ A > B ]]` with `sort -V` based helpers

## Root cause

```bash
# Wrong — compares min against $2:
version_ge() { [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -1)" != "$2" ]] || [[ "$1" == "$2" ]]; }

# Fixed — compares min against $1:
version_ge() { [[ "$(printf '%s\n' "$1" "$2" | sort -V | head -1)" != "$1" ]] || [[ "$1" == "$2" ]]; }
```

Logic: if `min(A,B) ≠ A`, then A is not the minimum → A ≥ B.

Note: `version_gt` was already correct (compared against `$1`).

## Test plan

- [ ] Merge to master
- [ ] Verify CI run creates tag `3.17.2-1` on current master commit and publishes release `v3.17.2-1`
- [ ] Confirm `release` job is green (not skipped) in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)