### PR TITLE
Fix macOS 15 CI build failure: install berkeley-db@5

### DIFF
--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -9,6 +9,7 @@ brew link --overwrite pkg-config
 cmake --version || brew install cmake
 
 brew install \
+  berkeley-db@5 \
   docbook \
   docbook-xsl \
   fftw wavpack \


### PR DESCRIPTION
## Summary

- macOS 15 CI builds have been failing since the runner image update to `20260622.0255.1` (Xcode 16.4, macOS 15.7.7)
- Root cause: CMake's `fixup_bundle` runs `otool -l` on all transitive dylib dependencies of the GrandOrgue binary and encounters `/usr/local/opt/berkeley-db@5/lib/libdb-5.3.dylib` — referenced by one of the installed brew packages (likely `imagemagick` or `jack`) but not installed on the runner
- Fix: add `berkeley-db@5` to the `brew install` list in `build-scripts/for-osx/prepare-osx.sh`

## Affected runs

| Date | Branch | Error |
|---|---|---|
| 2026-06-26 | master | `otool-classic: can't open file: …libdb-5.3.dylib` |
| 2026-06-28 | bugfix/memory-corruption | same |

## Test plan

- [ ] CI job `build (macos-15-intel, osx, osx, osx)` passes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)