### PR TITLE
Fixed -Wunused-but-set-variable warning in GOTestExe.cpp

### DIFF
--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -61,15 +61,10 @@ int main(int argc, char *argv[]) {
   test_result_collection = GOTestCollection::Instance()->Run(categoryFilter);
 
   // Display tests results
-  int run_number_ = 0;
-  std::vector<GOTestResult *> test_results
-    = test_result_collection.get_results();
   std::cout << "==================== TESTS RESULTS ====================\n";
-  for (auto current = test_results.begin(); current != test_results.end();
-       ++current, ++run_number_) {
-    auto test_result = *current;
+  for (GOTestResult *pResult : test_result_collection.get_results()) {
     std::cout << "-------------------------------------------------------\n";
-    std::cout << test_result->GetMessage() << "\n";
+    std::cout << pResult->GetMessage() << "\n";
   }
 
   const int failed_count = GOTestCollection::Instance()->get_failed_count();


### PR DESCRIPTION
## Changes

Replaced manual iterator loop with range-based `for`, removing the unused
`run_number_` counter variable that triggered `-Wunused-but-set-variable`.

## Test plan
- [ ] Build succeeds without warnings
- [ ] `GOTestExe` runs and prints results correctly