### PR TITLE
Moved sound/GOSoundRecorder to sound/tasks/GOSoundRecorderTask

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -229,13 +229,13 @@ sound/scheduler/GOSoundScheduler.cpp
 sound/scheduler/GOSoundThread.cpp
 sound/tasks/GOSoundGroupTask.cpp
 sound/tasks/GOSoundOutputTask.cpp
+sound/tasks/GOSoundRecorderTask.cpp
 sound/tasks/GOSoundReleaseTask.cpp
 sound/tasks/GOSoundTouchTask.cpp
 sound/tasks/GOSoundTremulantTask.cpp
 sound/tasks/GOSoundWindchestTask.cpp
 sound/GOSoundDevInfo.cpp
 sound/GOSoundOrganEngine.cpp
-sound/GOSoundRecorder.cpp
 sound/GOSoundSystem.cpp
 updater/GOUpdateChecker.cpp
 yaml/GOSaveableToYaml.cpp

--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -231,13 +231,13 @@ sound/scheduler/GOSoundScheduler.cpp
 sound/scheduler/GOSoundThread.cpp
 sound/tasks/GOSoundGroupTask.cpp
 sound/tasks/GOSoundOutputTask.cpp
+sound/tasks/GOSoundRecorderTask.cpp
 sound/tasks/GOSoundReleaseTask.cpp
 sound/tasks/GOSoundTouchTask.cpp
 sound/tasks/GOSoundTremulantTask.cpp
 sound/tasks/GOSoundWindchestTask.cpp
 sound/GOSoundDevInfo.cpp
 sound/GOSoundOrganEngine.cpp
-sound/GOSoundRecorder.cpp
 sound/GOSoundSystem.cpp
 updater/GOUpdateChecker.cpp
 yaml/GOSaveableToYaml.cpp

--- a/src/grandorgue/GOAudioRecorder.cpp
+++ b/src/grandorgue/GOAudioRecorder.cpp
@@ -13,7 +13,7 @@
 #include "config/GOConfig.h"
 #include "control/GOCallbackButtonControl.h"
 #include "midi/objects/GOMidiObjectContext.h"
-#include "sound/GOSoundRecorder.h"
+#include "sound/tasks/GOSoundRecorderTask.h"
 
 #include "GOEvent.h"
 #include "GOOrganController.h"
@@ -64,7 +64,7 @@ GOAudioRecorder::GOAudioRecorder(GOOrganController *organController)
 
 GOAudioRecorder::~GOAudioRecorder() { StopRecording(); }
 
