### PR TITLE
Fix heap overflow and wrong channel metering in GOSoundOutputTask https://github.com/GrandOrgue/grandorgue/issues/2531

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed heap overflow and wrong channel metering in audio output task https://github.com/GrandOrgue/grandorgue/issues/2531
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494

--- a/src/grandorgue/sound/tasks/GOSoundOutputTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundOutputTask.cpp
@@ -76,10 +76,10 @@ void GOSoundOutputTask::Run(GOSoundThread *pThread) {
 
   /* Clamp the output and put the maximum amplitude to m_MeterInfo */
   float *pData = GetData();
+  unsigned nChannelsRest = nChannels;
   float *pMeterInfo = m_MeterInfo.data();
 
-  for (unsigned nItems = GetNItems(), itemI = 0, channelI = 0; itemI < nItems;
-       itemI++, pData++, pMeterInfo++) {
+  for (unsigned nItemsRest = GetNItems(); nItemsRest; nItemsRest--, pData++) {
     float f = std::clamp(*pData, CLAMP_MIN, CLAMP_MAX);
     float absF = std::abs(f);
 
@@ -89,9 +89,9 @@ void GOSoundOutputTask::Run(GOSoundThread *pThread) {
       *pMeterInfo = absF;
 
     // Move to next channel (circular: after last channel, wrap to first)
-    channelI++;
-    if (channelI >= nChannels) {
-      channelI = 0;
+    pMeterInfo++;
+    if (!--nChannelsRest) {
+      nChannelsRest = nChannels;
       pMeterInfo = m_MeterInfo.data();
     }
   }


### PR DESCRIPTION
## Summary

Fixes #2531

`GOSoundOutputTask::Run()` had two bugs in its meter-info update loop,
both introduced by commit 4f848c81 (#2418).

### Root cause

The `for`-loop header contained `pMeterInfo++` as an unconditional
increment, while the wrap-around reset (`pMeterInfo = m_MeterInfo.data()`)
was inside the body.  Because the increment runs *after* the body,
every wrap-around was immediately followed by an extra `++`, drifting
the pointer one element ahead of the logical channel index (`channelI`).

### Two consequences

**1. Heap buffer overflow**

Every odd R-channel sample caused `pMeterInfo` to reach
`m_MeterInfo.data() + nChannels` — one element past the end of the
vector — and write a `float` there.  For a 2-channel output this
corrupts 4 bytes after an 8-byte heap allocation on every audio buffer,
continuously and deterministically during playback.

**2. Wrong channel VU levels**

Starting from the second audio frame, L-channel samples were
accumulated into `m_MeterInfo[1]` (R meter) instead of `m_MeterInfo[0]`
(L meter).  `m_MeterInfo[0]` only ever received the very first L sample
of the buffer.  Result: the left VU-meter was almost always
under-reading; the right VU-meter was over-reading because it mixed in
left-channel content.

### Fix

Remove `pMeterInfo++` from the loop header.  Advance the pointer inside
the body with a `nChannelsRest` countdown, so the wrap-around reset and
the advance are a single, self-consistent step with no extra increment.

### Note on the upstream PR #2532

The fix in #2532 (indexing via `pMeterInfo[channelI]`) is also correct.
Both approaches eliminate the drift; the difference is stylistic.

## Test plan

- [ ] Build and load an organ; confirm no crash / heap corruption under
      Application Verifier Page Heap (Windows) or ASan (Linux)
- [ ] Visually verify that L/R VU-meters track the correct channels
      (e.g. play a mono signal panned hard left — only the left meter
      should move)