### PR TITLE
Fixed MIDI REC resending external MIDI sends on recording start https://github.com/GrandOrgue/grandorgue/issues/2523

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed MIDI REC resending external MIDI sends on recording start https://github.com/GrandOrgue/grandorgue/issues/2523
 - Fixed crash on unknown command-line argument
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -898,6 +898,17 @@ void GOOrganController::PrepareRecording() {
   m_MidiRecorder->SetSamplesetId(m_SampleSetId1, m_SampleSetId2);
   PreconfigRecorder();
 
+  // The broadcasted PrepareRecording() below makes every MIDI-sending object
+  // resend its current value so that the new recording starts from a known
+  // state and can later be played back correctly. SetToSendMidi(false)
+  // keeps that resend from reaching external MIDI outputs (physical panels,
+  // LCDs, SysEx-driven consoles), which did not actually change and should
+  // not be refreshed just because recording started. SetToRecordMidi(true)
+  // ensures the resent values are still written into the recording itself.
+  GOMidiSendProxy::StateRestorer midiSendStateRestorer(*this);
+
+  SetToSendMidi(false);
+  SetToRecordMidi(true);
   GOEventDistributor::PrepareRecording();
 }
 

--- a/src/grandorgue/midi/elements/GOMidiSendProxy.cpp
+++ b/src/grandorgue/midi/elements/GOMidiSendProxy.cpp
@@ -10,6 +10,16 @@
 #include "midi/GOMidiRecorder.h"
 #include "midi/GOMidiSystem.h"
 