-void GOAudioRecorder::SetAudioRecorder(GOSoundRecorder *recorder) {
+void GOAudioRecorder::SetAudioRecorder(GOSoundRecorderTask *recorder) {
   StopRecording();
   m_recorder = recorder;
 }

--- a/src/grandorgue/GOAudioRecorder.h
+++ b/src/grandorgue/GOAudioRecorder.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -16,12 +16,12 @@
 #include "GOTimerCallback.h"
 
 class GOOrganController;
-class GOSoundRecorder;
+class GOSoundRecorderTask;
 
 class GOAudioRecorder : public GOElementCreator, private GOTimerCallback {
 private:
   GOOrganController *m_OrganController;
-  GOSoundRecorder *m_recorder;
+  GOSoundRecorderTask *m_recorder;
   GOLabelControl m_RecordingTime;
   unsigned m_RecordSeconds;
   wxString m_Filename;
@@ -36,7 +36,7 @@ public:
   GOAudioRecorder(GOOrganController *organController);
   ~GOAudioRecorder();
 
-  void SetAudioRecorder(GOSoundRecorder *recorder);
+  void SetAudioRecorder(GOSoundRecorderTask *recorder);
 
   void StartRecording(bool rename);
   bool IsRecording();

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -862,7 +862,9 @@ void GOOrganController::PreconfigRecorder() {
 }
 
 void GOOrganController::PreparePlayback(
-  GOSoundOrganEngine *engine, GOMidiSystem *midi, GOSoundRecorder *recorder) {
+  GOSoundOrganEngine *engine,
+  GOMidiSystem *midi,
+  GOSoundRecorderTask *recorder) {
   m_soundengine = engine;
   m_midi = midi;
   m_MidiRecorder->SetOutputDevice(m_config.MidiRecorderOutputDevice());

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -49,7 +49,7 @@ class GOMidiSystem;
 class GOOrgan;
 class GOSetter;
 class GOSoundProvider;
-class GOSoundRecorder;
+class GOSoundRecorderTask;
 class GOSoundSystem;
 class GOTemperament;
 class GOTimer;
@@ -170,7 +170,9 @@ public:
   void DeleteSettings();
   void Abort();
   void PreparePlayback(
-    GOSoundOrganEngine *engine, GOMidiSystem *midi, GOSoundRecorder *recorder);
+    GOSoundOrganEngine *engine,
+    GOMidiSystem *midi,
+    GOSoundRecorderTask *recorder);
   void PrepareRecording();
   void Update();
   void Reset();

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -50,7 +50,7 @@ class GOMidiRecorder;
 class GOMidiSystem;
 class GOSetter;
 class GOSoundProvider;
-class GOSoundRecorder;
+class GOSoundRecorderTask;
 class GOSoundSystem;
 class GOTemperament;
 class GOTimer;

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -20,6 +20,7 @@
 #include "scheduler/GOSoundThread.h"
 #include "tasks/GOSoundGroupTask.h"
 #include "tasks/GOSoundOutputTask.h"
+#include "tasks/GOSoundRecorderTask.h"
 #include "tasks/GOSoundReleaseTask.h"
 #include "tasks/GOSoundTouchTask.h"
 #include "tasks/GOSoundTremulantTask.h"
@@ -27,7 +28,6 @@
 #include "threading/GOMutexLocker.h"
 
 #include "GOEvent.h"
-#include "GOSoundRecorder.h"
 
 /*
  * Factory functions
@@ -168,7 +168,7 @@ void GOSoundOrganEngine::BuildEngine(
   const std::vector<AudioOutputConfig> &audioOutputConfigs,
   unsigned nSamplesPerBuffer,
   unsigned sampleRate,
-  GOSoundRecorder &recorder) {
+  GOSoundRecorderTask &recorder) {
   GOMutexLocker locker(m_LifecycleMutex);
 
   assert(m_LifecycleState.load() == LifecycleState::IDLE);
@@ -369,7 +369,7 @@ void GOSoundOrganEngine::BuildAndStart(
   const std::vector<AudioOutputConfig> &audioOutputConfigs,
   unsigned nSamplesPerBuffer,
   unsigned sampleRate,
-  GOSoundRecorder &recorder) {
+  GOSoundRecorderTask &recorder) {
   BuildEngine(audioOutputConfigs, nSamplesPerBuffer, sampleRate, recorder);
   StartEngine();
 }

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -16,6 +16,7 @@
 #include "scheduler/GOSoundThread.h"
 #include "tasks/GOSoundGroupTask.h"
 #include "tasks/GOSoundOutputTask.h"
+#include "tasks/GOSoundRecorderTask.h"
 #include "tasks/GOSoundReleaseTask.h"
 #include "tasks/GOSoundTouchTask.h"
 #include "tasks/GOSoundTremulantTask.h"
@@ -23,7 +24,6 @@
 #include "threading/GOMutexLocker.h"
 
 #include "GOEvent.h"
-#include "GOSoundRecorder.h"
 
 /*
  * Factory functions
@@ -150,7 +150,7 @@ void GOSoundOrganEngine::BuildEngine(
   const std::vector<AudioOutputConfig> &audioOutputConfigs,
   unsigned nSamplesPerBuffer,
   unsigned sampleRate,
-  GOSoundRecorder &recorder) {
+  GOSoundRecorderTask &recorder) {
   GOMutexLocker locker(m_LifecycleMutex);
 
   assert(m_LifecycleState.load() == LifecycleState::IDLE);
@@ -350,7 +350,7 @@ void GOSoundOrganEngine::BuildAndStart(
   const std::vector<AudioOutputConfig> &audioOutputConfigs,
   unsigned nSamplesPerBuffer,
   unsigned sampleRate,
-  GOSoundRecorder &recorder) {
+  GOSoundRecorderTask &recorder) {
   BuildEngine(audioOutputConfigs, nSamplesPerBuffer, sampleRate, recorder);
   StartEngine();
 }

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -29,7 +29,7 @@ class GOSoundBufferMutable;
 class GOSoundGroupTask;
 class GOSoundOutputTask;
 class GOSoundProvider;
-class GOSoundRecorder;
+class GOSoundRecorderTask;
 class GOSoundReleaseTask;
 class GOSoundTask;
 class GOSoundThread;
@@ -172,7 +172,7 @@ private:
   std::unique_ptr<GOSoundOutputTask> mp_DownmixTask;
   // [B5] p_AudioRecorder: non-owning pointer to the recorder passed in
   //   — uses mp_DownmixTask [B4] or mp_AudioOutputTasks [B2]
-  GOSoundRecorder *p_AudioRecorder;
+  GOSoundRecorderTask *p_AudioRecorder;
   // [B6] reverb: set up inline on mp_DownmixTask [B4] and mp_AudioOutputTasks
   // [B2]
   //   — uses m_ReverbConfig, m_SampleRate, m_NSamplesPerBuffer
@@ -208,7 +208,7 @@ private:
     const std::vector<AudioOutputConfig> &audioOutputConfigs,
     unsigned nSamplesPerBuffer,
     unsigned sampleRate,
-    GOSoundRecorder &recorder);
+    GOSoundRecorderTask &recorder);
   void DestroyEngine();
 
   void ResetCounters();
@@ -383,13 +383,14 @@ public:
    * @param audioOutputConfigs  Output configurations; must not be empty.
    * @param nSamplesPerBuffer   Buffer size in samples (from audio system).
    * @param sampleRate          Sample rate in Hz (from audio system).
-   * @param recorder            Recorder (non-owning).
+   * @param recorder            Recorder (non-owning, must be a
+   * GOSoundRecorderTask).
    */
   void BuildAndStart(
     const std::vector<AudioOutputConfig> &audioOutputConfigs,
     unsigned nSamplesPerBuffer,
     unsigned sampleRate,
-    GOSoundRecorder &recorder);
+    GOSoundRecorderTask &recorder);
 
   /**
    * @brief Stops the engine and destroys tasks.

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -22,7 +22,8 @@ class GOOrganModel;
 class GOSoundBufferMutable;
 class GOSoundGroupTask;
 class GOSoundOutputTask;
-class GOSoundRecorder;
+class GOSoundProvider;
+class GOSoundRecorderTask;
 class GOSoundReleaseTask;
 class GOSoundTask;
 class GOSoundThread;
@@ -159,7 +160,7 @@ private:
   std::unique_ptr<GOSoundOutputTask> mp_DownmixTask;
   // [B5] p_AudioRecorder: non-owning pointer to the recorder passed in
   //   — uses mp_DownmixTask [B4] or mp_AudioOutputTasks [B2]
-  GOSoundRecorder *p_AudioRecorder;
+  GOSoundRecorderTask *p_AudioRecorder;
   // [B6] reverb: set up inline on mp_DownmixTask [B4] and mp_AudioOutputTasks
   // [B2]
   //   — uses m_ReverbConfig, m_SampleRate, m_NSamplesPerBuffer
@@ -187,7 +188,7 @@ private:
     const std::vector<AudioOutputConfig> &audioOutputConfigs,
     unsigned nSamplesPerBuffer,
     unsigned sampleRate,
-    GOSoundRecorder &recorder);
+    GOSoundRecorderTask &recorder);
   void DestroyEngine();
 
   void ResetCounters();
@@ -340,13 +341,14 @@ public:
    * @param audioOutputConfigs  Output configurations; must not be empty.
    * @param nSamplesPerBuffer   Buffer size in samples (from audio system).
    * @param sampleRate          Sample rate in Hz (from audio system).
-   * @param recorder            Recorder (non-owning).
+   * @param recorder            Recorder (non-owning, must be a
+   * GOSoundRecorderTask).
    */
   void BuildAndStart(
     const std::vector<AudioOutputConfig> &audioOutputConfigs,
     unsigned nSamplesPerBuffer,
     unsigned sampleRate,
-    GOSoundRecorder &recorder);
+    GOSoundRecorderTask &recorder);
 
   /**
    * @brief Stops the engine and destroys tasks.

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -15,6 +15,7 @@
 #include <wx/string.h>
 
 #include "midi/GOMidiSystem.h"
+#include "tasks/GOSoundRecorderTask.h"
 #include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
 
@@ -23,7 +24,6 @@
 #include "GOSoundCloseListener.h"
 #include "GOSoundDevInfo.h"
 #include "GOSoundOrganEngine.h"
-#include "GOSoundRecorder.h"
 
 class GOConfig;
 class GODeviceNamePattern;
@@ -70,7 +70,7 @@ private:
   GOConfig &m_config;
 
   GOMidiSystem m_midi;
-  GOSoundRecorder m_AudioRecorder;
+  GOSoundRecorderTask m_AudioRecorder;
   std::unique_ptr<GOSoundOrganEngine> mp_SoundEngine;
 
   GOSoundCloseListener *p_CloseListener;
@@ -134,7 +134,7 @@ public:
   bool IsOpen() const { return m_open; }
 
   /** Returns the audio recorder associated with this sound system. */
