### PR TITLE
Fix organ volume not saved into organ settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed organ volume not saved into organ settings https://github.com/GrandOrgue/grandorgue/issues/2547
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -861,9 +861,16 @@ void GOOrganController::PreconfigRecorder() {
   }
 }
 
+void GOOrganController::SetVolume(int volume) {
+  m_volume = volume;
+  if (m_soundengine)
+    m_soundengine->SetVolume(volume);
+}
+
 void GOOrganController::PreparePlayback(
   GOSoundOrganEngine *engine, GOMidiSystem *midi, GOSoundRecorder *recorder) {
   m_soundengine = engine;
+  m_soundengine->SetVolume(m_volume);
   m_midi = midi;
   m_MidiRecorder->SetOutputDevice(m_config.MidiRecorderOutputDevice());
   m_AudioRecorder->SetAudioRecorder(recorder);

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -195,7 +195,7 @@ public:
 
   void LoadMIDIFile(const wxString &filename);
 
-  void SetVolume(int volume) { m_volume = volume; }
+  void SetVolume(int volume);
   int GetVolume() const { return m_volume; }
 
   unsigned GetReleaseTail() {

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -83,7 +83,6 @@ GOOrganController *GOGuiOrgan::LoadOrgan(
       p_MainWindow->SetPosSize(mRect);
 
     m_sound.AssignOrganFile(m_OrganController);
-    m_sound.GetEngine().SetVolume(m_OrganController->GetVolume());
     m_OrganFileReady = true;
     m_listener.SetCallback(this);
     if (!cmb.IsEmpty())

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -1221,7 +1221,8 @@ void GOAppWindow::OnHelp(wxCommandEvent &event) {
 void GOAppWindow::OnSettingsVolume(wxCommandEvent &event) {
   long n = m_Volume->GetValue();
 
-  r_SoundSystem.GetEngine().SetVolume(n);
+  if (p_OrganController)
+    p_OrganController->SetVolume(n);
   for (unsigned i = 0; i < m_VolumeGauge.size(); i++)
     m_VolumeGauge[i]->ResetClip();
 }


### PR DESCRIPTION
## Summary
- Fixes #2547: changing the volume spinner and saving the organ settings persisted the volume the organ was loaded with, not the current one, because commit 26f2cdf2 (#2464) dropped the line that pulled the live engine volume back into `GOOrganController` before `Save()`.
- Instead of restoring that pull-back step in `GOGuiOrgan::SyncState()` (which should stay a GUI-only sync point), `GOOrganController::SetVolume()` is now the single entry point that updates the persisted `m_volume` field and pushes the value to the live sound engine, matching the existing `SetTemperament()`/`SetTranspose()` pattern already used for other organ attributes.
- `PreparePlayback()` now applies the cached volume to the engine as soon as it becomes attached, making the separate volume-set call after `Load()` redundant (removed).
- `GOAppWindow::OnSettingsVolume` now goes through `GOOrganController::SetVolume()` instead of touching the sound engine directly.

## How volume is persisted in the preset file

`GOOrganController` keeps the volume in its own `m_volume` member. It is loaded from the preset (CMB) file in `GOOrganController::Load()`:

```cpp
m_volume = cfg.ReadInteger(
  CMBSetting, WX_ORGAN, wxT("Volume"), -120, 100, false, m_config.Volume());
```

and written back to it in `GOOrganController::Export()` (called by both `Save()` and `Export()`):

```cpp
cfg.WriteInteger(WX_ORGAN, wxT("Volume"), m_volume);
```

Since `Export()` always reads straight from `m_volume`, saving is correct as long as `m_volume` itself is kept current. That's what this PR fixes: `SetVolume()` is now the single place that updates `m_volume` and forwards the value to the live sound engine (when attached), instead of the volume only being pushed to the engine at load time while `m_volume` went stale.

## Test plan
- [ ] Load an organ, move the volume spinner, confirm the audio level changes live
- [ ] Save the organ settings, reload the organ, confirm the volume spinner shows the saved value