### PR TITLE
fix: keyboard shortcuts work in detached organ panel windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Fixed keyboard shortcuts (Panic, Help, Load/Open/Save/Install organ, MIDI player load) not working when a detached organ panel window has focus
+- Fixed keyboard shortcuts (Panic, Help, Load/Open/Save/Install organ, MIDI player load) not working when a detached organ panel window has focus https://github.com/GrandOrgue/grandorgue/issues/2541
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed keyboard shortcuts (Panic, Help, Load/Open/Save/Install organ, MIDI player load) not working when a detached organ panel window has focus
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -55,7 +55,6 @@
 #include "go_limits.h"
 #include "go_path.h"
 
-namespace {
 struct ShortcutEntry {
   int mod, key, id;
 };
@@ -63,7 +62,7 @@ struct ShortcutEntry {
 // To add a shortcut: append one line here. The menu label's \tXxx annotation
 // handles display; this table handles dispatch (for both GOAppWindow focus and
 // forwarded events from detached panel frames).
-const ShortcutEntry s_shortcuts[] = {
+static const ShortcutEntry s_shortcuts[] = {
   {wxACCEL_NORMAL, WXK_ESCAPE, ID_AUDIO_PANIC},
   {wxACCEL_NORMAL, WXK_F1,     wxID_HELP},
   {wxACCEL_CTRL,   'L',        ID_FILE_LOAD},
@@ -72,7 +71,6 @@ const ShortcutEntry s_shortcuts[] = {
   {wxACCEL_CTRL,   'I',        ID_FILE_INSTALL},
   {wxACCEL_CTRL,   'P',        ID_MIDI_LOAD},
 };
-} // namespace
 
 BEGIN_EVENT_TABLE(GOAppWindow, wxFrame)
 EVT_MSGBOX(GOAppWindow::OnMsgBox)
@@ -1311,20 +1309,26 @@ void GOAppWindow::OnChangeVolume(wxCommandEvent &event) {
 
 void GOAppWindow::OnKeyCommand(wxKeyEvent &event) {
   int flags = wxACCEL_NORMAL;
+
   if (event.ControlDown())
     flags |= wxACCEL_CTRL;
   if (event.AltDown())
     flags |= wxACCEL_ALT;
   if (event.ShiftDown())
     flags |= wxACCEL_SHIFT;
+
   const int k = event.GetKeyCode();
+  bool isProcessed = false;
+
   for (const auto &s : s_shortcuts) {
     if (s.mod == flags && s.key == k) {
       ProcessCommand(s.id);
-      return;
+      isProcessed = true;
+      break;
     }
   }
-  event.Skip();
+  if (!isProcessed)
+    event.Skip();
 }
 
 void GOAppWindow::OnMidiEvent(const GOMidiEvent &event) {

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -55,6 +55,25 @@
 #include "go_limits.h"
 #include "go_path.h"
 
+namespace {
+struct ShortcutEntry {
+  int mod, key, id;
+};
+// Single source of truth for all keyboard shortcuts.
+// To add a shortcut: append one line here. The menu label's \tXxx annotation
+// handles display; this table handles dispatch (for both GOAppWindow focus and
+// forwarded events from detached panel frames).
+const ShortcutEntry s_shortcuts[] = {
+  {wxACCEL_NORMAL, WXK_ESCAPE, ID_AUDIO_PANIC},
+  {wxACCEL_NORMAL, WXK_F1,     wxID_HELP},
+  {wxACCEL_CTRL,   'L',        ID_FILE_LOAD},
+  {wxACCEL_CTRL,   'O',        ID_FILE_OPEN},
+  {wxACCEL_CTRL,   'S',        ID_FILE_SAVE},
+  {wxACCEL_CTRL,   'I',        ID_FILE_INSTALL},
+  {wxACCEL_CTRL,   'P',        ID_MIDI_LOAD},
+};
+} // namespace
+
 BEGIN_EVENT_TABLE(GOAppWindow, wxFrame)
 EVT_MSGBOX(GOAppWindow::OnMsgBox)
 EVT_RENAMEFILE(GOAppWindow::OnRenameFile)
@@ -1291,13 +1310,18 @@ void GOAppWindow::OnChangeVolume(wxCommandEvent &event) {
 }
 
 void GOAppWindow::OnKeyCommand(wxKeyEvent &event) {
-  int k = event.GetKeyCode();
-  if (!event.AltDown()) {
-    switch (k) {
-    case WXK_ESCAPE: {
-      ProcessCommand(ID_AUDIO_PANIC);
-      break;
-    }
+  int flags = wxACCEL_NORMAL;
+  if (event.ControlDown())
+    flags |= wxACCEL_CTRL;
+  if (event.AltDown())
+    flags |= wxACCEL_ALT;
+  if (event.ShiftDown())
+    flags |= wxACCEL_SHIFT;
+  const int k = event.GetKeyCode();
+  for (const auto &s : s_shortcuts) {
+    if (s.mod == flags && s.key == k) {
+      ProcessCommand(s.id);
+      return;
     }
   }
   event.Skip();

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -64,12 +64,12 @@ struct ShortcutEntry {
 // forwarded events from detached panel frames).
 static const ShortcutEntry s_shortcuts[] = {
   {wxACCEL_NORMAL, WXK_ESCAPE, ID_AUDIO_PANIC},
-  {wxACCEL_NORMAL, WXK_F1,     wxID_HELP},
-  {wxACCEL_CTRL,   'L',        ID_FILE_LOAD},
-  {wxACCEL_CTRL,   'O',        ID_FILE_OPEN},
-  {wxACCEL_CTRL,   'S',        ID_FILE_SAVE},
-  {wxACCEL_CTRL,   'I',        ID_FILE_INSTALL},
-  {wxACCEL_CTRL,   'P',        ID_MIDI_LOAD},
+  {wxACCEL_NORMAL, WXK_F1, wxID_HELP},
+  {wxACCEL_CTRL, 'L', ID_FILE_LOAD},
+  {wxACCEL_CTRL, 'O', ID_FILE_OPEN},
+  {wxACCEL_CTRL, 'S', ID_FILE_SAVE},
+  {wxACCEL_CTRL, 'I', ID_FILE_INSTALL},
+  {wxACCEL_CTRL, 'P', ID_MIDI_LOAD},
 };
 
 BEGIN_EVENT_TABLE(GOAppWindow, wxFrame)

--- a/src/grandorgue/gui/panels/GOGUIPanelView.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelView.cpp
@@ -99,12 +99,14 @@ GOGUIPanelView::GOGUIPanelView(
   // called and GOGUIPanelWidget handles them normally.
   // Panels embedded directly inside GOAppWindow are skipped because
   // GOAppWindow's own EVT_CHAR_HOOK already covers them.
-  wxWindow *mainWin = wxTheApp->GetTopWindow();
-  if (mainWin && topWindow != mainWin) {
-    topWindow->Bind(wxEVT_CHAR_HOOK, [mainWin](wxKeyEvent &e) {
-      wxKeyEvent copy(e);
-      copy.SetEventObject(mainWin);
-      if (!mainWin->GetEventHandler()->ProcessEvent(copy))
+  wxWindow *pMainAppWin = wxTheApp->GetTopWindow();
+
+  if (pMainAppWin && topWindow != pMainAppWin) {
+    topWindow->Bind(wxEVT_CHAR_HOOK, [pMainAppWin](wxKeyEvent &e) {
+      wxKeyEvent eCopied(e);
+
+      eCopied.SetEventObject(pMainAppWin);
+      if (!pMainAppWin->ProcessWindowEvent(eCopied))
         e.Skip();
     });
   }

--- a/src/grandorgue/gui/panels/GOGUIPanelView.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelView.cpp
@@ -99,22 +99,34 @@ GOGUIPanelView::GOGUIPanelView(
   // called and GOGUIPanelWidget handles them normally.
   // Panels embedded directly inside GOAppWindow are skipped because
   // GOAppWindow's own EVT_CHAR_HOOK already covers them.
-  wxWindow *pMainAppWin = wxTheApp->GetTopWindow();
-
-  if (pMainAppWin && topWindow != pMainAppWin) {
-    topWindow->Bind(wxEVT_CHAR_HOOK, [pMainAppWin](wxKeyEvent &e) {
-      wxKeyEvent eCopied(e);
-
-      eCopied.SetEventObject(pMainAppWin);
-      if (!pMainAppWin->ProcessWindowEvent(eCopied))
-        e.Skip();
-    });
-  }
+  if (topWindow != wxTheApp->GetTopWindow())
+    topWindow->Bind(wxEVT_CHAR_HOOK, &GOGUIPanelView::OnCharHook, this);
 }
 
 GOGUIPanelView::~GOGUIPanelView() {
+  if (m_TopWindow && m_TopWindow != wxTheApp->GetTopWindow())
+    m_TopWindow->Unbind(wxEVT_CHAR_HOOK, &GOGUIPanelView::OnCharHook, this);
   if (m_panel)
     m_panel->SetView(NULL);
+}
+
+void GOGUIPanelView::OnCharHook(wxKeyEvent &e) {
+  wxWindow *pMainAppWin = wxTheApp->GetTopWindow();
+  bool isProcessed = false;
+
+  if (pMainAppWin) {
+    /* Copy the event: SetEventObject() below must not mutate the original e,
+     * because e is still routed further via e.Skip() to topWindow's own
+     * handlers (e.g. GOGUIPanelWidget playing a note) when the key is not a
+     * recognized shortcut, and those expect GetEventObject() to stay the
+     * panel/frame, not the main window. */
+    wxKeyEvent eCopied(e);
+
+    eCopied.SetEventObject(pMainAppWin);
+    isProcessed = pMainAppWin->ProcessWindowEvent(eCopied);
+  }
+  if (!isProcessed)
+    e.Skip();
 }
 
 void GOGUIPanelView::RemoveView() {

--- a/src/grandorgue/gui/panels/GOGUIPanelView.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanelView.cpp
@@ -7,6 +7,7 @@
 
 #include "GOGUIPanelView.h"
 
+#include <wx/app.h>
 #include <wx/display.h>
 #include <wx/frame.h>
 #include <wx/image.h>
@@ -88,6 +89,25 @@ GOGUIPanelView::GOGUIPanelView(
     m_panelwidget->CentreOnParent(wxVERTICAL);
 
   m_panel->SetView(this);
+
+  // Forward key events from detached panel frames to the main window so that
+  // keyboard shortcuts (e.g. Escape/Panic, Ctrl+S, F2-F12) work regardless of
+  // which panel has focus. GOAppWindow's OnKeyCommand returns without Skip()
+  // for recognized shortcuts, causing ProcessEvent() to return true; in that
+  // case we suppress e.Skip() so the panel widget does not also process the key
+  // (e.g. organ note). For unrecognized keys (organ notes, Shift) Skip() is
+  // called and GOGUIPanelWidget handles them normally.
+  // Panels embedded directly inside GOAppWindow are skipped because
+  // GOAppWindow's own EVT_CHAR_HOOK already covers them.
+  wxWindow *mainWin = wxTheApp->GetTopWindow();
+  if (mainWin && topWindow != mainWin) {
+    topWindow->Bind(wxEVT_CHAR_HOOK, [mainWin](wxKeyEvent &e) {
+      wxKeyEvent copy(e);
+      copy.SetEventObject(mainWin);
+      if (!mainWin->GetEventHandler()->ProcessEvent(copy))
+        e.Skip();
+    });
+  }
 }
 
 GOGUIPanelView::~GOGUIPanelView() {

--- a/src/grandorgue/gui/panels/GOGUIPanelView.h
+++ b/src/grandorgue/gui/panels/GOGUIPanelView.h
@@ -26,6 +26,7 @@ private:
   wxSize m_Scroll;
 
   void OnSize(wxSizeEvent &event);
+  void OnCharHook(wxKeyEvent &e);
 
 public:
   GOGUIPanelView(


### PR DESCRIPTION
Fixes #2541

## Problem

When a detached organ panel frame has keyboard focus, shortcuts like
**Escape** (Panic), **Ctrl+S**, **F1** etc. do nothing. The root
cause: wxWidgets accelerator processing is scoped to the focused
top-level window, and detached panel frames carry no menu bar.

## Solution

### `GOGUIPanelView` — forward key events to the main window

Each detached panel frame gets an `EVT_CHAR_HOOK` binding that
forwards every key event to the main window's event handler:

```cpp
topWindow->Bind(wxEVT_CHAR_HOOK, [mainWin](wxKeyEvent &e) {
    wxKeyEvent copy(e);
    copy.SetEventObject(mainWin);
    if (!mainWin->GetEventHandler()->ProcessEvent(copy))
        e.Skip();
});
```

`ProcessEvent()` returns `true` when `OnKeyCommand` consumed the
event (recognized shortcut). In that case `e.Skip()` is suppressed so
the organ panel does not simultaneously play a note for the same key.
For unrecognized keys (organ notes, Shift for setter) `Skip()` is
called and `GOGUIPanelWidget` handles them as before.

### `GOAppWindow` — single shortcut table in `OnKeyCommand`

The existing `OnKeyCommand` only handled Escape. Menu shortcuts (Ctrl+S
etc.) were handled by the OS/wxWidgets accelerator mechanism — which is
not reachable via `ProcessEvent`. Therefore `OnKeyCommand` is extended
to handle **all** shortcuts through a single `s_shortcuts[]` table:

```cpp
const ShortcutEntry s_shortcuts[] = {
  {wxACCEL_NORMAL, WXK_ESCAPE, ID_AUDIO_PANIC},
  {wxACCEL_NORMAL, WXK_F1,     wxID_HELP},
  {wxACCEL_CTRL,   'L',        ID_FILE_LOAD},
  {wxACCEL_CTRL,   'O',        ID_FILE_OPEN},
  {wxACCEL_CTRL,   'S',        ID_FILE_SAVE},
  {wxACCEL_CTRL,   'I',        ID_FILE_INSTALL},
  {wxACCEL_CTRL,   'P',        ID_MIDI_LOAD},
};
```

`OnKeyCommand` iterates the table and calls `ProcessCommand(id)`,
returning **without** `Skip()` on a match. This prevents the menu
system from double-firing. For unrecognized keys `Skip()` is called as
before.

**Adding a new shortcut** requires exactly one line in `s_shortcuts[]`
plus the `\tXxx` annotation in the menu label. Nothing else.

## Shortcuts covered

| Key | Action |
|-----|--------|
| Escape | Panic (stop all sound) |
| F1 | Help |
| Ctrl+L | Load organ |
| Ctrl+O | Open organ |
| Ctrl+S | Save |
| Ctrl+I | Install organ package |
| Ctrl+P | Load MIDI |

## Test plan

- [ ] Open an organ with multiple panels; detach at least one panel
- [ ] Click the detached panel to give it focus
- [ ] Press **Escape** → Panic fires
- [ ] Press **Ctrl+S** → Save occurs
- [ ] Press **F1** → Help opens
- [ ] Press **Ctrl+L / Ctrl+O** → Load/Open dialog appears
- [ ] Press **Ctrl+I** → Install dialog appears
- [ ] Press **Ctrl+P** → Load MIDI dialog appears
- [ ] Press organ keys (letters) → notes still play normally
- [ ] Press **Shift** → setter (Memory Set) still activates
- [ ] Verify all shortcuts still work when the main window has focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)