### PR TITLE
Removed usage of GOOrganController from GOMainWindowData

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -99,7 +99,7 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
     mp_ImageCache(nullptr),
     m_PitchLabel(*this),
     m_TemperamentLabel(*this),
-    m_MainWindowData(this, wxT("MainWindow")) {
+    m_MainWindowData(*this, wxT("MainWindow")) {
   if (isAppInitialized) {
     // Load here objects that needs App (wx) to be loaded
     m_timer = new GOTimer();

--- a/src/grandorgue/gui/frames/GOMainWindowData.cpp
+++ b/src/grandorgue/gui/frames/GOMainWindowData.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,10 +10,10 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
-#include "GOOrganController.h"
+#include "model/GOOrganModel.h"
 
 void GOMainWindowData::Load(GOConfigReader &cfg) {
-  p_organFile->RegisterSaveableObject(this);
+  r_OrganModel.RegisterSaveableObject(this);
   m_rect.x = cfg.ReadInteger(
     CMBSetting, m_group, wxT("WindowX"), -20, 10000, false, 0);
   m_rect.y = cfg.ReadInteger(

--- a/src/grandorgue/gui/frames/GOMainWindowData.h
+++ b/src/grandorgue/gui/frames/GOMainWindowData.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,16 +14,16 @@
 
 #include "GOSaveableObject.h"
 
-class GOOrganController;
+class GOOrganModel;
 
 class GOMainWindowData : private GOSaveableObject {
 protected:
-  GOOrganController *p_organFile;
+  GOOrganModel &r_OrganModel;
   GOLogicalRect m_rect;
 
 public:
-  GOMainWindowData(GOOrganController *pOrganFile, const wxString &group)
-    : p_organFile(pOrganFile) {
+  GOMainWindowData(GOOrganModel &organModel, const wxString &group)
+    : r_OrganModel(organModel) {
     m_group = group;
   }
   virtual ~GOMainWindowData() {}


### PR DESCRIPTION
Removes the direct dependency on GOOrganController from GOMainWindowData so the class depends only on the model layer (GOOrganModel), which is a prerequisite for moving GOMainWindowData ownership to GOGuiOrgan.

It is just refactoring. No GO behavior should be changed.