+GOMidiSendProxy::StateRestorer::StateRestorer(GOMidiSendProxy &midiSendProxy)
+  : r_MidiSendProxy(midiSendProxy),
+    m_IsToSendMidi(midiSendProxy.IsToSendMidi()),
+    m_IsToRecordMidi(midiSendProxy.IsToRecordMidi()) {}
+
+GOMidiSendProxy::StateRestorer::~StateRestorer() {
+  r_MidiSendProxy.SetToSendMidi(m_IsToSendMidi);
+  r_MidiSendProxy.SetToRecordMidi(m_IsToRecordMidi);
+}
+
 void GOMidiSendProxy::SetMidi(
   GOMidiSystem *pMidi, GOMidiRecorder *pMidiRecorder) {
   p_midi = pMidi;
@@ -17,11 +27,11 @@ void GOMidiSendProxy::SetMidi(
 }
 
 void GOMidiSendProxy::SendMidiMessage(const GOMidiEvent &e) {
-  if (p_midi)
+  if (p_midi && m_IsToSendMidi)
     p_midi->Send(e);
 }
 
 void GOMidiSendProxy::SendMidiRecorderMessage(GOMidiEvent &e) {
-  if (p_MidiRecorder)
+  if (p_MidiRecorder && m_IsToRecordMidi)
     p_MidiRecorder->SendMidiRecorderMessage(e);
 }

--- a/src/grandorgue/midi/elements/GOMidiSendProxy.h
+++ b/src/grandorgue/midi/elements/GOMidiSendProxy.h
@@ -16,10 +16,51 @@ class GOMidiSendProxy {
   GOMidiSystem *p_midi = nullptr;
   GOMidiRecorder *p_MidiRecorder = nullptr;
 
+  /** Whether object MIDI sends should reach external MIDI ports. */
+  bool m_IsToSendMidi = true;
+  /** Whether object MIDI events should reach the MIDI recorder. */
+  bool m_IsToRecordMidi = true;
+
 public:
+  class StateRestorer {
+    GOMidiSendProxy &r_MidiSendProxy;
+    const bool m_IsToSendMidi;
+    const bool m_IsToRecordMidi;
+
+  public:
+    /** Saves the current MIDI send and recording states. */
+    StateRestorer(GOMidiSendProxy &midiSendProxy);
+    /** Restores the saved MIDI send and recording states. */
+    ~StateRestorer();
+  };
+
   void SetMidi(GOMidiSystem *pMidi, GOMidiRecorder *pMidiRecorder);
   void SendMidiMessage(const GOMidiEvent &e);
   void SendMidiRecorderMessage(GOMidiEvent &e);
+
+  /**
+   * Returns whether object MIDI sends are forwarded to external MIDI ports.
+   */
+  bool IsToSendMidi() const { return m_IsToSendMidi; }
+
+  /**
+   * Enables or disables forwarding object MIDI sends to external MIDI ports.
+   * @param isToSendMidi whether MIDI sends should reach GOMidiSystem
+   */
+  void SetToSendMidi(bool isToSendMidi) { m_IsToSendMidi = isToSendMidi; }
+
+  /**
+   * Returns whether object MIDI events are forwarded to the MIDI recorder.
+   */
+  bool IsToRecordMidi() const { return m_IsToRecordMidi; }
+
+  /**
+   * Enables or disables forwarding object MIDI events to the MIDI recorder.
+   * @param isToRecordMidi whether MIDI events should reach GOMidiRecorder
+   */
+  void SetToRecordMidi(bool isToRecordMidi) {
+    m_IsToRecordMidi = isToRecordMidi;
+  }
 };
 
 #endif /* GOMIDISENDPROXY_H */

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -11,6 +11,7 @@
 
 #include "common/GOTestCollection.h"
 #include "testing/GOTestNameMap.h"
+#include "testing/midi/GOTestMidiSendProxy.h"
 #include "testing/model/GOTestDrawStop.h"
 #include "testing/model/GOTestOrganModel.h"
 #include "testing/model/GOTestSwitch.h"
@@ -50,6 +51,7 @@ int main(int argc, char *argv[]) {
   GOTestSwitch testSwitch;
   GOTestWindchest testWindchest;
   GOTestNameMap goTestNameMap;
+  GOTestMidiSendProxy testMidiSendProxy;
   GOTestSoundBuffer goTestSoundBuffer;
   GOTestSoundBufferManaged testSoundBufferManaged;
   GOTestSoundBufferMutable testSoundBufferMutable;

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(go_tests
     # Add here your tests files
+    midi/GOTestMidiSendProxy.cpp
     model/GOTestDrawStop.cpp
     model/GOTestOrganModel.cpp
     model/GOTestSwitch.cpp

--- a/src/tests/testing/midi/GOTestMidiSendProxy.cpp
+++ b/src/tests/testing/midi/GOTestMidiSendProxy.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestMidiSendProxy.h"
+
+#include "midi/elements/GOMidiSendProxy.h"
+
+const std::string GOTestMidiSendProxy::TEST_NAME = "GOTestMidiSendProxy";
+
+void GOTestMidiSendProxy::TestDefaultState() {
+  GOMidiSendProxy proxy;
+
+  GOAssert(proxy.IsToSendMidi(), "IsToSendMidi() should be true by default");
+  GOAssert(
+    proxy.IsToRecordMidi(), "IsToRecordMidi() should be true by default");
+}
+
+void GOTestMidiSendProxy::TestToSendMidiIsIndependent() {
+  GOMidiSendProxy proxy;
+
+  proxy.SetToSendMidi(false);
+  GOAssert(
+    !proxy.IsToSendMidi(),
+    "IsToSendMidi() should be false after SetToSendMidi(false)");
+  GOAssert(
+    proxy.IsToRecordMidi(),
+    "IsToRecordMidi() should stay true after SetToSendMidi(false)");
+
+  proxy.SetToSendMidi(true);
+  GOAssert(
+    proxy.IsToSendMidi(),
+    "IsToSendMidi() should be true after SetToSendMidi(true)");
+}
+
+void GOTestMidiSendProxy::TestToRecordMidiIsIndependent() {
+  GOMidiSendProxy proxy;
+
+  proxy.SetToRecordMidi(false);
+  GOAssert(
+    !proxy.IsToRecordMidi(),
+    "IsToRecordMidi() should be false after SetToRecordMidi(false)");
+  GOAssert(
+    proxy.IsToSendMidi(),
+    "IsToSendMidi() should stay true after SetToRecordMidi(false)");
+
+  proxy.SetToRecordMidi(true);
+  GOAssert(
+    proxy.IsToRecordMidi(),
+    "IsToRecordMidi() should be true after SetToRecordMidi(true)");
+}
+
+void GOTestMidiSendProxy::TestStateRestorer() {
+  GOMidiSendProxy proxy;
+
+  proxy.SetToSendMidi(false);
+  proxy.SetToRecordMidi(true);
+
+  {
+    GOMidiSendProxy::StateRestorer restorer(proxy);
+
+    proxy.SetToSendMidi(true);
+    proxy.SetToRecordMidi(false);
+  }
+
+  GOAssert(
+    !proxy.IsToSendMidi(),
+    "StateRestorer should restore IsToSendMidi() to its saved value");
+  GOAssert(
+    proxy.IsToRecordMidi(),
+    "StateRestorer should restore IsToRecordMidi() to its saved value");
+}
+
+void GOTestMidiSendProxy::run() {
+  TestDefaultState();
+  TestToSendMidiIsIndependent();
+  TestToRecordMidiIsIndependent();
+  TestStateRestorer();
+}

--- a/src/tests/testing/midi/GOTestMidiSendProxy.h
+++ b/src/tests/testing/midi/GOTestMidiSendProxy.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTMIDISENDPROXY_H
+#define GOTESTMIDISENDPROXY_H
+
+#include "GOTest.h"
+
+class GOTestMidiSendProxy : public GOTest {
+
+private:
+  static const std::string TEST_NAME;
+
+  void TestDefaultState();
+  void TestToSendMidiIsIndependent();
+  void TestToRecordMidiIsIndependent();
+  void TestStateRestorer();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTMIDISENDPROXY_H */


### PR DESCRIPTION
## Summary
- Starting MIDI recording broadcasts `GOEventDistributor::PrepareRecording()`, which makes every MIDI-sending object (buttons, labels, SysEx sends) resend its current value. This is required so the new recording starts from a known state and can be played back correctly, but it was also unexpectedly resending that state to external MIDI outputs (Hauptwerk-style SysEx labels, physical console panels/LCDs), even though nothing had actually changed. `AUDIO REC` does not exhibit this because it never reaches `PrepareRecording()`.
- `GOMidiSendProxy` now exposes two independent, positively-named routing flags: `IsToSendMidi()`/`SetToSendMidi()` (external MIDI ports) and `IsToRecordMidi()`/`SetToRecordMidi()` (the internal MIDI recorder stream), plus a `GOMidiSendProxy::StateRestorer` RAII helper to save/restore both.
- `GOOrganController::PrepareRecording()` now disables `ToSendMidi` (keeping `ToRecordMidi` enabled) only while broadcasting `PrepareRecording()`, so the initial state is still written into the `.mid` file but is not re-sent to external hardware. The direct `GOEventDistributor::PrepareRecording()` call made when starting/loading an organ is untouched, so external console synchronization on startup still works as before.
- This addresses only the "MIDI REC resends external sends" half of https://github.com/GrandOrgue/grandorgue/issues/2523. The separate standard-MIDI-file channel-mapping issue reported in the same issue is not addressed here.

## Test plan
- [x] `GOTestMidiSendProxy` unit test added (default state, independence of the two flags, `StateRestorer` behavior) — all 12 functional tests pass (`bin/GOTestExe --no-perf`)
- [x] Verified the same pre-existing ASan leak count appears on `master` without this change (unrelated to `GOTestWindchest`)
- [ ] Manual verification with a MIDI monitor (e.g. `aseqdump`) recommended: confirm no configured external send fires on MIDI REC, while the recorded `.mid` file still contains the initial GO setup/control state and plays back correctly; confirm organ startup still resyncs external console state

#2523 (partial — MIDI REC external sends only)