-  GOSoundRecorder &GetAudioRecorder() { return m_AudioRecorder; }
+  GOSoundRecorderTask &GetAudioRecorder() { return m_AudioRecorder; }
 
   unsigned GetSampleRate() const { return m_SampleRate; }
   unsigned GetSamplesPerBuffer() const { return m_SamplesPerBuffer; }

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -14,6 +14,7 @@
 #include <wx/string.h>
 
 #include "midi/GOMidiSystem.h"
+#include "tasks/GOSoundRecorderTask.h"
 #include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
 
@@ -21,7 +22,6 @@
 
 #include "GOSoundCloseListener.h"
 #include "GOSoundDevInfo.h"
-#include "GOSoundRecorder.h"
 
 class GOSoundOrganEngine;
 
@@ -69,7 +69,7 @@ private:
   GOConfig &m_config;
 
   GOMidiSystem m_midi;
-  GOSoundRecorder m_AudioRecorder;
+  GOSoundRecorderTask m_AudioRecorder;
   std::atomic<GOSoundOrganEngine *> p_OrganEngine;
 
   GOSoundCloseListener *p_CloseListener;
@@ -129,7 +129,7 @@ public:
   bool IsOpen() const { return m_open; }
 
   /** Returns the audio recorder associated with this sound system. */
