### PR TITLE
Fixed organ volume not saved into organ settings https://github.com/GrandOrgue/grandorgue/issues/2547

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed organ volume not saved into organ settings https://github.com/GrandOrgue/grandorgue/issues/2547
 - Fixed slow/flickery panel resizing while dragging a panel window's border https://github.com/GrandOrgue/grandorgue/issues/2537
 - Fixed heap overflow and wrong channel metering in audio output task https://github.com/GrandOrgue/grandorgue/issues/2531
 - Fixed crash when loading PNG images with embedded alpha channel used with mask images https://github.com/GrandOrgue/grandorgue/issues/2535


### PR DESCRIPTION
Resolves: #2547

## Summary
- Fixes #2547: changing the volume spinner and saving the organ settings persisted the volume the organ was loaded with, not the current one, because commit 26f2cdf2 (#2464) dropped the line that pulled the live engine volume back into `GOOrganController` before `Save()`.
- Instead of restoring that pull-back step in `GOGuiOrgan::SyncState()` (which should stay a GUI-only sync point), `GOOrganController::SetVolume()` is now the single entry point that updates the persisted `m_volume` field and pushes the value to the live sound engine, matching the existing `SetTemperament()`/`SetTranspose()` pattern already used for other organ attributes.
- `PreparePlayback()` now applies the cached volume to the engine as soon as it becomes attached, making the separate volume-set call after `Load()` redundant (removed).
- `GOAppWindow::OnSettingsVolume` now goes through `GOOrganController::SetVolume()` instead of touching the sound engine directly.

## How volume is persisted in the preset file

`GOOrganController` keeps the volume in its own `m_volume` member. It is loaded from the preset (CMB) file in `GOOrganController::Load()`:

```cpp
m_volume = cfg.ReadInteger(
  CMBSetting, WX_ORGAN, wxT("Volume"), -120, 100, false, m_config.Volume());
```

and written back to it in `GOOrganController::Export()` (called by both `Save()` and `Export()`):

```cpp
cfg.WriteInteger(WX_ORGAN, wxT("Volume"), m_volume);
```

Since `Export()` always reads straight from `m_volume`, saving is correct as long as `m_volume` itself is kept current. That's what this PR fixes: `SetVolume()` is now the single place that updates `m_volume` and forwards the value to the live sound engine (when attached), instead of the volume only being pushed to the engine at load time while `m_volume` went stale.

## Test plan
- [ ] Load an organ, move the volume spinner, confirm the audio level changes live
- [ ] Save the organ settings, reload the organ, confirm the volume spinner shows the saved value