### PR TITLE
Extracted GOSoundOrganInterface implementation into GOSoundSamplerPlayer

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -211,6 +211,7 @@ sound/playing/GOSoundFader.cpp
 sound/playing/GOSoundFilter.cpp
 sound/playing/GOSoundReleaseAlignTable.cpp
 sound/playing/GOSoundResample.cpp
+sound/playing/GOSoundSamplerPlayer.cpp
 sound/playing/GOSoundSamplerPool.cpp
 sound/playing/GOSoundStream.cpp
 sound/playing/GOSoundToneBalanceFilter.cpp

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -875,7 +875,8 @@ void GOOrganController::PreparePlayback(
 
   m_MidiSamplesetMatch.clear();
   GOOrganModel::SetMidi(midi, m_MidiRecorder);
-  GOOrganModel::GOSoundOrganInterfaceProxy::Connect(engine);
+  GOOrganModel::GOSoundOrganInterfaceProxy::Connect(
+    &engine->GetSamplerPlayer());
   GOEventDistributor::PreparePlayback();
 
   m_setter->UpdateModified(m_OrganModified);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -872,7 +872,8 @@ void GOOrganController::StartOrgan(GOSoundSystem &soundSystem) {
 
   m_MidiSamplesetMatch.clear();
   GOOrganModel::SetMidi(&midi, m_MidiRecorder);
-  GOOrganModel::GOSoundOrganInterfaceProxy::Connect(&m_SoundEngine);
+  GOOrganModel::GOSoundOrganInterfaceProxy::Connect(
+    &m_SoundEngine.GetSamplerPlayer());
   GOEventDistributor::PreparePlayback();
 
   m_setter->UpdateModified(m_OrganModified);

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -12,11 +12,7 @@
 #include "buffer/GOSoundBufferMutable.h"
 #include "config/GOConfig.h"
 #include "model/GOOrganModel.h"
-#include "model/GOPipe.h"
 #include "model/GOWindchest.h"
-#include "playing/GOSoundReleaseAlignTable.h"
-#include "playing/GOSoundSampler.h"
-#include "providers/GOSoundProvider.h"
 #include "scheduler/GOSoundThread.h"
 #include "tasks/GOSoundGroupTask.h"
 #include "tasks/GOSoundOutputTask.h"
@@ -99,29 +95,20 @@ GOSoundOrganEngine::GOSoundOrganEngine(
   GOOrganModel &organModel, GOMemoryPool &memoryPool)
   : r_OrganModel(organModel),
     r_MemoryPool(memoryPool),
-    mp_ReleaseTask(
-      std::make_unique<GOSoundReleaseTask>(*this, mp_AudioGroupTasks)),
     mp_TouchTask(std::make_unique<GOSoundTouchTask>(r_MemoryPool)),
+    m_SamplerPlayer(
+      mp_AudioGroupTasks, mp_WindchestTasks, mp_TremulantTasks, mp_ReleaseTask),
     m_NAudioGroups(1),
     m_NAuxThreads(0),
     m_IsDownmix(false),
     m_NReleaseRepeats(1),
-    m_IsPolyphonyLimiting(true),
-    m_PolyphonySoftLimit(0),
-    m_IsScaledReleases(true),
-    m_IsReleaseAlignmentEnabled(true),
-    m_IsRandomizeSpeaking(true),
-    m_InterpolationType(GOSoundResample::GO_LINEAR_INTERPOLATION),
     m_ReverbConfig(GOSoundReverb::CONFIG_REVERB_DISABLED),
     m_NSamplesPerBuffer(1),
-    m_SampleRate(0),
     m_LifecycleState(LifecycleState::IDLE),
-    p_AudioRecorder(nullptr),
-    m_CurrentTime(1),
-    m_UsedPolyphony(0) {
+    p_AudioRecorder(nullptr) {
   SetVolume(-15);
-  m_SamplerPool.SetUsageLimit(2048);
-  m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
+  mp_ReleaseTask
+    = std::make_unique<GOSoundReleaseTask>(m_SamplerPlayer, mp_AudioGroupTasks);
 }
 
 // The destructor body is empty, but it must be defined here (not in the header)
@@ -138,11 +125,6 @@ GOSoundOrganEngine::~GOSoundOrganEngine() {}
 void GOSoundOrganEngine::SetVolume(int volume) {
   m_volume = volume;
   m_gain = powf(10.0f, m_volume * 0.05f);
-}
-
-void GOSoundOrganEngine::SetHardPolyphony(unsigned polyphony) {
-  m_SamplerPool.SetUsageLimit(polyphony);
-  m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
 }
 
 void GOSoundOrganEngine::SetFromConfig(GOConfig &config) {
@@ -174,7 +156,6 @@ void GOSoundOrganEngine::BuildEngine(
   assert(m_LifecycleState.load() == LifecycleState::IDLE);
 
   m_NSamplesPerBuffer = nSamplesPerBuffer;
-  m_SampleRate = sampleRate;
   p_AudioRecorder = &recorder;
 
   // [B1] Build audio group tasks
@@ -182,7 +163,7 @@ void GOSoundOrganEngine::BuildEngine(
 
   for (unsigned groupI = 0; groupI < m_NAudioGroups; groupI++) {
     GOSoundGroupTask *pGroupTask
-      = new GOSoundGroupTask(*this, m_NSamplesPerBuffer);
+      = new GOSoundGroupTask(m_SamplerPlayer, m_NSamplesPerBuffer);
 
     mp_AudioGroupTasks.push_back(pGroupTask);
     groupOutputs.push_back(pGroupTask);
@@ -255,15 +236,15 @@ void GOSoundOrganEngine::BuildEngine(
   // [B6] Set up reverb
   if (mp_DownmixTask)
     mp_DownmixTask->SetupReverb(
-      m_ReverbConfig, m_NSamplesPerBuffer, m_SampleRate);
+      m_ReverbConfig, m_NSamplesPerBuffer, sampleRate);
   for (auto &pTask : mp_AudioOutputTasks)
-    pTask->SetupReverb(m_ReverbConfig, m_NSamplesPerBuffer, m_SampleRate);
+    pTask->SetupReverb(m_ReverbConfig, m_NSamplesPerBuffer, sampleRate);
 
   // [B7] Build tremulant tasks
   for (unsigned n = r_OrganModel.GetTremulantCount(), tremI = 0; tremI < n;
        tremI++)
     mp_TremulantTasks.push_back(
-      new GOSoundTremulantTask(*this, m_NSamplesPerBuffer));
+      new GOSoundTremulantTask(m_SamplerPlayer, m_NSamplesPerBuffer));
 
   // [B8] Build windchest tasks
   // Special windchest task for detached releases (index 0 =
@@ -301,6 +282,7 @@ void GOSoundOrganEngine::BuildEngine(
   for (auto &pThread : mp_threads)
     pThread->Run();
 
+  m_SamplerPlayer.Build(sampleRate);
   m_LifecycleState.store(LifecycleState::BUILT);
 }
 
@@ -340,13 +322,12 @@ void GOSoundOrganEngine::DestroyEngine() {
     pGroupTask->WaitAndClear();
   mp_AudioGroupTasks.clear();
 
+  m_SamplerPlayer.Destroy();
   m_LifecycleState.store(LifecycleState::IDLE);
 }
 
 void GOSoundOrganEngine::ResetCounters() {
-  m_UsedPolyphony.store(0);
-  m_SamplerPool.ReturnAll();
-  m_CurrentTime = 1;
+  m_SamplerPlayer.Reset();
   m_Scheduler.Reset();
 }
 
@@ -424,8 +405,9 @@ void GOSoundOrganEngine::NextPeriod() {
   assert(IsWorking());
   m_Scheduler.Exec();
 
-  m_CurrentTime += m_NSamplesPerBuffer;
-  atomic_fetch_max_relaxed(m_UsedPolyphony, m_SamplerPool.UsedSamplerCount());
+  // AdvanceTime advances m_CurrentTime and records peak used polyphony
+  // (both previously done inline here; now delegated to GOSoundSamplerPlayer).
+  m_SamplerPlayer.AdvanceTime(m_NSamplesPerBuffer);
 
   // Accumulate per-channel peak levels from each output task into m_MeterInfo
   // for the GUI meter display. Values accumulate between GUI polls;
@@ -455,410 +437,6 @@ void GOSoundOrganEngine::WakeupThreads() {
 }
 
 /*
- * Organ interface implementation (from GOSoundOrganInterface)
- */
-
-unsigned GOSoundOrganEngine::SamplesDiffToMs(
-  uint64_t fromSamples, uint64_t toSamples) const {
-  return (unsigned)std::min(
-    (toSamples - fromSamples) * 1000 / m_SampleRate, (uint64_t)UINT_MAX);
-}
-
-float GOSoundOrganEngine::GetRandomFactor() const {
-  float result = 1;
-
-  if (m_IsRandomizeSpeaking) {
-    const double factor = (pow(2, 1.0 / 1200.0) - 1) / (RAND_MAX / 2);
-    int num = rand() - RAND_MAX / 2;
-
-    result = 1 + num * factor;
-  }
-  return result;
-}
-
-void GOSoundOrganEngine::PassSampler(GOSoundSampler *sampler) {
-  int taskId = sampler->m_SamplerTaskId;
-
-  if (isWindchestTask(taskId))
-    mp_AudioGroupTasks[sampler->m_AudioGroupId]->Add(sampler);
-  else
-    mp_TremulantTasks[tremulantTaskToIndex(taskId)]->Add(sampler);
-}
-
-void GOSoundOrganEngine::StartSampler(GOSoundSampler *sampler) {
-  int taskId = sampler->m_SamplerTaskId;
-
-  sampler->stop = 0;
-  sampler->new_attack = 0;
-  sampler->p_WindchestTask = isWindchestTask(taskId)
-    ? mp_WindchestTasks[windchestTaskToIndex(taskId)].get()
-    : nullptr;
-  PassSampler(sampler);
-}
-
-bool GOSoundOrganEngine::ProcessSampler(
-  float *output_buffer,
-  GOSoundSampler *sampler,
-  unsigned n_frames,
-  float volume) {
-  float temp[n_frames * 2];
-  const bool process_sampler = (sampler->time <= m_CurrentTime);
-
-  if (process_sampler) {
-    if (sampler->is_release &&
-        ((m_IsPolyphonyLimiting &&
-          m_SamplerPool.UsedSamplerCount() >= m_PolyphonySoftLimit &&
-          m_CurrentTime - sampler->time > 172 * 16) ||
-         sampler->drop_counter > 1))
-      sampler->fader.StartDecreasingVolume(MsToSamples(370));
-
-    /* The decoded sampler frame will contain values containing
-     * sampler->pipe_section->sample_bits worth of significant bits.
-     * It is the responsibility of the fade engine to bring these bits
-     * back into a sensible state. This is achieved during setup of the
-     * fade parameters. The gain target should be:
-     *
-     *     playback gain * (2 ^ -sampler->pipe_section->sample_bits)
-     */
-    if (!sampler->stream.ReadBlock(temp, n_frames))
-      sampler->p_SoundProvider = NULL;
-
-    sampler->fader.Process(n_frames, temp, volume);
-    if (sampler->toneBalanceFilterState.IsToApply())
-      sampler->toneBalanceFilterState.ProcessBuffer(n_frames, temp);
-
-    /* Add these samples to the current output buffer shifting
-     * right by the necessary amount to bring the sample gain back
-     * to unity (this value is computed in GOPipe.cpp)
-     */
-    for (unsigned i = 0; i < n_frames * 2; i++)
-      output_buffer[i] += temp[i];
-
-    if (
-      (sampler->stop && sampler->stop <= m_CurrentTime)
-      || (sampler->new_attack && sampler->new_attack <= m_CurrentTime)) {
-      mp_ReleaseTask->Add(sampler);
-      return false;
-    }
-  }
-
-  if (
-    !sampler->p_SoundProvider
-    || (sampler->fader.IsSilent() && process_sampler)) {
-    ReturnSampler(sampler);
-    return false;
-  } else
-    return true;
-}
-
-void GOSoundOrganEngine::ProcessRelease(GOSoundSampler *sampler) {
-  if (sampler->stop) {
-    CreateReleaseSampler(sampler);
-    sampler->stop = 0;
-  } else if (sampler->new_attack) {
-    SwitchToAnotherAttack(sampler);
-    sampler->new_attack = 0;
-  }
-  PassSampler(sampler);
-}
-
-void GOSoundOrganEngine::ReturnSampler(GOSoundSampler *sampler) {
-  m_SamplerPool.ReturnSampler(sampler);
-}
-
-GOSoundSampler *GOSoundOrganEngine::CreateTaskSample(
-  const GOSoundProvider *pSoundProvider,
-  int samplerTaskId,
-  unsigned audioGroup,
-  unsigned velocity,
-  unsigned delay,
-  uint64_t prevEventTime,
-  bool isRelease,
-  uint64_t *pStartTimeSamples) {
-  unsigned delay_samples = (delay * m_SampleRate) / (1000);
-  uint64_t start_time = m_CurrentTime + delay_samples;
-  unsigned eventIntervalMs = SamplesDiffToMs(prevEventTime, start_time);
-
-  GOSoundSampler *sampler = nullptr;
-  const GOSoundAudioSection *section = isRelease
-    ? pSoundProvider->GetRelease(BOOL3_DEFAULT, eventIntervalMs)
-    : pSoundProvider->GetAttack(velocity, eventIntervalMs);
-
-  if (pStartTimeSamples) {
-    *pStartTimeSamples = start_time;
-  }
-  if (section && section->GetChannels()) {
-    sampler = m_SamplerPool.GetSampler();
-    if (sampler) {
-      sampler->p_SoundProvider = pSoundProvider;
-      sampler->m_WaveTremulantStateFor = section->GetWaveTremulantStateFor();
-      sampler->velocity = velocity;
-      sampler->stream.InitStream(
-        &m_resample,
-        section,
-        m_InterpolationType,
-        GetRandomFactor() * pSoundProvider->GetTuning() / (float)m_SampleRate);
-
-      const float playback_gain
-        = pSoundProvider->GetGain() * section->GetNormGain();
-
-      sampler->fader.Setup(
-        playback_gain, pSoundProvider->GetVelocityVolume(velocity));
-      sampler->delay = delay_samples;
-      sampler->time = start_time;
-      sampler->toneBalanceFilterState.Init(
-        sampler->p_SoundProvider->GetToneBalance()->GetFilter());
-      sampler->is_release = isRelease;
-      sampler->m_SamplerTaskId = samplerTaskId;
-      sampler->m_AudioGroupId = audioGroup;
-      StartSampler(sampler);
-    }
-  }
-  return sampler;
-}
-
-void GOSoundOrganEngine::SwitchToAnotherAttack(GOSoundSampler *pSampler) {
-  const GOSoundProvider *pProvider = pSampler->p_SoundProvider;
-
-  if (pProvider && !pSampler->is_release) {
-    const GOSoundAudioSection *section
-      = pProvider->GetAttack(pSampler->velocity, 1000);
-
-    if (section) {
-      GOSoundSampler *new_sampler = m_SamplerPool.GetSampler();
-
-      if (new_sampler != NULL) {
-        float gain_target = pProvider->GetGain() * section->GetNormGain();
-        unsigned crossFadeSamples
-          = MsToSamples(pProvider->GetAttackSwitchCrossfadeLength());
-
-        // copy old sampler to the new one
-        *new_sampler = *pSampler;
-
-        // start decay in the new sampler
-        new_sampler->is_release = true;
-        new_sampler->time = m_CurrentTime;
-        new_sampler->fader.StartDecreasingVolume(crossFadeSamples);
-
-        // start new section stream in the old sampler
-        pSampler->m_WaveTremulantStateFor = section->GetWaveTremulantStateFor();
-        pSampler->stream.InitAlignedStream(
-          section, m_InterpolationType, &new_sampler->stream);
-        pSampler->p_SoundProvider = pProvider;
-        pSampler->time = m_CurrentTime + 1;
-
-        pSampler->fader.Setup(
-          gain_target,
-          new_sampler->fader.GetVelocityVolume(),
-          crossFadeSamples);
-        pSampler->is_release = false;
-
-        new_sampler->toneBalanceFilterState.Init(
-          new_sampler->p_SoundProvider->GetToneBalance()->GetFilter());
-
-        StartSampler(new_sampler);
-      }
-    }
-  }
-}
-
-void GOSoundOrganEngine::CreateReleaseSampler(GOSoundSampler *handle) {
-  if (!handle->p_SoundProvider)
-    return;
-
-  /* The below code creates a new sampler to playback the release, the
-   * following code takes the active sampler for this pipe (which will be
-   * in either the attack or loop section) and sets the fadeout property
-   * which will decay this portion of the pipe. The sampler will
-   * automatically be placed back in the pool when the fade restores to
-   * zero. */
-  const GOSoundProvider *this_pipe = handle->p_SoundProvider;
-  const GOSoundAudioSection *release_section = this_pipe->GetRelease(
-    handle->m_WaveTremulantStateFor,
-    SamplesDiffToMs(handle->time, m_CurrentTime));
-  unsigned crossFadeSamples = MsToSamples(
-    release_section ? release_section->GetReleaseCrossfadeLength()
-                    : this_pipe->GetAttackSwitchCrossfadeLength());
-
-  handle->fader.StartDecreasingVolume(crossFadeSamples);
-  handle->is_release = true;
-
-  int taskId = handle->m_SamplerTaskId;
-  float vol = isWindchestTask(taskId)
-    ? mp_WindchestTasks[windchestTaskToIndex(taskId)]->GetWindchestVolume()
-    : 1.0f;
-
-  // FIXME: this is wrong... the intention is to not create a release for a
-  // sample being played back with zero amplitude but this is a comparison
-  // against a double. We should test against a minimum level.
-  if (vol && release_section) {
-    GOSoundSampler *new_sampler = m_SamplerPool.GetSampler();
-
-    if (new_sampler != NULL) {
-      new_sampler->p_SoundProvider = this_pipe;
-      new_sampler->time = m_CurrentTime + 1;
-      new_sampler->m_WaveTremulantStateFor
-        = release_section->GetWaveTremulantStateFor();
-
-      unsigned gain_decay_length = 0;
-      float gain_target = this_pipe->GetGain() * release_section->GetNormGain();
-      const bool not_a_tremulant = isWindchestTask(handle->m_SamplerTaskId);
-
-      if (not_a_tremulant) {
-        /* Because this sampler is about to be moved to a detached
-         * windchest, we must apply the gain of the existing windchest
-         * to the gain target for this fader - otherwise the playback
-         * volume on the detached chest will not match the volume on
-         * the existing chest. */
-        gain_target *= vol;
-        if (m_IsScaledReleases) {
-          /* Note: "time" is in milliseconds. */
-          int time = ((m_CurrentTime - handle->time) * 1000) / m_SampleRate;
-          /* TODO: below code should be replaced by a more accurate model of the
-           * attack to get a better estimate of the amplitude when playing very
-           * short notes; estimating attack duration from pipe MIDI pitch */
-          unsigned midikey_frequency = this_pipe->GetMidiKeyNumber();
-          /* if MidiKeyNumber is not within the range of organ pipes (64 feet
-           * to 1 foot), we assume average pipe (MIDI = 60) */
-          if (midikey_frequency > 133 || midikey_frequency == 0)
-            midikey_frequency = 60;
-          /* attack duration is assumed 50 ms above MIDI 96, 800 ms below MIDI
-           * 24 and linear in between */
-          float attack_duration = 50.0f;
-          if (midikey_frequency < 96) {
-            if (midikey_frequency < 24)
-              attack_duration = 500.0f;
-            else
-              attack_duration
-                = 500.0f + ((24.0f - (float)midikey_frequency) * 6.25f);
-          }
-          /* calculate gain (gain_target) to apply to tail amplitude as a
-           * function of when the note is released during the attack */
-          if (time < (int)attack_duration) {
-            float attack_index = (float)time / attack_duration;
-            float gain_delta
-              = (0.2f + (0.8f * (2.0f * attack_index - (attack_index * attack_index))));
-            gain_target *= gain_delta;
-          }
-          /* calculate the volume decay to be applied to the release to take
-           * into account the fact that reverb is not completely formed during
-           * staccato. Time to full reverb is estimated as a function of release
-           * length: for an organ with a release length of 5 seconds or more,
-           * time_to_full_reverb is around 350 ms; for an organ with a release
-           * length of 1 second or less, time_to_full_reverb is around 100 ms;
-           * time_to_full_reverb is linear in between */
-          int time_to_full_reverb = ((60 * release_section->GetLength())
-                                     / release_section->GetSampleRate())
-            + 40;
-          if (time_to_full_reverb > 350)
-            time_to_full_reverb = 350;
-          if (time_to_full_reverb < 100)
-            time_to_full_reverb = 100;
-          if (time < time_to_full_reverb) {
-            /* as a function of note duration, fading happens between:
-             * 200 ms and 6 s for release with little reverberation e.g. short
-             * release
-             * 700 ms and 6 s for release with large reverberation e.g. long
-             * release */
-            gain_decay_length
-              = time_to_full_reverb + 6000 * time / time_to_full_reverb;
-          }
-        }
-      }
-
-      const unsigned releaseLength = this_pipe->GetReleaseTail();
-
-      new_sampler->fader.Setup(
-        gain_target, handle->fader.GetVelocityVolume(), crossFadeSamples);
-
-      if (
-        releaseLength > 0
-        && (releaseLength < gain_decay_length || gain_decay_length == 0))
-        gain_decay_length = releaseLength;
-
-      if (gain_decay_length > 0)
-        new_sampler->fader.StartDecreasingVolume(
-          MsToSamples(gain_decay_length));
-
-      if (
-        m_IsReleaseAlignmentEnabled
-        && release_section->SupportsStreamAlignment()) {
-        new_sampler->stream.InitAlignedStream(
-          release_section, m_InterpolationType, &handle->stream);
-      } else {
-        new_sampler->stream.InitStream(
-          &m_resample,
-          release_section,
-          m_InterpolationType,
-          this_pipe->GetTuning() / (float)m_SampleRate);
-      }
-      new_sampler->is_release = true;
-
-      new_sampler->m_SamplerTaskId = not_a_tremulant
-        ? /* detached releases are enabled and the pipe was on a regular
-           * windchest. Play the release on the detached windchest */
-        DETACHED_RELEASE_TASK_ID
-        /* detached releases are disabled (or this isn't really a pipe)
-         * so put the release on the same windchest as the pipe (which
-         * means it will still be affected by tremulants - yuck). */
-        : handle->m_SamplerTaskId;
-      new_sampler->m_AudioGroupId = handle->m_AudioGroupId;
-      new_sampler->toneBalanceFilterState.Init(
-        new_sampler->p_SoundProvider->GetToneBalance()->GetFilter());
-      StartSampler(new_sampler);
-      handle->time = m_CurrentTime;
-    }
-  }
-}
-
-uint64_t GOSoundOrganEngine::StopSample(
-  const GOSoundProvider *pipe, GOSoundSampler *handle) {
-  assert(handle);
-  assert(pipe);
-
-  // The following condition could arise if a one-shot sample is played,
-  // decays away (and hence the sampler is discarded back into the pool), and
-  // then the user releases a key. If the sampler had already been reused
-  // with another pipe, that sample would erroneously be told to decay.
-  if (pipe != handle->p_SoundProvider)
-    return 0;
-
-  handle->stop = m_CurrentTime + handle->delay;
-  return handle->stop;
-}
-
-void GOSoundOrganEngine::SwitchSample(
-  const GOSoundProvider *pipe, GOSoundSampler *handle) {
-  assert(handle);
-  assert(pipe);
-
-  // The following condition could arise if a one-shot sample is played,
-  // decays away (and hence the sampler is discarded back into the pool), and
-  // then the user releases a key. If the sampler had already been reused
-  // with another pipe, that sample would erroneously be told to decay.
-  if (pipe != handle->p_SoundProvider)
-    return;
-
-  handle->new_attack = m_CurrentTime + handle->delay;
-}
-
-void GOSoundOrganEngine::UpdateVelocity(
-  const GOSoundProvider *pipe, GOSoundSampler *handle, unsigned velocity) {
-  assert(handle);
-  assert(pipe);
-
-  if (handle->p_SoundProvider == pipe) {
-    // we've just checked that handle is still playing the same pipe;
-    // maybe handle was switched to another pipe between checking and
-    // SetVelocityVolume, but we don't want to lock it because this
-    // functionality is not so important. Concurrent update is acceptable,
-    // as it just updates a float
-    handle->velocity = velocity;
-    handle->fader.SetVelocityVolume(pipe->GetVelocityVolume(velocity));
-  }
-}
-
-/*
  * Other functions
  */
 
@@ -876,9 +454,9 @@ std::vector<float> GOSoundOrganEngine::GetMeterInfo() {
     float *pResult = result.data();
 
     assert(hardPolyphony > 0);
-    // exchange(0) reads accumulated max and resets it for the next poll
-    *(pResult++)
-      = m_UsedPolyphony.exchange(0) / static_cast<float>(hardPolyphony);
+    // GetAndResetUsedPolyphony() reads accumulated peak polyphony and resets it
+    *(pResult++) = m_SamplerPlayer.GetAndResetUsedPolyphony()
+      / static_cast<float>(hardPolyphony);
     for (std::atomic<float> &v : m_MeterInfo)
       *(pResult++) = v.exchange(0.0f);
   }

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -12,15 +12,9 @@
 #include <memory>
 #include <vector>
 
-#include "threading/GOMutex.h"
-
-#include "playing/GOSoundResample.h"
-#include "playing/GOSoundSampler.h"
-#include "playing/GOSoundSamplerPool.h"
+#include "playing/GOSoundSamplerPlayer.h"
 #include "reverb/GOSoundReverb.h"
 #include "scheduler/GOSoundScheduler.h"
-
-#include "GOSoundOrganInterface.h"
 
 class GOConfig;
 class GOMemoryPool;
@@ -28,7 +22,6 @@ class GOOrganModel;
 class GOSoundBufferMutable;
 class GOSoundGroupTask;
 class GOSoundOutputTask;
-class GOSoundProvider;
 class GOSoundRecorder;
 class GOSoundReleaseTask;
 class GOSoundTask;
@@ -50,7 +43,7 @@ class GOWindchest;
  *      ... GetAudioOutput() is called from the audio thread ...
  *   4. StopAndDestroy() — stops the engine and destroys tasks
  */
-class GOSoundOrganEngine : public GOSoundOrganInterface {
+class GOSoundOrganEngine {
 public:
   /*
    * Nested type
@@ -90,21 +83,22 @@ public:
     unsigned nAudioGroups = 1);
 
 private:
-  static constexpr int DETACHED_RELEASE_TASK_ID = 0;
-
   /*
    * Constructor constants: objects that live for the entire instance lifetime
    */
 
   GOOrganModel &r_OrganModel;
   GOMemoryPool &r_MemoryPool;
-  // mp_ReleaseTask references mp_AudioGroupTasks [B1]; created in constructor,
-  // added to m_Scheduler in BuildEngine [B8]
+  // mp_ReleaseTask references mp_AudioGroupTasks [B1]; created in constructor
+  // body (after m_SamplerPlayer), added to m_Scheduler in BuildEngine [B8]
   std::unique_ptr<GOSoundReleaseTask> mp_ReleaseTask;
   // mp_TouchTask references r_MemoryPool; created in constructor,
   // added to m_Scheduler in BuildEngine [B8]
   std::unique_ptr<GOSoundTouchTask> mp_TouchTask;
-  GOSoundResample m_resample;
+  // m_SamplerPlayer is declared after mp_ReleaseTask so that mp_ReleaseTask
+  // is already a valid (though null) unique_ptr when passed by reference to
+  // the player constructor.
+  GOSoundSamplerPlayer m_SamplerPlayer;
 
   /*
    * Configuration parameters
@@ -114,18 +108,12 @@ private:
   unsigned m_NAuxThreads;
   bool m_IsDownmix;
   unsigned m_NReleaseRepeats;
-  bool m_IsPolyphonyLimiting;
-  unsigned m_PolyphonySoftLimit;
-  bool m_IsScaledReleases;
-  bool m_IsReleaseAlignmentEnabled;
-  bool m_IsRandomizeSpeaking;
   // TODO: rename to m_gain (stores gain in dB; in GrandOrgue "gain" means dB)
   int m_volume;
   // TODO: rename to m_amplitude (stores the linear amplitude coefficient
-  // derived
-  //       from m_volume; in GrandOrgue "amplitude" means a linear coefficient)
+  //       derived from m_volume; in GrandOrgue "amplitude" means a linear
+  //       coefficient)
   float m_gain;
-  GOSoundResample::InterpolationType m_InterpolationType;
   GOSoundReverb::ReverbConfig m_ReverbConfig;
 
   /*
@@ -133,7 +121,6 @@ private:
    */
 
   unsigned m_NSamplesPerBuffer;
-  unsigned m_SampleRate;
 
   /*
    * Lifecycle state
@@ -193,14 +180,6 @@ private:
   std::vector<std::unique_ptr<GOSoundThread>> mp_threads;
 
   /*
-   * Counters
-   */
-
-  uint64_t m_CurrentTime;
-  GOSoundSamplerPool m_SamplerPool;
-  std::atomic_uint m_UsedPolyphony;
-
-  /*
    * Private lifecycle functions (callee first)
    */
 
@@ -216,48 +195,6 @@ private:
   void StartEngine();
   void StopEngine();
 
-  /*
-   * Other private functions
-   */
-
-  unsigned MsToSamples(unsigned ms) const { return m_SampleRate * ms / 1000; }
-
-  unsigned SamplesDiffToMs(uint64_t fromSamples, uint64_t toSamples) const;
-
-  inline static unsigned isWindchestTask(int taskId) { return taskId >= 0; }
-
-  inline static unsigned windchestTaskToIndex(int taskId) {
-    return (unsigned)taskId;
-  }
-
-  inline static unsigned tremulantTaskToIndex(int taskId) {
-    return -taskId - 1;
-  }
-
-  void StartSampler(GOSoundSampler *sampler);
-
-  GOSoundSampler *CreateTaskSample(
-    const GOSoundProvider *soundProvider,
-    int samplerTaskId,
-    unsigned audioGroup,
-    unsigned velocity,
-    unsigned delay,
-    uint64_t prevEventTime,
-    bool isRelease,
-    uint64_t *pStartTimeSamples);
-
-  void CreateReleaseSampler(GOSoundSampler *sampler);
-
-  /**
-   * Creates a new sampler with decay of current loop.
-   * Switches this sampler to the new attack.
-   * Used when a wave tremulant is switched on or off.
-   * @param pSampler current playing sampler for switching to a new attack
-   */
-  void SwitchToAnotherAttack(GOSoundSampler *pSampler);
-
-  float GetRandomFactor() const;
-
 public:
   /*
    * Constructors and destructors
@@ -268,6 +205,14 @@ public:
   // the complete type of the managed object, which is only forward-declared
   // here.
   ~GOSoundOrganEngine();
+
+  /*
+   * Sampler player accessor
+   */
+
+  /** Returns a reference to the sampler player (used to connect the organ
+   * model via GOSoundOrganInterfaceProxy). */
+  GOSoundSamplerPlayer &GetSamplerPlayer() { return m_SamplerPlayer; }
 
   /*
    * Configuration getters and setters
@@ -287,9 +232,11 @@ public:
     m_NReleaseRepeats = nReleaseRepeats;
   }
 
-  bool IsReleaseAlignmentEnabled() const { return m_IsReleaseAlignmentEnabled; }
+  bool IsReleaseAlignmentEnabled() const {
+    return m_SamplerPlayer.IsReleaseAlignmentEnabled();
+  }
   void SetReleaseAlignmentEnabled(bool isEnabled) {
-    m_IsReleaseAlignmentEnabled = isEnabled;
+    m_SamplerPlayer.SetReleaseAlignmentEnabled(isEnabled);
   }
 
   const GOSoundReverb::ReverbConfig &GetReverbConfig() const {
@@ -307,27 +254,37 @@ public:
   // TODO: rename to SetGain(int gain)
   void SetVolume(int volume);
 
-  unsigned GetHardPolyphony() const { return m_SamplerPool.GetUsageLimit(); }
-  void SetHardPolyphony(unsigned polyphony);
-
-  bool IsPolyphonyLimiting() const { return m_IsPolyphonyLimiting; }
-  void SetPolyphonyLimiting(bool isLimiting) {
-    m_IsPolyphonyLimiting = isLimiting;
+  unsigned GetHardPolyphony() const {
+    return m_SamplerPlayer.GetHardPolyphony();
+  }
+  void SetHardPolyphony(unsigned polyphony) {
+    m_SamplerPlayer.SetHardPolyphony(polyphony);
   }
 
-  bool IsScaledReleases() const { return m_IsScaledReleases; }
-  void SetScaledReleases(bool isEnabled) { m_IsScaledReleases = isEnabled; }
+  bool IsPolyphonyLimiting() const {
+    return m_SamplerPlayer.IsPolyphonyLimiting();
+  }
+  void SetPolyphonyLimiting(bool isLimiting) {
+    m_SamplerPlayer.SetPolyphonyLimiting(isLimiting);
+  }
 
-  bool IsRandomizeSpeaking() const { return m_IsRandomizeSpeaking; }
+  bool IsScaledReleases() const { return m_SamplerPlayer.IsScaledReleases(); }
+  void SetScaledReleases(bool isEnabled) {
+    m_SamplerPlayer.SetScaledReleases(isEnabled);
+  }
+
+  bool IsRandomizeSpeaking() const {
+    return m_SamplerPlayer.IsRandomizeSpeaking();
+  }
   void SetRandomizeSpeaking(bool isEnabled) {
-    m_IsRandomizeSpeaking = isEnabled;
+    m_SamplerPlayer.SetRandomizeSpeaking(isEnabled);
   }
 
   GOSoundResample::InterpolationType GetInterpolationType() const {
-    return m_InterpolationType;
+    return m_SamplerPlayer.GetInterpolationType();
   }
   void SetInterpolationType(unsigned type) {
-    m_InterpolationType = (GOSoundResample::InterpolationType)type;
+    m_SamplerPlayer.SetInterpolationType(type);
   }
 
   /** Reads parameters from GOConfig and stores them via setters. */
@@ -337,14 +294,14 @@ public:
    * Start parameter getters (values come via BuildAndStart)
    */
 
-  unsigned GetSampleRate() const override { return m_SampleRate; }
+  unsigned GetSampleRate() const { return m_SamplerPlayer.GetSampleRate(); }
   unsigned GetNSamplesPerBuffer() const { return m_NSamplesPerBuffer; }
 
   /*
    * Other getters
    */
 
-  uint64_t GetTime() const { return m_CurrentTime; }
+  uint64_t GetTime() const { return m_SamplerPlayer.GetTime(); }
   std::vector<float> GetMeterInfo();
   GOSoundScheduler &GetScheduler() { return m_Scheduler; }
 
@@ -399,47 +356,6 @@ public:
   void StopAndDestroy();
 
   /*
-   * Organ interface (from GOSoundOrganInterface)
-   */
-
-  GOSoundSampler *StartPipeSample(
-    const GOSoundProvider *pipeProvider,
-    unsigned windchestN,
-    unsigned audioGroup,
-    unsigned velocity,
-    unsigned delay,
-    uint64_t prevEventTime,
-    bool isRelease = false,
-    uint64_t *pStartTimeSamples = nullptr) override {
-    return CreateTaskSample(
-      pipeProvider,
-      windchestN,
-      audioGroup,
-      velocity,
-      delay,
-      prevEventTime,
-      isRelease,
-      pStartTimeSamples);
-  }
-
-  inline GOSoundSampler *StartTremulantSample(
-    const GOSoundProvider *tremProvider,
-    unsigned tremulantN,
-    uint64_t prevEventTime) override {
-    return CreateTaskSample(
-      tremProvider, -tremulantN, 0, 0x7f, 0, prevEventTime, false, nullptr);
-  }
-
-  uint64_t StopSample(
-    const GOSoundProvider *pipe, GOSoundSampler *handle) override;
-  void SwitchSample(
-    const GOSoundProvider *pipe, GOSoundSampler *handle) override;
-  void UpdateVelocity(
-    const GOSoundProvider *pipe,
-    GOSoundSampler *handle,
-    unsigned velocity) override;
-
-  /*
    * Functions called from GOSoundSystem
    */
 
@@ -449,12 +365,6 @@ public:
 
   /** Wake up all worker threads. Called from the audio callback. */
   void WakeupThreads();
-
-  bool ProcessSampler(
-    float *buffer, GOSoundSampler *sampler, unsigned n_frames, float volume);
-  void ProcessRelease(GOSoundSampler *sampler);
-  void PassSampler(GOSoundSampler *sampler);
-  void ReturnSampler(GOSoundSampler *sampler);
 };
 
 #endif /* GOSOUNDORGANENGINE_H */

--- a/src/grandorgue/sound/playing/GOSoundSamplerPlayer.cpp
+++ b/src/grandorgue/sound/playing/GOSoundSamplerPlayer.cpp
@@ -1,0 +1,516 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSoundSamplerPlayer.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+
+#include "GOSoundReleaseAlignTable.h"
+#include "GOSoundSampler.h"
+#include "sound/providers/GOSoundProvider.h"
+#include "sound/tasks/GOSoundGroupTask.h"
+#include "sound/tasks/GOSoundReleaseTask.h"
+#include "sound/tasks/GOSoundTremulantTask.h"
+#include "sound/tasks/GOSoundWindchestTask.h"
+
+/*
+ * Constructor
+ */
+
+GOSoundSamplerPlayer::GOSoundSamplerPlayer(
+  ptr_vector<GOSoundGroupTask> &audioGroupTasks,
+  std::vector<std::unique_ptr<GOSoundWindchestTask>> &windchestTasks,
+  ptr_vector<GOSoundTremulantTask> &tremulantTasks,
+  std::unique_ptr<GOSoundReleaseTask> &pReleaseTask)
+  : r_AudioGroupTasks(audioGroupTasks),
+    r_WindchestTasks(windchestTasks),
+    r_TremulantTasks(tremulantTasks),
+    rp_ReleaseTask(pReleaseTask),
+    m_IsScaledReleases(true),
+    m_IsReleaseAlignmentEnabled(true),
+    m_IsRandomizeSpeaking(true),
+    m_IsPolyphonyLimiting(true),
+    m_PolyphonySoftLimit(0),
+    m_InterpolationType(GOSoundResample::GO_LINEAR_INTERPOLATION),
+    m_SampleRate(0),
+    m_CurrentTime(1),
+    m_UsedPolyphony(0) {
+  m_SamplerPool.SetUsageLimit(2048);
+  m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
+}
+
+/*
+ * Configuration getters and setters
+ */
+
+void GOSoundSamplerPlayer::SetHardPolyphony(unsigned polyphony) {
+  m_SamplerPool.SetUsageLimit(polyphony);
+  m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
+}
+
+/*
+ * Lifecycle
+ */
+
+void GOSoundSamplerPlayer::Build(unsigned sampleRate) {
+  assert(rp_ReleaseTask);
+  assert(r_AudioGroupTasks.size() > 0);
+  assert(!r_WindchestTasks.empty());
+  m_SampleRate = sampleRate;
+}
+
+void GOSoundSamplerPlayer::Destroy() { m_SampleRate = 0; }
+
+void GOSoundSamplerPlayer::Reset() {
+  m_UsedPolyphony.store(0);
+  m_SamplerPool.ReturnAll();
+  m_CurrentTime = 1;
+}
+
+void GOSoundSamplerPlayer::AdvanceTime(unsigned nSamplesPerBuffer) {
+  m_CurrentTime += nSamplesPerBuffer;
+
+  const unsigned usedSamplers = m_SamplerPool.UsedSamplerCount();
+
+  if (usedSamplers > m_UsedPolyphony.load())
+    m_UsedPolyphony.store(usedSamplers);
+}
+
+/*
+ * Organ interface (from GOSoundOrganInterface)
+ */
+
+unsigned GOSoundSamplerPlayer::SamplesDiffToMs(
+  uint64_t fromSamples, uint64_t toSamples) const {
+  return (unsigned)std::min(
+    (toSamples - fromSamples) * 1000 / m_SampleRate, (uint64_t)UINT_MAX);
+}
+
+float GOSoundSamplerPlayer::GetRandomFactor() const {
+  float result = 1;
+
+  if (m_IsRandomizeSpeaking) {
+    const double factor = (pow(2, 1.0 / 1200.0) - 1) / (RAND_MAX / 2);
+    int num = rand() - RAND_MAX / 2;
+
+    result = 1 + num * factor;
+  }
+  return result;
+}
+
+void GOSoundSamplerPlayer::PassSampler(GOSoundSampler *sampler) {
+  int taskId = sampler->m_SamplerTaskId;
+
+  if (isWindchestTask(taskId))
+    r_AudioGroupTasks[sampler->m_AudioGroupId]->Add(sampler);
+  else
+    r_TremulantTasks[tremulantTaskToIndex(taskId)]->Add(sampler);
+}
+
+void GOSoundSamplerPlayer::StartSampler(GOSoundSampler *sampler) {
+  int taskId = sampler->m_SamplerTaskId;
+
+  sampler->stop = 0;
+  sampler->new_attack = 0;
+  sampler->p_WindchestTask = isWindchestTask(taskId)
+    ? r_WindchestTasks[windchestTaskToIndex(taskId)].get()
+    : nullptr;
+  PassSampler(sampler);
+}
+
+bool GOSoundSamplerPlayer::ProcessSampler(
+  float *output_buffer,
+  GOSoundSampler *sampler,
+  unsigned n_frames,
+  float volume) {
+  float temp[n_frames * 2];
+  const bool process_sampler = (sampler->time <= m_CurrentTime);
+
+  if (process_sampler) {
+    if (sampler->is_release &&
+        ((m_IsPolyphonyLimiting &&
+          m_SamplerPool.UsedSamplerCount() >= m_PolyphonySoftLimit &&
+          m_CurrentTime - sampler->time > 172 * 16) ||
+         sampler->drop_counter > 1))
+      sampler->fader.StartDecreasingVolume(MsToSamples(370));
+
+    /* The decoded sampler frame will contain values containing
+     * sampler->pipe_section->sample_bits worth of significant bits.
+     * It is the responsibility of the fade engine to bring these bits
+     * back into a sensible state. This is achieved during setup of the
+     * fade parameters. The gain target should be:
+     *
+     *     playback gain * (2 ^ -sampler->pipe_section->sample_bits)
+     */
+    if (!sampler->stream.ReadBlock(temp, n_frames))
+      sampler->p_SoundProvider = NULL;
+
+    sampler->fader.Process(n_frames, temp, volume);
+    if (sampler->toneBalanceFilterState.IsToApply())
+      sampler->toneBalanceFilterState.ProcessBuffer(n_frames, temp);
+
+    /* Add these samples to the current output buffer shifting
+     * right by the necessary amount to bring the sample gain back
+     * to unity (this value is computed in GOPipe.cpp)
+     */
+    for (unsigned i = 0; i < n_frames * 2; i++)
+      output_buffer[i] += temp[i];
+
+    if (
+      (sampler->stop && sampler->stop <= m_CurrentTime)
+      || (sampler->new_attack && sampler->new_attack <= m_CurrentTime)) {
+      rp_ReleaseTask->Add(sampler);
+      return false;
+    }
+  }
+
+  if (
+    !sampler->p_SoundProvider
+    || (sampler->fader.IsSilent() && process_sampler)) {
+    ReturnSampler(sampler);
+    return false;
+  } else
+    return true;
+}
+
+void GOSoundSamplerPlayer::ProcessRelease(GOSoundSampler *sampler) {
+  if (sampler->stop) {
+    CreateReleaseSampler(sampler);
+    sampler->stop = 0;
+  } else if (sampler->new_attack) {
+    SwitchToAnotherAttack(sampler);
+    sampler->new_attack = 0;
+  }
+  PassSampler(sampler);
+}
+
+void GOSoundSamplerPlayer::ReturnSampler(GOSoundSampler *sampler) {
+  m_SamplerPool.ReturnSampler(sampler);
+}
+
+GOSoundSampler *GOSoundSamplerPlayer::CreateTaskSample(
+  const GOSoundProvider *pSoundProvider,
+  int samplerTaskId,
+  unsigned audioGroup,
+  unsigned velocity,
+  unsigned delay,
+  uint64_t prevEventTime,
+  bool isRelease,
+  uint64_t *pStartTimeSamples) {
+  unsigned delay_samples = (delay * m_SampleRate) / (1000);
+  uint64_t start_time = m_CurrentTime + delay_samples;
+  unsigned eventIntervalMs = SamplesDiffToMs(prevEventTime, start_time);
+
+  GOSoundSampler *sampler = nullptr;
+  const GOSoundAudioSection *section = isRelease
+    ? pSoundProvider->GetRelease(BOOL3_DEFAULT, eventIntervalMs)
+    : pSoundProvider->GetAttack(velocity, eventIntervalMs);
+
+  if (pStartTimeSamples) {
+    *pStartTimeSamples = start_time;
+  }
+  if (section && section->GetChannels()) {
+    sampler = m_SamplerPool.GetSampler();
+    if (sampler) {
+      sampler->p_SoundProvider = pSoundProvider;
+      sampler->m_WaveTremulantStateFor = section->GetWaveTremulantStateFor();
+      sampler->velocity = velocity;
+      sampler->stream.InitStream(
+        &m_resample,
+        section,
+        m_InterpolationType,
+        GetRandomFactor() * pSoundProvider->GetTuning() / (float)m_SampleRate);
+
+      const float playback_gain
+        = pSoundProvider->GetGain() * section->GetNormGain();
+
+      sampler->fader.Setup(
+        playback_gain, pSoundProvider->GetVelocityVolume(velocity));
+      sampler->delay = delay_samples;
+      sampler->time = start_time;
+      sampler->toneBalanceFilterState.Init(
+        sampler->p_SoundProvider->GetToneBalance()->GetFilter());
+      sampler->is_release = isRelease;
+      sampler->m_SamplerTaskId = samplerTaskId;
+      sampler->m_AudioGroupId = audioGroup;
+      StartSampler(sampler);
+    }
+  }
+  return sampler;
+}
+
+void GOSoundSamplerPlayer::SwitchToAnotherAttack(GOSoundSampler *pSampler) {
+  const GOSoundProvider *pProvider = pSampler->p_SoundProvider;
+
+  if (pProvider && !pSampler->is_release) {
+    const GOSoundAudioSection *section
+      = pProvider->GetAttack(pSampler->velocity, 1000);
+
+    if (section) {
+      GOSoundSampler *new_sampler = m_SamplerPool.GetSampler();
+
+      if (new_sampler != NULL) {
+        float gain_target = pProvider->GetGain() * section->GetNormGain();
+        unsigned crossFadeSamples
+          = MsToSamples(pProvider->GetAttackSwitchCrossfadeLength());
+
+        // copy old sampler to the new one
+        *new_sampler = *pSampler;
+
+        // start decay in the new sampler
+        new_sampler->is_release = true;
+        new_sampler->time = m_CurrentTime;
+        new_sampler->fader.StartDecreasingVolume(crossFadeSamples);
+
+        // start new section stream in the old sampler
+        pSampler->m_WaveTremulantStateFor = section->GetWaveTremulantStateFor();
+        pSampler->stream.InitAlignedStream(
+          section, m_InterpolationType, &new_sampler->stream);
+        pSampler->p_SoundProvider = pProvider;
+        pSampler->time = m_CurrentTime + 1;
+
+        pSampler->fader.Setup(
+          gain_target,
+          new_sampler->fader.GetVelocityVolume(),
+          crossFadeSamples);
+        pSampler->is_release = false;
+
+        new_sampler->toneBalanceFilterState.Init(
+          new_sampler->p_SoundProvider->GetToneBalance()->GetFilter());
+
+        StartSampler(new_sampler);
+      }
+    }
+  }
+}
+
+void GOSoundSamplerPlayer::CreateReleaseSampler(GOSoundSampler *handle) {
+  if (!handle->p_SoundProvider)
+    return;
+
+  /* The below code creates a new sampler to playback the release, the
+   * following code takes the active sampler for this pipe (which will be
+   * in either the attack or loop section) and sets the fadeout property
+   * which will decay this portion of the pipe. The sampler will
+   * automatically be placed back in the pool when the fade restores to
+   * zero. */
+  const GOSoundProvider *this_pipe = handle->p_SoundProvider;
+  const GOSoundAudioSection *release_section = this_pipe->GetRelease(
+    handle->m_WaveTremulantStateFor,
+    SamplesDiffToMs(handle->time, m_CurrentTime));
+  unsigned crossFadeSamples = MsToSamples(
+    release_section ? release_section->GetReleaseCrossfadeLength()
+                    : this_pipe->GetAttackSwitchCrossfadeLength());
+
+  handle->fader.StartDecreasingVolume(crossFadeSamples);
+  handle->is_release = true;
+
+  int taskId = handle->m_SamplerTaskId;
+  float vol = isWindchestTask(taskId)
+    ? r_WindchestTasks[windchestTaskToIndex(taskId)]->GetWindchestVolume()
+    : 1.0f;
+
+  // FIXME: this is wrong... the intention is to not create a release for a
+  // sample being played back with zero amplitude but this is a comparison
+  // against a double. We should test against a minimum level.
+  if (vol && release_section) {
+    GOSoundSampler *new_sampler = m_SamplerPool.GetSampler();
+
+    if (new_sampler != NULL) {
+      new_sampler->p_SoundProvider = this_pipe;
+      new_sampler->time = m_CurrentTime + 1;
+      new_sampler->m_WaveTremulantStateFor
+        = release_section->GetWaveTremulantStateFor();
+
+      unsigned gain_decay_length = 0;
+      float gain_target = this_pipe->GetGain() * release_section->GetNormGain();
+      const bool not_a_tremulant = isWindchestTask(handle->m_SamplerTaskId);
+
+      if (not_a_tremulant) {
+        /* Because this sampler is about to be moved to a detached
+         * windchest, we must apply the gain of the existing windchest
+         * to the gain target for this fader - otherwise the playback
+         * volume on the detached chest will not match the volume on
+         * the existing chest. */
+        gain_target *= vol;
+        if (m_IsScaledReleases) {
+          /* Note: "time" is in milliseconds. */
+          int time = ((m_CurrentTime - handle->time) * 1000) / m_SampleRate;
+          /* TODO: below code should be replaced by a more accurate model of the
+           * attack to get a better estimate of the amplitude when playing very
+           * short notes; estimating attack duration from pipe MIDI pitch */
+          unsigned midikey_frequency = this_pipe->GetMidiKeyNumber();
+          /* if MidiKeyNumber is not within the range of organ pipes (64 feet
+           * to 1 foot), we assume average pipe (MIDI = 60) */
+          if (midikey_frequency > 133 || midikey_frequency == 0)
+            midikey_frequency = 60;
+          /* attack duration is assumed 50 ms above MIDI 96, 800 ms below MIDI
+           * 24 and linear in between */
+          float attack_duration = 50.0f;
+          if (midikey_frequency < 96) {
+            if (midikey_frequency < 24)
+              attack_duration = 500.0f;
+            else
+              attack_duration
+                = 500.0f + ((24.0f - (float)midikey_frequency) * 6.25f);
+          }
+          /* calculate gain (gain_target) to apply to tail amplitude as a
+           * function of when the note is released during the attack */
+          if (time < (int)attack_duration) {
+            float attack_index = (float)time / attack_duration;
+            float gain_delta
+              = (0.2f + (0.8f * (2.0f * attack_index - (attack_index * attack_index))));
+            gain_target *= gain_delta;
+          }
+          /* calculate the volume decay to be applied to the release to take
+           * into account the fact that reverb is not completely formed during
+           * staccato. Time to full reverb is estimated as a function of release
+           * length: for an organ with a release length of 5 seconds or more,
+           * time_to_full_reverb is around 350 ms; for an organ with a release
+           * length of 1 second or less, time_to_full_reverb is around 100 ms;
+           * time_to_full_reverb is linear in between */
+          int time_to_full_reverb = ((60 * release_section->GetLength())
+                                     / release_section->GetSampleRate())
+            + 40;
+          if (time_to_full_reverb > 350)
+            time_to_full_reverb = 350;
+          if (time_to_full_reverb < 100)
+            time_to_full_reverb = 100;
+          if (time < time_to_full_reverb) {
+            /* as a function of note duration, fading happens between:
+             * 200 ms and 6 s for release with little reverberation e.g. short
+             * release
+             * 700 ms and 6 s for release with large reverberation e.g. long
+             * release */
+            gain_decay_length
+              = time_to_full_reverb + 6000 * time / time_to_full_reverb;
+          }
+        }
+      }
+
+      const unsigned releaseLength = this_pipe->GetReleaseTail();
+
+      new_sampler->fader.Setup(
+        gain_target, handle->fader.GetVelocityVolume(), crossFadeSamples);
+
+      if (
+        releaseLength > 0
+        && (releaseLength < gain_decay_length || gain_decay_length == 0))
+        gain_decay_length = releaseLength;
+
+      if (gain_decay_length > 0)
+        new_sampler->fader.StartDecreasingVolume(
+          MsToSamples(gain_decay_length));
+
+      if (
+        m_IsReleaseAlignmentEnabled
+        && release_section->SupportsStreamAlignment()) {
+        new_sampler->stream.InitAlignedStream(
+          release_section, m_InterpolationType, &handle->stream);
+      } else {
+        new_sampler->stream.InitStream(
+          &m_resample,
+          release_section,
+          m_InterpolationType,
+          this_pipe->GetTuning() / (float)m_SampleRate);
+      }
+      new_sampler->is_release = true;
+
+      new_sampler->m_SamplerTaskId = not_a_tremulant
+        ? /* detached releases are enabled and the pipe was on a regular
+           * windchest. Play the release on the detached windchest */
+        DETACHED_RELEASE_TASK_ID
+        /* detached releases are disabled (or this isn't really a pipe)
+         * so put the release on the same windchest as the pipe (which
+         * means it will still be affected by tremulants - yuck). */
+        : handle->m_SamplerTaskId;
+      new_sampler->m_AudioGroupId = handle->m_AudioGroupId;
+      new_sampler->toneBalanceFilterState.Init(
+        new_sampler->p_SoundProvider->GetToneBalance()->GetFilter());
+      StartSampler(new_sampler);
+      handle->time = m_CurrentTime;
+    }
+  }
+}
+
+GOSoundSampler *GOSoundSamplerPlayer::StartPipeSample(
+  const GOSoundProvider *pipeProvider,
+  unsigned windchestN,
+  unsigned audioGroup,
+  unsigned velocity,
+  unsigned delay,
+  uint64_t prevEventTime,
+  bool isRelease,
+  uint64_t *pStartTimeSamples) {
+  return CreateTaskSample(
+    pipeProvider,
+    windchestN,
+    audioGroup,
+    velocity,
+    delay,
+    prevEventTime,
+    isRelease,
+    pStartTimeSamples);
+}
+
+GOSoundSampler *GOSoundSamplerPlayer::StartTremulantSample(
+  const GOSoundProvider *tremProvider,
+  unsigned tremulantN,
+  uint64_t prevEventTime) {
+  return CreateTaskSample(
+    tremProvider, -tremulantN, 0, 0x7f, 0, prevEventTime, false, nullptr);
+}
+
+uint64_t GOSoundSamplerPlayer::StopSample(
+  const GOSoundProvider *pipe, GOSoundSampler *handle) {
+  assert(handle);
+  assert(pipe);
+
+  // The following condition could arise if a one-shot sample is played,
+  // decays away (and hence the sampler is discarded back into the pool), and
+  // then the user releases a key. If the sampler had already been reused
+  // with another pipe, that sample would erroneously be told to decay.
+  if (pipe != handle->p_SoundProvider)
+    return 0;
+
+  handle->stop = m_CurrentTime + handle->delay;
+  return handle->stop;
+}
+
+void GOSoundSamplerPlayer::SwitchSample(
+  const GOSoundProvider *pipe, GOSoundSampler *handle) {
+  assert(handle);
+  assert(pipe);
+
+  // The following condition could arise if a one-shot sample is played,
+  // decays away (and hence the sampler is discarded back into the pool), and
+  // then the user releases a key. If the sampler had already been reused
+  // with another pipe, that sample would erroneously be told to decay.
+  if (pipe != handle->p_SoundProvider)
+    return;
+
+  handle->new_attack = m_CurrentTime + handle->delay;
+}
+
+void GOSoundSamplerPlayer::UpdateVelocity(
+  const GOSoundProvider *pipe, GOSoundSampler *handle, unsigned velocity) {
+  assert(handle);
+  assert(pipe);
+
+  if (handle->p_SoundProvider == pipe) {
+    // we've just checked that handle is still playing the same pipe;
+    // maybe handle was switched to another pipe between checking and
+    // SetVelocityVolume, but we don't want to lock it because this
+    // functionality is not so important. Concurrent update is acceptable,
+    // as it just updates a float
+    handle->velocity = velocity;
+    handle->fader.SetVelocityVolume(pipe->GetVelocityVolume(velocity));
+  }
+}

--- a/src/grandorgue/sound/playing/GOSoundSamplerPlayer.h
+++ b/src/grandorgue/sound/playing/GOSoundSamplerPlayer.h
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDSAMPLERPLAYER_H
+#define GOSOUNDSAMPLERPLAYER_H
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "GOSoundResample.h"
+#include "GOSoundSamplerPool.h"
+#include "sound/GOSoundOrganInterface.h"
+
+#include "ptrvector.h"
+
+class GOSoundGroupTask;
+class GOSoundReleaseTask;
+class GOSoundTremulantTask;
+class GOSoundWindchestTask;
+
+/**
+ * @brief Manages samplers and implements the organ sound interface.
+ *
+ * Handles sampler lifecycle (start, stop, release, switch), sampler pool
+ * management, and the GOSoundOrganInterface methods called by the organ model.
+ * Designed to be owned by GOSoundOrganEngine.
+ */
+class GOSoundSamplerPlayer : public GOSoundOrganInterface {
+private:
+  /*
+   * Constructor constants
+   */
+
+  ptr_vector<GOSoundGroupTask> &r_AudioGroupTasks;
+  std::vector<std::unique_ptr<GOSoundWindchestTask>> &r_WindchestTasks;
+  ptr_vector<GOSoundTremulantTask> &r_TremulantTasks;
+  /** nullptr when player is constructed; populated in the body of
+   * GOSoundOrganEngine constructor. Used only during playback (after Build). */
+  std::unique_ptr<GOSoundReleaseTask> &rp_ReleaseTask;
+  GOSoundSamplerPool m_SamplerPool;
+  GOSoundResample m_resample;
+
+  /*
+   * Configuration parameters
+   */
+
+  bool m_IsScaledReleases;
+  bool m_IsReleaseAlignmentEnabled;
+  bool m_IsRandomizeSpeaking;
+  bool m_IsPolyphonyLimiting;
+  unsigned m_PolyphonySoftLimit;
+  GOSoundResample::InterpolationType m_InterpolationType;
+
+  /*
+   * Start parameters (set in Build())
+   */
+
+  unsigned m_SampleRate;
+
+  /*
+   * State
+   */
+
+  /** Current engine time in samples. Starts at 1 after Reset() so that zero
+   * can be used as a sentinel meaning "not set" in sampler fields (e.g.
+   * stop, new_attack). */
+  uint64_t m_CurrentTime;
+  std::atomic_uint m_UsedPolyphony;
+
+  /*
+   * Private helpers
+   */
+
+  unsigned MsToSamples(unsigned ms) const { return m_SampleRate * ms / 1000; }
+
+  unsigned SamplesDiffToMs(uint64_t fromSamples, uint64_t toSamples) const;
+
+  static constexpr int DETACHED_RELEASE_TASK_ID = 0;
+
+  static bool isWindchestTask(int taskId) { return taskId >= 0; }
+
+  static unsigned windchestTaskToIndex(int taskId) { return (unsigned)taskId; }
+
+  static unsigned tremulantTaskToIndex(int taskId) { return -taskId - 1; }
+
+  float GetRandomFactor() const;
+
+  void StartSampler(GOSoundSampler *sampler);
+
+  /**
+   * @brief Creates and starts a new sampler.
+   *
+   * @param pSoundProvider     Audio data source.
+   * @param samplerTaskId      Windchest task index (>=0) or negated tremulant
+   *                           index (<0).
+   * @param audioGroup         Audio group index.
+   * @param velocity           MIDI velocity (0–127).
+   * @param delay              Start delay in milliseconds.
+   * @param prevEventTime      Time of the previous event in samples.
+   * @param isRelease          true to start with the release section.
+   * @param pStartTimeSamples  If non-null, receives the actual start time
+   *                           in samples.
+   * @return the new sampler, or nullptr if the pool is exhausted.
+   */
+  GOSoundSampler *CreateTaskSample(
+    const GOSoundProvider *pSoundProvider,
+    int samplerTaskId,
+    unsigned audioGroup,
+    unsigned velocity,
+    unsigned delay,
+    uint64_t prevEventTime,
+    bool isRelease,
+    uint64_t *pStartTimeSamples);
+
+  /**
+   * @brief Creates a release tail sampler for the given pipe sampler.
+   * @param handle  The currently playing pipe sampler being released.
+   */
+  void CreateReleaseSampler(GOSoundSampler *handle);
+
+  /**
+   * @brief Creates a new sampler with decay of current loop and switches
+   * this sampler to the new attack. Used when a wave tremulant is switched
+   * on or off.
+   * @param pSampler  Current playing sampler for switching to a new attack.
+   */
+  void SwitchToAnotherAttack(GOSoundSampler *pSampler);
+
+public:
+  /*
+   * Constructor
+   */
+
+  /**
+   * @brief Constructs the player.
+   *
+   * Task containers are passed by reference; they may be empty at construction
+   * time and are populated later by GOSoundOrganEngine::BuildEngine().
+   * pReleaseTask is nullptr at construction; it is set in
+   * GOSoundOrganEngine's constructor body before any playback begins.
+   */
+  GOSoundSamplerPlayer(
+    ptr_vector<GOSoundGroupTask> &audioGroupTasks,
+    std::vector<std::unique_ptr<GOSoundWindchestTask>> &windchestTasks,
+    ptr_vector<GOSoundTremulantTask> &tremulantTasks,
+    std::unique_ptr<GOSoundReleaseTask> &pReleaseTask);
+
+  /*
+   * Configuration getters and setters
+   */
+
+  unsigned GetHardPolyphony() const { return m_SamplerPool.GetUsageLimit(); }
+  void SetHardPolyphony(unsigned polyphony);
+
+  bool IsPolyphonyLimiting() const { return m_IsPolyphonyLimiting; }
+  void SetPolyphonyLimiting(bool isLimiting) {
+    m_IsPolyphonyLimiting = isLimiting;
+  }
+
+  bool IsScaledReleases() const { return m_IsScaledReleases; }
+  void SetScaledReleases(bool isEnabled) { m_IsScaledReleases = isEnabled; }
+
+  bool IsReleaseAlignmentEnabled() const { return m_IsReleaseAlignmentEnabled; }
+  void SetReleaseAlignmentEnabled(bool isEnabled) {
+    m_IsReleaseAlignmentEnabled = isEnabled;
+  }
+
+  bool IsRandomizeSpeaking() const { return m_IsRandomizeSpeaking; }
+  void SetRandomizeSpeaking(bool isEnabled) {
+    m_IsRandomizeSpeaking = isEnabled;
+  }
+
+  GOSoundResample::InterpolationType GetInterpolationType() const {
+    return m_InterpolationType;
+  }
+  void SetInterpolationType(unsigned type) {
+    m_InterpolationType = (GOSoundResample::InterpolationType)type;
+  }
+
+  /*
+   * Start parameter getters
+   */
+
+  unsigned GetSampleRate() const override { return m_SampleRate; }
+
+  /*
+   * Other getters
+   */
+
+  /** Returns the current engine time in samples. Starts at 1 after Reset()
+   * so that zero can be used as a sentinel meaning "not set". */
+  uint64_t GetTime() const { return m_CurrentTime; }
+
+  /** Returns the peak used polyphony since the last call and resets the
+   * counter to zero. */
+  unsigned GetAndResetUsedPolyphony() { return m_UsedPolyphony.exchange(0); }
+
+  /*
+   * Lifecycle
+   */
+
+  /**
+   * @brief Stores the sample rate and asserts that tasks are ready.
+   *
+   * Must be called after GOSoundOrganEngine builds and populates the task
+   * containers and sets rp_ReleaseTask.
+   * @param sampleRate  Sample rate in Hz.
+   */
+  void Build(unsigned sampleRate);
+
+  /** @brief Symmetric to Build: resets m_SampleRate. */
+  void Destroy();
+
+  /** @brief Resets m_CurrentTime to 1 (0 is sentinel "not set"), returns
+   * all samplers to the pool, and clears m_UsedPolyphony. */
+  void Reset();
+
+  /**
+   * @brief Advances the current time by nSamplesPerBuffer samples and
+   * updates the used polyphony counter.
+   */
+  void AdvanceTime(unsigned nSamplesPerBuffer);
+
+  /*
+   * Organ interface (from GOSoundOrganInterface)
+   */
+
+  GOSoundSampler *StartPipeSample(
+    const GOSoundProvider *pipeProvider,
+    unsigned windchestN,
+    unsigned audioGroup,
+    unsigned velocity,
+    unsigned delay,
+    uint64_t prevEventTime,
+    bool isRelease = false,
+    uint64_t *pStartTimeSamples = nullptr) override;
+
+  GOSoundSampler *StartTremulantSample(
+    const GOSoundProvider *tremProvider,
+    unsigned tremulantN,
+    uint64_t prevEventTime) override;
+
+  uint64_t StopSample(
+    const GOSoundProvider *pipe, GOSoundSampler *handle) override;
+  void SwitchSample(
+    const GOSoundProvider *pipe, GOSoundSampler *handle) override;
+  void UpdateVelocity(
+    const GOSoundProvider *pipe,
+    GOSoundSampler *handle,
+    unsigned velocity) override;
+
+  /*
+   * Functions called from tasks
+   */
+
+  /**
+   * @brief Processes one period of audio for a single sampler.
+   *
+   * @param output_buffer  Interleaved stereo buffer to mix into.
+   * @param sampler        The sampler to process.
+   * @param n_frames       Number of frames.
+   * @param volume         Windchest/tremulant volume factor.
+   * @return true if the sampler should be kept alive for the next period.
+   */
+  bool ProcessSampler(
+    float *output_buffer,
+    GOSoundSampler *sampler,
+    unsigned n_frames,
+    float volume);
+
+  /**
+   * @brief Processes a release or attack-switch event for a sampler.
+   *
+   * Called from GOSoundReleaseTask. Starts a release tail (if stop is set)
+   * or switches to another attack (if new_attack is set), then re-queues
+   * the sampler.
+   * @param sampler  The sampler to process.
+   */
+  void ProcessRelease(GOSoundSampler *sampler);
+
+  /**
+   * @brief Queues a sampler into the appropriate group or tremulant task.
+   * @param sampler  The sampler to pass to its task.
+   */
+  void PassSampler(GOSoundSampler *sampler);
+
+  /**
+   * @brief Returns a sampler to the pool.
+   * @param sampler  The sampler to return.
+   */
+  void ReturnSampler(GOSoundSampler *sampler);
+};
+
+#endif /* GOSOUNDSAMPLERPLAYER_H */

--- a/src/grandorgue/sound/tasks/GOSoundGroupTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundGroupTask.cpp
@@ -7,15 +7,15 @@
 
 #include "GOSoundGroupTask.h"
 
-#include "sound/GOSoundOrganEngine.h"
+#include "sound/playing/GOSoundSamplerPlayer.h"
 #include "threading/GOMutexLocker.h"
 
 #include "GOSoundWindchestTask.h"
 
 GOSoundGroupTask::GOSoundGroupTask(
-  GOSoundOrganEngine &sound_engine, unsigned samples_per_buffer)
-  : GOSoundBufferTaskBase(2, samples_per_buffer),
-    m_engine(sound_engine),
+  GOSoundSamplerPlayer &samplerPlayer, unsigned nFramesPerBuffer)
+  : GOSoundBufferTaskBase(2, nFramesPerBuffer),
+    r_SamplerPlayer(samplerPlayer),
     m_Condition(m_Mutex),
     m_ActiveCount(0),
     m_Done(0),
@@ -46,9 +46,10 @@ void GOSoundGroupTask::ProcessList(
 
   while ((sampler = list.Get())) {
     if (
-      toDropOld && m_Stop.load() && sampler->time + 2000 < m_engine.GetTime()) {
+      toDropOld && m_Stop.load()
+      && sampler->time + 2000 < r_SamplerPlayer.GetTime()) {
       if (sampler->drop_counter++ > 3) {
-        m_engine.ReturnSampler(sampler);
+        r_SamplerPlayer.ReturnSampler(sampler);
         continue;
       }
     }
@@ -58,7 +59,7 @@ void GOSoundGroupTask::ProcessList(
 
     if (
       windchest
-      && m_engine.ProcessSampler(
+      && r_SamplerPlayer.ProcessSampler(
         output_buffer, sampler, GetNFrames(), windchest->GetVolume()))
       Add(sampler);
   }

--- a/src/grandorgue/sound/tasks/GOSoundGroupTask.h
+++ b/src/grandorgue/sound/tasks/GOSoundGroupTask.h
@@ -18,11 +18,11 @@
 
 #include "GOSoundBufferTaskBase.h"
 
-class GOSoundOrganEngine;
+class GOSoundSamplerPlayer;
 
 class GOSoundGroupTask : public GOSoundBufferTaskBase {
 private:
-  GOSoundOrganEngine &m_engine;
+  GOSoundSamplerPlayer &r_SamplerPlayer;
   GOSoundSamplerList m_Active;
   GOSoundSamplerList m_Release;
   GOMutex m_Mutex;
@@ -44,7 +44,7 @@ private:
 
 public:
   GOSoundGroupTask(
-    GOSoundOrganEngine &sound_engine, unsigned samples_per_buffer);
+    GOSoundSamplerPlayer &samplerPlayer, unsigned nFramesPerBuffer);
 
   unsigned GetGroup();
   unsigned GetCost();

--- a/src/grandorgue/sound/tasks/GOSoundReleaseTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundReleaseTask.cpp
@@ -8,11 +8,14 @@
 #include "GOSoundReleaseTask.h"
 
 #include "GOSoundGroupTask.h"
-#include "sound/GOSoundOrganEngine.h"
+#include "sound/playing/GOSoundSamplerPlayer.h"
 
 GOSoundReleaseTask::GOSoundReleaseTask(
-  GOSoundOrganEngine &sound_engine, ptr_vector<GOSoundGroupTask> &audio_groups)
-  : m_engine(sound_engine), m_AudioGroups(audio_groups), m_Stop(false) {}
+  GOSoundSamplerPlayer &samplerPlayer,
+  ptr_vector<GOSoundGroupTask> &audioGroupTaskPtrs)
+  : r_SamplerPlayer(samplerPlayer),
+    m_AudioGroups(audioGroupTaskPtrs),
+    m_Stop(false) {}
 
 unsigned GOSoundReleaseTask::GetGroup() { return RELEASE; }
 
@@ -35,7 +38,7 @@ void GOSoundReleaseTask::Run(GOSoundThread *pThread) {
   do {
     while ((sampler = m_List.Get())) {
       m_Cnt.fetch_add(1);
-      m_engine.ProcessRelease(sampler);
+      r_SamplerPlayer.ProcessRelease(sampler);
       if (m_Stop.load() && m_Cnt > 10)
         break;
     }
@@ -52,5 +55,5 @@ void GOSoundReleaseTask::Exec() {
   Run();
   GOSoundSampler *sampler;
   while ((sampler = m_List.Get()))
-    m_engine.PassSampler(sampler);
+    r_SamplerPlayer.PassSampler(sampler);
 }

--- a/src/grandorgue/sound/tasks/GOSoundReleaseTask.h
+++ b/src/grandorgue/sound/tasks/GOSoundReleaseTask.h
@@ -15,13 +15,13 @@
 
 #include "ptrvector.h"
 
-class GOSoundOrganEngine;
 class GOSoundGroupTask;
 class GOSoundSampler;
+class GOSoundSamplerPlayer;
 
 class GOSoundReleaseTask : public GOSoundTask {
 private:
-  GOSoundOrganEngine &m_engine;
+  GOSoundSamplerPlayer &r_SamplerPlayer;
   ptr_vector<GOSoundGroupTask> &m_AudioGroups;
   GOSoundSimpleSamplerList m_List;
   std::atomic_uint m_WaitCnt;
@@ -30,8 +30,8 @@ private:
 
 public:
   GOSoundReleaseTask(
-    GOSoundOrganEngine &sound_engine,
-    ptr_vector<GOSoundGroupTask> &audio_groups);
+    GOSoundSamplerPlayer &samplerPlayer,
+    ptr_vector<GOSoundGroupTask> &audioGroupTaskPtrs);
 
   unsigned GetGroup();
   unsigned GetCost();

--- a/src/grandorgue/sound/tasks/GOSoundTremulantTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundTremulantTask.cpp
@@ -7,14 +7,14 @@
 
 #include "GOSoundTremulantTask.h"
 
-#include "sound/GOSoundOrganEngine.h"
+#include "sound/playing/GOSoundSamplerPlayer.h"
 #include "threading/GOMutexLocker.h"
 
 GOSoundTremulantTask::GOSoundTremulantTask(
-  GOSoundOrganEngine &sound_engine, unsigned samples_per_buffer)
-  : m_engine(sound_engine),
+  GOSoundSamplerPlayer &samplerPlayer, unsigned nFramesPerBuffer)
+  : r_SamplerPlayer(samplerPlayer),
     m_Volume(0),
-    m_SamplesPerBuffer(samples_per_buffer),
+    m_SamplesPerBuffer(nFramesPerBuffer),
     m_Done(false) {}
 
 void GOSoundTremulantTask::Reset() {
@@ -56,8 +56,8 @@ void GOSoundTremulantTask::Run(GOSoundThread *thread) {
   for (GOSoundSampler *sampler = m_Samplers.Get(); sampler;
        sampler = m_Samplers.Get()) {
     bool keep;
-    keep
-      = m_engine.ProcessSampler(output_buffer, sampler, m_SamplesPerBuffer, 1);
+    keep = r_SamplerPlayer.ProcessSampler(
+      output_buffer, sampler, m_SamplesPerBuffer, 1);
 
     if (keep)
       m_Samplers.Put(sampler);

--- a/src/grandorgue/sound/tasks/GOSoundTremulantTask.h
+++ b/src/grandorgue/sound/tasks/GOSoundTremulantTask.h
@@ -12,11 +12,11 @@
 #include "sound/scheduler/GOSoundTask.h"
 #include "threading/GOMutex.h"
 
-class GOSoundOrganEngine;
+class GOSoundSamplerPlayer;
 
 class GOSoundTremulantTask : public GOSoundTask {
 private:
-  GOSoundOrganEngine &m_engine;
+  GOSoundSamplerPlayer &r_SamplerPlayer;
   GOSoundSamplerList m_Samplers;
   GOMutex m_Mutex;
   float m_Volume;
@@ -25,7 +25,7 @@ private:
 
 public:
   GOSoundTremulantTask(
-    GOSoundOrganEngine &sound_engine, unsigned samples_per_buffer);
+    GOSoundSamplerPlayer &samplerPlayer, unsigned nFramesPerBuffer);
 
   unsigned GetGroup();
   unsigned GetCost();

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -17,6 +17,7 @@
 #include "sound/GOSoundOrganEngine.h"
 #include "sound/GOSoundRecorder.h"
 #include "sound/buffer/GOSoundBufferMutable.h"
+#include "sound/playing/GOSoundSamplerPlayer.h"
 #include "sound/providers/GOSoundProviderWave.h"
 
 #include "GOOrganController.h"
@@ -134,10 +135,12 @@ void GOPerfTestApp::RunTest(
 
       std::vector<GOSoundSampler *> handles;
       float output_buffer[samples_per_frame * 2];
+      GOSoundSamplerPlayer &samplerPlayer = engine->GetSamplerPlayer();
 
-      for (unsigned i = 0; i < pipes.size(); i++) {
+      for (GOSoundProvider *pPipe : pipes) {
         GOSoundSampler *handle
-          = engine->StartPipeSample(pipes[i], 1, 0, 127, 0, 0);
+          = samplerPlayer.StartPipeSample(pPipe, 1, 0, 127, 0, 0);
+
         if (handle)
           handles.push_back(handle);
       }

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -16,6 +16,7 @@
 #include "model/GOWindchest.h"
 #include "sound/GOSoundRecorder.h"
 #include "sound/buffer/GOSoundBufferMutable.h"
+#include "sound/playing/GOSoundSamplerPlayer.h"
 #include "sound/providers/GOSoundProviderWave.h"
 
 #include "GOOrganController.h"
@@ -131,10 +132,12 @@ void GOPerfTestApp::RunTest(
 
       std::vector<GOSoundSampler *> handles;
       float output_buffer[samples_per_frame * 2];
+      GOSoundSamplerPlayer &samplerPlayer = engine.GetSamplerPlayer();
 
-      for (unsigned i = 0; i < pipes.size(); i++) {
+      for (GOSoundProvider *pPipe : pipes) {
         GOSoundSampler *handle
-          = engine.StartPipeSample(pipes[i], 1, 0, 127, 0, 0);
+          = samplerPlayer.StartPipeSample(pPipe, 1, 0, 127, 0, 0);
+
         if (handle)
           handles.push_back(handle);
       }


### PR DESCRIPTION
## Summary
- Extracted all sampler lifecycle/pool management and the `GOSoundOrganInterface` implementation out of `GOSoundOrganEngine` into a new class `GOSoundSamplerPlayer` (`src/grandorgue/sound/playing/`).
- `GOSoundOrganEngine` no longer inherits `GOSoundOrganInterface`; it owns `GOSoundSamplerPlayer` by value and exposes `GetSamplerPlayer()` for organ model connection.
- `GOSoundGroupTask`, `GOSoundReleaseTask`, and `GOSoundTremulantTask` now reference `GOSoundSamplerPlayer` instead of `GOSoundOrganEngine`. `GOSoundWindchestTask` is unchanged (still uses the engine for `GetGain()`).
- `m_volume`/`m_gain` stay in `GOSoundOrganEngine`, since they're only consumed by `GOSoundWindchestTask` via the engine.

(Cherry-picked from commit 8edf40f3, originally on `refactor/init-sound16`, adapted to this branch's `PreparePlayback`/`Abort` + `GOAppWindow` orchestration structure.)

## Test plan
- [x] `make -k -j16` builds cleanly (Debug + ASAN)
- [x] `./bin/GOTestExe` — all functional tests pass (one perf test fails as expected on a debug/ASAN build vs release baselines, unrelated to this change)
- [x] Verified no remaining references to the removed `GOSoundOrganEngine` sampler methods outside `GOSoundSamplerPlayer`/`GOPerfTest.cpp`