### PR TITLE
Fixed GOSoundReleaseAlignTable::GetPositionFor() assert-before-clamp and channel count mismatch https://github.com/GrandOrgue/grandorgue/issues/2504

### DIFF
--- a/src/grandorgue/sound/playing/GOSoundAudioSection.cpp
+++ b/src/grandorgue/sound/playing/GOSoundAudioSection.cpp
@@ -7,6 +7,8 @@
 
 #include "GOSoundAudioSection.h"
 
+#include <algorithm>
+
 #include <wx/intl.h>
 #include <wx/log.h>
 
@@ -273,14 +275,14 @@ void GOSoundAudioSection::GetMaxAmplitudeAndDerivative() {
         m_MaxAmplitude = abs(val);
     }
 
-    if (abs(f) > m_MaxAbsAmplitude)
-      m_MaxAbsAmplitude = abs(f);
+    m_MaxAbsAmplitude
+      = std::max(m_MaxAbsAmplitude, static_cast<unsigned>(std::abs(f)));
 
     if (i != 0) {
       /* Get v */
       int v = f - f_p;
-      if (abs(v) > m_MaxAbsDerivative)
-        m_MaxAbsDerivative = abs(v);
+      m_MaxAbsDerivative
+        = std::max(m_MaxAbsDerivative, static_cast<unsigned>(std::abs(v)));
     }
     f_p = f;
   }
