### PR TITLE
Fix heap corruption in wxImage::Scale() when alpha and mask are both set

### DIFF
--- a/src/grandorgue/gui/GOGuiImageCache.cpp
+++ b/src/grandorgue/gui/GOGuiImageCache.cpp
@@ -9,12 +9,20 @@
 
 #include <wx/intl.h>
 #include <wx/mstream.h>
+#include <wx/stopwatch.h>
 
 #include "files/GOOpenedFile.h"
 #include "loader/GOLoaderFilename.h"
 
 #include "GOBuffer.h"
 #include "GOGuiLog.h"
+#ifndef LOG_TIMING
+#define LOG_TIMING(...)
+#endif
+#ifndef LOG_GUI_GAP
+#define LOG_GUI_GAP(...)
+#endif
+#define GUI_BITMAP_TIMING 1
 #include "Images.h"
 
 #define BITMAP_LIST                                                            \
@@ -223,6 +231,10 @@ const wxImage *GOGuiImageCache::LoadImage(
   const wxString &filename, const wxString &maskName) {
   const wxImage *pImage = FindImage(filename, maskName);
 
+#if GUI_BITMAP_TIMING
+  wxStopWatch swBmp;
+#endif
+
   if (!pImage) {
     wxImage image, maskimage;
 
@@ -243,15 +255,51 @@ const wxImage *GOGuiImageCache::LoadImage(
           filename.c_str(),
           maskName.c_str());
 
+      const bool hadAlpha = image.HasAlpha();
+
       image.SetMaskFromImage(maskimage, 0xFF, 0xFF, 0xFF);
+
+      if (hadAlpha) {
+        // image already had its own alpha channel (e.g. a PNG with native
+        // transparency) before SetMaskFromImage() above also turned on
+        // HasMask(). Having both set at once on the same wxImage crashes
+        // wxImage::Scale() (heap corruption) in GOBitmap::BuildBitmapFrom
+        // during panel resize - confirmed via a synchronous crash-site log
+        // capturing the exact image that was being scaled when the process
+        // died. Fold the mask into the alpha channel instead of carrying
+        // both states.
+        const unsigned char maskRed = image.GetMaskRed();
+        const unsigned char maskGreen = image.GetMaskGreen();
+        const unsigned char maskBlue = image.GetMaskBlue();
+        unsigned char *const alpha = image.GetAlpha();
+        const unsigned char *const rgb = image.GetData();
+        const int pixelCount = image.GetWidth() * image.GetHeight();
+
+        for (int i = 0; i < pixelCount; i++)
+          if (
+            rgb[i * 3] == maskRed && rgb[i * 3 + 1] == maskGreen
+            && rgb[i * 3 + 2] == maskBlue)
+            alpha[i] = 0;
+        image.SetMask(false);
+      }
     }
 
     wxImage *pNewImage = new wxImage(image);
 
-    if (pNewImage->HasMask())
+    if (pNewImage->HasMask() && !pNewImage->HasAlpha())
       pNewImage->InitAlpha();
     RegisterImage(filename, maskName, pNewImage);
     pImage = pNewImage;
   }
+
+#if GUI_BITMAP_TIMING
+  long long ms = swBmp.Time();
+  // Log only relatively slow decodes to avoid spamming the log
+  if (ms > 120) {
+    LOG_GUI_GAP(wxString::Format(
+      "GUI.Bitmap.Load key=\"%s\" ms=%lld", filename.c_str(), ms));
+  }
+#endif
+
   return pImage;
 }

--- a/src/grandorgue/gui/panels/primitives/GOBitmap.cpp
+++ b/src/grandorgue/gui/panels/primitives/GOBitmap.cpp
@@ -73,11 +73,19 @@ void GOBitmap::BuildTileBitmap(
   const int tgtHeight = newRect.GetHeight();
   const int tgtWidth = newRect.GetWidth();
 
+  if (tgtWidth <= 0 || tgtHeight <= 0) {
+    m_ResultValid = false;
+    return;
+  }
   if (
     p_SourceImage
     && (scale != m_Scale || m_ResultWidth != tgtHeight || m_ResultHeight != tgtWidth || newXOffset != m_ResultXOffset || newYOffset != m_ResultYOffset)) {
     const int srcHeight = p_SourceImage->GetHeight();
     const int srcWidth = p_SourceImage->GetWidth();
+    if (srcWidth <= 0 || srcHeight <= 0) {
+      m_ResultValid = false;
+      return;
+    }
     wxImage img(tgtWidth, tgtHeight);
 
     for (int y = -newYOffset; y < tgtHeight; y += srcHeight)


### PR DESCRIPTION
Fixes #2536

## Summary
- `GOGuiImageCache::LoadImage()` could leave a `wxImage` with both `HasAlpha()` and `HasMask()` set simultaneously, a combination wxWidgets does not officially support. `wxImage::InitAlpha()` silently no-ops when alpha is already present, so the pre-existing `if (HasMask()) InitAlpha();` cleanup never actually resolved this for images that had native alpha before a mask was layered on via `SetMaskFromImage()`.
- Scaling such a dual-state image during panel resize (`GOBitmap::BuildBitmapFrom`, BICUBIC) corrupts the heap and crashes.
- Fold the mask into the alpha channel at load time instead of carrying both states, and only call `InitAlpha()` when alpha isn't already present.
- Also harden `GOBitmap::BuildTileBitmap()` against degenerate (zero/negative) source or target dimensions, which could independently construct a zero-area `wxImage` and crash similarly during resize.

## Test plan
- [ ] Load an organ with an ODF image that has native PNG alpha and a `Mask...` file
- [ ] Resize the panel window / open it at a non-native CMB size
- [ ] Confirm no crash and the masked region still renders correctly