-  GOSoundRecorder &GetAudioRecorder() { return m_AudioRecorder; }
+  GOSoundRecorderTask &GetAudioRecorder() { return m_AudioRecorder; }
 
   unsigned GetSampleRate() const { return m_SampleRate; }
   unsigned GetSamplesPerBuffer() const { return m_SamplesPerBuffer; }

--- a/src/grandorgue/sound/tasks/GOSoundRecorderTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundRecorderTask.cpp
@@ -5,14 +5,14 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOSoundRecorder.h"
+#include "GOSoundRecorderTask.h"
 
 #include <wx/intl.h>
 #include <wx/log.h>
 
-#include "tasks/GOSoundBufferTaskBase.h"
 #include "threading/GOMutexLocker.h"
 
+#include "GOSoundBufferTaskBase.h"
 #include "GOWaveTypes.h"
 
 #pragma pack(push, 1)
@@ -27,7 +27,7 @@ struct struct_WAVE {
 
 #pragma pack(pop)
 
-GOSoundRecorder::GOSoundRecorder()
+GOSoundRecorderTask::GOSoundRecorderTask()
   : m_file(),
     m_lock(),
     m_SampleRate(0),
@@ -41,13 +41,13 @@ GOSoundRecorder::GOSoundRecorder()
   SetupBuffer();
 }
 
