### PR TITLE
Moved Start/Stop orchestration from GOSoundSystem to GOAppWindow

### DIFF
--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -163,6 +163,7 @@ GOAppWindow::GOAppWindow(
     m_AfterSettingsEventType(wxEVT_NULL),
     m_AfterSettingsEventId(0),
     p_AfterSettingsEventOrgan(NULL) {
+  r_SoundSystem.SetCloseListener(this);
   SetIcon(get_go_icon());
 
   wxArrayString choices;
@@ -393,6 +394,7 @@ GOAppWindow::GOAppWindow(
 }
 
 GOAppWindow::~GOAppWindow() {
+  r_SoundSystem.SetCloseListener(nullptr);
   m_isMeterReady = false;
   m_listener.SetCallback(NULL);
 }
@@ -570,9 +572,40 @@ void GOAppWindow::Init(const wxString &filename, bool isGuiOnly) {
   clean.Cleanup();
 }
 
-void GOAppWindow::AttachDetachOrganController(bool isToAttach) {
-  if (p_OrganController)
-    p_OrganController->SetModificationListener(isToAttach ? this : nullptr);
+void GOAppWindow::OnBeforeSoundClose() { EnsureOrganStopped(); }
+
+void GOAppWindow::EnsureOrganStartedIfReady() {
+  if (
+    p_OrganController && r_SoundSystem.IsOpen() && r_SoundSystem.GetOrganFile()
+    && !r_SoundSystem.GetEngine().IsWorking()) {
+    GOSoundOrganEngine &engine = r_SoundSystem.GetEngine();
+
+    engine.SetFromConfig(r_SoundSystem.GetSettings());
+
+    auto configs = GOSoundOrganEngine::createAudioOutputConfigs(
+      r_SoundSystem.GetSettings(), engine.GetNAudioGroups());
+
+    engine.BuildAndStart(
+      configs,
+      r_SoundSystem.GetSamplesPerBuffer(),
+      r_SoundSystem.GetSampleRate(),
+      r_SoundSystem.GetAudioRecorder());
+    r_SoundSystem.ConnectToEngine(engine);
+    p_OrganController->PreparePlayback(
+      &engine, &r_SoundSystem.GetMidi(), &r_SoundSystem.GetAudioRecorder());
+  }
+}
+
+void GOAppWindow::EnsureOrganStopped() {
+  if (
+    p_OrganController && r_SoundSystem.GetOrganFile()
+    && r_SoundSystem.GetEngine().IsWorking()) {
+    GOSoundOrganEngine &engine = r_SoundSystem.GetEngine();
+
+    p_OrganController->Abort();
+    r_SoundSystem.DisconnectFromEngine(engine);
+    engine.StopAndDestroy();
+  }
 }
 
 bool GOAppWindow::CloseOrgan(bool isForce) {
@@ -602,7 +635,8 @@ bool GOAppWindow::CloseOrgan(bool isForce) {
       GOMutexLocker m_locker(m_mutex, true);
 
       if (m_locker.IsLocked()) {
-        AttachDetachOrganController(false);
+        EnsureOrganStopped();
+        p_OrganController->SetModificationListener(nullptr);
         p_OrganController = nullptr;
         mp_organ.reset();
         UpdatePanelMenu();
@@ -620,8 +654,9 @@ void GOAppWindow::LoadOrgan(const GOOrgan &organ, const wxString &cmb) {
     p_OrganController = mp_organ->LoadOrgan(organ, cmb, m_IsGuiOnly, dlg);
     OnIsModifiedChanged(false);
 
-    // for reflecting model changes
-    AttachDetachOrganController(true);
+    if (p_OrganController)
+      p_OrganController->SetModificationListener(this);
+    EnsureOrganStartedIfReady();
   }
 }
 
@@ -1096,6 +1131,7 @@ void GOAppWindow::OnProperties(wxCommandEvent &event) {
 void GOAppWindow::OnAudioPanic(wxCommandEvent &WXUNUSED(event)) {
   r_SoundSystem.AssureSoundIsClosed();
   r_SoundSystem.AssureSoundIsOpen();
+  EnsureOrganStartedIfReady();
 }
 
 void GOAppWindow::OnMidiMonitor(wxCommandEvent &WXUNUSED(event)) {
@@ -1163,7 +1199,7 @@ void GOAppWindow::OnSettings(wxCommandEvent &event) {
       SetEventAfterSettings(wxEVT_COMMAND_MENU_SELECTED, ID_FILE_EXIT);
       isToContinue = false;
     } else if (
-      dialog.NeedReload() && r_SoundSystem.GetOrganFile() != NULL
+      dialog.NeedReload() && p_OrganController
       && wxMessageBox(
            _("Some changed settings effect unless the sample "
              "set is reloaded.\n\nWould you like to reload "
@@ -1180,8 +1216,10 @@ void GOAppWindow::OnSettings(wxCommandEvent &event) {
 
   // The sound might be closed in the settings dialog (for obtaining the list of
   // devices) or later if the settings were changed
-  if (isToContinue)
+  if (isToContinue) {
     r_SoundSystem.AssureSoundIsOpen();
+    EnsureOrganStartedIfReady();
+  }
 
   if (m_AfterSettingsEventType != wxEVT_NULL) {
     wxCommandEvent event(m_AfterSettingsEventType, m_AfterSettingsEventId);
@@ -1221,7 +1259,8 @@ void GOAppWindow::OnHelp(wxCommandEvent &event) {
 void GOAppWindow::OnSettingsVolume(wxCommandEvent &event) {
   long n = m_Volume->GetValue();
 
-  r_SoundSystem.GetEngine().SetVolume(n);
+  if (p_OrganController)
+    p_OrganController->SetVolume(n);
   for (unsigned i = 0; i < m_VolumeGauge.size(); i++)
     m_VolumeGauge[i]->ResetClip();
 }
@@ -1230,7 +1269,8 @@ void GOAppWindow::OnSettingsPolyphony(wxCommandEvent &event) {
   long n = m_Polyphony->GetValue();
 
   r_config.PolyphonyLimit(n);
-  r_SoundSystem.GetEngine().SetHardPolyphony(n);
+  if (r_SoundSystem.GetOrganFile())
+    r_SoundSystem.GetEngine().SetHardPolyphony(n);
   m_SamplerUsage->ResetClip();
 }
 

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -1261,6 +1261,8 @@ void GOAppWindow::OnSettingsVolume(wxCommandEvent &event) {
 
   if (p_OrganController)
     p_OrganController->SetVolume(n);
+  if (r_SoundSystem.GetOrganFile())
+    r_SoundSystem.GetEngine().SetVolume(n);
   for (unsigned i = 0; i < m_VolumeGauge.size(); i++)
     m_VolumeGauge[i]->ResetClip();
 }

--- a/src/grandorgue/gui/frames/GOAppWindow.h
+++ b/src/grandorgue/gui/frames/GOAppWindow.h
@@ -18,6 +18,7 @@
 #include "midi/GOMidiListener.h"
 #include "midi/events/GOMidiCallback.h"
 #include "modification/GOModificationListener.h"
+#include "sound/GOSoundCloseListener.h"
 #include "threading/GOMutex.h"
 #include "updater/GOUpdateChecker.h"
 
@@ -41,7 +42,8 @@ class GOAppWindow : public wxFrame,
                     private GOHelpRequestor,
                     public GOResizable,
                     protected GOMidiCallback,
-                    private GOModificationListener {
+                    private GOModificationListener,
+                    private GOSoundCloseListener {
 private:
   GOGuiApp &r_app;
   GOConfig &r_config;
@@ -94,7 +96,20 @@ private:
   void UpdateSize();
   void UpdateVolumeControlWithSettings();
 
-  void AttachDetachOrganController(bool isToAttach);
+  /** GOSoundCloseListener: stops the organ before the sound system closes. */
+  void OnBeforeSoundClose() override;
+
+  /**
+   * Starts the organ if a controller is present, the sound system is open,
+   * and the organ has not yet been started. Safe to call multiple times.
+   */
+  void EnsureOrganStartedIfReady();
+
+  /**
+   * Stops the organ if a controller is present and the organ is currently
+   * started. Safe to call multiple times.
+   */
+  void EnsureOrganStopped();
 
   // Processes the organ model modification event:
   // updates some controls according the organ model changes

--- a/src/grandorgue/sound/GOSoundCloseListener.h
+++ b/src/grandorgue/sound/GOSoundCloseListener.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDCLOSELISTENER_H
+#define GOSOUNDCLOSELISTENER_H
+
+/**
+ * Interface for objects that need to be notified before the sound system
+ * closes its audio ports. Implement this to perform cleanup (e.g. stopping
+ * the organ engine) before audio output becomes unavailable.
+ */
+class GOSoundCloseListener {
+public:
+  virtual ~GOSoundCloseListener() = default;
+
+  /** Called by GOSoundSystem immediately before closing audio ports. */
+  virtual void OnBeforeSoundClose() = 0;
+};
+
+#endif

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -21,18 +21,17 @@
 #include "GOEvent.h"
 #include "GOOrganController.h"
 #include "GOSoundDefs.h"
-#include "GOSoundOrganEngine.h"
 
 GOSoundSystem::GOSoundSystem(GOConfig &settings)
   : m_config(settings),
     m_midi(settings),
+    p_CloseListener(nullptr),
     m_open(false),
     logSoundErrors(true),
     m_SampleRate(0),
     m_SamplesPerBuffer(0),
     m_OrganController(0),
     m_DefaultAudioDevice(GOSoundDevInfo::getInvalideDeviceInfo()),
-    m_IsRunning(false),
     m_NCallbacksEntered(0),
     m_CallbackCondition(m_CallbackMutex),
     meter_counter(0),
@@ -109,55 +108,6 @@ void GOSoundSystem::OpenSoundSystem() {
   }
 }
 
-void GOSoundSystem::StartSoundSystem() {
-  // Enable all outputs
-  for (GOSoundOutput &output : m_AudioOutputs) {
-    GOMutexLocker dev_lock(output.mutex);
-
-    output.wait = false;
-    output.waiting = true;
-  }
-  m_WaitCount.store(0);
-  m_CalcCount.store(0);
-  m_NCallbacksEntered.store(0);
-  m_IsRunning.store(true);
-}
-
-void GOSoundSystem::NotifySoundIsOpen() {
-  m_OrganController->PreparePlayback(
-    &GetEngine(), &GetMidi(), &m_AudioRecorder);
-}
-
-void GOSoundSystem::NotifySoundIsClosing() { m_OrganController->Abort(); }
-
-void GOSoundSystem::StopSoundSystem() {
-  m_IsRunning.store(false);
-
-  // wait for all started callbacks to finish
-  {
-    GOMutexLocker lock(m_CallbackMutex);
-
-    while (m_NCallbacksEntered.load() > 0)
-      m_CallbackCondition.WaitOrStop(
-        "GOSoundSystem::StopSoundSystem waits for all callbacks to finish",
-        nullptr);
-  }
-
-  // Disable all outputs
-  {
-    GOMultiMutexLocker multi;
-
-    for (GOSoundOutput &output : m_AudioOutputs)
-      multi.Add(output.mutex);
-
-    for (GOSoundOutput &output : m_AudioOutputs) {
-      output.waiting = false;
-      output.wait = false;
-      output.condition.Broadcast();
-    }
-  }
-}
-
 void GOSoundSystem::CloseSoundSystem() {
   for (int i = m_AudioOutputs.size() - 1; i >= 0; i--) {
     if (m_AudioOutputs[i].port) {
@@ -187,44 +137,18 @@ void GOSoundSystem::StartStreams() {
     output.port->StartStream();
 }
 
-void GOSoundSystem::BuildAndStartEngine() {
-  GOOrganModel &organModel = static_cast<GOOrganModel &>(*m_OrganController);
-
-  mp_SoundEngine = std::make_unique<GOSoundOrganEngine>(
-    organModel, m_OrganController->GetMemoryPool());
-  mp_SoundEngine->SetFromConfig(m_config);
-
-  auto configs = GOSoundOrganEngine::createAudioOutputConfigs(
-    m_config, mp_SoundEngine->GetNAudioGroups());
-
-  mp_SoundEngine->BuildAndStart(
-    configs, m_SamplesPerBuffer, m_SampleRate, m_AudioRecorder);
-}
-
-void GOSoundSystem::StopAndDestroyEngine() {
-  mp_SoundEngine->StopAndDestroy();
-  mp_SoundEngine.reset();
-}
-
 bool GOSoundSystem::AssureSoundIsOpen() {
   if (!m_open) {
     OpenSoundSystem();
-    if (m_open && m_OrganController) {
-      BuildAndStartEngine();
-      StartSoundSystem();
-      NotifySoundIsOpen();
-    }
   }
   return m_open;
 }
 
 void GOSoundSystem::AssureSoundIsClosed() {
   if (m_open) {
-    if (m_OrganController) {
-      NotifySoundIsClosing();
-      StopSoundSystem();
-      StopAndDestroyEngine();
-    }
+    if (p_CloseListener) // The callback must call to DisconnectFromEngine()
+      p_CloseListener->OnBeforeSoundClose();
+
     CloseSoundSystem();
   }
 }
@@ -233,18 +157,15 @@ void GOSoundSystem::AssignOrganFile(GOOrganController *pNewOrganController) {
   if (pNewOrganController != m_OrganController) {
     GOMutexLocker locker(m_lock);
 
-    if (m_open && m_OrganController) {
-      NotifySoundIsClosing();
-      StopSoundSystem();
-      StopAndDestroyEngine();
-    }
-
+    mp_SoundEngine.reset();
     m_OrganController = pNewOrganController;
 
-    if (m_open && m_OrganController) {
-      BuildAndStartEngine();
-      StartSoundSystem();
-      NotifySoundIsOpen();
+    if (m_OrganController) {
+      GOOrganModel &organModel
+        = static_cast<GOOrganModel &>(*m_OrganController);
+
+      mp_SoundEngine = std::make_unique<GOSoundOrganEngine>(
+        organModel, m_OrganController->GetMemoryPool());
     }
   }
 }
@@ -312,8 +233,9 @@ bool GOSoundSystem::AudioCallback(
   unsigned devIndex, GOSoundBufferMutable &outBuffer) {
   bool wasEntered = false;
   const unsigned nSamples = outBuffer.GetNFrames();
+  GOSoundOrganEngine *const pEngine = mp_SoundEngine.get();
 
-  if (m_IsRunning.load()) {
+  if (pEngine && pEngine->IsUsed()) {
     if (nSamples == m_SamplesPerBuffer) {
       m_NCallbacksEntered.fetch_add(1);
       wasEntered = true;
@@ -323,9 +245,9 @@ bool GOSoundSystem::AudioCallback(
           "changed by the sound driver to %d"),
         nSamples);
   }
-  // assure that m_IsRunning has not yet been changed after
+  // assure that IsUsed has not yet been changed after
   // m_NCallbacksEntered.fetch_add, otherwise the control thread may not wait
-  if (wasEntered && m_IsRunning.load()) {
+  if (wasEntered && pEngine && pEngine->IsUsed()) {
     GOSoundOutput &device = m_AudioOutputs[devIndex];
     GOMutexLocker locker(device.mutex);
 
@@ -334,16 +256,16 @@ bool GOSoundSystem::AudioCallback(
 
     unsigned cnt = m_CalcCount.fetch_add(1);
 
-    mp_SoundEngine->GetAudioOutput(
+    pEngine->GetAudioOutput(
       devIndex, cnt + 1 >= m_AudioOutputs.size(), outBuffer);
     device.wait = true;
     unsigned count = m_WaitCount.fetch_add(1);
 
     if (count + 1 == m_AudioOutputs.size()) {
-      mp_SoundEngine->NextPeriod();
+      pEngine->NextPeriod();
       UpdateMeter();
 
-      mp_SoundEngine->WakeupThreads();
+      pEngine->WakeupThreads();
       m_CalcCount.exchange(0);
       m_WaitCount.exchange(0);
 
@@ -357,7 +279,7 @@ bool GOSoundSystem::AudioCallback(
     outBuffer.FillWithSilence();
   if (
     wasEntered && m_NCallbacksEntered.fetch_sub(1) <= 1
-    && !m_IsRunning.load()) {
+    && !(pEngine && pEngine->IsUsed())) {
     // ensure that the control thread enters into m_NCallbackCondition.Wait()
     GOMutexLocker lk(m_CallbackMutex);
 
@@ -375,4 +297,57 @@ wxString GOSoundSystem::getState() {
   for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
     result = result + _("\n") + m_AudioOutputs[i].port->getPortState();
   return result;
+}
+
+void GOSoundSystem::ConnectToEngine(GOSoundOrganEngine &engine) {
+  assert(m_open);
+  assert(p_CloseListener);
+  assert(engine.IsWorking());
+
+  engine.SetUsed(true);
+
+  // Enable all outputs before making the engine visible to callbacks
+  for (GOSoundOutput &output : m_AudioOutputs) {
+    GOMutexLocker dev_lock(output.mutex);
+
+    output.wait = false;
+    output.waiting = true;
+  }
+  m_WaitCount.store(0);
+  m_CalcCount.store(0);
+  m_NCallbacksEntered.store(0);
+}
+
+void GOSoundSystem::DisconnectFromEngine(GOSoundOrganEngine &engine) {
+  // Signal callbacks to stop by clearing IsUsed
+  engine.SetUsed(false);
+
+  // wait for all started callbacks to finish
+  {
+    GOMutexLocker lock(m_CallbackMutex);
+
+    while (m_NCallbacksEntered.load() > 0)
+      m_CallbackCondition.WaitOrStop(
+        "GOSoundSystem::DisconnectFromEngine waits for all callbacks to finish",
+        nullptr);
+  }
+
+  // Disable all outputs
+  {
+    GOMultiMutexLocker multi;
+
+    for (GOSoundOutput &output : m_AudioOutputs)
+      multi.Add(output.mutex);
+
+    for (GOSoundOutput &output : m_AudioOutputs) {
+      output.waiting = false;
+      output.wait = false;
+      output.condition.Broadcast();
+    }
+
+    for (unsigned n = m_AudioOutputs.size(), i = 1; i < n; i++) {
+      GOMutexLocker dev_lock(m_AudioOutputs[i].mutex);
+      m_AudioOutputs[i].condition.Broadcast();
+    }
+  }
 }


### PR DESCRIPTION
When opening or closing sound and when Panic buttton is pressed, lots of GrandOrgue components are involved: GOSoundSystem, GOSoundEngine, GOAppWindow, GOOrganController.

Earlier GOSoundSystem was responsible for orchestration of all necessary actions between components. But GOAppWindow already has an orchestration code for other cases, so it is better to move the open/close sound orchestration there.

This PR:
- Adds GOSoundCloseListener: new interface for pre-close notification
- GOAppWindow: implements GOSoundCloseListener; added EnsureOrganStartedIfReady (builds+starts engine, calls ConnectToEngine+PreparePlayback) and EnsureOrganStopped (calls Abort+DisconnectFromEngine+StopAndDestroy); registers itself as close listener in constructor
- GOSoundSystem: added SetCloseListener/ConnectToEngine/DisconnectFromEngine/ IsOpen/GetAudioRecorder; removed m_IsRunning (use engine->IsUsed() instead); removed Start/Stop/NotifySound* helpers; AssignOrganFile now only creates/ destroys the engine object (no start/stop); AssureSoundIsOpen only opens ports; AssureSoundIsClosed calls listener before closing

This is just refactoring, no GO behavior should be changed.