@@ -571,13 +573,12 @@ void GOSoundAudioSection::SetupStreamAlignment(
   if (!joinables.size())
     return;
 
-  int max_amplitude = m_MaxAbsAmplitude;
-  int max_derivative = m_MaxAbsDerivative;
-  for (unsigned i = 0; i < joinables.size(); i++) {
-    if (joinables[i]->m_MaxAbsAmplitude > max_amplitude)
-      max_amplitude = joinables[i]->m_MaxAbsAmplitude;
-    if (joinables[i]->m_MaxAbsDerivative > max_derivative)
-      max_derivative = joinables[i]->m_MaxAbsDerivative;
+  unsigned max_amplitude = m_MaxAbsAmplitude;
+  unsigned max_derivative = m_MaxAbsDerivative;
+
+  for (const GOSoundAudioSection *pJoinable : joinables) {
+    max_amplitude = std::max(max_amplitude, pJoinable->m_MaxAbsAmplitude);
+    max_derivative = std::max(max_derivative, pJoinable->m_MaxAbsDerivative);
   }
   m_ReleaseStartSegment = start_index;
   if (m_ReleaseStartSegment >= m_StartSegments.size())

--- a/src/grandorgue/sound/playing/GOSoundAudioSection.h
+++ b/src/grandorgue/sound/playing/GOSoundAudioSection.h
@@ -113,8 +113,8 @@ private:
   unsigned m_AllocSize;
 
   unsigned m_MaxAmplitude;
-  int m_MaxAbsAmplitude;
-  int m_MaxAbsDerivative;
+  unsigned m_MaxAbsAmplitude;
+  unsigned m_MaxAbsDerivative;
   unsigned m_ReleaseCrossfadeLength; // in ms
 
   void ClearData();

--- a/src/grandorgue/sound/playing/GOSoundReleaseAlignTable.cpp
+++ b/src/grandorgue/sound/playing/GOSoundReleaseAlignTable.cpp
@@ -7,6 +7,7 @@
 
 #include "GOSoundReleaseAlignTable.h"
 
+#include <algorithm>
 #include <stdlib.h>
 
 #include "loader/cache/GOCache.h"
@@ -96,10 +97,24 @@ bool GOSoundReleaseAlignTable::Save(GOCacheWriter &cache) {
   return true;
 }
 
+unsigned GOSoundReleaseAlignTable::computeBucketIndex(
+  int shiftedValue, unsigned maxValue, unsigned nBuckets) {
+  const unsigned result = maxValue
+    // clamp to valid range, then map to bucket
+    ? static_cast<unsigned>(
+        std::clamp(shiftedValue, 0, static_cast<int>(2 * maxValue - 1)))
+      * nBuckets / (2 * maxValue)
+    // maxValue == 0: table was not built, fall back to midpoint
+    : nBuckets / 2;
+
+  assert(result < nBuckets);
+  return result;
+}
+
 void GOSoundReleaseAlignTable::ComputeTable(
   const GOSoundAudioSection &release,
-  int phase_align_max_amplitude,
-  int phase_align_max_derivative,
+  unsigned phase_align_max_amplitude,
+  unsigned phase_align_max_derivative,
   unsigned int sample_rate,
   unsigned start_position) {
   GOSoundCompressionCache cache;
@@ -144,29 +159,18 @@ void GOSoundReleaseAlignTable::ComputeTable(
     for (unsigned int j = 0; j < channels; j++)
       f += release.GetSample(start_position + i, j, &cache);
 
-    /* Bring v into the range -1..2*m_PhaseAlignMaxDerivative-1 */
-    int v_mod = (f - f_p) + m_PhaseAlignMaxDerivative - 1;
-    int derivIndex
-      = (PHASE_ALIGN_DERIVATIVES * v_mod) / (2 * m_PhaseAlignMaxDerivative);
+    /* Bring v into the range [0, 2*m_PhaseAlignMaxDerivative) */
+    const int v_mod
+      = (f - f_p) + static_cast<int>(m_PhaseAlignMaxDerivative) - 1;
+    const unsigned derivIndex = computeBucketIndex(
+      v_mod, m_PhaseAlignMaxDerivative, PHASE_ALIGN_DERIVATIVES);
 
-    /* Bring f into the range -1..2*m_PhaseAlignMaxAmplitude-1 */
-    int f_mod = f + m_PhaseAlignMaxAmplitude - 1;
-    int ampIndex
-      = (PHASE_ALIGN_AMPLITUDES * f_mod) / (2 * m_PhaseAlignMaxAmplitude);
+    /* Bring f into the range [0, 2*m_PhaseAlignMaxAmplitude) */
+    const int f_mod = f + static_cast<int>(m_PhaseAlignMaxAmplitude) - 1;
+    const unsigned ampIndex = computeBucketIndex(
+      f_mod, m_PhaseAlignMaxAmplitude, PHASE_ALIGN_AMPLITUDES);
 
     /* Store this release point if it was not already filled */
-    derivIndex = (derivIndex < 0)
-      ? 0
-      : (
-        (derivIndex >= PHASE_ALIGN_DERIVATIVES) ? PHASE_ALIGN_DERIVATIVES - 1
-                                                : derivIndex);
-    ampIndex = (ampIndex < 0)
-      ? 0
-      : (
-        (ampIndex >= PHASE_ALIGN_AMPLITUDES) ? PHASE_ALIGN_AMPLITUDES - 1
-                                             : ampIndex);
-    assert((derivIndex >= 0) && (derivIndex < PHASE_ALIGN_DERIVATIVES));
-    assert((ampIndex >= 0) && (ampIndex < PHASE_ALIGN_AMPLITUDES));
     if (!areCellsFilled[derivIndex][ampIndex]) {
       m_PositionEntries[derivIndex][ampIndex] = i + 1 + start_position;
       areCellsFilled[derivIndex][ampIndex] = true;
@@ -209,41 +213,24 @@ void GOSoundReleaseAlignTable::ComputeTable(
 }
 
 unsigned GOSoundReleaseAlignTable::GetPositionFor(
-  int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]) const {
+  int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS], unsigned nChannels) const {
   /* Get combined release f's and v's */
   int f_mod = 0;
   int v_mod = 0;
-  for (unsigned i = 0; i < MAX_OUTPUT_CHANNELS; i++) {
+  for (unsigned i = 0; i < nChannels; i++) {
     f_mod += history[(BLOCK_HISTORY - 1)][i];
     v_mod += history[(BLOCK_HISTORY - 2)][i];
   }
   v_mod = f_mod - v_mod;
 
-  /* Bring f and v into the range -1..2*m_PhaseAlignMaxDerivative-1 */
-  v_mod += (m_PhaseAlignMaxDerivative - 1);
-  f_mod += (m_PhaseAlignMaxAmplitude - 1);
+  /* Bring f and v into the range [0, 2*m_PhaseAlignMax*) */
+  v_mod += static_cast<int>(m_PhaseAlignMaxDerivative) - 1;
+  f_mod += static_cast<int>(m_PhaseAlignMaxAmplitude) - 1;
 
-  int derivIndex = m_PhaseAlignMaxDerivative
-    ? (PHASE_ALIGN_DERIVATIVES * v_mod) / (2 * m_PhaseAlignMaxDerivative)
-    : PHASE_ALIGN_DERIVATIVES / 2;
+  const unsigned derivIndex = computeBucketIndex(
+    v_mod, m_PhaseAlignMaxDerivative, PHASE_ALIGN_DERIVATIVES);
+  const unsigned ampIndex = computeBucketIndex(
+    f_mod, m_PhaseAlignMaxAmplitude, PHASE_ALIGN_AMPLITUDES);
 
-  /* Bring f into the range -1..2*m_PhaseAlignMaxAmplitude-1 */
-  int ampIndex = m_PhaseAlignMaxAmplitude
-    ? (PHASE_ALIGN_AMPLITUDES * f_mod) / (2 * m_PhaseAlignMaxAmplitude)
-    : PHASE_ALIGN_AMPLITUDES / 2;
-
-  /* Store this release point if it was not already found */
-  assert((derivIndex >= 0) && (derivIndex < PHASE_ALIGN_DERIVATIVES));
-  assert((ampIndex >= 0) && (ampIndex < PHASE_ALIGN_AMPLITUDES));
-  derivIndex = (derivIndex < 0)
-    ? 0
-    : (
-      (derivIndex >= PHASE_ALIGN_DERIVATIVES) ? PHASE_ALIGN_DERIVATIVES - 1
-                                              : derivIndex);
-  ampIndex = (ampIndex < 0)
-    ? 0
-    : (
-      (ampIndex >= PHASE_ALIGN_AMPLITUDES) ? PHASE_ALIGN_AMPLITUDES - 1
-                                           : ampIndex);
   return m_PositionEntries[derivIndex][ampIndex];
 }

--- a/src/grandorgue/sound/playing/GOSoundReleaseAlignTable.h
+++ b/src/grandorgue/sound/playing/GOSoundReleaseAlignTable.h
@@ -26,12 +26,25 @@ class GOSoundReleaseAlignTable {
   friend class GOTestReleaseAlignTable;
 
 private:
-  int m_PhaseAlignMaxAmplitude;
-  int m_PhaseAlignMaxDerivative;
+  unsigned m_PhaseAlignMaxAmplitude;
+  unsigned m_PhaseAlignMaxDerivative;
   /* Sample-position lookup table indexed by (derivative bucket, amplitude
-   * bucket). Each entry is an absolute sample offset within the release
-   * segment, so values are always non-negative. */
+   * bucket). Values are absolute sample offsets, always non-negative. */
   unsigned m_PositionEntries[PHASE_ALIGN_DERIVATIVES][PHASE_ALIGN_AMPLITUDES];
+
+  /**
+   * Maps a shifted value into a bucket index in [0, nBuckets).
+   * Clamps shiftedValue to [0, 2*maxValue) before dividing, so the result
+   * is always in range. Returns the midpoint bucket when maxValue is zero.
+   *
+   * @param shiftedValue  Value shifted by (maxValue - 1), may be out of range.
+   * @param maxValue      Half-width of the symmetric range; zero means unknown.
+   * @param nBuckets      Number of buckets (PHASE_ALIGN_DERIVATIVES or
+   *                      PHASE_ALIGN_AMPLITUDES).
+   * @return              Index in [0, nBuckets).
+   */
+  static unsigned computeBucketIndex(
+    int shiftedValue, unsigned maxValue, unsigned nBuckets);
 
   /** Row/column coordinates into the phase-align lookup table. */
   struct CellCoords {
@@ -70,14 +83,14 @@ public:
   bool Save(GOCacheWriter &cache);
 
   void ComputeTable(
-    const GOSoundAudioSection &m_release,
-    int phase_align_max_amplitude,
-    int phase_align_max_derivative,
+    const GOSoundAudioSection &release,
+    unsigned phase_align_max_amplitude,
+    unsigned phase_align_max_derivative,
     unsigned int sample_rate,
     unsigned start_position);
 
   unsigned GetPositionFor(
-    int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS]) const;
+    int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS], unsigned nChannels) const;
 };
 
 #endif /* GOSOUNDRELEASEALIGNTABLE_H */

--- a/src/grandorgue/sound/playing/GOSoundStream.cpp
+++ b/src/grandorgue/sound/playing/GOSoundStream.cpp
@@ -339,7 +339,8 @@ void GOSoundStream::InitAlignedStream(
     int history[BLOCK_HISTORY][MAX_OUTPUT_CHANNELS];
 
     pExistingStream->GetHistory(history);
-    startOffset = releaseAligner->GetPositionFor(history);
+    startOffset
+      = releaseAligner->GetPositionFor(history, pSection->GetChannels());
   }
   m_ResamplingPos.Init(
     (float)pSection->GetSampleRate()

--- a/src/tests/testing/sound/playing/GOTestReleaseAlignTable.cpp
+++ b/src/tests/testing/sound/playing/GOTestReleaseAlignTable.cpp
@@ -13,6 +13,65 @@
 const std::string GOTestReleaseAlignTable::TEST_NAME
   = "GOTestReleaseAlignTable";
 
+void GOTestReleaseAlignTable::TestComputeBucketIndexNormal() {
+  // shiftedValue at midpoint of [0, 2*maxValue) maps to center bucket
+  const unsigned result
+    = GOSoundReleaseAlignTable::computeBucketIndex(10, 10u, 4u);
+
+  GOAssert(
+    result == 2u,
+    std::format("center value should map to bucket 2, got: {}", result));
+}
+
+void GOTestReleaseAlignTable::TestComputeBucketIndexBelowRange() {
+  // negative shiftedValue clamps to bucket 0
+  const unsigned result
+    = GOSoundReleaseAlignTable::computeBucketIndex(-5, 10u, 4u);
+
+  GOAssert(
+    result == 0u,
+    std::format("negative value should map to bucket 0, got: {}", result));
+}
+
+void GOTestReleaseAlignTable::TestComputeBucketIndexAboveRange() {
+  // shiftedValue >= 2*maxValue clamps to last bucket
+  const unsigned result
+    = GOSoundReleaseAlignTable::computeBucketIndex(20, 10u, 4u);
+
+  GOAssert(
+    result == 3u,
+    std::format("value above range should map to bucket 3, got: {}", result));
+}
+
+void GOTestReleaseAlignTable::TestComputeBucketIndexZeroMaxValue() {
+  // maxValue == 0 returns midpoint bucket
+  const unsigned result
+    = GOSoundReleaseAlignTable::computeBucketIndex(0, 0u, 8u);
+
+  GOAssert(
+    result == 4u,
+    std::format("zero maxValue should return midpoint 4, got: {}", result));
+}
+
+void GOTestReleaseAlignTable::TestComputeBucketIndexBoundaries() {
+  // lower boundary: shiftedValue == 0 maps to bucket 0
+  const unsigned resultLow
+    = GOSoundReleaseAlignTable::computeBucketIndex(0, 10u, 4u);
+
+  GOAssert(
+    resultLow == 0u,
+    std::format("lower boundary 0 should map to bucket 0, got: {}", resultLow));
+
+  // upper boundary: shiftedValue == 2*maxValue-1 maps to last bucket
+  const unsigned resultHigh
+    = GOSoundReleaseAlignTable::computeBucketIndex(19, 10u, 4u);
+
+  GOAssert(
+    resultHigh == 3u,
+    std::format(
+      "upper boundary 19 should map to bucket 3, got: {}", resultHigh));
+}
+
 static void clearTable(
   bool table[PHASE_ALIGN_DERIVATIVES][PHASE_ALIGN_AMPLITUDES]) {
   for (unsigned derivI = 0; derivI < PHASE_ALIGN_DERIVATIVES; derivI++)
@@ -133,6 +192,11 @@ void GOTestReleaseAlignTable::TestAmplitudeOrdering() {
 }
 
 void GOTestReleaseAlignTable::run() {
+  TestComputeBucketIndexNormal();
+  TestComputeBucketIndexBelowRange();
+  TestComputeBucketIndexAboveRange();
+  TestComputeBucketIndexZeroMaxValue();
+  TestComputeBucketIndexBoundaries();
   TestBugRegression();
   TestSameRowPreference();
   TestDistantSingleCell();

--- a/src/tests/testing/sound/playing/GOTestReleaseAlignTable.h
+++ b/src/tests/testing/sound/playing/GOTestReleaseAlignTable.h
@@ -15,6 +15,12 @@ class GOTestReleaseAlignTable : public GOTest {
 private:
   static const std::string TEST_NAME;
 
+  void TestComputeBucketIndexNormal();
+  void TestComputeBucketIndexBelowRange();
+  void TestComputeBucketIndexAboveRange();
+  void TestComputeBucketIndexZeroMaxValue();
+  void TestComputeBucketIndexBoundaries();
+
   /**
    * Regression test for the original bug: when only one cell in the table is
    * filled, its direct vertical neighbor (same amplitude, other derivative row)


### PR DESCRIPTION
Resolves: #2504

## Summary

Fixes two bugs in `GOSoundReleaseAlignTable::GetPositionFor()` reported in issue #2504.

**Root cause 1 — assert before clamp (confirmed crash in debug builds):**
In `GetPositionFor()` the assert on `derivIndex`/`ampIndex` fired *before* the clamp, so releasing a note when the live signal's amplitude or derivative exceeded the maximum seen during `ComputeTable()` would crash in debug builds. `ComputeTable()` in the same file already had the correct order (clamp then assert).

**Root cause 2 — channel count mismatch (latent):**
`GetPositionFor()` summed over `MAX_OUTPUT_CHANNELS = 2`, while `ComputeTable()` summed over the section's actual channel count. For mono samples, `GetHistory()` zeroes unused slots via `memset`, so there was no wrong-value bug today, but the implicit contract was fragile.

## Changes

- **`computeBucketIndex` private static helper** — clamps the physical value (`shiftedValue`) *before* dividing into a bucket index (not the index after), handles `maxValue == 0`, uses `std::clamp`. Both `ComputeTable()` and `GetPositionFor()` now go through this helper, so the clamping logic is shared and consistent.
- **`nChannels` parameter added to `GetPositionFor()`** — caller passes `pSection->GetChannels()` so the summation loop matches `ComputeTable()` exactly.
- **`unsigned` types** for `m_PhaseAlignMaxAmplitude`, `m_PhaseAlignMaxDerivative`, `m_PositionEntries`, `m_MaxAbsAmplitude`, `m_MaxAbsDerivative` — all are non-negative magnitudes; `std::max` used for maximum tracking.
- **Unit test** `GOTestReleaseAlignTable` covers `computeBucketIndex`: normal mapping, below-range clamp, above-range clamp, `maxValue == 0` fallback, boundary values.

The first commit adds only the empty `GOTestReleaseAlignTable` stub and `friend` declaration — it can be cherry-picked as a common base for the related `bugfix/assert-foundsecond` branch.

## Test plan

- [ ] Debug build: release a note and confirm no assertion fires in `GetPositionFor()`
- [ ] `./bin/GOTestExe` — `GOTestReleaseAlignTable succeeded`
- [ ] All other functional tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)