### PR TITLE
Introduced GOOrganReader/GOLoadedOrganInfo to isolate ODF/CMB resolution

### DIFF
--- a/src/core/GOOrgan.cpp
+++ b/src/core/GOOrgan.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -16,6 +16,7 @@
 #include "GOHash.h"
 #include "GOOrganList.h"
 #include "archive/GOArchiveFile.h"
+#include "go_path.h"
 
 GOOrgan::GOOrgan(
   const wxString &odf,
@@ -24,17 +25,18 @@ GOOrgan::GOOrgan(
   const wxString &church_name,
   const wxString &organ_builder,
   const wxString &recording_detail)
-  : m_ODF(odf),
-    m_ChurchName(church_name),
+  : m_ChurchName(church_name),
     m_OrganBuilder(organ_builder),
     m_RecordingDetail(recording_detail),
     m_ArchiveID(archive),
     m_ArchivePath(archivePath),
     m_NamesInitialized(true) {
+  SetODFPath(odf);
   m_LastUse = wxGetUTCTime();
 }
 
-GOOrgan::GOOrgan(wxString odf) : m_ODF(odf), m_NamesInitialized(false) {
+GOOrgan::GOOrgan(wxString odf) : m_NamesInitialized(false) {
+  SetODFPath(odf);
   m_LastUse = wxGetUTCTime();
 }
 
@@ -56,6 +58,10 @@ void GOOrgan::Update(const GOOrgan &organ) {
 }
 
 const wxString &GOOrgan::GetODFPath() const { return m_ODF; }
+
+void GOOrgan::SetODFPath(const wxString &newPath) {
+  m_ODF = m_ArchiveID.IsEmpty() ? go_normalize_path(newPath) : newPath;
+}
 
 const wxString &GOOrgan::GetChurchName() const { return m_ChurchName; }
 

--- a/src/core/GOOrgan.h
+++ b/src/core/GOOrgan.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -37,7 +37,14 @@ public:
   void Update(const GOOrgan &organ);
 
   const wxString &GetODFPath() const;
-  void SetODFPath(const wxString &newPath) { m_ODF = newPath; }
+  /**
+   * Sets the path of the ODF file. If an archive is set (GetArchiveID() is
+   * not empty), the path is relative to that archive and is stored as-is;
+   * otherwise it is a normal filesystem path and is normalized to an
+   * absolute path.
+   * @param newPath - the archive-relative or filesystem ODF path
+   */
+  void SetODFPath(const wxString &newPath);
   const wxString &GetChurchName() const;
   const wxString &GetOrganBuilder() const;
   const wxString &GetRecordingDetail() const;

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -147,6 +147,7 @@ loader/GOFileStore.cpp
 loader/GOLoaderFilename.cpp
 loader/GOLoadThread.cpp
 loader/GOLoadWorker.cpp
+loader/GOOrganReader.cpp
 loader/cache/GOCache.cpp
 loader/cache/GOCacheCleaner.cpp
 loader/cache/GOCacheWriter.cpp

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -28,7 +28,6 @@
 #include "config/GOConfigWriter.h"
 #include "control/GOElementCreator.h"
 #include "files/GOOpenedFile.h"
-#include "files/GOStdFileName.h"
 #include "gui/GOGuiImageCache.h"
 #include "gui/dialogs/go-message-boxes.h"
 #include "gui/panels/GOGUIBankedGeneralsPanel.h"
@@ -44,6 +43,7 @@
 #include "gui/panels/GOGUISequencerPanel.h"
 #include "loader/GOLoadThread.h"
 #include "loader/GOLoaderFilename.h"
+#include "loader/GOOrganReader.h"
 #include "loader/GOProgressMonitor.h"
 #include "loader/cache/GOCache.h"
 #include "loader/cache/GOCacheWriter.h"
@@ -81,6 +81,7 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
   : GOEventDistributor(this),
     GOOrganModel(config),
     m_config(config),
+    m_ConfiguredOrgan(wxEmptyString),
     m_FileStore(config),
     m_Cacheable(false),
     m_setter(0),
@@ -89,7 +90,6 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
     m_MidiRecorder(NULL),
     m_timer(NULL),
     p_OnStateButton(nullptr),
-    m_b_customized(false),
     m_CurrentPitch(999999.0), // for enforcing updating the label first time
     m_OrganModified(false),
     m_midi(0),
@@ -319,16 +319,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
     | (result.hash[7] & 0x7F);
 }
 
-wxString GOOrganController::GenerateSettingFileName() {
-  return m_config.OrganSettingsPath() + wxFileName::GetPathSeparator()
-    + GOStdFileName::composeSettingFileName(GetOrganHash(), m_config.Preset());
-}
-
-wxString GOOrganController::GenerateCacheFileName() {
-  return m_config.OrganCachePath() + wxFileName::GetPathSeparator()
-    + GOStdFileName::composeCacheFileName(GetOrganHash(), m_config.Preset());
-}
-
 class GOLoadAborted : public std::exception {};
 
 wxString GOOrganController::Load(
@@ -340,131 +330,14 @@ wxString GOOrganController::Load(
   wxString errMsg;
 
   try {
-    GOLoaderFilename odf_name;
+    GOOrganReader organReader(m_config, organ, file2, m_FileStore, monitor);
 
-    m_ArchiveID = organ.GetArchiveID();
-    if (m_ArchiveID != wxEmptyString) {
-      monitor.Setup(1, _("Loading sample set"), _("Parsing organ packages"));
-
-      wxString errMsg1;
-
-      if (!m_FileStore.LoadArchives(
-            m_config,
-            m_config.OrganCachePath(),
-            organ.GetArchiveID(),
-            organ.GetArchivePath(),
-            errMsg1))
-        throw errMsg1;
-      m_ArchivePath = organ.GetArchivePath();
-      m_odf = organ.GetODFPath();
-      odf_name.Assign(m_odf);
-    } else {
-      wxString file = organ.GetODFPath();
-      m_odf = go_normalize_path(file);
-      odf_name.AssignAbsolute(m_odf);
-      m_FileStore.SetDirectory(go_get_path(m_odf));
-    }
-    m_hash = organ.GetOrganHash();
-    monitor.Setup(
-      1, _("Loading sample set"), _("Parsing sample set definition file"));
-    m_SettingFilename = GenerateSettingFileName();
-    m_CacheFilename = GenerateCacheFileName();
+    m_ConfiguredOrgan = organ;
+    m_LoadedOrganInfo = organReader.GetLoadedOrganInfo();
     m_Cacheable = false;
 
-    GOConfigFileReader odf_ini_file;
-
-    if (!odf_ini_file.Read(odf_name.Open(m_FileStore).get()))
-      throw wxString::Format(_("Unable to read '%s'"), odf_name.GetPath());
-
-    m_ODFHash = odf_ini_file.GetHash();
-    m_b_customized = false;
-    GOConfigReaderDB ini(m_config.ODFCheck());
-    ini.ReadData(odf_ini_file, ODFSetting, false);
-
-    wxString setting_file = file2;
-    bool can_read_cmb_directly = true;
-
-    if (setting_file.IsEmpty()) {
-      if (wxFileExists(m_SettingFilename)) {
-        setting_file = m_SettingFilename;
-        m_b_customized = true;
-      } else {
-        wxString bundledSettingsFile = m_odf.BeforeLast('.') + wxT(".cmb");
-        if (!m_FileStore.AreArchivesUsed()) {
-          if (wxFileExists(bundledSettingsFile)) {
-            setting_file = bundledSettingsFile;
-            m_b_customized = true;
-          }
-        } else {
-          if (m_FileStore.FindArchiveContaining(m_odf)->containsFile(
-                bundledSettingsFile)) {
-            setting_file = bundledSettingsFile;
-            m_b_customized = true;
-            can_read_cmb_directly = false;
-          }
-        }
-      }
-    }
-
-    if (!setting_file.IsEmpty()) {
-      GOConfigFileReader extra_odf_config;
-      if (can_read_cmb_directly) {
-        if (!extra_odf_config.Read(setting_file))
-          throw wxString::Format(_("Unable to read '%s'"), setting_file);
-      } else {
-        if (!extra_odf_config.Read(
-              m_FileStore.FindArchiveContaining(m_odf)->OpenFile(setting_file)))
-          throw wxString::Format(_("Unable to read '%s'"), setting_file);
-      }
-
-      if (
-        odf_ini_file.getEntry(WX_ORGAN, wxT("ChurchName")).Trim()
-        != extra_odf_config.getEntry(WX_ORGAN, wxT("ChurchName")).Trim())
-        wxLogWarning(
-          _("This .cmb file was originally created for:\n%s"),
-          extra_odf_config.getEntry(WX_ORGAN, wxT("ChurchName")).c_str());
-
-      ini.ReadData(extra_odf_config, CMBSetting, false);
-      wxString hash = extra_odf_config.getEntry(WX_ORGAN, wxT("ODFHash"));
-      if (hash != wxEmptyString)
-        if (hash != m_ODFHash) {
-          if (
-            wxMessageBox(
-              _("The .cmb file does not exactly match the current "
-                "ODF. Importing it can cause various problems. "
-                "Should it really be imported?"),
-              _("Import"),
-              wxYES_NO,
-              NULL)
-            == wxNO) {
-            ini.ClearCMB();
-          }
-        }
-    } else {
-      bool old_go_settings = ini.ReadData(odf_ini_file, CMBSetting, true);
-      if (old_go_settings)
-        if (
-          wxMessageBox(
-            _("The ODF contains GrandOrgue 0.2 styled saved "
-              "settings. Should they be imported?"),
-            _("Import"),
-            wxYES_NO,
-            NULL)
-          == wxNO) {
-          ini.ClearCMB();
-        }
-    }
-
-    GOConfigReader cfg(ini, m_config.ODFCheck(), m_config.ODFHw1Check());
-
-    /* skip informational items */
-    cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ChurchName"), false);
-    cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ChurchAddress"), false);
-    cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ODFPath"), false);
-    cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ODFHash"), false);
-    cfg.ReadString(CMBSetting, WX_ORGAN, wxT("ArchiveID"), false);
-    ReadOrganFile(cfg);
-    ini.ReportUnused();
+    ReadOrganFile(organReader.GetConfigReader());
+    organReader.ReportUnused();
 
     if (!isGuiOnly) {
       try {
@@ -481,8 +354,8 @@ wxString GOOrganController::Load(
         GOCacheObject *obj = nullptr;
 
         /* Load pipes */
-        if (wxFileExists(m_CacheFilename)) {
-          wxFile cache_file(m_CacheFilename);
+        if (wxFileExists(m_LoadedOrganInfo.cacheFilePath)) {
+          wxFile cache_file(m_LoadedOrganInfo.cacheFilePath);
           GOCache reader(cache_file, m_pool);
           cache_ok = cache_file.IsOpened();
 
@@ -655,7 +528,7 @@ void GOOrganController::LoadCombination(const wxString &file) {
             GetOrganName(), wxT("Organ Settings"), file, fileOrganName)) {
         wxString hash = odf_ini_file.getEntry(WX_ORGAN, wxT("ODFHash"));
         if (hash != wxEmptyString)
-          if (hash != m_ODFHash) {
+          if (hash != m_LoadedOrganInfo.odfHash) {
             wxLogWarning(_(
               "The combination file does not exactly match the current ODF."));
           }
@@ -691,7 +564,7 @@ bool GOOrganController::UpdateCache(bool compress, GOProgressMonitor &monitor) {
 
   monitor.Setup(objectDistributor.GetNObjects(), _("Creating sample cache"));
 
-  wxFileOutputStream file(m_CacheFilename);
+  wxFileOutputStream file(m_LoadedOrganInfo.cacheFilePath);
 
   if (file.IsOk()) {
     GOCacheWriter writer(file, compress);
@@ -723,19 +596,22 @@ bool GOOrganController::UpdateCache(bool compress, GOProgressMonitor &monitor) {
     if (!isOk)
       DeleteCache();
   } else
-    wxLogError(_("Opening the cache file %s failed"), m_CacheFilename);
+    wxLogError(
+      _("Opening the cache file %s failed"), m_LoadedOrganInfo.cacheFilePath);
   return isOk;
 }
 
 void GOOrganController::DeleteCache() {
   if (CachePresent())
-    wxRemoveFile(m_CacheFilename);
+    wxRemoveFile(m_LoadedOrganInfo.cacheFilePath);
 }
 
-void GOOrganController::DeleteSettings() { wxRemoveFile(m_SettingFilename); }
+void GOOrganController::DeleteSettings() {
+  wxRemoveFile(m_LoadedOrganInfo.settingsFilePath);
+}
 
 bool GOOrganController::Save() {
-  if (!Export(m_SettingFilename))
+  if (!Export(m_LoadedOrganInfo.settingsFilePath))
     return false;
   ResetOrganModified();
   return true;
@@ -745,13 +621,14 @@ bool GOOrganController::Export(const wxString &cmb) {
   GOConfigFileWriter cfg_file;
   GOConfigWriter cfg(cfg_file, false);
 
-  m_b_customized = true;
-  cfg.WriteString(WX_ORGAN, wxT("ODFHash"), m_ODFHash);
+  m_LoadedOrganInfo.isCustomized = true;
+  cfg.WriteString(WX_ORGAN, wxT("ODFHash"), m_LoadedOrganInfo.odfHash);
   cfg.WriteString(WX_ORGAN, wxT("ChurchName"), GetOrganName());
   cfg.WriteString(WX_ORGAN, wxT("ChurchAddress"), m_ChurchAddress);
   cfg.WriteString(WX_ORGAN, wxT("ODFPath"), GetODFFilename());
-  if (m_ArchiveID != wxEmptyString)
-    cfg.WriteString(WX_ORGAN, wxT("ArchiveID"), m_ArchiveID);
+  if (m_ConfiguredOrgan.GetArchiveID() != wxEmptyString)
+    cfg.WriteString(
+      WX_ORGAN, wxT("ArchiveID"), m_ConfiguredOrgan.GetArchiveID());
   cfg.WriteString(WX_ORGAN, WX_GRANDORGUE_VERSION, wxT(APP_VERSION));
   cfg.WriteInteger(WX_ORGAN, wxT("Volume"), m_SoundEngine.GetVolume());
   cfg.WriteString(WX_ORGAN, wxT("Temperament"), m_Temperament);
@@ -807,23 +684,25 @@ GOButtonControl *GOOrganController::GetButtonControl(
 }
 
 const wxString GOOrganController::GetOrganPathInfo() {
-  if (m_ArchiveID == wxEmptyString)
+  const wxString &archiveID = m_ConfiguredOrgan.GetArchiveID();
+
+  if (archiveID == wxEmptyString)
     return GetODFFilename();
-  const GOArchiveFile *archive = m_config.GetArchiveByID(m_ArchiveID);
+  const GOArchiveFile *archive = m_config.GetArchiveByID(archiveID);
   wxString name = GetODFFilename();
   if (archive)
     name += wxString::Format(
-      _(" from '%s' (%s)"), archive->GetName().c_str(), m_ArchiveID.c_str());
+      _(" from '%s' (%s)"), archive->GetName().c_str(), archiveID.c_str());
   else
-    name += wxString::Format(_(" from %s"), m_ArchiveID.c_str());
+    name += wxString::Format(_(" from %s"), archiveID.c_str());
   return name;
 }
 
 GOOrgan GOOrganController::GetOrganInfo() {
   return GOOrgan(
     GetODFFilename(),
-    m_ArchiveID,
-    m_ArchivePath,
+    m_ConfiguredOrgan.GetArchiveID(),
+    m_ConfiguredOrgan.GetArchivePath(),
     GetOrganName(),
     GetOrganBuilder(),
     GetRecordingDetails());

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -21,6 +21,7 @@
 #include "gui/frames/GOMainWindowData.h"
 #include "gui/panels/GOGUIMouseState.h"
 #include "loader/GOFileStore.h"
+#include "loader/GOLoadedOrganInfo.h"
 #include "loader/GOProgressMonitor.h"
 #include "model/GOOrganModel.h"
 #include "modification/GOModificationProxy.h"
@@ -28,6 +29,7 @@
 #include "sound/GOSoundOrganEngine.h"
 
 #include "GOMemoryPool.h"
+#include "GOOrgan.h"
 #include "GOVirtualCouplerController.h"
 
 class GOArchive;
@@ -46,7 +48,6 @@ class GOMidiEvent;
 class GOMidiPlayer;
 class GOMidiRecorder;
 class GOMidiSystem;
-class GOOrgan;
 class GOSetter;
 class GOSoundProvider;
 class GOSoundRecorder;
@@ -60,14 +61,9 @@ class GOOrganController : public GOEventDistributor,
                           public GOModificationProxy {
 private:
   GOConfig &m_config;
-  wxString m_odf;
-  wxString m_ArchiveID;
-  wxString m_ArchivePath;
-  wxString m_hash;
+  GOOrgan m_ConfiguredOrgan;
+  GOLoadedOrganInfo m_LoadedOrganInfo;
   GOFileStore m_FileStore;
-  wxString m_CacheFilename;
-  wxString m_SettingFilename;
-  wxString m_ODFHash;
   bool m_Cacheable;
   GOSetter *m_setter;
   GODivisionalSetter *m_DivisionalSetter;
@@ -79,7 +75,6 @@ private:
   GOButtonControl *p_OnStateButton;
   wxString m_Temperament;
 
-  bool m_b_customized;
   float m_CurrentPitch; // organ pitch
   bool m_OrganModified; // always m_IsOrganModified >= IsModelModified()
 
@@ -116,12 +111,8 @@ private:
 
   void ReadOrganFile(GOConfigReader &cfg);
   GOHashType GenerateCacheHash();
-  wxString GenerateSettingFileName();
-  wxString GenerateCacheFileName();
   void SetTemperament(const GOTemperament &temperament);
   void PreconfigRecorder();
-
-  const wxString &GetOrganHash() const { return m_hash; }
 
 public:
   GOOrganController(GOConfig &config, bool isAppInitialized = false);
@@ -162,7 +153,9 @@ public:
   void LoadCombination(const wxString &cmb);
   bool Save();
   bool Export(const wxString &cmb);
-  bool CachePresent() const { return wxFileExists(m_CacheFilename); }
+  bool CachePresent() const {
+    return wxFileExists(m_LoadedOrganInfo.cacheFilePath);
+  }
   bool IsCacheable() const { return m_Cacheable; }
   bool UpdateCache(bool compress, GOProgressMonitor &monitor);
   void DeleteCache();
@@ -237,14 +230,20 @@ public:
     const wxString &name, bool is_panel = false);
 
   /* TODO: can somebody figure out what this thing is */
-  bool IsCustomized() const { return m_b_customized; }
+  bool IsCustomized() const { return m_LoadedOrganInfo.isCustomized; }
 
   /* Filename of the organ definition used to load */
-  const wxString &GetODFFilename() const { return m_odf; }
+  const wxString &GetODFFilename() const {
+    return m_ConfiguredOrgan.GetODFPath();
+  }
   const wxString GetOrganPathInfo();
   GOOrgan GetOrganInfo();
-  const wxString &GetSettingFilename() const { return m_SettingFilename; }
-  const wxString &GetCacheFilename() const { return m_CacheFilename; }
+  const wxString &GetSettingFilename() const {
+    return m_LoadedOrganInfo.settingsFilePath;
+  }
+  const wxString &GetCacheFilename() const {
+    return m_LoadedOrganInfo.cacheFilePath;
+  }
   wxString GetCombinationsDir() const;
 
   /* Organ and Building general information */

--- a/src/grandorgue/loader/GOLoadedOrganInfo.h
+++ b/src/grandorgue/loader/GOLoadedOrganInfo.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOLOADEDORGANINFO_H
+#define GOLOADEDORGANINFO_H
+
+#include <wx/string.h>
+
+/** Everything GOOrganReader discovers about an organ that has no
+ * equivalent field in GOOrgan and must outlive a single Load() call. */
+struct GOLoadedOrganInfo {
+  /** Path of the per-user CMB this organ is saved to. */
+  wxString settingsFilePath;
+  /** Path of the precomputed sample cache file for this organ. */
+  wxString cacheFilePath;
+  /** Hash of the ODF's contents, written into exported CMB files. */
+  wxString odfHash;
+  /** True if a CMB (explicit, saved, bundled, or archived) was applied. */
+  bool isCustomized = false;
+};
+
+#endif /* GOLOADEDORGANINFO_H */

--- a/src/grandorgue/loader/GOOrganReader.cpp
+++ b/src/grandorgue/loader/GOOrganReader.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOOrganReader.h"
+
+#include <wx/filename.h>
+#include <wx/log.h>
+#include <wx/msgdlg.h>
+
+#include "archive/GOArchive.h"
+#include "config/GOConfig.h"
+#include "config/GOConfigFileReader.h"
+#include "files/GOOpenedFile.h"
+#include "files/GOStdFileName.h"
+
+#include "GOFileStore.h"
+#include "GOLoaderFilename.h"
+#include "GOOrgan.h"
+#include "GOProgressMonitor.h"
+#include "go_path.h"
+
+static const wxString WX_ORGAN = wxT("Organ");
+
+GOOrganReader::GOOrganReader(
+  GOConfig &config,
+  const GOOrgan &organ,
+  const wxString &settingsPath,
+  GOFileStore &fileStore,
+  GOProgressMonitor &monitor)
+  : m_ConfigDB(config.ODFCheck()),
+    m_ConfigReader(m_ConfigDB, config.ODFCheck(), config.ODFHw1Check()) {
+  GOLoaderFilename odfName;
+  const wxString &archiveID = organ.GetArchiveID();
+
+  if (!archiveID.IsEmpty()) {
+    monitor.Setup(1, _("Loading sample set"), _("Parsing organ packages"));
+
+    wxString archiveErrMsg;
+
+    if (!fileStore.LoadArchives(
+          config,
+          config.OrganCachePath(),
+          archiveID,
+          organ.GetArchivePath(),
+          archiveErrMsg))
+      throw archiveErrMsg;
+    odfName.Assign(organ.GetODFPath());
+  } else {
+    odfName.AssignAbsolute(organ.GetODFPath());
+    fileStore.SetDirectory(go_get_path(organ.GetODFPath()));
+  }
+  m_Hash = organ.GetOrganHash();
+  monitor.Setup(
+    1, _("Loading sample set"), _("Parsing sample set definition file"));
+  m_LoadedOrganInfo.settingsFilePath = config.OrganSettingsPath()
+    + wxFileName::GetPathSeparator()
+    + GOStdFileName::composeSettingFileName(m_Hash, config.Preset());
+  m_LoadedOrganInfo.cacheFilePath = config.OrganCachePath()
+    + wxFileName::GetPathSeparator()
+    + GOStdFileName::composeCacheFileName(m_Hash, config.Preset());
+
+  GOConfigFileReader odfIniFile;
+
+  if (!odfIniFile.Read(odfName.Open(fileStore).get()))
+    throw wxString::Format(_("Unable to read '%s'"), odfName.GetPath());
+
+  m_LoadedOrganInfo.odfHash = odfIniFile.GetHash();
+  m_LoadedOrganInfo.isCustomized = false;
+  m_ConfigDB.ReadData(odfIniFile, ODFSetting, false);
+
+  wxString effectiveSettingsPath = settingsPath;
+  bool canReadSettingsDirectly = true;
+
+  if (effectiveSettingsPath.IsEmpty()) {
+    if (wxFileExists(m_LoadedOrganInfo.settingsFilePath)) {
+      effectiveSettingsPath = m_LoadedOrganInfo.settingsFilePath;
+      m_LoadedOrganInfo.isCustomized = true;
+    } else {
+      wxString bundledSettingsPath
+        = organ.GetODFPath().BeforeLast('.') + wxT(".cmb");
+
+      if (!fileStore.AreArchivesUsed()) {
+        if (wxFileExists(bundledSettingsPath)) {
+          effectiveSettingsPath = bundledSettingsPath;
+          m_LoadedOrganInfo.isCustomized = true;
+        }
+      } else {
+        if (fileStore.FindArchiveContaining(organ.GetODFPath())
+              ->containsFile(bundledSettingsPath)) {
+          effectiveSettingsPath = bundledSettingsPath;
+          m_LoadedOrganInfo.isCustomized = true;
+          canReadSettingsDirectly = false;
+        }
+      }
+    }
+  }
+
+  if (!effectiveSettingsPath.IsEmpty()) {
+    GOConfigFileReader settingsConfig;
+
+    if (canReadSettingsDirectly) {
+      if (!settingsConfig.Read(effectiveSettingsPath))
+        throw wxString::Format(_("Unable to read '%s'"), effectiveSettingsPath);
+    } else {
+      if (!settingsConfig.Read(
+            fileStore.FindArchiveContaining(organ.GetODFPath())
+              ->OpenFile(effectiveSettingsPath)))
+        throw wxString::Format(_("Unable to read '%s'"), effectiveSettingsPath);
+    }
+
+    if (
+      odfIniFile.getEntry(WX_ORGAN, wxT("ChurchName")).Trim()
+      != settingsConfig.getEntry(WX_ORGAN, wxT("ChurchName")).Trim())
+      wxLogWarning(
+        _("This .cmb file was originally created for:\n%s"),
+        settingsConfig.getEntry(WX_ORGAN, wxT("ChurchName")).c_str());
+
+    m_ConfigDB.ReadData(settingsConfig, CMBSetting, false);
+    wxString settingsOdfHash
+      = settingsConfig.getEntry(WX_ORGAN, wxT("ODFHash"));
+
+    if (settingsOdfHash != wxEmptyString)
+      if (settingsOdfHash != m_LoadedOrganInfo.odfHash) {
+        if (
+          wxMessageBox(
+            _("The .cmb file does not exactly match the current "
+              "ODF. Importing it can cause various problems. "
+              "Should it really be imported?"),
+            _("Import"),
+            wxYES_NO,
+            NULL)
+          == wxNO) {
+          m_ConfigDB.ClearCMB();
+        }
+      }
+  } else {
+    bool hasOldGoSettings = m_ConfigDB.ReadData(odfIniFile, CMBSetting, true);
+
+    if (hasOldGoSettings)
+      if (
+        wxMessageBox(
+          _("The ODF contains GrandOrgue 0.2 styled saved "
+            "settings. Should they be imported?"),
+          _("Import"),
+          wxYES_NO,
+          NULL)
+        == wxNO) {
+        m_ConfigDB.ClearCMB();
+      }
+  }
+
+  /* skip informational items */
+  m_ConfigReader.ReadString(CMBSetting, WX_ORGAN, wxT("ChurchName"), false);
+  m_ConfigReader.ReadString(CMBSetting, WX_ORGAN, wxT("ChurchAddress"), false);
+  m_ConfigReader.ReadString(CMBSetting, WX_ORGAN, wxT("ODFPath"), false);
+  m_ConfigReader.ReadString(CMBSetting, WX_ORGAN, wxT("ODFHash"), false);
+  m_ConfigReader.ReadString(CMBSetting, WX_ORGAN, wxT("ArchiveID"), false);
+}

--- a/src/grandorgue/loader/GOOrganReader.h
+++ b/src/grandorgue/loader/GOOrganReader.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOORGANREADER_H
+#define GOORGANREADER_H
+
+#include <wx/string.h>
+
+#include "config/GOConfigReader.h"
+#include "config/GOConfigReaderDB.h"
+
+#include "GOLoadedOrganInfo.h"
+
+class GOConfig;
+class GOFileStore;
+class GOOrgan;
+class GOProgressMonitor;
+
+/**
+ * Resolves an organ's archive/ODF/CMB files, reads them into a config
+ * database, and reports the paths and hash discovered along the way. Owns
+ * the GOConfigReaderDB/GOConfigReader pair for the duration of one load, so
+ * the caller must keep the GOOrganReader instance alive while reading from
+ * GetConfigReader().
+ */
+class GOOrganReader {
+private:
+  wxString m_Hash;
+  GOConfigReaderDB m_ConfigDB;
+  GOConfigReader m_ConfigReader;
+  GOLoadedOrganInfo m_LoadedOrganInfo;
+
+public:
+  /**
+   * Reads the ODF and its matching CMB (explicit `settingsPath`, the
+   * previously saved per-user CMB if it exists, or a bundled/embedded
+   * CMB) for `organ`, populating the config DB and the result returned by
+   * GetLoadedOrganInfo(). Throws a wxString error message on failure.
+   * @param config - the application config, used for ODF strictness checks
+   *   and settings/cache path generation. Not const because it is passed on
+   *   to GOFileStore::LoadArchives(GOOrganList&, ...), which takes its
+   *   GOOrganList base (config's archive list) by non-const reference even
+   *   though it only reads from it
+   * @param organ - the organ to load, giving the (self-normalized) ODF
+   *   path and/or archive info
+   * @param settingsPath - an explicit CMB path to import, or empty to
+   *   auto-discover (previously saved per-user CMB, then bundled/embedded
+   *   CMB)
+   * @param fileStore - the file store to resolve archives and read the
+   *   ODF/CMB from
+   * @param monitor - receives the same progress messages the code this
+   *   replaces reported
+   */
+  GOOrganReader(
+    GOConfig &config,
+    const GOOrgan &organ,
+    const wxString &settingsPath,
+    GOFileStore &fileStore,
+    GOProgressMonitor &monitor);
+
+  /**
+   * @return the config database populated by the constructor, shared with
+   *   GetConfigReader()
+   */
+  GOConfigReaderDB &GetConfigDB() { return m_ConfigDB; }
+  /**
+   * @return the config reader wrapping GetConfigDB(), for reading ODF/CMB
+   *   settings
+   */
+  GOConfigReader &GetConfigReader() { return m_ConfigReader; }
+  /**
+   * @return the paths, hash, and customization flag discovered while
+   *   reading the organ
+   */
+  const GOLoadedOrganInfo &GetLoadedOrganInfo() const {
+    return m_LoadedOrganInfo;
+  }
+  /** Logs a warning for every ODF/CMB entry that was never read. */
+  void ReportUnused() { m_ConfigDB.ReportUnused(); }
+};
+
+#endif /* GOORGANREADER_H */

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -11,6 +11,7 @@
 
 #include "common/GOTestCollection.h"
 #include "testing/GOTestNameMap.h"
+#include "testing/loader/GOTestOrganReader.h"
 #include "testing/model/GOTestDrawStop.h"
 #include "testing/model/GOTestOrganModel.h"
 #include "testing/model/GOTestSwitch.h"
@@ -46,6 +47,7 @@ int main(int argc, char *argv[]) {
   }
 
   /* Instantiate all the test classes here */
+  GOTestOrganReader testOrganReader;
   GOTestDrawStop testDrawStop;
   GOTestOrganModel testOrganModel;
   GOTestSwitch testSwitch;

--- a/src/tests/common/GOTest.cpp
+++ b/src/tests/common/GOTest.cpp
@@ -8,6 +8,7 @@
 #include "GOTestCollection.h"
 #include "config/GOConfig.h"
 #include <cstdio>
+#include <filesystem>
 #include <iostream>
 
 GOTest::GOTest(Category category) : m_Category(category) {
@@ -36,8 +37,8 @@ bool GOCommonControllerTest::setUp() {
 
   // Make organ temporary directory
   GOTest::setUp();
-  char path[] = ".";
-  this->organ_directory = mkdtemp(path);
+  m_OrganDirectoryTemplate = "./GOTestXXXXXX";
+  this->organ_directory = mkdtemp(&m_OrganDirectoryTemplate[0]);
   mp_config.emplace(GetName(), "");
   this->controller = new GOOrganController(*mp_config);
   this->controller->InitOrganDirectory(this->organ_directory);
@@ -50,6 +51,7 @@ bool GOCommonControllerTest::tearDown() {
   delete this->controller;
   this->controller = nullptr;
   mp_config.reset();
-  unlink(this->organ_directory);
+  if (this->organ_directory)
+    std::filesystem::remove_all(this->organ_directory);
   return true;
 }

--- a/src/tests/common/GOTest.h
+++ b/src/tests/common/GOTest.h
@@ -41,6 +41,11 @@ public:
 
 class GOCommonControllerTest : public GOTest {
 private:
+  // mkdtemp() writes the actual directory name into this buffer and
+  // organ_directory points into it, so it must outlive setUp() (a member,
+  // not a setUp()-local string).
+  std::string m_OrganDirectoryTemplate;
+
   // Owns the GOConfig that controller's GOOrganController::m_config
   // reference points to. GOConfig has no default constructor and needs
   // GetName(), which only resolves to the derived test's actual name once

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(go_tests
     # Add here your tests files
+    loader/GOTestOrganReader.cpp
     model/GOTestDrawStop.cpp
     model/GOTestOrganModel.cpp
     model/GOTestSwitch.cpp

--- a/src/tests/testing/loader/GOTestOrganReader.cpp
+++ b/src/tests/testing/loader/GOTestOrganReader.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestOrganReader.h"
+
+#include <fstream>
+
+#include "archive/GOArchive.h"
+#include "config/GOConfig.h"
+#include "loader/GOFileStore.h"
+#include "loader/GOOrganReader.h"
+#include "loader/GOProgressMonitor.h"
+
+#include "GOOrgan.h"
+#include "go_path.h"
+
+namespace {
+
+class GOTestProgressMonitor : public GOProgressMonitor {
+public:
+  void Setup(long max, const wxString &title, const wxString &msg) override {}
+  void Reset(long max, const wxString &msg) override {}
+  bool Update(unsigned value, const wxString &msg) override { return true; }
+};
+
+void writeTextFile(const wxString &path, const wxString &content) {
+  std::ofstream file(path.ToStdString());
+
+  file << content.ToStdString();
+}
+
+} // namespace
+
+GOTestOrganReader::~GOTestOrganReader() {}
+
+std::string GOTestOrganReader::GetName() { return name; }
+
+void GOTestOrganReader::run() {
+  try {
+    runImpl();
+  } catch (const wxString &e) {
+    throw GOTestException(
+      std::string("Unexpected wxString exception: ") + e.ToStdString());
+  }
+}
+
+void GOTestOrganReader::runImpl() {
+  GOConfig config(GetName(), "");
+  GOFileStore fileStore(config);
+  GOTestProgressMonitor monitor;
+  const wxString odfPath
+    = wxString::Format(wxT("%s/test.organ"), organ_directory);
+
+  writeTextFile(odfPath, wxT("[Organ]\nChurchName=Test Organ\n"));
+
+  GOOrgan organ(odfPath);
+
+  GOAssert(
+    organ.GetODFPath() == go_normalize_path(odfPath),
+    "GOOrgan should normalize the ODF path on construction");
+
+  GOOrganReader organReader(config, organ, wxEmptyString, fileStore, monitor);
+  const GOLoadedOrganInfo &info = organReader.GetLoadedOrganInfo();
+
+  GOAssert(
+    !info.isCustomized,
+    "A freshly loaded ODF without a CMB should not be "
+    "reported as customized");
+  GOAssert(!info.odfHash.IsEmpty(), "odfHash should be filled in");
+  GOAssert(
+    !info.settingsFilePath.IsEmpty(), "settingsFilePath should be filled in");
+  GOAssert(!info.cacheFilePath.IsEmpty(), "cacheFilePath should be filled in");
+
+  wxString churchName = organReader.GetConfigReader().ReadString(
+    ODFSetting, wxT("Organ"), wxT("ChurchName"));
+
+  GOAssert(
+    churchName == wxT("Test Organ"),
+    "GetConfigReader() should read back the ChurchName written to the ODF");
+
+  wxString churchNameFromDb;
+
+  organReader.GetConfigDB().GetString(
+    ODFSetting, wxT("Organ"), wxT("ChurchName"), churchNameFromDb);
+  GOAssert(
+    churchNameFromDb == churchName,
+    "GetConfigDB() and GetConfigReader() should share the same underlying "
+    "data");
+
+  const wxString cmbPath
+    = wxString::Format(wxT("%s/test.cmb"), organ_directory);
+
+  writeTextFile(
+    cmbPath,
+    wxString::Format(
+      wxT("[Organ]\nChurchName=Overridden Organ\nODFHash=%s\n"), info.odfHash));
+
+  // cmbPath equals the ODF path with its extension replaced by ".cmb", i.e.
+  // the bundled settings file GOOrganReader auto-discovers next to the ODF
+  // when settingsPath is empty.
+  GOOrganReader cmbOrganReader(
+    config, organ, wxEmptyString, fileStore, monitor);
+  const GOLoadedOrganInfo &cmbInfo = cmbOrganReader.GetLoadedOrganInfo();
+
+  GOAssert(
+    cmbInfo.isCustomized,
+    "Loading with a bundled .cmb file should mark the organ as customized");
+
+  wxString overriddenChurchName = cmbOrganReader.GetConfigReader().ReadString(
+    CMBSetting, wxT("Organ"), wxT("ChurchName"));
+
+  GOAssert(
+    overriddenChurchName == wxT("Overridden Organ"),
+    "The .cmb file should be layered over the ODF, not ignored");
+
+  const GOOrgan missingOrgan(
+    wxString::Format(wxT("%s/nonexistent.organ"), organ_directory));
+  bool wasExceptionThrown = false;
+
+  try {
+    GOOrganReader missingOrganReader(
+      config, missingOrgan, wxEmptyString, fileStore, monitor);
+  } catch (const wxString &) {
+    wasExceptionThrown = true;
+  }
+  GOAssert(
+    wasExceptionThrown,
+    "Constructing a GOOrganReader for a nonexistent ODF should throw");
+
+  organReader.ReportUnused();
+}

--- a/src/tests/testing/loader/GOTestOrganReader.cpp
+++ b/src/tests/testing/loader/GOTestOrganReader.cpp
@@ -49,6 +49,14 @@ void GOTestOrganReader::run() {
 
 void GOTestOrganReader::runImpl() {
   GOConfig config(GetName(), "");
+
+  // Without a call to config.Load(), OrganSettingsPath() defaults to an
+  // empty string, which would make settingsFilePath resolve under the
+  // filesystem root. Redirect it into organ_directory so the "previously
+  // saved per-user CMB" case below can safely write there.
+  config.OrganSettingsPath(
+    wxString::Format(wxT("%s/settings"), organ_directory));
+
   GOFileStore fileStore(config);
   GOTestProgressMonitor monitor;
   const wxString odfPath
@@ -115,6 +123,81 @@ void GOTestOrganReader::runImpl() {
   GOAssert(
     overriddenChurchName == wxT("Overridden Organ"),
     "The .cmb file should be layered over the ODF, not ignored");
+
+  // An explicit settingsPath must bypass auto-discovery entirely: even
+  // though a bundled .cmb (test.cmb, "Overridden Organ") already exists
+  // next to the ODF, the explicitly named file must win.
+  const wxString explicitCmbPath
+    = wxString::Format(wxT("%s/explicit.cmb"), organ_directory);
+
+  writeTextFile(
+    explicitCmbPath,
+    wxString::Format(
+      wxT("[Organ]\nChurchName=Explicit Organ\nODFHash=%s\n"), info.odfHash));
+
+  GOOrganReader explicitOrganReader(
+    config, organ, explicitCmbPath, fileStore, monitor);
+  const GOLoadedOrganInfo &explicitInfo
+    = explicitOrganReader.GetLoadedOrganInfo();
+
+  GOAssert(
+    !explicitInfo.isCustomized,
+    "Loading with an explicit settingsPath should not mark the organ as "
+    "customized, matching GOOrganController's pre-refactor behaviour");
+
+  wxString explicitChurchName
+    = explicitOrganReader.GetConfigReader().ReadString(
+      CMBSetting, wxT("Organ"), wxT("ChurchName"));
+
+  GOAssert(
+    explicitChurchName == wxT("Explicit Organ"),
+    "An explicit settingsPath should be read directly, bypassing both the "
+    "saved-settings and bundled-cmb auto-discovery checks");
+
+  // A previously saved per-user CMB (at the computed settingsFilePath) must
+  // be auto-discovered and take priority over the bundled .cmb next to the
+  // ODF, even though both exist at this point.
+  writeTextFile(
+    info.settingsFilePath,
+    wxString::Format(
+      wxT("[Organ]\nChurchName=Saved Organ\nODFHash=%s\n"), info.odfHash));
+
+  GOOrganReader savedOrganReader(
+    config, organ, wxEmptyString, fileStore, monitor);
+  const GOLoadedOrganInfo &savedInfo = savedOrganReader.GetLoadedOrganInfo();
+
+  GOAssert(
+    savedInfo.isCustomized,
+    "Loading a previously saved per-user CMB should mark the organ as "
+    "customized");
+
+  wxString savedChurchName = savedOrganReader.GetConfigReader().ReadString(
+    CMBSetting, wxT("Organ"), wxT("ChurchName"));
+
+  GOAssert(
+    savedChurchName == wxT("Saved Organ"),
+    "The previously saved per-user CMB should take priority over the "
+    "bundled .cmb next to the ODF");
+
+  // A CMB with a matching ChurchName (no mismatch warning) and no ODFHash
+  // entry at all (skipping the hash-mismatch check, which would otherwise
+  // pop up a blocking wxMessageBox) must still be read and applied.
+  const wxString matchingNoHashCmbPath
+    = wxString::Format(wxT("%s/matching-no-hash.cmb"), organ_directory);
+
+  writeTextFile(matchingNoHashCmbPath, wxT("[Organ]\nChurchName=Test Organ\n"));
+
+  GOOrganReader matchingNoHashOrganReader(
+    config, organ, matchingNoHashCmbPath, fileStore, monitor);
+
+  wxString matchingChurchNameFromDb;
+  bool wasFoundInCmb = matchingNoHashOrganReader.GetConfigDB().GetString(
+    CMBSetting, wxT("Organ"), wxT("ChurchName"), matchingChurchNameFromDb);
+
+  GOAssert(
+    wasFoundInCmb && matchingChurchNameFromDb == wxT("Test Organ"),
+    "A CMB with a matching ChurchName and no ODFHash entry should still be "
+    "read into the CMB config, without hitting the mismatch dialogs");
 
   const GOOrgan missingOrgan(
     wxString::Format(wxT("%s/nonexistent.organ"), organ_directory));

--- a/src/tests/testing/loader/GOTestOrganReader.h
+++ b/src/tests/testing/loader/GOTestOrganReader.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTORGANREADER_H
+#define GOTESTORGANREADER_H
+
+#include <string>
+
+#include "GOTest.h"
+
+class GOTestOrganReader : public GOCommonControllerTest {
+
+private:
+  std::string name = "GOTestOrganReader";
+
+public:
+  GOTestOrganReader() { name = "GOTestOrganReader"; }
+  virtual ~GOTestOrganReader();
+  virtual void run();
+  std::string GetName();
+
+private:
+  void runImpl();
+};
+
+#endif


### PR DESCRIPTION
## Summary
- Extracts the archive/ODF/CMB resolution logic out of `GOOrganController::Load()` into a new `GOOrganReader` class (owning its own `GOConfigReaderDB`/`GOConfigReader` pair) and a `GOLoadedOrganInfo` struct holding the paths/hash/customization flag it discovers.
- `GOOrganController` now stores `GOOrgan m_ConfiguredOrgan` and `GOLoadedOrganInfo m_LoadedOrganInfo` instead of the separate `m_ArchiveID`/`m_ArchivePath`/`m_odf`/`m_SettingFilename`/`m_CacheFilename`/`m_ODFHash`/`m_b_customized` members.
- `GOOrgan` now self-normalizes its ODF path on construction (`SetODFPath()`), so `GOOrganReader` can take it as a plain in-parameter with no separate normalization step.
- This is the first step (PR A) of a larger plan to move GUI-related state out of `GOOrganController` into `GOGuiOrgan`; `Load()`/`ReadOrganFile()` orchestration itself is not split yet (that's a later PR).

Also fixes a latent bug in the shared test fixture `GOCommonControllerTest::setUp()`: it called `mkdtemp()` on an invalid template (`"."`, missing the required `XXXXXX` placeholder) stored in a `setUp()`-local array, so `organ_directory` was always null (and would have dangled after `setUp()` returned even had it succeeded). It now uses a member `std::string` buffer, which lets the new `GOTestOrganReader` test create real fixture files on disk.

## Test plan
- [x] `ctest` (both `GOTestFunctional` and `GOTestPerf`) passes
- [x] `./bin/GOTestExe` passes all 13 tests, including the new `GOTestOrganReader`
- [x] Full `make -k -j$(nproc)` build succeeds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)