### PR TITLE
Fix dangling GOConfig reference in GOCommonControllerTest

### DIFF
--- a/src/tests/common/GOTest.cpp
+++ b/src/tests/common/GOTest.cpp
@@ -38,16 +38,18 @@ bool GOCommonControllerTest::setUp() {
   GOTest::setUp();
   char path[] = ".";
   this->organ_directory = mkdtemp(path);
-  GOConfig settings(GetName(), "");
-  this->controller = new GOOrganController(settings);
+  mp_config.emplace(GetName(), "");
+  this->controller = new GOOrganController(*mp_config);
   this->controller->InitOrganDirectory(this->organ_directory);
   return true;
 }
 
 bool GOCommonControllerTest::tearDown() {
-  // This initialize a new GOOrganController object that will be destroyed
-  // during test teardown().
+  // Delete controller before resetting mp_config: ~GOOrganController() may
+  // still read m_config, so mp_config must outlive it.
+  delete this->controller;
   this->controller = nullptr;
+  mp_config.reset();
   unlink(this->organ_directory);
   return true;
 }

--- a/src/tests/common/GOTest.h
+++ b/src/tests/common/GOTest.h
@@ -7,8 +7,12 @@
 #ifndef GOTEST_H
 #define GOTEST_H
 
+#include <optional>
+
 #include "GOOrganController.h"
 #include "GOTestUtils.h"
+
+#include "config/GOConfig.h"
 
 class GOTest : public GOTestUtils {
   /*
@@ -36,6 +40,18 @@ public:
 };
 
 class GOCommonControllerTest : public GOTest {
+private:
+  // Owns the GOConfig that controller's GOOrganController::m_config
+  // reference points to. GOConfig has no default constructor and needs
+  // GetName(), which only resolves to the derived test's actual name once
+  // the derived constructor has run - so this is constructed in setUp(),
+  // not in the constructor's initializer list, via std::optional's
+  // deferred-construction (hence the mp_ prefix, matching this codebase's
+  // convention for members that are absent until explicitly constructed).
+  // Must outlive controller: tearDown() deletes controller before
+  // resetting mp_config (see GOTest.cpp), since ~GOOrganController() may
+  // still read m_config.
+  std::optional<GOConfig> mp_config;
 
 public:
   GOCommonControllerTest();

--- a/src/tests/testing/model/GOTestWindchest.cpp
+++ b/src/tests/testing/model/GOTestWindchest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -45,6 +45,11 @@ void GOTestWindchest::run() {
 
   // Check enclosure volume values from midi ones
   GOEnclosure *enclosure = new GOEnclosure(*this->controller);
+  // windchest->AddEnclosure() only registers enclosure in a non-owning
+  // std::vector (GOWindchest::m_enclosure) for volume grouping; ownership
+  // (and destruction) comes from the model's own ptr_vector, registered
+  // via controller->AddEnclosure().
+  controller->AddEnclosure(enclosure);
   windchest->AddEnclosure(enclosure);
 
   enclosure->SetEnclosureValue(127);
@@ -75,6 +80,11 @@ void GOTestWindchest::run() {
   GORank *rank = new GORank(*this->controller);
   message = "The Rank count for Windchest should be 0";
   this->GOAssert(windchest->GetRankCount() == 0, message);
+  // windchest->AddRank() only registers rank in a non-owning std::vector
+  // (GOWindchest::m_ranks) for grouping; ownership (and destruction, which
+  // transitively frees rank's own owned pipes via GORank::m_Pipes) comes
+  // from the model's own ptr_vector, registered via controller->AddRank().
+  controller->AddRank(rank);
   windchest->AddRank(rank);
   this->GOAssert(windchest->GetRankCount() == 1, message);
 


### PR DESCRIPTION
## Summary
- `GOCommonControllerTest::setUp()` constructed `GOOrganController` with a `GOConfig` local to `setUp()`, leaving `controller->m_config` dangling as soon as `setUp()` returned. Any test that exercises `Load()`/`Export()`/`Save()` through `controller` would hit undefined behavior. Store the `GOConfig` as a deferred-constructed member (`mp_config`, via `std::optional` since `GOConfig` has no default constructor and needs `GetName()`, only valid once the derived test's constructor has run) that outlives `controller`.
- `tearDown()` now actually `delete`s `controller` instead of leaking it, and resets `mp_config` afterward.
- `GOTestWindchest` registered `enclosure`/`rank` only via the non-owning `GOWindchest::AddEnclosure()`/`AddRank()` instead of the owning `GOOrganController::AddEnclosure()`/`AddRank()`, leaking both (and the rank's pipe) now that `controller` is actually destroyed.

## Test plan
- [x] `GOTestExe --no-perf`: all 11 functional tests pass
- [ ] Note: a pre-existing, separate leak remains and is out of scope here — `GOOrganController::m_setter` is always `new`'d in the constructor but only registered (and thus freed) via `m_elementcreators` inside `Load()`; tests that never call `Load()` (all `GOCommonControllerTest`-based tests) leak it. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)