### PR TITLE
Fixed crash when loading PNG images with embedded alpha channel used with mask images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash when loading PNG images with embedded alpha channel used with mask images https://github.com/GrandOrgue/grandorgue/issues/2535
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494

--- a/src/grandorgue/gui/GOGuiImageCache.cpp
+++ b/src/grandorgue/gui/GOGuiImageCache.cpp
@@ -248,8 +248,46 @@ const wxImage *GOGuiImageCache::LoadImage(
 
     wxImage *pNewImage = new wxImage(image);
 
-    if (pNewImage->HasMask())
-      pNewImage->InitAlpha();
+    if (pNewImage->HasMask()) {
+      if (!pNewImage->HasAlpha()) {
+        /* No alpha channel yet: convert mask to alpha.
+          InitAlpha() sets mask-colored pixels to alpha=0, all others to
+          alpha=255, then removes the mask. Calling it when HasAlpha() is
+          true would trigger a wxWidgets assertion and corrupt the image. */
+        pNewImage->InitAlpha();
+      } else {
+        /* Image already has an alpha channel (e.g. a PNG with embedded alpha).
+          InitAlpha() must not be called here — apply the mask manually:
+          pixels whose RGB matches the mask color are made fully transparent;
+          all other pixels keep their existing alpha value.
+
+          We cannot rely on the wxImage mask (chroma-key) alone because
+          GOBitmap::BuildBitmapFrom() copies img.GetAlpha() directly into the
+          compositing result (memcpy on img.GetAlpha()). The mask is never
+          consulted there, so any mask-colored pixel that the PNG marks as
+          opaque (alpha=255) would be rendered opaque — the mask would be
+          silently ignored. Applying the mask to the alpha channel here ensures
+          correct transparency regardless of how the image is later composited.
+        */
+        const unsigned char maskR = pNewImage->GetMaskRed();
+        const unsigned char maskG = pNewImage->GetMaskGreen();
+        const unsigned char maskB = pNewImage->GetMaskBlue();
+        const unsigned nPixels = pNewImage->GetWidth() * pNewImage->GetHeight();
+        const unsigned char *pData = pNewImage->GetData();
+        unsigned char *pAlpha = pNewImage->GetAlpha();
+
+        for (unsigned nPixelsRest = nPixels; nPixelsRest > 0;
+             nPixelsRest--, pAlpha++) {
+          const unsigned char r = *pData++;
+          const unsigned char g = *pData++;
+          const unsigned char b = *pData++;
+
+          if (r == maskR && g == maskG && b == maskB)
+            *pAlpha = 0;
+        }
+        pNewImage->SetMask(false);
+      }
+    }
     RegisterImage(filename, maskName, pNewImage);
     pImage = pNewImage;
   }

--- a/src/grandorgue/gui/GOGuiImageCache.cpp
+++ b/src/grandorgue/gui/GOGuiImageCache.cpp
@@ -268,6 +268,10 @@ const wxImage *GOGuiImageCache::LoadImage(
           opaque (alpha=255) would be rendered opaque — the mask would be
           silently ignored. Applying the mask to the alpha channel here ensures
           correct transparency regardless of how the image is later composited.
+
+          GetData() returns pixels as RGBRGBRGB... with no padding — exactly
+          3 bytes per pixel — per wxImage::GetData() documentation:
+          https://docs.wxwidgets.org/latest/classwx_image.html
         */
         const unsigned char maskR = pNewImage->GetMaskRed();
         const unsigned char maskG = pNewImage->GetMaskGreen();


### PR DESCRIPTION
Fixes #2535

## Summary

- `GOGuiImageCache::LoadImage()` called `wxImage::InitAlpha()` unconditionally when `HasMask()` was true, without checking `HasAlpha()` first. If a PNG image already had an embedded alpha channel and a mask was applied via `SetMaskFromImage()`, this triggered a wxWidgets assertion in debug builds and corrupted the alpha buffer in release builds, leading to a crash during panel rendering.
- When the image already has an alpha channel, `InitAlpha()` must not be called. Instead, the mask is applied manually: pixels matching the mask color are set to `alpha=0`; all other pixels keep their existing alpha value. Relying on the wxImage mask (chroma-key) alone is not sufficient because `GOBitmap::BuildBitmapFrom()` copies `img.GetAlpha()` directly into the compositing result and never consults the mask.

## Test plan

- [ ] Load an organ with an ODF image that has native PNG alpha and a `Mask...` file
- [ ] Confirm no assertion dialog (debug build) and no crash (release build)
- [ ] Confirm the masked region renders correctly (transparency preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)