### PR TITLE
Fix heap buffer overflow in GOSoundOutputTask meter info update

### DIFF
--- a/src/grandorgue/sound/tasks/GOSoundOutputTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundOutputTask.cpp
@@ -79,21 +79,19 @@ void GOSoundOutputTask::Run(GOSoundThread *pThread) {
   float *pMeterInfo = m_MeterInfo.data();
 
   for (unsigned nItems = GetNItems(), itemI = 0, channelI = 0; itemI < nItems;
-       itemI++, pData++, pMeterInfo++) {
+       itemI++, pData++) {
     float f = std::clamp(*pData, CLAMP_MIN, CLAMP_MAX);
     float absF = std::abs(f);
 
     if (f != *pData)
       *pData = f;
-    if (absF > *pMeterInfo)
-      *pMeterInfo = absF;
+    if (absF > pMeterInfo[channelI])
+      pMeterInfo[channelI] = absF;
 
     // Move to next channel (circular: after last channel, wrap to first)
     channelI++;
-    if (channelI >= nChannels) {
+    if (channelI >= nChannels)
       channelI = 0;
-      pMeterInfo = m_MeterInfo.data();
-    }
   }
 
   m_Done.store(true);


### PR DESCRIPTION
## Summary

Fixes #2531

`GOSoundOutputTask::Run()` indexed `m_MeterInfo` (one float per channel) through a raw pointer that was incremented in two independent places: unconditionally by the `for` loop's own increment clause, and additionally reset inside the loop body on channel wrap-around. The loop header's increment always runs *after* the body, so right after a wrap-around reset, the pointer immediately gets bumped one element past where it should be - drifting it out of sync with the (correctly wrapped) `channelI` index. Every second wrap-around this overflows `m_MeterInfo` by one element, writing past the end of its heap allocation.

Confirmed as a real heap corruption via Application Verifier's Page Heap on Windows (`Corrupted suffix pattern for heap block`, 8-byte block = a 2-channel `m_MeterInfo`, corruption address = block start + 8).

## Fix

Index `m_MeterInfo` via `channelI` directly (`pMeterInfo[channelI]`) instead of maintaining a second, separately-advanced pointer. `channelI` is now the only thing that determines the position, removing the possibility of drift.

```diff
   for (unsigned nItems = GetNItems(), itemI = 0, channelI = 0; itemI < nItems;
-       itemI++, pData++, pMeterInfo++) {
+       itemI++, pData++) {
     float f = std::clamp(*pData, CLAMP_MIN, CLAMP_MAX);
     float absF = std::abs(f);

     if (f != *pData)
       *pData = f;
-    if (absF > *pMeterInfo)
-      *pMeterInfo = absF;
+    if (absF > pMeterInfo[channelI])
+      pMeterInfo[channelI] = absF;

     // Move to next channel (circular: after last channel, wrap to first)
     channelI++;
-    if (channelI >= nChannels) {
+    if (channelI >= nChannels)
       channelI = 0;
-      pMeterInfo = m_MeterInfo.data();
-    }
   }
```

Introduced in 4f848c81f / #2418 (3.17.1).

## Test plan

- [x] Compiles cleanly (`-fsyntax-only` against the win64 cross-toolchain)
- [x] Root cause confirmed by reproducing the corruption under Application Verifier's Page Heap on the *unfixed* code (Audio Panic with a loaded organ, `-Og -g` build) - the report's address/size matched this exact allocation
- [ ] Re-running the same repro with this fix applied, to confirm the corruption no longer occurs, is still pending
