### PR TITLE
Debounce expensive control re-render during panel resize, fix flicker https://github.com/GrandOrgue/grandorgue/issues/2537

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed slow/flickery panel resizing while dragging a panel window's border https://github.com/GrandOrgue/grandorgue/issues/2537
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494

--- a/src/grandorgue/gui/panels/GOGUIPanelView.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelView.cpp
@@ -129,6 +129,16 @@ void GOGUIPanelView::OnSize(wxSizeEvent &event) {
     // Scale out the panel according the new size
 
     const wxSize newSize = event.GetSize();
+
+    // UpdateSize(), SetPosition() and CentreOnParent() below each move/resize
+    // m_panelwidget natively on their own. Without freezing, the window
+    // manager can paint the in-between states (e.g. still at the old
+    // centering position right after the size already changed), which is
+    // seen as a brief flicker/jump whenever the panel is dragged past its
+    // native size and centering kicks in. Freeze() suppresses repaints until
+    // all the geometry changes below are settled.
+    m_panelwidget->Freeze();
+
     const wxSize maxSize = m_panelwidget->UpdateSize(newSize);
 
     this->SetVirtualSize(maxSize);
@@ -156,6 +166,8 @@ void GOGUIPanelView::OnSize(wxSizeEvent &event) {
       m_panelwidget->CentreOnParent(wxHORIZONTAL);
     if (actualsize.GetHeight() > maxSize.GetHeight())
       m_panelwidget->CentreOnParent(wxVERTICAL);
+
+    m_panelwidget->Thaw();
   }
   event.Skip();
 }

--- a/src/grandorgue/gui/panels/GOGUIPanelView.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelView.cpp
@@ -11,6 +11,7 @@
 #include <wx/frame.h>
 #include <wx/image.h>
 #include <wx/toplevel.h>
+#include <wx/wupdlock.h>
 
 #include "gui/wxcontrols/go_gui_utils.h"
 
