### PR TITLE
fix: off-by-one in compressed ring-buffer skip-ahead Seek()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed a rare glitch right after a loop wrap in compressed samples, caused by an off-by-one in the read-ahead ring buffer
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494

--- a/src/grandorgue/sound/playing/GOSoundStream.cpp
+++ b/src/grandorgue/sound/playing/GOSoundStream.cpp
@@ -89,9 +89,13 @@ public:
       while (r_cache.m_position < readAheadIndexTo) {
         r_cache.DecompressionStep(nChannels, format16);
 
-        /* fill the read ahead buffer. If r_cache.position > index we assume
-          that the previous samples already present */
-        if (r_cache.m_position >= index) {
+        /* DecompressionStep increments m_position AFTER decoding, so the
+         * sample it just produced has index (m_position - 1). Store it only
+         * if that index is >= the requested index, i.e. m_position > index
+         * (not >=): on a Seek() to a fresh/skip-ahead position, using ">="
+         * stored one sample too early, shifting every subsequent tap in the
+         * window by one until it self-healed after windowLen samples. */
+        if (r_cache.m_position > index) {
           const int *pRead = r_cache.m_value;
 
           for (uint8_t i = nChannels; i > 0; i--)

--- a/src/grandorgue/sound/playing/GOSoundStream.cpp
+++ b/src/grandorgue/sound/playing/GOSoundStream.cpp
@@ -87,15 +87,16 @@ public:
       int *pWrite2 = pWrite1 + WINDOW_SAMPLES;
 
       while (r_cache.m_position < readAheadIndexTo) {
+        /* The sample about to be decoded has this index; DecompressionStep
+         * increments m_position afterwards, so m_position itself no longer
+         * identifies it. */
+        unsigned lastDecompressedPos = r_cache.m_position;
+
         r_cache.DecompressionStep(nChannels, format16);
 
-        /* DecompressionStep increments m_position AFTER decoding, so the
-         * sample it just produced has index (m_position - 1). Store it only
-         * if that index is >= the requested index, i.e. m_position > index
-         * (not >=): on a Seek() to a fresh/skip-ahead position, using ">="
-         * stored one sample too early, shifting every subsequent tap in the
-         * window by one until it self-healed after windowLen samples. */
-        if (r_cache.m_position > index) {
+        /* fill the read ahead buffer. If lastDecompressedPos >= index we
+          assume that the previous samples already present */
+        if (lastDecompressedPos >= index) {
           const int *pRead = r_cache.m_value;
 
           for (uint8_t i = nChannels; i > 0; i--)

--- a/src/tests/testing/sound/playing/GOTestSoundStream.cpp
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.cpp
@@ -231,6 +231,77 @@ void GOTestSoundStream::TestLoopTransitionAcrossDifferentEndPos() {
   }
 }
 
+void GOTestSoundStream::TestCompressedLoopWrapMatchesUncompressed() {
+  constexpr unsigned N_TOTAL_FRAMES = 1100;
+  constexpr unsigned N_ITERATIONS = 500;
+  const std::vector<GOWaveLoop> loops = {
+    {500, 999}, // long loop, start_offset=500, end_pos=1000
+    {200, 599}, // long loop, start_offset=200, end_pos=600
+  };
+  const unsigned nChannels = 1;
+  const unsigned nSamples = nChannels * N_TOTAL_FRAMES;
+  std::vector<GOInt24> pcmData(nSamples);
+
+  for (unsigned i = 0; i < nSamples; i++)
+    pcmData[i] = (i % 100) * 30000 - 1500000;
+
+  auto runCapture = [&](bool isCompressed) {
+    auto pSection = std::make_unique<GOSoundAudioSection>(m_pool);
+
+    pSection->Setup(
+      nullptr,
+      nullptr,
+      pcmData.data(),
+      GOWave::SF_SIGNEDINT24_24,
+      nChannels,
+      SECTION_RATE,
+      N_TOTAL_FRAMES,
+      &loops,
+      BOOL3_DEFAULT,
+      isCompressed,
+      0,
+      0);
+
+    GOSoundResample resample;
+    GOSoundStream stream;
+
+    // Same seed for both runs: PickEndSegment() uses rand() to choose among
+    // multiple valid end segments, and both runs must pick identically so
+    // the wrap timing (and hence the skip-ahead pattern) matches.
+    std::srand(0);
+    stream.InitStream(
+      &resample,
+      pSection.get(),
+      GOSoundResample::GO_LINEAR_INTERPOLATION,
+      SAMPLE_RATE_ADJUSTMENT);
+
+    std::vector<float> captured(N_ITERATIONS * N_BUFFER_ITEMS);
+    float buffer[N_BUFFER_ITEMS];
+
+    for (unsigned iterI = 0; iterI < N_ITERATIONS; iterI++) {
+      stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+      for (unsigned i = 0; i < N_BUFFER_ITEMS; i++)
+        captured[iterI * N_BUFFER_ITEMS + i] = buffer[i];
+    }
+    return captured;
+  };
+
+  const std::vector<float> uncompressed = runCapture(false);
+  const std::vector<float> compressed = runCapture(true);
+
+  for (unsigned i = 0; i < uncompressed.size(); i++)
+    GOAssert(
+      compressed[i] == uncompressed[i],
+      std::format(
+        "compressed/uncompressed mismatch at output sample {} (iteration {}, "
+        "offset {}): compressed={} uncompressed={}",
+        i,
+        i / N_BUFFER_ITEMS,
+        i % N_BUFFER_ITEMS,
+        compressed[i],
+        uncompressed[i]));
+}
+
 void GOTestSoundStream::run() {
   for (unsigned nChannels : {1u, 2u}) {
     for (bool isCompressed : {false, true}) {
@@ -243,4 +314,5 @@ void GOTestSoundStream::run() {
   TestLoopedStreamAlwaysReturnsTrue();
   TestLoopTransitionAcrossDifferentEndPos();
   TestInitAlignedStream();
+  TestCompressedLoopWrapMatchesUncompressed();
 }

--- a/src/tests/testing/sound/playing/GOTestSoundStream.h
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.h
@@ -66,6 +66,25 @@ private:
    */
   void TestInitAlignedStream();
 
+  /**
+   * Regression test for an off-by-one in
+   * StreamCacheReadAheadWindow::Seek() (GOSoundStream.cpp): after a loop
+   * wraps to a new start segment, the compressed decoder resumes from a
+   * precomputed cache snapshot pinned at that segment's start_offset, while
+   * the resampling position typically requests a few samples further in
+   * (the wrap remainder) - a genuine skip-ahead Seek() on an otherwise-fresh
+   * cache. Using ">= index" instead of "> index" to decide whether a freshly
+   * decoded sample should be stored shifted every FIR tap by one sample
+   * until it self-healed after windowLen samples.
+   *
+   * Verified differentially: with LINEAR interpolation and factor 1.0
+   * (identity), decoding is lossless, so a compressed and an uncompressed
+   * section with identical PCM data and identical loop layout must produce
+   * bit-identical ReadBlock() output for every frame, including immediately
+   * after a wrap - no assumption about "realistic" sample values is needed.
+   */
+  void TestCompressedLoopWrapMatchesUncompressed();
+
 public:
   std::string GetName() override { return TEST_NAME; }
   void run() override;


### PR DESCRIPTION
## Summary

- `StreamCacheReadAheadWindow::Seek()` (`GOSoundStream.cpp`) decides whether a freshly decoded sample should be stored with `if (r_cache.m_position >= index)`. But `DecompressionStep()` increments `m_position` *after* decoding, so the sample it just produced has index `m_position - 1`, not `m_position`.
- Using `>=` stores one sample too early on any skip-ahead `Seek()` where the cache starts behind the requested index — shifting every subsequent FIR tap in the polyphase resampler's read-ahead window by one, until it self-heals after `windowLen` (8) samples.

## Root cause

This is a frequent, everyday trigger, not an exotic edge case: `GOSoundAudioSection::Compress()` pins a precomputed cache snapshot at each loop start segment's `start_offset`, and after a loop wrap the resampling position typically lands a few samples further in (the wrap remainder) than that snapshot — a skip-ahead `Seek()` on an otherwise-fresh cache on *every* such wrap, for any compressed, looped sample.

```cpp
// Wrong — off by one: the sample just decoded has index (m_position - 1),
// so this fires one iteration too early:
if (r_cache.m_position >= index) { ... }

// Fixed:
if (r_cache.m_position > index) { ... }
```

## Test plan

- [x] Added `TestCompressedLoopWrapMatchesUncompressed` to the existing `GOTestSoundStream` suite: with `LINEAR` interpolation and factor 1.0 (identity), decoding is lossless, so a compressed and an uncompressed section with identical PCM data and loop layout must produce bit-identical `ReadBlock()` output for every frame, including immediately after a wrap. No assumption about "realistic" sample values is needed — any divergence is the bug.
- [x] Verified locally with a standalone harness against the real production `GOSoundCompressionCache`/`GOSoundResample` headers: with the `>=` bug, skip-ahead reads deviate from ground truth for exactly `windowLen` taps after every fresh `Seek()`, healing afterwards; with `>`, output is bit-identical to the uncompressed reference in all cases tested.
- [ ] New test not yet run in this local environment (toolchain lacks C++20 `<format>`, GCC 12); should pass in CI (`ubuntu-latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)