-GOSoundRecorder::~GOSoundRecorder() {
+GOSoundRecorderTask::~GOSoundRecorderTask() {
   Close();
   if (m_Buffer)
     delete[] m_Buffer;
 }
 
-struct_WAVE GOSoundRecorder::generateHeader(unsigned datasize) {
+struct_WAVE GOSoundRecorderTask::generateHeader(unsigned datasize) {
   struct_WAVE WAVE = {
     {WAVE_TYPE_RIFF, datasize + 36},
     WAVE_TYPE_WAVE,
@@ -62,7 +62,7 @@ struct_WAVE GOSoundRecorder::generateHeader(unsigned datasize) {
   return WAVE;
 }
 
-void GOSoundRecorder::Open(wxString filename) {
+void GOSoundRecorderTask::Open(wxString filename) {
   struct_WAVE WAVE = generateHeader(0);
 
   Close();
@@ -81,9 +81,9 @@ void GOSoundRecorder::Open(wxString filename) {
   m_BufferPos = 0;
 }
 
-bool GOSoundRecorder::IsOpen() { return m_Recording; }
+bool GOSoundRecorderTask::IsOpen() { return m_Recording; }
 
-void GOSoundRecorder::Close() {
+void GOSoundRecorderTask::Close() {
   GOMutexLocker locker(m_lock);
   {
     GOMutexLocker locker(m_Mutex);
@@ -98,25 +98,25 @@ void GOSoundRecorder::Close() {
   m_file.Close();
 }
 
-void GOSoundRecorder::SetSampleRate(unsigned sample_rate) {
+void GOSoundRecorderTask::SetSampleRate(unsigned sample_rate) {
   m_SampleRate = sample_rate;
 }
 
-void GOSoundRecorder::SetBytesPerSample(unsigned value) {
+void GOSoundRecorderTask::SetBytesPerSample(unsigned value) {
   if (value < 1 || value > 4)
     value = 4;
   m_BytesPerSample = value;
   SetupBuffer();
 }
 
-void GOSoundRecorder::SetOutputs(
+void GOSoundRecorderTask::SetOutputs(
   std::vector<GOSoundBufferTaskBase *> outputs, unsigned samples_per_buffer) {
   m_Outputs = outputs;
   m_SamplesPerBuffer = samples_per_buffer;
   SetupBuffer();
 }
 
-void GOSoundRecorder::SetupBuffer() {
+void GOSoundRecorderTask::SetupBuffer() {
   Close();
   if (m_Buffer)
     delete[] m_Buffer;
@@ -152,7 +152,7 @@ static void convertValue(float value, GOInt8 &result) {
 
 static void convertValue(float value, float &result) { result = value; }
 
-template <class T> void GOSoundRecorder::ConvertData() {
+template <class T> void GOSoundRecorderTask::ConvertData() {
   unsigned start_pos = 0;
   T *buf = (T *)m_Buffer;
 
@@ -175,13 +175,13 @@ template <class T> void GOSoundRecorder::ConvertData() {
   }
 }
 
-unsigned GOSoundRecorder::GetGroup() { return AUDIORECORDER; }
+unsigned GOSoundRecorderTask::GetGroup() { return AUDIORECORDER; }
 
-unsigned GOSoundRecorder::GetCost() { return 0; }
+unsigned GOSoundRecorderTask::GetCost() { return 0; }
 
-bool GOSoundRecorder::GetRepeat() { return false; }
+bool GOSoundRecorderTask::GetRepeat() { return false; }
 
-void GOSoundRecorder::Run(GOSoundThread *thread) {
+void GOSoundRecorderTask::Run(GOSoundThread *thread) {
   if (!m_Recording)
     return;
   if (m_Done)
@@ -211,17 +211,17 @@ void GOSoundRecorder::Run(GOSoundThread *thread) {
   m_Done = true;
 }
 
-void GOSoundRecorder::Exec() {
+void GOSoundRecorderTask::Exec() {
   m_Stop.store(true);
   Run();
 }
 
-void GOSoundRecorder::Clear() {
+void GOSoundRecorderTask::Clear() {
   Close();
   Reset();
 }
 
-void GOSoundRecorder::Reset() {
+void GOSoundRecorderTask::Reset() {
   GOMutexLocker locker(m_Mutex);
   m_Done = false;
   m_Stop.store(false);

--- a/src/grandorgue/sound/tasks/GOSoundRecorderTask.h
+++ b/src/grandorgue/sound/tasks/GOSoundRecorderTask.h
@@ -5,8 +5,8 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GOSOUNDRECORDER_H
-#define GOSOUNDRECORDER_H
+#ifndef GOSOUNDRECORDERTASK_H
+#define GOSOUNDRECORDERTASK_H
 
 #include <atomic>
 #include <vector>
@@ -14,13 +14,13 @@
 #include <wx/file.h>
 #include <wx/string.h>
 
-#include "scheduler/GOSoundTask.h"
+#include "sound/scheduler/GOSoundTask.h"
 #include "threading/GOMutex.h"
 
 class GOSoundBufferTaskBase;
 struct struct_WAVE;
 
-class GOSoundRecorder : public GOSoundTask {
+class GOSoundRecorderTask : public GOSoundTask {
 private:
   wxFile m_file;
   GOMutex m_lock;
@@ -42,8 +42,8 @@ private:
   struct_WAVE generateHeader(unsigned datasize);
 
 public:
-  GOSoundRecorder();
-  virtual ~GOSoundRecorder();
+  GOSoundRecorderTask();
+  virtual ~GOSoundRecorderTask();
 
   void Open(wxString filename);
   bool IsOpen();
@@ -51,6 +51,7 @@ public:
   void SetSampleRate(unsigned sample_rate);
   /* 1 = 8 bit, 2 = 16 bit, 3 = 24 bit, 4 = float */
   void SetBytesPerSample(unsigned value);
+  unsigned GetBytesPerSample() const { return m_BytesPerSample; }
   void SetOutputs(
     std::vector<GOSoundBufferTaskBase *> outputs, unsigned samples_per_buffer);
 

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -14,10 +14,10 @@
 
 #include "config/GOConfig.h"
 #include "model/GOWindchest.h"
-#include "sound/GOSoundRecorder.h"
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/playing/GOSoundSamplerPlayer.h"
 #include "sound/providers/GOSoundProviderWave.h"
+#include "sound/tasks/GOSoundRecorderTask.h"
 
 #include "GOOrganController.h"
 #include "GOStdPath.h"
@@ -79,7 +79,7 @@ void GOPerfTestApp::RunTest(
     organController->InitOrganDirectory(testsDir);
     organController->AddWindchest(new GOWindchest(*organController));
 
-    GOSoundRecorder recorder;
+    GOSoundRecorderTask recorder;
     GOSoundOrganEngine &engine = organController->GetSoundEngine();
 
     try {

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -15,9 +15,9 @@
 #include "config/GOConfig.h"
 #include "model/GOWindchest.h"
 #include "sound/GOSoundOrganEngine.h"
-#include "sound/GOSoundRecorder.h"
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/providers/GOSoundProviderWave.h"
+#include "sound/tasks/GOSoundRecorderTask.h"
 
 #include "GOOrganController.h"
 #include "GOStdPath.h"
@@ -82,7 +82,7 @@ void GOPerfTestApp::RunTest(
     GOSoundOrganEngine *engine = new GOSoundOrganEngine(
       static_cast<GOOrganModel &>(*organController),
       organController->GetMemoryPool());
-    GOSoundRecorder recorder;
+    GOSoundRecorderTask recorder;
 
     try {
       ptr_vector<GOSoundProvider> pipes;


### PR DESCRIPTION
## Summary
- Renamed `GOSoundRecorder` to `GOSoundRecorderTask` and moved it from `src/grandorgue/sound/` to `src/grandorgue/sound/tasks/`, aligning it with the other `GOSoundTask`-derived classes that already live in `sound/tasks/`.
- Updated all call sites accordingly (`GOAudioRecorder`, `GOSoundOrganEngine`, `GOSoundSystem`, `GOOrganController`, `GOPerfTest`).

## Test plan
- [x] `make -k -j16` builds cleanly
- [x] `ctest` functional test suite passes (12/12); the LeakSanitizer failures present are pre-existing and unrelated to this change (allocations in `GOSetter`/`GOOrganController` test setup, not `GOSoundRecorderTask`)