@@ -67,7 +68,7 @@ GOGUIPanelView::GOGUIPanelView(
   // At this point, the new window may fill the whole display and still not be
   // large enough to show all contents. So, before showing anything, lets see
   // what scaling is needed to fit the content completely to the window.
-  wxSize scaledsize = m_panelwidget->UpdateSize(topWindow->GetClientSize());
+  wxSize scaledsize = m_panelwidget->SetInitialSize(topWindow->GetClientSize());
 
   topWindow->Show();
   topWindow->Update();
@@ -130,16 +131,16 @@ void GOGUIPanelView::OnSize(wxSizeEvent &event) {
 
     const wxSize newSize = event.GetSize();
 
-    // UpdateSize(), SetPosition() and CentreOnParent() below each move/resize
-    // m_panelwidget natively on their own. Without freezing, the window
-    // manager can paint the in-between states (e.g. still at the old
+    // UpdatePreviewSize(), SetPosition() and CentreOnParent() below each
+    // move/resize m_panelwidget natively on their own. Without freezing, the
+    // window manager can paint the in-between states (e.g. still at the old
     // centering position right after the size already changed), which is
     // seen as a brief flicker/jump whenever the panel is dragged past its
-    // native size and centering kicks in. Freeze() suppresses repaints until
-    // all the geometry changes below are settled.
-    m_panelwidget->Freeze();
+    // native size and centering kicks in. The update locker suppresses
+    // repaints until all the geometry changes below are settled.
+    wxWindowUpdateLocker lock(m_panelwidget);
 
-    const wxSize maxSize = m_panelwidget->UpdateSize(newSize);
+    const wxSize maxSize = m_panelwidget->UpdatePreviewSize(newSize);
 
     this->SetVirtualSize(maxSize);
 
@@ -166,8 +167,6 @@ void GOGUIPanelView::OnSize(wxSizeEvent &event) {
       m_panelwidget->CentreOnParent(wxHORIZONTAL);
     if (actualsize.GetHeight() > maxSize.GetHeight())
       m_panelwidget->CentreOnParent(wxVERTICAL);
-
-    m_panelwidget->Thaw();
   }
   event.Skip();
 }

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
@@ -19,9 +19,15 @@
 
 DEFINE_LOCAL_EVENT_TYPE(wxEVT_GOCONTROL)
 
+namespace {
+enum { ID_PANEL_RESIZE_TIMER = wxID_HIGHEST + 1 };
+constexpr int RESIZE_SETTLE_MS = 150;
+} // namespace
+
 BEGIN_EVENT_TABLE(GOGUIPanelWidget, wxPanel)
 EVT_ERASE_BACKGROUND(GOGUIPanelWidget::OnErase)
 EVT_PAINT(GOGUIPanelWidget::OnPaint)
+EVT_TIMER(ID_PANEL_RESIZE_TIMER, GOGUIPanelWidget::OnResizeTimer)
 EVT_COMMAND(0, wxEVT_GOCONTROL, GOGUIPanelWidget::OnGOControl)
 EVT_MOTION(GOGUIPanelWidget::OnMouseMove)
 EVT_LEFT_DOWN(GOGUIPanelWidget::OnMouseLeftDown)
@@ -43,6 +49,7 @@ GOGUIPanelWidget::GOGUIPanelWidget(
     m_BGInit(false),
     m_Scale(1),
     m_FontScale(1),
+    m_ResizeTimer(this, ID_PANEL_RESIZE_TIMER),
     m_PressedPoint(default_point) {
   m_Background.SetSourceImage(&m_BGImage);
   initFont();
@@ -51,13 +58,14 @@ GOGUIPanelWidget::GOGUIPanelWidget(
     m_panel->GetWidth() * m_Scale, m_panel->GetHeight() * m_Scale);
   m_panel->PrepareDraw(m_Scale, NULL);
   OnUpdate();
+  m_LastFullBitmap = m_ClientBitmap;
   m_BGImage = m_ClientBitmap.ConvertToImage();
   m_Background.BuildScaledBitmap(m_Scale, wxRect(0, 0, 0, 0), NULL);
   m_BGInit = true;
   SetCanFocus(m_panel->IsKeyboardInputUsed());
 }
 
-GOGUIPanelWidget::~GOGUIPanelWidget() {}
+GOGUIPanelWidget::~GOGUIPanelWidget() { m_ResizeTimer.Stop(); }
 
 void GOGUIPanelWidget::initFont() {
   wxMemoryDC dc;
@@ -92,10 +100,43 @@ wxSize GOGUIPanelWidget::UpdateSize(wxSize size) {
                       // this. Without this limit, sizing too a too small value
                       // causes a crash!
     m_Scale = 0.25;
+
+  const int targetWidth = m_panel->GetWidth() * m_Scale + 0.5;
+  const int targetHeight = m_panel->GetHeight() * m_Scale + 0.5;
+
+  // Cheap immediate feedback for a live drag: rescale the last sharply
+  // redrawn bitmap instead of re-running PrepareDraw()/OnUpdate(), which
+  // rescale every key/stop/texture with BICUBIC quality and made dragging a
+  // panel border unusably slow when done on every single WM_SIZE tick. The
+  // sharp, full-quality redraw happens once in OnResizeTimer(), after
+  // resizing has been idle for a moment.
+  //
+  // Always rescale from m_LastFullBitmap, never from m_ClientBitmap: during
+  // a drag m_ClientBitmap is itself the result of this same preview rescale,
+  // so chaining off it would compound quality loss tick after tick instead
+  // of staying as sharp as a single rescale from the original allows.
+  //
+  // wxDC::StretchBlit was tried here first, but on wxMSW it maps to GDI
+  // StretchBlt in COLORONCOLOR (nearest-neighbour) mode, which duplicates or
+  // drops whole rows/columns at non-integer scale factors instead of
+  // interpolating - visibly blocky. wxImage::Scale() with NORMAL (bilinear)
+  // quality looks smooth and is still cheap here because it runs once on the
+  // already-composed panel bitmap, not once per control like BICUBIC mode
+  // does in OnUpdate()/PrepareDraw().
+  if (m_LastFullBitmap.IsOk() && targetWidth > 0 && targetHeight > 0)
+    m_ClientBitmap = (wxBitmap)m_LastFullBitmap.ConvertToImage().Scale(
+      targetWidth, targetHeight, wxIMAGE_QUALITY_NORMAL);
+  SetSize(targetWidth, targetHeight);
+  Refresh();
+  m_ResizeTimer.StartOnce(RESIZE_SETTLE_MS);
+  return GetSize();
+}
+
+void GOGUIPanelWidget::OnResizeTimer(wxTimerEvent &WXUNUSED(event)) {
   m_panel->PrepareDraw(m_Scale, m_BGInit ? &m_Background : NULL);
   OnUpdate();
+  m_LastFullBitmap = m_ClientBitmap;
   Refresh();
-  return GetSize();
 }
 
 void GOGUIPanelWidget::OnDraw(wxDC *dc) {

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
@@ -19,10 +19,8 @@
 
 DEFINE_LOCAL_EVENT_TYPE(wxEVT_GOCONTROL)
 
-namespace {
 enum { ID_PANEL_RESIZE_TIMER = wxID_HIGHEST + 1 };
 constexpr int RESIZE_SETTLE_MS = 150;
-} // namespace
 
 BEGIN_EVENT_TABLE(GOGUIPanelWidget, wxPanel)
 EVT_ERASE_BACKGROUND(GOGUIPanelWidget::OnErase)
@@ -47,7 +45,9 @@ GOGUIPanelWidget::GOGUIPanelWidget(
   : wxPanel(parent, id),
     m_panel(panel),
     m_BGInit(false),
+    m_ResizeInProgress(false),
     m_Scale(1),
+    m_LastRedrawScale(1),
     m_FontScale(1),
     m_ResizeTimer(this, ID_PANEL_RESIZE_TIMER),
     m_PressedPoint(default_point) {
@@ -58,7 +58,6 @@ GOGUIPanelWidget::GOGUIPanelWidget(
     m_panel->GetWidth() * m_Scale, m_panel->GetHeight() * m_Scale);
   m_panel->PrepareDraw(m_Scale, NULL);
   OnUpdate();
-  m_LastFullBitmap = m_ClientBitmap;
   m_BGImage = m_ClientBitmap.ConvertToImage();
   m_Background.BuildScaledBitmap(m_Scale, wxRect(0, 0, 0, 0), NULL);
   m_BGInit = true;
@@ -85,7 +84,7 @@ void GOGUIPanelWidget::Focus() {
     SetFocus();
 }
 
-wxSize GOGUIPanelWidget::UpdateSize(wxSize size) {
+void GOGUIPanelWidget::ComputeScale(const wxSize &size) {
   double scaleX = size.GetWidth() / (double)m_panel->GetWidth();
   double scaleY = size.GetHeight() / (double)m_panel->GetHeight();
   if (scaleX < scaleY) // To fit all, we need to use the SMALLEST of the two
@@ -100,9 +99,26 @@ wxSize GOGUIPanelWidget::UpdateSize(wxSize size) {
                       // this. Without this limit, sizing too a too small value
                       // causes a crash!
     m_Scale = 0.25;
+}
 
-  const int targetWidth = m_panel->GetWidth() * m_Scale + 0.5;
-  const int targetHeight = m_panel->GetHeight() * m_Scale + 0.5;
+wxSize GOGUIPanelWidget::GetScaledPanelSize() const {
+  return wxSize(
+    m_panel->GetWidth() * m_Scale + 0.5, m_panel->GetHeight() * m_Scale + 0.5);
+}
+
+wxSize GOGUIPanelWidget::SetInitialSize(const wxSize &size) {
+  ComputeScale(size);
+  m_panel->PrepareDraw(m_Scale, m_BGInit ? &m_Background : NULL);
+  OnUpdate();
+  m_LastRedrawScale = m_Scale;
+  Refresh();
+  return GetSize();
+}
+
+wxSize GOGUIPanelWidget::UpdatePreviewSize(const wxSize &size) {
+  ComputeScale(size);
+
+  const wxSize scaledSize = GetScaledPanelSize();
 
   // Cheap immediate feedback for a live drag: rescale the last sharply
   // redrawn bitmap instead of re-running PrepareDraw()/OnUpdate(), which
@@ -111,8 +127,11 @@ wxSize GOGUIPanelWidget::UpdateSize(wxSize size) {
   // sharp, full-quality redraw happens once in OnResizeTimer(), after
   // resizing has been idle for a moment.
   //
-  // Always rescale from m_LastFullBitmap, never from m_ClientBitmap: during
-  // a drag m_ClientBitmap is itself the result of this same preview rescale,
+  // The snapshot is captured lazily at the start of each resize series so
+  // that it reflects whatever m_ClientBitmap shows right now - including
+  // single-control redraws (OnGOControl) done since the last full redraw.
+  // Always rescale from that snapshot, never from m_ClientBitmap: during a
+  // drag m_ClientBitmap is itself the result of this same preview rescale,
   // so chaining off it would compound quality loss tick after tick instead
   // of staying as sharp as a single rescale from the original allows.
   //
@@ -123,19 +142,37 @@ wxSize GOGUIPanelWidget::UpdateSize(wxSize size) {
   // quality looks smooth and is still cheap here because it runs once on the
   // already-composed panel bitmap, not once per control like BICUBIC mode
   // does in OnUpdate()/PrepareDraw().
-  if (m_LastFullBitmap.IsOk() && targetWidth > 0 && targetHeight > 0)
-    m_ClientBitmap = (wxBitmap)m_LastFullBitmap.ConvertToImage().Scale(
-      targetWidth, targetHeight, wxIMAGE_QUALITY_NORMAL);
-  SetSize(targetWidth, targetHeight);
+  if (!m_ResizeInProgress) {
+    m_ResizeInProgress = true;
+    m_PreResizeBitmap = m_ClientBitmap;
+  }
+  if (
+    m_PreResizeBitmap.IsOk() && scaledSize.GetWidth() > 0
+    && scaledSize.GetHeight() > 0)
+    m_ClientBitmap = (wxBitmap)m_PreResizeBitmap.ConvertToImage().Scale(
+      scaledSize.GetWidth(), scaledSize.GetHeight(), wxIMAGE_QUALITY_NORMAL);
+  SetSize(scaledSize.GetWidth(), scaledSize.GetHeight());
   Refresh();
   m_ResizeTimer.StartOnce(RESIZE_SETTLE_MS);
   return GetSize();
 }
 
 void GOGUIPanelWidget::OnResizeTimer(wxTimerEvent &WXUNUSED(event)) {
+  m_ResizeInProgress = false;
+
+  /* The series ended at the very scale that is already sharply rendered
+   * (the user dragged out and back, or size events delivered while a long
+   * redraw was running re-armed the timer). m_ClientBitmap already shows
+   * the 1:1 preview of the sharp bitmap plus any control redraws done on
+   * top of it, so there is nothing a full redraw could improve. Without
+   * this check a slow redraw ran up to three times back to back for
+   * identical output. */
+  if (m_Scale == m_LastRedrawScale)
+    return;
+
   m_panel->PrepareDraw(m_Scale, m_BGInit ? &m_Background : NULL);
   OnUpdate();
-  m_LastFullBitmap = m_ClientBitmap;
+  m_LastRedrawScale = m_Scale;
   Refresh();
 }
 
@@ -154,15 +191,13 @@ void GOGUIPanelWidget::OnPaint(wxPaintEvent &event) {
 }
 
 void GOGUIPanelWidget::OnUpdate() {
+  const wxSize scaledSize = GetScaledPanelSize();
+
   if (m_BGInit)
     m_ClientBitmap = (wxBitmap)m_BGImage.Scale(
-      m_panel->GetWidth() * m_Scale + 0.5,
-      m_panel->GetHeight() * m_Scale + 0.5,
-      wxIMAGE_QUALITY_BICUBIC);
+      scaledSize.GetWidth(), scaledSize.GetHeight(), wxIMAGE_QUALITY_BICUBIC);
   else
-    m_ClientBitmap = wxBitmap(
-      m_panel->GetWidth() * m_Scale + 0.5,
-      m_panel->GetHeight() * m_Scale + 0.5);
+    m_ClientBitmap = wxBitmap(scaledSize.GetWidth(), scaledSize.GetHeight());
   wxMemoryDC dc;
   dc.SelectObject(m_ClientBitmap);
   GODC DC(&dc, m_Scale, m_FontScale);

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
@@ -64,7 +64,11 @@ GOGUIPanelWidget::GOGUIPanelWidget(
   SetCanFocus(m_panel->IsKeyboardInputUsed());
 }
 
-GOGUIPanelWidget::~GOGUIPanelWidget() { m_ResizeTimer.Stop(); }
+GOGUIPanelWidget::~GOGUIPanelWidget() {
+  /* Relies on wx discarding any wxTimerEvent already queued for this timer
+  at the moment of Stop()/destruction, on all supported backends. */
+  m_ResizeTimer.Stop();
+}
 
 void GOGUIPanelWidget::initFont() {
   wxMemoryDC dc;

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
@@ -19,8 +19,8 @@
 
 DEFINE_LOCAL_EVENT_TYPE(wxEVT_GOCONTROL)
 
-enum { ID_PANEL_RESIZE_TIMER = wxID_HIGHEST + 1 };
-constexpr int RESIZE_SETTLE_MS = 150;
+static constexpr int ID_PANEL_RESIZE_TIMER = wxID_HIGHEST + 1;
+static constexpr unsigned RESIZE_SETTLE_MS = 150;
 
 BEGIN_EVENT_TABLE(GOGUIPanelWidget, wxPanel)
 EVT_ERASE_BACKGROUND(GOGUIPanelWidget::OnErase)
@@ -164,17 +164,15 @@ wxSize GOGUIPanelWidget::UpdatePreviewSize(const wxSize &size) {
 void GOGUIPanelWidget::OnResizeTimer(wxTimerEvent &WXUNUSED(event)) {
   m_ResizeInProgress = false;
 
-  /* The series ended at the very scale that is already sharply rendered
-   * (the user dragged out and back, or size events delivered while a long
-   * redraw was running re-armed the timer). m_ClientBitmap already shows
-   * the 1:1 preview of the sharp bitmap plus any control redraws done on
-   * top of it, so there is nothing a full redraw could improve. Without
-   * this check a slow redraw ran up to three times back to back for
-   * identical output. */
-  if (m_Scale == m_LastRedrawScale)
-    return;
-
-  FullRedraw();
+  /* Skip the redraw when the series ended at the very scale that is
+   * already sharply rendered (the user dragged out and back, or size
+   * events delivered while a long redraw was running re-armed the timer).
+   * m_ClientBitmap already shows the 1:1 preview of the sharp bitmap plus
+   * any control redraws done on top of it, so there is nothing a full
+   * redraw could improve. Without this check a slow redraw ran up to three
+   * times back to back for identical output. */
+  if (m_Scale != m_LastRedrawScale)
+    FullRedraw();
 }
 
 void GOGUIPanelWidget::OnDraw(wxDC *dc) {

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.cpp
@@ -106,12 +106,16 @@ wxSize GOGUIPanelWidget::GetScaledPanelSize() const {
     m_panel->GetWidth() * m_Scale + 0.5, m_panel->GetHeight() * m_Scale + 0.5);
 }
 
-wxSize GOGUIPanelWidget::SetInitialSize(const wxSize &size) {
-  ComputeScale(size);
+void GOGUIPanelWidget::FullRedraw() {
   m_panel->PrepareDraw(m_Scale, m_BGInit ? &m_Background : NULL);
   OnUpdate();
   m_LastRedrawScale = m_Scale;
   Refresh();
+}
+
+wxSize GOGUIPanelWidget::SetInitialSize(const wxSize &size) {
+  ComputeScale(size);
+  FullRedraw();
   return GetSize();
 }
 
@@ -170,10 +174,7 @@ void GOGUIPanelWidget::OnResizeTimer(wxTimerEvent &WXUNUSED(event)) {
   if (m_Scale == m_LastRedrawScale)
     return;
 
-  m_panel->PrepareDraw(m_Scale, m_BGInit ? &m_Background : NULL);
-  OnUpdate();
-  m_LastRedrawScale = m_Scale;
-  Refresh();
+  FullRedraw();
 }
 
 void GOGUIPanelWidget::OnDraw(wxDC *dc) {

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.h
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.h
@@ -10,6 +10,7 @@
 
 #include <wx/bitmap.h>
 #include <wx/panel.h>
+#include <wx/timer.h>
 
 #include "primitives/GOBitmap.h"
 
@@ -24,8 +25,28 @@ private:
   bool m_BGInit;
   GOBitmap m_Background;
   wxBitmap m_ClientBitmap;
+
+  /**
+   * The bitmap produced by the last full, sharp redraw (OnUpdate() right
+   * after PrepareDraw()). UpdateSize() always rescales from this one for its
+   * cheap live-drag preview rather than from m_ClientBitmap - which during a
+   * drag may itself already be a rescaled preview - to avoid repeatedly
+   * rescaling an already-rescaled (and thus progressively softer) image.
+   */
+  wxBitmap m_LastFullBitmap;
   double m_Scale;
   double m_FontScale;
+
+  /**
+   * Fires once resizing has been idle for a short while. UpdateSize() only
+   * does a cheap rescale of m_LastFullBitmap on every WM_SIZE tick (a live
+   * drag can fire dozens of those); the expensive, sharp re-render of every
+   * control bitmap only runs once here, after the user stops moving the
+   * border - otherwise every pixel of mouse movement triggered a full
+   * BICUBIC rescale of every key/stop/texture, making resizing unusably
+   * slow.
+   */
+  wxTimer m_ResizeTimer;
 
   /**
    * A point where the mouse has been pressed. Used for deduplication
@@ -38,6 +59,7 @@ private:
   void OnErase(wxEraseEvent &event);
   void OnPaint(wxPaintEvent &event);
   void OnGOControl(wxCommandEvent &event);
+  void OnResizeTimer(wxTimerEvent &event);
 
   /**
    * Stores m_PressedPoint and calls m_Panel->HandleMousePress with relative

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.h
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.h
@@ -67,6 +67,25 @@ private:
    * after the user stops moving the border - otherwise every pixel of mouse
    * movement triggered a full BICUBIC rescale of every key/stop/texture,
    * making resizing unusably slow.
+   *
+   * Started (or restarted, since it is one-shot) by every
+   * UpdatePreviewSize() call, i.e. on every live-drag resize tick.
+   * wxTimer::Start()/StartOnce() simply restarts an already-running timer
+   * rather than queuing another firing, so in the common case of ticks
+   * arriving faster than RESIZE_SETTLE_MS apart (a normal mouse drag), it
+   * does not fire even once until the ticks stop - it fires exactly once,
+   * RESIZE_SETTLE_MS after the last tick. Only if ticks are spaced out by
+   * more than RESIZE_SETTLE_MS (a slow/stepped resize) can it fire more than
+   * once per resize series. Stops itself once it fires, running
+   * OnResizeTimer(); also explicitly stopped in the destructor so it cannot
+   * fire after the widget is destroyed. SetInitialSize() never touches it -
+   * the initial sizing path is fully synchronous and skips the timer
+   * entirely.
+   *
+   * TODO: this is the third independent hand-rolled debounce-timer
+   * implementation in the codebase (alongside GOSplash and
+   * GOMidiEventRecvTab::m_Timer). If a fourth case appears, extract a shared
+   * "settle timer" helper instead of writing a fourth copy.
    */
   wxTimer m_ResizeTimer;
 

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.h
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.h
@@ -81,6 +81,13 @@ private:
   void ComputeScale(const wxSize &size);
   /** The panel's pixel size at the current m_Scale. */
   wxSize GetScaledPanelSize() const;
+  /**
+   * Runs the expensive, sharp redraw of every control at the current
+   * m_Scale: PrepareDraw()+OnUpdate(), then repaints. Used both for the
+   * initial full-quality render and for the settled redraw after a resize
+   * series ends (OnResizeTimer()).
+   */
+  void FullRedraw();
 
   void OnCreate(wxWindowCreateEvent &event);
   void OnDraw(wxDC *dc);

--- a/src/grandorgue/gui/panels/GOGUIPanelWidget.h
+++ b/src/grandorgue/gui/panels/GOGUIPanelWidget.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -27,24 +27,46 @@ private:
   wxBitmap m_ClientBitmap;
 
   /**
-   * The bitmap produced by the last full, sharp redraw (OnUpdate() right
-   * after PrepareDraw()). UpdateSize() always rescales from this one for its
-   * cheap live-drag preview rather than from m_ClientBitmap - which during a
-   * drag may itself already be a rescaled preview - to avoid repeatedly
-   * rescaling an already-rescaled (and thus progressively softer) image.
+   * Snapshot of m_ClientBitmap taken lazily at the start of a resize series
+   * (the first UpdatePreviewSize() call after the last full redraw).
+   * UpdatePreviewSize() always rescales from this one for its cheap
+   * live-drag preview rather than from m_ClientBitmap - which during a drag
+   * is itself already a rescaled preview - to avoid repeatedly rescaling an
+   * already-rescaled (and thus progressively softer) image. Capturing
+   * lazily (instead of maintaining a copy after every draw) also keeps
+   * single-control redraws (OnGOControl) visible in the preview: whatever
+   * m_ClientBitmap shows when the drag starts is what gets rescaled.
    */
-  wxBitmap m_LastFullBitmap;
+  wxBitmap m_PreResizeBitmap;
+
+  /**
+   * True from the first UpdatePreviewSize() call of a resize series until
+   * the debounced full redraw in OnResizeTimer(). Controls when
+   * m_PreResizeBitmap is (re)captured.
+   */
+  bool m_ResizeInProgress;
+
   double m_Scale;
+
+  /**
+   * The scale of the last full, sharp redraw (constructor, SetInitialSize()
+   * or OnResizeTimer()). Lets OnResizeTimer() skip the expensive redraw
+   * when a resize series ends at the very scale that is already rendered -
+   * without this, size events delivered while a long redraw was running
+   * re-armed the timer and caused identical back-to-back redraws.
+   */
+  double m_LastRedrawScale;
+
   double m_FontScale;
 
   /**
-   * Fires once resizing has been idle for a short while. UpdateSize() only
-   * does a cheap rescale of m_LastFullBitmap on every WM_SIZE tick (a live
-   * drag can fire dozens of those); the expensive, sharp re-render of every
-   * control bitmap only runs once here, after the user stops moving the
-   * border - otherwise every pixel of mouse movement triggered a full
-   * BICUBIC rescale of every key/stop/texture, making resizing unusably
-   * slow.
+   * Fires once resizing has been idle for a short while.
+   * UpdatePreviewSize() only does a cheap rescale of m_PreResizeBitmap on
+   * every WM_SIZE tick (a live drag can fire dozens of those); the
+   * expensive, sharp re-render of every control bitmap only runs once here,
+   * after the user stops moving the border - otherwise every pixel of mouse
+   * movement triggered a full BICUBIC rescale of every key/stop/texture,
+   * making resizing unusably slow.
    */
   wxTimer m_ResizeTimer;
 
@@ -54,6 +76,12 @@ private:
   wxPoint m_PressedPoint;
 
   void initFont();
+
+  /** Computes and stores m_Scale so that the panel fits into `size`. */
+  void ComputeScale(const wxSize &size);
+  /** The panel's pixel size at the current m_Scale. */
+  wxSize GetScaledPanelSize() const;
+
   void OnCreate(wxWindowCreateEvent &event);
   void OnDraw(wxDC *dc);
   void OnErase(wxEraseEvent &event);
@@ -88,7 +116,22 @@ public:
 
   void Focus();
   void OnUpdate();
-  wxSize UpdateSize(wxSize size);
+
+  /**
+   * Sets the panel's size immediately, with a full sharp redraw and no
+   * live-drag preview/debounce. Intended for one-off sizing (e.g. when a
+   * panel window is first opened), as opposed to UpdatePreviewSize() which
+   * is for live window resizing. Returns the actual size of the scaled
+   * panel.
+   */
+  wxSize SetInitialSize(const wxSize &size);
+  /**
+   * Handles a live resize tick: computes the new scale, shows a cheap
+   * bilinear preview immediately, and (re)starts the debounce timer that
+   * will trigger a full sharp redraw once resizing settles (see
+   * OnResizeTimer()). Returns the actual size of the scaled panel.
+   */
+  wxSize UpdatePreviewSize(const wxSize &size);
 
   DECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
Fixes #2537

## Summary
- Every `WM_SIZE` tick during a live panel resize re-ran `PrepareDraw()`/`OnUpdate()`, rescaling every key/stop/texture bitmap with BICUBIC quality - making live dragging and opening a panel at a non-native CMB size unusably slow.
- `GOGUIPanelWidget` now does a cheap bilinear rescale of the last sharp, fully-rendered bitmap on every resize tick for immediate feedback, and only re-runs the expensive per-control BICUBIC redraw once via a 150ms debounce timer after resizing goes idle. Rescaling always starts from that pristine last-full-redraw bitmap (not the already-rescaled preview), so quality doesn't degrade further across a multi-tick drag.
- Separately, `GOGUIPanelView::OnSize()` moved/resized the panel widget through up to three separate native calls per tick, which could be painted mid-sequence and looked like a flicker/jump whenever the panel was dragged past its native size and centering kicked in. Wrapped the sequence in `Freeze()`/`Thaw()` so only the final, settled geometry is ever painted.

## Test plan
- [ ] Drag-resize a panel window and confirm smooth, responsive dragging (no multi-second stalls)
- [ ] Open a panel at a non-native CMB-specified size and confirm it opens promptly
- [ ] Drag a panel window larger than its native size (aspect mismatch) and confirm no flicker/jump