### PR TITLE
Moved audio callback processing from GOSoundSystem to GOSoundOrganEngine

### DIFF
--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -91,6 +91,16 @@ std::vector<GOSoundOrganEngine::AudioOutputConfig> GOSoundOrganEngine::
  * Constructors and destructors
  */
 
+GOSoundOrganEngine::OutputState::OutputState()
+  : condition(mutex), isFinishedCurrPeriod(false) {}
+
+GOSoundOrganEngine::OutputState::OutputState(OutputState &&other) noexcept
+  : mp_task(std::move(other.mp_task)),
+    condition(mutex),
+    isFinishedCurrPeriod(other.isFinishedCurrPeriod) {}
+
+GOSoundOrganEngine::OutputState::~OutputState() = default;
+
 GOSoundOrganEngine::GOSoundOrganEngine(
   GOOrganModel &organModel, GOMemoryPool &memoryPool)
   : r_OrganModel(organModel),
@@ -105,7 +115,9 @@ GOSoundOrganEngine::GOSoundOrganEngine(
     m_ReverbConfig(GOSoundReverb::CONFIG_REVERB_DISABLED),
     m_NSamplesPerBuffer(1),
     m_LifecycleState(LifecycleState::IDLE),
-    p_AudioRecorder(nullptr) {
+    p_AudioRecorder(nullptr),
+    m_NCallbacksEnteredCurrPeriod(0),
+    m_NCallbacksFinishedCurrPeriod(0) {
   SetVolume(-15);
   mp_ReleaseTask
     = std::make_unique<GOSoundReleaseTask>(m_SamplerPlayer, mp_AudioGroupTasks);
@@ -155,6 +167,7 @@ void GOSoundOrganEngine::BuildEngine(
 
   assert(m_LifecycleState.load() == LifecycleState::IDLE);
 
+  // Fill out thr start parameters
   m_NSamplesPerBuffer = nSamplesPerBuffer;
   p_AudioRecorder = &recorder;
 
@@ -169,10 +182,12 @@ void GOSoundOrganEngine::BuildEngine(
     groupOutputs.push_back(pGroupTask);
   }
 
-  // [B2] Build audio output tasks (per-device only)
+  // [B2] Build audio output states (per-device output task + callback sync)
   unsigned nTotalChannels = 0;
 
+  m_OutputStates.resize(audioOutputConfigs.size());
   for (unsigned deviceI = 0; deviceI < audioOutputConfigs.size(); deviceI++) {
+    OutputState &outputState = m_OutputStates[deviceI];
     const AudioOutputConfig &devConfig = audioOutputConfigs[deviceI];
     const unsigned nChannels = devConfig.channels;
     std::vector<float> scaleFactors;
@@ -191,9 +206,9 @@ void GOSoundOrganEngine::BuildEngine(
         scaleFactors[channelI * m_NAudioGroups * 2 + k] = factor;
       }
     }
-    mp_AudioOutputTasks.push_back(std::make_unique<GOSoundOutputTask>(
-      nChannels, scaleFactors, m_NSamplesPerBuffer));
-    mp_AudioOutputTasks.back()->SetOutputs(groupOutputs);
+    outputState.mp_task = std::make_unique<GOSoundOutputTask>(
+      nChannels, scaleFactors, m_NSamplesPerBuffer);
+    outputState.mp_task->SetOutputs(groupOutputs);
     nTotalChannels += nChannels;
   }
 
@@ -228,8 +243,8 @@ void GOSoundOrganEngine::BuildEngine(
     if (mp_DownmixTask)
       recorderOutputs.push_back(mp_DownmixTask.get());
     else
-      for (auto &pTask : mp_AudioOutputTasks)
-        recorderOutputs.push_back(pTask.get());
+      for (OutputState &state : m_OutputStates)
+        recorderOutputs.push_back(state.mp_task.get());
     p_AudioRecorder->SetOutputs(recorderOutputs, m_NSamplesPerBuffer);
   }
 
@@ -237,8 +252,8 @@ void GOSoundOrganEngine::BuildEngine(
   if (mp_DownmixTask)
     mp_DownmixTask->SetupReverb(
       m_ReverbConfig, m_NSamplesPerBuffer, sampleRate);
-  for (auto &pTask : mp_AudioOutputTasks)
-    pTask->SetupReverb(m_ReverbConfig, m_NSamplesPerBuffer, sampleRate);
+  for (OutputState &state : m_OutputStates)
+    state.mp_task->SetupReverb(m_ReverbConfig, m_NSamplesPerBuffer, sampleRate);
 
   // [B7] Build tremulant tasks
   for (unsigned n = r_OrganModel.GetTremulantCount(), tremI = 0; tremI < n;
@@ -270,8 +285,8 @@ void GOSoundOrganEngine::BuildEngine(
     m_Scheduler.Add(pGroupTask);
   if (mp_DownmixTask)
     m_Scheduler.Add(mp_DownmixTask.get());
-  for (auto &pOutputTask : mp_AudioOutputTasks)
-    m_Scheduler.Add(pOutputTask.get());
+  for (OutputState &state : m_OutputStates)
+    m_Scheduler.Add(state.mp_task.get());
   m_Scheduler.Add(p_AudioRecorder);
   m_Scheduler.Add(mp_ReleaseTask.get());
   m_Scheduler.Add(mp_TouchTask.get());
@@ -315,8 +330,8 @@ void GOSoundOrganEngine::DestroyEngine() {
   // [B3] Clear meter info
   m_MeterInfo.clear();
 
-  // [B2] Destroy audio output tasks
-  mp_AudioOutputTasks.clear();
+  // [B2] Destroy audio output states
+  m_OutputStates.clear();
 
   // [B1] Destroy audio group tasks
   for (GOSoundGroupTask *pGroupTask : mp_AudioGroupTasks)
@@ -331,11 +346,13 @@ void GOSoundOrganEngine::StartEngine() {
   assert(m_LifecycleState.load() == LifecycleState::BUILT);
   m_Scheduler.Reset();
   m_Scheduler.ResumeGivingWork();
+
   m_LifecycleState.store(LifecycleState::WORKING);
 }
 
 void GOSoundOrganEngine::StopEngine() {
   assert(m_LifecycleState.load() == LifecycleState::WORKING);
+
   m_Scheduler.PauseGivingWork();
   for (auto &pThread : mp_threads)
     pThread->WaitForIdle();
@@ -354,20 +371,49 @@ void GOSoundOrganEngine::SetUsed(bool isUsed) {
     isUsed ? LifecycleState::USED : LifecycleState::WORKING);
 }
 
+void GOSoundOrganEngine::SetStreaming(bool isActive) {
+  // Load first so the assert catches bad transitions before the exchange.
+  LifecycleState oldState = m_LifecycleState.load();
+
+  assert(
+    oldState >= LifecycleState::USED && oldState <= LifecycleState::STREAMING);
+
+  const LifecycleState newState
+    = isActive ? LifecycleState::STREAMING : LifecycleState::USED;
+
+  // Atomically transition; re-read the actual previous state from exchange
+  // so that the side effects below are based on the real transition.
+  oldState = m_LifecycleState.exchange(newState);
+
+  if (newState != oldState) {
+    if (isActive) {
+      // USED → STREAMING: reset period counters and per-output wait flags so
+      // the first callback of each output in the new streaming session is not
+      // blocked at [W1]. Counters must be reset here (not just in the
+      // constructor) because the engine may be reconnected without a full
+      // rebuild, leaving counters dirty from the previous streaming session.
+      m_NCallbacksEnteredCurrPeriod.store(0);
+      m_NCallbacksFinishedCurrPeriod.store(0);
+      for (OutputState &state : m_OutputStates) {
+        GOMutexLocker locker(state.mutex);
+
+        state.isFinishedCurrPeriod = false;
+      }
+    } else {
+      // STREAMING → USED: unblock any callbacks waiting at [W1] so they can
+      // check IsStreaming() and exit gracefully.
+      for (OutputState &state : m_OutputStates) {
+        GOMutexLocker locker(state.mutex);
+
+        state.condition.Broadcast();
+      }
+    }
+  }
+}
+
 /*
  * Functions called from GOSoundSystem
  */
-
-void GOSoundOrganEngine::GetAudioOutput(
-  unsigned outputIndex, bool isLast, GOSoundBufferMutable &outBuffer) {
-  if (IsWorking()) {
-    GOSoundOutputTask *pOutputTask = mp_AudioOutputTasks[outputIndex].get();
-
-    pOutputTask->Finish(isLast);
-    outBuffer.CopyFrom(*pOutputTask);
-  } else
-    outBuffer.FillWithSilence();
-}
 
 /**
  * Atomically updates maxValue to max(maxValue, value) with relaxed ordering.
@@ -394,28 +440,101 @@ void GOSoundOrganEngine::NextPeriod() {
   // Accumulate per-channel peak levels from each output task into m_MeterInfo
   // for the GUI meter display. Values accumulate between GUI polls;
   // GetMeterInfo() resets them via exchange(0). Only real device outputs
-  // (mp_AudioOutputTasks) are counted; mp_DownmixTask is excluded.
+  // (m_OutputStates tasks) are counted; mp_DownmixTask is excluded.
   // Guarded by assert(IsWorking()) above: m_MeterInfo is valid in WORKING
   // state.
   const auto meterEnd = m_MeterInfo.end();
   auto meterIt = m_MeterInfo.begin();
 
-  for (auto &pTask : mp_AudioOutputTasks) {
-    for (const float f : pTask->GetMeterInfo()) {
+  for (auto &state : m_OutputStates) {
+    for (const float f : state.mp_task->GetMeterInfo()) {
       // m_MeterInfo.size() == nTotalChannels [B3] == sum of channels across
-      // all mp_AudioOutputTasks [B2], so the iterator never overflows.
+      // all m_OutputStates [B2], so the iterator never overflows.
       assert(meterIt < meterEnd);
       atomic_fetch_max_relaxed(*meterIt++, f);
     }
-    pTask->ResetMeterInfo();
+    state.mp_task->ResetMeterInfo();
   }
 
   m_Scheduler.Reset();
 }
 
-void GOSoundOrganEngine::WakeupThreads() {
-  for (auto &pThread : mp_threads)
-    pThread->Wakeup();
+bool GOSoundOrganEngine::ProcessAudioCallback(
+  unsigned outputIndex, GOSoundBufferMutable &outBuffer) {
+  assert(IsWorking());
+
+  const unsigned nOutputs = m_OutputStates.size();
+
+  assert(outputIndex < nOutputs);
+
+  bool isNewPeriod = false;
+  OutputState &state = m_OutputStates[outputIndex];
+
+  // Only one callback for this output may hold this mutex at a time.
+  GOMutexLocker locker(state.mutex);
+
+  // [W1] Wait until this output has not yet been processed in the current
+  // period. Exits immediately if the engine leaves STREAMING (e.g.
+  // SetStreaming(false) was called during disconnect).
+  while (IsStreaming() && state.isFinishedCurrPeriod)
+    state.condition.Wait();
+
+  if (IsStreaming()) {
+    /*
+     * The main callback critical section. Only one callback per output may
+     * enter here, and only once per period.
+     */
+
+    // Number of callbacks that have entered the critical section this period.
+    unsigned nEntered = ++m_NCallbacksEnteredCurrPeriod; // atomic
+    bool isLastEntered = nEntered >= nOutputs;
+
+    // Finish computing the output task and copy the result into the buffer.
+    GOSoundOutputTask &outputTask = *m_OutputStates[outputIndex].mp_task;
+
+    outputTask.Finish(isLastEntered);
+    outBuffer.CopyFrom(outputTask);
+
+    // Mark this output as done for the current period so that future callbacks
+    // for this output will block at [W1] until the period advances.
+    state.isFinishedCurrPeriod = true;
+
+    unsigned nFinished = ++m_NCallbacksFinishedCurrPeriod; // atomic
+    bool isLastFinished = nFinished >= nOutputs;
+
+    // The last output to enter may not be the last to finish.
+    if (isLastFinished) {
+      // Advance to the next period.
+      NextPeriod();
+
+      // Wake up worker threads to start processing the new period.
+      for (auto &pThread : mp_threads)
+        pThread->Wakeup();
+
+      // Reset per-period counters.
+      m_NCallbacksEnteredCurrPeriod.store(0);
+      m_NCallbacksFinishedCurrPeriod.store(0);
+
+      // Mark all outputs as not yet processed for the new period and wake up
+      // callbacks waiting at [W1]. Each output's mutex must be held when
+      // writing isFinishedCurrPeriod, because another thread may be
+      // reading it at [W1] under that mutex.
+      for (OutputState &otherState : m_OutputStates) {
+        // The current output's mutex is already held (locker above), so
+        // try_lock=true prevents re-locking and deadlocking; all other outputs
+        // are locked unconditionally (try_lock=false).
+        GOMutexLocker otherLocker(otherState.mutex, &otherState == &state);
+
+        otherState.isFinishedCurrPeriod = false;
+        otherState.condition.Signal();
+      }
+      isNewPeriod = true;
+    }
+  } else
+    // SetStreaming(false) unblocked [W1]; engine is no longer STREAMING.
+    outBuffer.FillWithSilence();
+
+  return isNewPeriod;
 }
 
 /*

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -239,7 +239,6 @@ private:
 
   void NextPeriod();
 
-
 public:
   /*
    * Constructors and destructors

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -15,6 +15,8 @@
 #include "playing/GOSoundSamplerPlayer.h"
 #include "reverb/GOSoundReverb.h"
 #include "scheduler/GOSoundScheduler.h"
+#include "threading/GOCondition.h"
+#include "threading/GOMutex.h"
 
 class GOConfig;
 class GOMemoryPool;
@@ -22,7 +24,6 @@ class GOOrganModel;
 class GOSoundBufferMutable;
 class GOSoundGroupTask;
 class GOSoundOutputTask;
-class GOSoundProvider;
 class GOSoundRecorderTask;
 class GOSoundReleaseTask;
 class GOSoundTask;
@@ -44,7 +45,7 @@ class GOWindchest;
  *      recorder) — builds tasks and the sampler pool. IDLE → BUILT.
  *   4. StartEngine() — starts dispatching work to worker threads. BUILT →
  *      WORKING.
- *      ... GetAudioOutput() is called from the audio thread ...
+ *      ... ProcessAudioCallback() is called from the audio thread ...
  *   5. StopEngine() — halts work dispatch without touching any task's
  *      content, so a subsequent StartEngine() resumes rather than restarts.
  *      WORKING → BUILT. Repeat from step 4 to resume.
@@ -92,6 +93,34 @@ public:
 
 private:
   /*
+   * Private nested types
+   */
+
+  /**
+   * @brief Per-output state: owns the output task and carries the callback
+   * synchronization primitives shared between concurrent audio callbacks.
+   */
+  struct OutputState {
+    std::unique_ptr<GOSoundOutputTask> mp_task;
+    GOMutex mutex;
+    GOCondition condition;
+
+    /** true if this output has already been processed in the current period.
+     * The next audio callback for this output will block at [W1] until
+     * the period advances and this flag is reset to false. */
+    bool isFinishedCurrPeriod;
+
+    OutputState();
+    // Needed to allow std::vector<OutputState>::resize(): GOMutex and
+    // GOCondition are not moveable, so condition must be re-constructed
+    // referencing the new object's mutex rather than the old one.
+    OutputState(OutputState &&other) noexcept;
+    ~OutputState();
+  };
+
+  static constexpr int DETACHED_RELEASE_TASK_ID = 0;
+
+  /*
    * Constructor constants: objects that live for the entire instance lifetime
    */
 
@@ -134,7 +163,7 @@ private:
    * Lifecycle state
    */
 
-  enum class LifecycleState { IDLE, BUILT, WORKING, USED };
+  enum class LifecycleState { IDLE, BUILT, WORKING, USED, STREAMING };
 
   // Protects the IDLE↔BUILT transition (BuildEngine / DestroyEngine).
   // Any function that must guarantee the lifecycle state does not change
@@ -149,15 +178,15 @@ private:
    */
 
   // [B1] mp_AudioGroupTasks: created per audio group (m_NAudioGroups entries)
-  //   — referenced by: mp_ReleaseTask (constructor), mp_AudioOutputTasks [B2]
+  //   — referenced by: mp_ReleaseTask (constructor), m_OutputStates [B2]
   ptr_vector<GOSoundGroupTask> mp_AudioGroupTasks;
-  // [B2] mp_AudioOutputTasks: created from audioOutputConfigs (per-device
-  // tasks)
+  // [B2] m_OutputStates: created from audioOutputConfigs (per-device
+  // tasks + callback sync state)
   //   — uses mp_AudioGroupTasks [B1] via SetOutputs()
   //   — referenced by: m_MeterInfo [B3], p_AudioRecorder [B5], reverb [B6]
-  std::vector<std::unique_ptr<GOSoundOutputTask>> mp_AudioOutputTasks;
+  std::vector<OutputState> m_OutputStates;
   // [B3] m_MeterInfo: per-channel peak levels for the meter display
-  //   — uses nTotalChannels accumulated over mp_AudioOutputTasks [B2]
+  //   — uses nTotalChannels accumulated over m_OutputStates [B2]
   //   — audio thread: NextPeriod() writes via atomic_fetch_max_relaxed()
   //   — GUI thread: GetMeterInfo() reads and resets under m_LifecycleMutex
   std::vector<std::atomic<float>> m_MeterInfo;
@@ -166,11 +195,11 @@ private:
   //   — referenced by: p_AudioRecorder [B5], reverb setup [B6]
   std::unique_ptr<GOSoundOutputTask> mp_DownmixTask;
   // [B5] p_AudioRecorder: non-owning pointer to the recorder passed in
-  //   — uses mp_DownmixTask [B4] or mp_AudioOutputTasks [B2]
+  //   — uses mp_DownmixTask [B4] or m_OutputStates [B2]
   GOSoundRecorderTask *p_AudioRecorder;
-  // [B6] reverb: set up inline on mp_DownmixTask [B4] and mp_AudioOutputTasks
-  // [B2]
-  //   — uses m_ReverbConfig, m_SampleRate, m_NSamplesPerBuffer
+  // [B6] reverb: set up inline on mp_DownmixTask [B4] and m_OutputStates [B2]
+  //   — uses m_ReverbConfig, sampleRate (BuildEngine parameter),
+  //     m_NSamplesPerBuffer
   //
   // [B7] mp_TremulantTasks: one per tremulant in r_OrganModel
   //   — referenced by mp_WindchestTasks after [B9] Init()
@@ -186,6 +215,30 @@ private:
   // [B11] mp_threads: worker threads created via BuildThreads(m_NAuxThreads)
   //   — uses m_Scheduler [B10]
   std::vector<std::unique_ptr<GOSoundThread>> mp_threads;
+
+  /*
+   * Per-period counters reset by SetStreaming(true) at each streaming session
+   */
+
+  /** Number of audio callbacks that have entered the processing critical
+   * section in the current period. Incremented atomically at the start of
+   * the critical section in ProcessAudioCallback(). Reset to zero at the
+   * end of each period and at the start of each streaming session. */
+  std::atomic_uint m_NCallbacksEnteredCurrPeriod;
+
+  /** Number of audio callbacks that have finished processing in the current
+   * period. Incremented atomically after the output buffer is filled in
+   * ProcessAudioCallback(). When it reaches the total number of outputs,
+   * the period advances and both counters are reset to zero. Reset at the
+   * start of each streaming session. */
+  std::atomic_uint m_NCallbacksFinishedCurrPeriod;
+
+  /*
+   * Private helpers for functions called from GOSoundSystem
+   */
+
+  void NextPeriod();
+
 
 public:
   /*
@@ -317,13 +370,24 @@ public:
     return m_LifecycleState.load() >= LifecycleState::WORKING;
   }
 
-  /** true if the engine is connected to the audio system. */
+  /** true if the engine is connected to the audio system (USED or STREAMING).
+   */
   bool IsUsed() const {
     return m_LifecycleState.load() >= LifecycleState::USED;
   }
 
+  /** true if audio callbacks are flowing (STREAMING). */
+  bool IsStreaming() const {
+    return m_LifecycleState.load() >= LifecycleState::STREAMING;
+  }
+
   /** Switches between WORKING and USED; called from GOSoundSystem. */
   void SetUsed(bool isUsed);
+
+  /** Switches between USED and STREAMING; called from GOSoundSystem.
+   *  SetStreaming(false) broadcasts all output conditions to unblock any
+   *  callbacks waiting at [W1]. */
+  void SetStreaming(bool isActive);
 
   /*
    * Public lifecycle functions
@@ -379,12 +443,21 @@ public:
    * Functions called from GOSoundSystem
    */
 
-  void GetAudioOutput(
-    unsigned outputIndex, bool isLast, GOSoundBufferMutable &outBuffer);
-  void NextPeriod();
-
-  /** Wake up all worker threads. Called from the audio callback. */
-  void WakeupThreads();
+  /**
+   * @brief Fills one output buffer and, when all outputs have been filled,
+   * advances to the next period.
+   *
+   * Several callbacks may be called cuncurrently, but only one callback per
+   * output may finish in one period. All other callbacks will wait for thr next
+   * periods.
+   *
+   * @param outputIndex  Zero-based index of the audio output device.
+   * @param outBuffer    Buffer to fill with audio data for this device.
+   * @return true if all outputs have been processed and a new period has been
+   * started (NextPeriod was invoked and worker threads were woken up).
+   */
+  bool ProcessAudioCallback(
+    unsigned outputIndex, GOSoundBufferMutable &outBuffer);
 };
 
 #endif /* GOSOUNDORGANENGINE_H */

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -15,7 +15,6 @@
 #include "config/GOConfig.h"
 #include "config/GOPortsConfig.h"
 #include "ports/GOSoundPortFactory.h"
-#include "threading/GOMultiMutexLocker.h"
 #include "threading/GOMutexLocker.h"
 
 #include "GOEvent.h"
@@ -34,9 +33,7 @@ GOSoundSystem::GOSoundSystem(GOConfig &settings)
     m_DefaultAudioDevice(GOSoundDevInfo::getInvalideDeviceInfo()),
     m_NCallbacksEntered(0),
     m_CallbackCondition(m_CallbackMutex),
-    meter_counter(0),
-    m_WaitCount(0),
-    m_CalcCount(0) {}
+    meter_counter(0) {}
 
 GOSoundSystem::~GOSoundSystem() {
   AssureSoundIsClosed();
@@ -47,7 +44,7 @@ GOSoundSystem::~GOSoundSystem() {
 
 void GOSoundSystem::OpenSoundSystem() {
   assert(!m_open);
-  assert(m_AudioOutputs.size() == 0);
+  assert(mp_SoundPorts.empty());
 
   std::vector<GOAudioDeviceConfig> &audio_config
     = m_config.GetAudioDeviceConfig();
@@ -57,14 +54,12 @@ void GOSoundSystem::OpenSoundSystem() {
   m_SamplesPerBuffer = m_config.SamplesPerBuffer();
   m_AudioRecorder.SetBytesPerSample(m_config.WaveFormatBytesPerSample());
 
-  m_AudioOutputs.resize(audio_config.size());
-  for (GOSoundOutput &output : m_AudioOutputs)
-    output.port = NULL;
+  mp_SoundPorts.resize(audio_config.size());
 
   const GOPortsConfig &portsConfig(m_config.GetSoundPortsConfig());
 
   try {
-    for (unsigned n = m_AudioOutputs.size(), i = 0; i < n; i++) {
+    for (unsigned n = mp_SoundPorts.size(), i = 0; i < n; i++) {
       GOAudioDeviceConfig &deviceConfig = audio_config[i];
       GODeviceNamePattern *pNamePattern = &deviceConfig;
       GODeviceNamePattern defaultDevicePattern;
@@ -82,7 +77,7 @@ void GOSoundSystem::OpenSoundSystem() {
         throw wxString::Format(
           _("Output device %s not found - no sound output will occur"),
           pNamePattern->GetRegEx());
-      m_AudioOutputs[i].port = pPort;
+      mp_SoundPorts[i].reset(pPort);
       pPort->Init(
         deviceConfig.GetChannels(),
         m_SampleRate,
@@ -109,32 +104,29 @@ void GOSoundSystem::OpenSoundSystem() {
 }
 
 void GOSoundSystem::CloseSoundSystem() {
-  for (int i = m_AudioOutputs.size() - 1; i >= 0; i--) {
-    if (m_AudioOutputs[i].port) {
-      GOSoundPort *const port = m_AudioOutputs[i].port;
-
-      m_AudioOutputs[i].port = NULL;
-      port->Close();
-      delete port;
+  for (int i = mp_SoundPorts.size() - 1; i >= 0; i--) {
+    if (mp_SoundPorts[i]) {
+      mp_SoundPorts[i]->Close();
+      mp_SoundPorts[i].reset();
     }
   }
 
   ResetMeters();
-  m_AudioOutputs.clear();
+  mp_SoundPorts.clear();
   m_open = false;
 }
 
 void GOSoundSystem::StartStreams() {
-  for (GOSoundOutput &output : m_AudioOutputs)
-    output.port->Open();
+  for (auto &pPort : mp_SoundPorts)
+    pPort->Open();
 
   if (m_SamplesPerBuffer > MAX_FRAME_SIZE)
     throw wxString::Format(
       _("Cannot use buffer size above %d samples; "
         "unacceptable quantization would occur."),
       MAX_FRAME_SIZE);
-  for (GOSoundOutput &output : m_AudioOutputs)
-    output.port->StartStream();
+  for (auto &pPort : mp_SoundPorts)
+    pPort->StartStream();
 }
 
 bool GOSoundSystem::AssureSoundIsOpen() {
@@ -235,32 +227,8 @@ bool GOSoundSystem::AudioCallback(
     = wasEntered ? p_OrganEngine.load() : nullptr;
 
   if (pOrganEngine) {
-    GOSoundOutput &device = m_AudioOutputs[devIndex];
-    GOMutexLocker locker(device.mutex);
-
-    while (device.wait && device.waiting)
-      device.condition.Wait();
-
-    unsigned cnt = m_CalcCount.fetch_add(1);
-
-    pOrganEngine->GetAudioOutput(
-      devIndex, cnt + 1 >= m_AudioOutputs.size(), outBuffer);
-    device.wait = true;
-    unsigned count = m_WaitCount.fetch_add(1);
-
-    if (count + 1 == m_AudioOutputs.size()) {
-      pOrganEngine->NextPeriod();
-      pOrganEngine->WakeupThreads();
+    if (pOrganEngine->ProcessAudioCallback(devIndex, outBuffer))
       UpdateMeter();
-      m_CalcCount.exchange(0);
-      m_WaitCount.exchange(0);
-
-      for (unsigned i = 0; i < m_AudioOutputs.size(); i++) {
-        GOMutexLocker lock(m_AudioOutputs[i].mutex, i == devIndex);
-        m_AudioOutputs[i].wait = false;
-        m_AudioOutputs[i].condition.Signal();
-      }
-    }
   } else
     outBuffer.FillWithSilence();
   if (
@@ -276,13 +244,13 @@ bool GOSoundSystem::AudioCallback(
 }
 
 wxString GOSoundSystem::getState() {
-  if (!m_AudioOutputs.size())
+  if (!mp_SoundPorts.size())
     return _("No sound output occurring");
   wxString result = wxString::Format(
     _("%d samples per buffer, %d Hz\n"), m_SamplesPerBuffer, m_SampleRate);
 
-  for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
-    result = result + _("\n") + m_AudioOutputs[i].port->getPortState();
+  for (auto &pPort : mp_SoundPorts)
+    result = result + _("\n") + pPort->getPortState();
   return result;
 }
 
@@ -292,23 +260,17 @@ void GOSoundSystem::ConnectToEngine(GOSoundOrganEngine &engine) {
   assert(engine.IsWorking());
 
   engine.SetUsed(true);
-
-  // Enable all outputs before making the engine visible to callbacks
-  for (GOSoundOutput &output : m_AudioOutputs) {
-    GOMutexLocker dev_lock(output.mutex);
-
-    output.wait = false;
-    output.waiting = true;
-  }
-  m_WaitCount.store(0);
-  m_CalcCount.store(0);
   m_NCallbacksEntered.store(0);
+  engine.SetStreaming(true);
   p_OrganEngine.store(&engine);
 }
 
 void GOSoundSystem::DisconnectFromEngine(GOSoundOrganEngine &engine) {
   // Signal callbacks to stop by clearing the engine pointer
   p_OrganEngine.store(nullptr);
+
+  // Unblock any callbacks waiting at [W1] and prevent new ones from blocking
+  engine.SetStreaming(false);
 
   // wait for all started callbacks to finish
   {
@@ -318,25 +280,6 @@ void GOSoundSystem::DisconnectFromEngine(GOSoundOrganEngine &engine) {
       m_CallbackCondition.WaitOrStop(
         "GOSoundSystem::DisconnectFromEngine waits for all callbacks to finish",
         nullptr);
-  }
-
-  // Disable all outputs
-  {
-    GOMultiMutexLocker multi;
-
-    for (GOSoundOutput &output : m_AudioOutputs)
-      multi.Add(output.mutex);
-
-    for (GOSoundOutput &output : m_AudioOutputs) {
-      output.waiting = false;
-      output.wait = false;
-      output.condition.Broadcast();
-    }
-
-    for (unsigned n = m_AudioOutputs.size(), i = 1; i < n; i++) {
-      GOMutexLocker dev_lock(m_AudioOutputs[i].mutex);
-      m_AudioOutputs[i].condition.Broadcast();
-    }
   }
 
   engine.SetUsed(false);

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -9,6 +9,7 @@
 #define GOSOUNDSYSTEM_H
 
 #include <atomic>
+#include <memory>
 #include <vector>
 
 #include <wx/string.h>
@@ -17,8 +18,6 @@
 #include "tasks/GOSoundRecorderTask.h"
 #include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
-
-#include "ptrvector.h"
 
 #include "GOSoundCloseListener.h"
 #include "GOSoundDevInfo.h"
@@ -37,34 +36,6 @@ class GOSoundPort;
  */
 
 class GOSoundSystem {
-  class GOSoundOutput {
-  public:
-    GOSoundPort *port;
-    GOMutex mutex;
-    GOCondition condition;
-    bool wait;
-    bool waiting;
-
-    GOSoundOutput() : condition(mutex) {
-      port = 0;
-      wait = false;
-      waiting = false;
-    }
-
-    GOSoundOutput(const GOSoundOutput &old) : condition(mutex) {
-      port = old.port;
-      wait = old.wait;
-      waiting = old.waiting;
-    }
-
-    const GOSoundOutput &operator=(const GOSoundOutput &old) {
-      port = old.port;
-      wait = old.wait;
-      waiting = old.waiting;
-      return *this;
-    }
-  };
-
 private:
   GOConfig &m_config;
 
@@ -78,7 +49,7 @@ private:
   bool logSoundErrors;
   unsigned m_SampleRate;
   unsigned m_SamplesPerBuffer;
-  std::vector<GOSoundOutput> m_AudioOutputs;
+  std::vector<std::unique_ptr<GOSoundPort>> mp_SoundPorts;
 
   wxString m_LastErrorMessage;
 
@@ -95,9 +66,6 @@ private:
   GOMutex m_lock;
 
   unsigned meter_counter;
-
-  std::atomic_uint m_WaitCount;
-  std::atomic_uint m_CalcCount;
 
   void StartStreams();
   void OpenMidi() { m_midi.Open(); }

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -20,6 +20,7 @@
 #include "testing/model/GOTestOrganModel.h"
 #include "testing/model/GOTestSwitch.h"
 #include "testing/model/GOTestWindchest.h"
+#include "testing/sound/GOTestSoundOrganEngine.h"
 #include "testing/sound/buffer/GOTestPerfSoundBufferMutable.h"
 #include "testing/sound/buffer/GOTestSoundBuffer.h"
 #include "testing/sound/buffer/GOTestSoundBufferManaged.h"
@@ -68,6 +69,7 @@ int main(int argc, char *argv[]) {
   GOTestPerfSoundBufferMutable testPerfSoundBufferMutable;
   GOTestReleaseAlignTable testReleaseAlignTable;
   GOTestSoundStream testSoundStream;
+  GOTestSoundOrganEngine testSoundOrganEngine;
   /* end of instanciation */
   GOTestResultCollection test_result_collection;
   test_result_collection = GOTestCollection::Instance()->Run(categoryFilter);

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -16,6 +16,8 @@ set(go_tests
     sound/buffer/GOTestSoundBufferMutableMono.cpp
     sound/playing/GOTestReleaseAlignTable.cpp
     sound/playing/GOTestSoundStream.cpp
+    sound/GOTestSoundOrganEngineBase.cpp
+    sound/GOTestSoundOrganEngine.cpp
     GOTestNameMap.cpp
     GOTestOrganController.cpp
 )

--- a/src/tests/testing/sound/GOTestSoundOrganEngine.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngine.cpp
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundOrganEngine.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <format>
+#include <iterator>
+#include <mutex>
+#include <thread>
+
+#include "sound/GOSoundOrganEngine.h"
+#include "sound/buffer/GOSoundBufferMutable.h"
+
+const std::string GOTestSoundOrganEngine::TEST_NAME = "GOTestSoundOrganEngine";
+
+struct EngineConfig {
+  unsigned nAudioGroups;
+  unsigned nAuxThreads;
+  unsigned nOutputs;
+};
+
+static const EngineConfig MULTIPLE_CONFIGS[] = {
+  {1, 0, 1},
+  {2, 0, 1},
+  {1, 1, 1},
+  {2, 1, 1},
+  {1, 0, 2},
+  {2, 0, 2},
+  {1, 1, 2},
+  {2, 1, 2},
+};
+
+static constexpr unsigned N_MULTIPLE_CONFIGS = std::size(MULTIPLE_CONFIGS);
+
+GOSoundOrganEngine &GOTestSoundOrganEngine::BuildStartAndConnectEngine(
+  unsigned nAudioGroups, unsigned nAuxThreads, unsigned nOutputs) {
+  GOSoundOrganEngine &engine
+    = BuildAndStartEngine(nAudioGroups, nAuxThreads, nOutputs);
+
+  engine.SetUsed(true);
+  engine.SetStreaming(true);
+
+  GOAssert(
+    engine.IsUsed() && engine.IsStreaming(),
+    "Engine should be USED and STREAMING after connect");
+
+  return engine;
+}
+
+void GOTestSoundOrganEngine::DisconnectStopAndDestroyEngine() {
+  GOSoundOrganEngine &engine = controller->GetSoundEngine();
+
+  engine.SetStreaming(false);
+  engine.SetUsed(false);
+
+  GOAssert(
+    engine.IsWorking() && !engine.IsUsed() && !engine.IsStreaming(),
+    "Engine should be WORKING and not USED after disconnect");
+
+  StopAndDestroyEngine();
+}
+
+void GOTestSoundOrganEngine::TestSingleOutputLifecycle() {
+  GOSoundOrganEngine &engine = BuildStartAndConnectEngine(
+    /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 1);
+
+  for (unsigned periodI = 0; periodI < 5; ++periodI) {
+    GO_DECLARE_LOCAL_SOUND_BUFFER(buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+    const bool didAdvance = engine.ProcessAudioCallback(0, buf);
+
+    GOAssert(
+      didAdvance,
+      std::format(
+        "Period {}: single output should advance the period", periodI));
+  }
+
+  DisconnectStopAndDestroyEngine();
+}
+
+void GOTestSoundOrganEngine::TestTwoOutputsLifecycleWith(
+  unsigned nAudioGroups) {
+  GOSoundOrganEngine &engine = BuildStartAndConnectEngine(nAudioGroups, 0, 2);
+
+  for (unsigned periodI = 0; periodI < 5; ++periodI) {
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf0, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf1, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+    const bool didAdvanceAfter0 = engine.ProcessAudioCallback(0, buf0);
+    const bool didAdvanceAfter1 = engine.ProcessAudioCallback(1, buf1);
+
+    GOAssert(
+      !didAdvanceAfter0,
+      std::format(
+        "Period {}: output 0 of 2 should not advance the period", periodI));
+    GOAssert(
+      didAdvanceAfter1,
+      std::format(
+        "Period {}: output 1 of 2 should advance the period", periodI));
+  }
+
+  DisconnectStopAndDestroyEngine();
+}
+
+void GOTestSoundOrganEngine::TestTwoOutputsLifecycle() {
+  TestTwoOutputsLifecycleWith(1);
+}
+
+void GOTestSoundOrganEngine::TestTwoGroupsTwoOutputsLifecycle() {
+  TestTwoOutputsLifecycleWith(2);
+}
+
+void GOTestSoundOrganEngine::TestSetUsedTransitions() {
+  GOSoundOrganEngine &engine = BuildAndStartEngine(
+    /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 1);
+
+  for (unsigned cycleI = 0; cycleI < 3; ++cycleI) {
+    GOAssert(
+      engine.IsWorking() && !engine.IsUsed() && !engine.IsStreaming(),
+      std::format(
+        "Cycle {}: engine should be WORKING before SetUsed(true)", cycleI));
+
+    engine.SetUsed(true);
+
+    GOAssert(
+      engine.IsUsed() && !engine.IsStreaming(),
+      std::format(
+        "Cycle {}: engine should be USED after SetUsed(true)", cycleI));
+
+    engine.SetStreaming(true);
+
+    GOAssert(
+      engine.IsUsed() && engine.IsStreaming(),
+      std::format(
+        "Cycle {}: engine should be STREAMING after SetStreaming(true)",
+        cycleI));
+
+    engine.SetStreaming(false);
+
+    GOAssert(
+      engine.IsUsed() && !engine.IsStreaming(),
+      std::format(
+        "Cycle {}: engine should be USED after SetStreaming(false)", cycleI));
+
+    engine.SetUsed(false);
+
+    GOAssert(
+      engine.IsWorking() && !engine.IsUsed() && !engine.IsStreaming(),
+      std::format(
+        "Cycle {}: engine should be WORKING after SetUsed(false)", cycleI));
+  }
+
+  StopAndDestroyEngine();
+}
+
+void GOTestSoundOrganEngine::TestBuildStopCyclesAsyncCallbacksXrun() {
+  for (unsigned cycleI = 0; cycleI < 100; ++cycleI) {
+    GOSoundOrganEngine &engine = BuildStartAndConnectEngine(
+      /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 1);
+
+    std::atomic_bool isRunning{true};
+
+    auto threadBody = [&]() {
+      while (isRunning.load()) {
+        GO_DECLARE_LOCAL_SOUND_BUFFER(
+          buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+        engine.ProcessAudioCallback(0, buf);
+      }
+    };
+
+    std::thread t1(threadBody);
+    std::thread t2(threadBody);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    isRunning.store(false);
+    t1.join();
+    t2.join();
+
+    DisconnectStopAndDestroyEngine();
+  }
+}
+
+void GOTestSoundOrganEngine::TestMultipleConfigsAsyncCallbacks() {
+  static constexpr unsigned N_PERIODS = 100;
+
+  for (unsigned cycleI = 0; cycleI < 100; ++cycleI) {
+    const EngineConfig &cfg = MULTIPLE_CONFIGS[cycleI % N_MULTIPLE_CONFIGS];
+
+    GOSoundOrganEngine &engine = BuildStartAndConnectEngine(
+      cfg.nAudioGroups, cfg.nAuxThreads, cfg.nOutputs);
+
+    std::vector<std::thread> threads;
+
+    for (unsigned outputI = 0; outputI < cfg.nOutputs; ++outputI) {
+      threads.emplace_back([&, outputI]() {
+        for (unsigned periodI = 0; periodI < N_PERIODS; ++periodI) {
+          GO_DECLARE_LOCAL_SOUND_BUFFER(
+            buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+          engine.ProcessAudioCallback(outputI, buf);
+        }
+      });
+    }
+
+    for (std::thread &t : threads)
+      t.join();
+
+    DisconnectStopAndDestroyEngine();
+  }
+}
+
+void GOTestSoundOrganEngine::TestDisconnectWithXrunDeadlock() {
+  GOSoundOrganEngine &engine = BuildAndStartEngine(
+    /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 2);
+
+  engine.SetUsed(true);
+  engine.SetStreaming(true);
+
+  // Period 0: complete normally so the engine is ready for period 1.
+  {
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf0, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf1, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+    engine.ProcessAudioCallback(0, buf0);
+    engine.ProcessAudioCallback(1, buf1);
+  }
+
+  // Period 1, output 0 (first call) — marks state.wait=true for output 0.
+  // Output 1 is not yet processed, so the period has not advanced.
+  {
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf0, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+    engine.ProcessAudioCallback(0, buf0);
+  }
+
+  // Simulate GOSoundSystem's m_NCallbacksEntered / disconnect logic.
+  std::atomic_uint nActiveCallbacks{0};
+  std::mutex mu;
+  std::condition_variable cv;
+  std::atomic_bool isStopping{false};
+  std::atomic_bool isRunning{true};
+
+  // Audio thread: calls PAC(0) in a tight loop (xrun on output 0).
+  // Since state.wait=true and IsStreaming()=true, the first call immediately
+  // blocks at [W1].
+  std::thread audioThread([&]() {
+    while (isRunning.load()) {
+      if (!isStopping.load()) {
+        ++nActiveCallbacks;
+
+        GO_DECLARE_LOCAL_SOUND_BUFFER(
+          buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+        engine.ProcessAudioCallback(0, buf); // blocks at [W1]
+
+        if (--nActiveCallbacks == 0 && isStopping.load())
+          cv.notify_all();
+      }
+    }
+  });
+
+  // Spin until the audio thread is inside PAC (blocked at [W1]).
+  while (nActiveCallbacks.load() == 0)
+    std::this_thread::yield();
+
+  // Mirrors GOSoundSystem::DisconnectFromEngine:
+  // stop accepting new callbacks, then unblock callbacks waiting at [W1].
+  isStopping.store(true);
+  engine.SetStreaming(false);
+
+  // SetStreaming(false) broadcast [W1]: PAC(0) exits early (fills silence),
+  // nActiveCallbacks drops to 0, and the wait completes within 1s.
+  bool didFinish;
+
+  {
+    std::unique_lock<std::mutex> lk(mu);
+
+    didFinish = cv.wait_for(lk, std::chrono::seconds(1), [&] {
+      return nActiveCallbacks.load() == 0;
+    });
+  }
+
+  // Audio thread has exited PAC; let it see isRunning=false and terminate.
+  isRunning.store(false);
+  audioThread.join();
+
+  engine.SetUsed(false);
+  StopAndDestroyEngine();
+
+  GOAssert(
+    didFinish,
+    "DisconnectFromEngine should not deadlock: all active callbacks should "
+    "finish within 1s of isStopping being set");
+}
+
+void GOTestSoundOrganEngine::TestReconnectAfterMidPeriodDisconnect() {
+  GOSoundOrganEngine &engine = BuildAndStartEngine(
+    /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 3);
+
+  // First streaming session: process only outputs 0 and 1, leaving the period
+  // incomplete. This leaves m_NCallbacksEntered=2 and m_NCallbacksFinished=2.
+  engine.SetUsed(true);
+  engine.SetStreaming(true);
+
+  {
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf0, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf1, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+    engine.ProcessAudioCallback(0, buf0);
+    engine.ProcessAudioCallback(1, buf1);
+  }
+
+  engine.SetStreaming(false);
+  engine.SetUsed(false);
+
+  // Second streaming session: SetStreaming(true) must reset the dirty counters.
+  // Without the reset, output 0 alone would advance the period (dirty counter
+  // makes nCallbacksFinished reach nOutputs after just one call), leaving
+  // outputs 1 and 2 blocked at [W1] with wasProcessedInCurrentPeriod=true.
+  engine.SetUsed(true);
+  engine.SetStreaming(true);
+
+  for (unsigned periodI = 0; periodI < 5; ++periodI) {
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf0, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf1, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+    GO_DECLARE_LOCAL_SOUND_BUFFER(
+      buf2, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+    const bool didAdvanceAfter0 = engine.ProcessAudioCallback(0, buf0);
+    const bool didAdvanceAfter1 = engine.ProcessAudioCallback(1, buf1);
+    const bool didAdvanceAfter2 = engine.ProcessAudioCallback(2, buf2);
+
+    GOAssert(
+      !didAdvanceAfter0 && !didAdvanceAfter1 && didAdvanceAfter2,
+      std::format(
+        "Period {}: only output 2 should advance the period", periodI));
+  }
+
+  engine.SetStreaming(false);
+  engine.SetUsed(false);
+  StopAndDestroyEngine();
+}
+
+void GOTestSoundOrganEngine::run() {
+  TestSingleOutputLifecycle();
+  TestTwoOutputsLifecycle();
+  TestTwoGroupsTwoOutputsLifecycle();
+  TestSetUsedTransitions();
+  TestBuildStopCyclesAsyncCallbacksXrun();
+  TestMultipleConfigsAsyncCallbacks();
+  TestDisconnectWithXrunDeadlock();
+  TestReconnectAfterMidPeriodDisconnect();
+}

--- a/src/tests/testing/sound/GOTestSoundOrganEngine.h
+++ b/src/tests/testing/sound/GOTestSoundOrganEngine.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDORGANENGINE_H
+#define GOTESTSOUNDORGANENGINE_H
+
+#include "GOTestSoundOrganEngineBase.h"
+
+/*
+ * Tests for GOSoundOrganEngine using direct ProcessAudioCallback calls,
+ * without GOSoundCallbackConnector. SetUsed is managed manually.
+ */
+class GOTestSoundOrganEngine : public GOTestSoundOrganEngineBase {
+private:
+  static const std::string TEST_NAME;
+
+  /* BuildAndStartEngine + SetUsed(true) + SetStreaming(true). */
+  GOSoundOrganEngine &BuildStartAndConnectEngine(
+    unsigned nAudioGroups, unsigned nAuxThreads, unsigned nOutputs);
+
+  /* SetStreaming(false) + SetUsed(false) + StopAndDestroyEngine. */
+  void DisconnectStopAndDestroyEngine();
+
+  /* Build→SetUsed→SetStreaming→PAC×5→SetStreaming(false)→SetUsed(false)→Stop.
+   */
+  void TestSingleOutputLifecycle();
+
+  /* 5 periods of PAC(0)+PAC(1); checks didAdvance per output. */
+  void TestTwoOutputsLifecycleWith(unsigned nAudioGroups);
+  void TestTwoOutputsLifecycle();
+  void TestTwoGroupsTwoOutputsLifecycle();
+
+  /* 3 cycles of WORKING↔USED; checks IsWorking&&!IsUsed at each step. */
+  void TestSetUsedTransitions();
+
+  /*
+   * 100 build/stop cycles; 2 threads both call PAC(0) concurrently (xrun).
+   * Threads start after SetUsed(true) and stop before SetUsed(false).
+   */
+  void TestBuildStopCyclesAsyncCallbacksXrun();
+
+  /*
+   * 100 cycles over 8 engine configurations; one thread per output calls
+   * PAC(outputI) for N_PERIODS iterations.
+   */
+  void TestMultipleConfigsAsyncCallbacks();
+
+  /*
+   * Verifies that SetStreaming(false) unblocks PAC(0) blocked at [W1] during
+   * a simulated disconnect: with 2 outputs, an xrun on output 0 causes PAC(0)
+   * to block at [W1]; SetStreaming(false) broadcasts [W1], PAC(0) exits early,
+   * and the 1-second disconnect wait completes without timeout.
+   */
+  void TestDisconnectWithXrunDeadlock();
+
+  /*
+   * Verifies that SetStreaming(true) resets the per-period counters
+   * (m_NCallbacksEntered, m_NCallbacksFinished): with 3 outputs, the first
+   * streaming session processes only outputs 0 and 1 (incomplete period),
+   * leaving the counters dirty. Without the reset, the second session
+   * deadlocks because the dirty counters cause output 0 alone to advance
+   * the period, leaving outputs 1 and 2 with wasProcessedInCurrentPeriod=true
+   * and no callback to reset them.
+   */
+  void TestReconnectAfterMidPeriodDisconnect();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTSOUNDORGANENGINE_H */

--- a/src/tests/testing/sound/GOTestSoundOrganEngineBase.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineBase.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundOrganEngineBase.h"
+
+#include <format>
+
+#include "sound/GOSoundOrganEngine.h"
+
+GOSoundOrganEngine &GOTestSoundOrganEngineBase::BuildAndStartEngine(
+  unsigned nAudioGroups, unsigned nAuxThreads, unsigned nOutputs) {
+  GOSoundOrganEngine &engine = controller->GetSoundEngine();
+
+  engine.SetNAudioGroups(nAudioGroups);
+  engine.SetNAuxThreads(nAuxThreads);
+
+  const auto defaultConfigs
+    = GOSoundOrganEngine::createDefaultOutputConfigs(nAudioGroups);
+  const std::vector<GOSoundOrganEngine::AudioOutputConfig> configs(
+    nOutputs, defaultConfigs[0]);
+
+  GOAssert(
+    defaultConfigs[0].channels == N_OUTPUT_CHANNELS,
+    std::format(
+      "Default output config should have {} channels but has {}",
+      N_OUTPUT_CHANNELS,
+      defaultConfigs[0].channels));
+
+  engine.BuildEngine(configs, N_SAMPLES_PER_BUFFER, SAMPLE_RATE, m_recorder);
+  engine.StartEngine();
+
+  GOAssert(engine.IsWorking(), "Engine should be WORKING after BuildEngine");
+  GOAssert(!engine.IsUsed(), "Engine should not be USED after BuildEngine");
+  GOAssert(
+    !engine.IsStreaming(), "Engine should not be STREAMING after BuildEngine");
+
+  return engine;
+}
+
+void GOTestSoundOrganEngineBase::StopAndDestroyEngine() {
+  GOSoundOrganEngine &engine = controller->GetSoundEngine();
+
+  engine.StopEngine();
+  engine.DestroyEngine();
+
+  GOAssert(engine.IsIdle(), "Engine should be IDLE after DestroyEngine");
+}

--- a/src/tests/testing/sound/GOTestSoundOrganEngineBase.h
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineBase.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDORGANENGINEBASE_H
+#define GOTESTSOUNDORGANENGINEBASE_H
+
+#include "GOTest.h"
+
+#include "sound/tasks/GOSoundRecorderTask.h"
+
+class GOSoundOrganEngine;
+
+/*
+ * Base class for GOSoundOrganEngine tests.
+ *
+ * Provides helpers for building and stopping the engine and owns the recorder
+ * passed to BuildAndStart.
+ */
+class GOTestSoundOrganEngineBase : public GOCommonControllerTest {
+public:
+  /*
+   * Number of channels in each output buffer.
+   */
+  static constexpr unsigned N_OUTPUT_CHANNELS = 2;
+
+  static constexpr unsigned N_SAMPLES_PER_BUFFER = 128;
+  static constexpr unsigned SAMPLE_RATE = 96000;
+
+private:
+  GOSoundRecorderTask m_recorder;
+
+protected:
+  /*
+   * Configures and starts the engine with the given parameters.
+   * Asserts that the engine is WORKING and not USED after start.
+   * Returns a reference to the started engine.
+   */
+  GOSoundOrganEngine &BuildAndStartEngine(
+    unsigned nAudioGroups, unsigned nAuxThreads, unsigned nOutputs);
+
+  /*
+   * Stops and destroys the engine.
+   * Asserts that the engine is IDLE after stop.
+   */
+  void StopAndDestroyEngine();
+};
+
+#endif /* GOTESTSOUNDORGANENGINEBASE_H */

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -130,6 +130,8 @@ void GOPerfTestApp::RunTest(
         sample_rate,
         recorder);
       engine.StartEngine();
+      engine.SetUsed(true);
+      engine.SetStreaming(true);
 
       std::vector<GOSoundSampler *> handles;
       float output_buffer[samples_per_frame * 2];
@@ -153,8 +155,7 @@ void GOPerfTestApp::RunTest(
 
       do {
         for (unsigned i = 0; i < batch_size; i++) {
-          engine.GetAudioOutput(0, false, outputBufferMutable);
-          engine.NextPeriod();
+          engine.ProcessAudioCallback(0, outputBufferMutable);
           blocks++;
         }
         end = getCPUTime();
@@ -177,9 +178,11 @@ void GOPerfTestApp::RunTest(
         diff.ToLong(),
         playback_time * 1000.0 * pipes.size() / diff.ToLong());
 
-      pipes.clear();
+      engine.SetStreaming(false);
+      engine.SetUsed(false);
       engine.StopEngine();
       engine.DestroyEngine();
+      pipes.clear();
     } catch (wxString msg) {
       wxLogError(wxT("Error: %s"), msg.c_str());
     }


### PR DESCRIPTION
## Summary

Previously, the double-buffered/multi-device audio callback synchronization logic (waiting for all output devices to fill their buffer before advancing to the next period, waking worker threads, etc.) lived in `GOSoundSystem`, in a private nested `GOSoundOutput` struct plus a set of atomic counters (`m_WaitCount`, `m_CalcCount`) and per-output mutex/condition pairs. `GOSoundSystem::AudioCallback()` directly manipulated this per-output locking/waiting state and called `GOSoundOrganEngine::GetAudioOutput()` / `NextPeriod()` / `WakeupThreads()` as separate steps.

After this PR, that synchronization logic has moved into `GOSoundOrganEngine` itself:
- `GOSoundSystem` now only owns the audio ports (`std::vector<std::unique_ptr<GOSoundPort>> mp_SoundPorts`, replacing the old `m_AudioOutputs` vector of `GOSoundOutput`) and calls a single new entry point, `GOSoundOrganEngine::ProcessAudioCallback(outputIndex, outBuffer)`, which fills the buffer for one output and, once all outputs have been filled in the current period, advances to the next period and wakes up the worker threads.
- `GOSoundOrganEngine` gained a private `OutputState` struct (task + mutex/condition + "already processed this period" flag) per output, and two per-period atomic counters (`m_NCallbacksEnteredCurrPeriod`, `m_NCallbacksFinishedCurrPeriod`).
- The engine's lifecycle gained a new `STREAMING` state (`IDLE -> BUILT -> WORKING -> USED -> STREAMING`), with a new `SetStreaming(bool)` method. `GOSoundSystem::ConnectToEngine`/`DisconnectFromEngine` now call `SetStreaming(true/false)` instead of directly resetting counters and manipulating output mutexes/conditions. `SetStreaming(false)` also broadcasts all output conditions so that any callback blocked waiting for the next period is unblocked immediately, fixing a deadlock that could otherwise occur when disconnecting while an output was mid-wait (xrun scenario).
- Reconnecting after a mid-period disconnect now correctly resets the per-period counters and per-output "already processed" flags, instead of carrying over dirty state that could deadlock a subsequent streaming session.
- `GOPerfTest` was adapted to call the engine through the same new API.

Net effect for callers: `GOSoundSystem` is now a thinner audio-port/backend wrapper, and all of the audio-thread synchronization/period-advancing logic (previously split across two classes) is consolidated in one place, `GOSoundOrganEngine`, alongside the rest of the engine's per-period processing.

## Tests added

New test suite `GOTestSoundOrganEngine` (with a shared `GOTestSoundOrganEngineBase` providing engine build/stop helpers), registered in `GOTestExe.cpp` / `CMakeLists.txt`:

- **Single-output lifecycle**: build → `SetUsed` → `SetStreaming` → 5 `ProcessAudioCallback` calls → `SetStreaming(false)` → `SetUsed(false)` → stop, checking state transitions throughout.
- **Multi-output lifecycle** (`TestTwoOutputsLifecycle`, `TestTwoGroupsTwoOutputsLifecycle`): 5 periods of calling `ProcessAudioCallback` for each output and checking that the period only advances once every output has been processed.
- **`SetUsed` transitions**: 3 cycles of WORKING↔USED, checking `IsWorking() && !IsUsed()` at each step.
- **Concurrent-callback stress tests**: 100 build/stop cycles with two threads concurrently calling `ProcessAudioCallback` for the same output (simulating an xrun), and 100 cycles across 8 engine configurations with one thread per output.
- **Deadlock regression test** (`TestDisconnectWithXrunDeadlock`): with 2 outputs, forces an xrun on output 0 so that its callback blocks; verifies `SetStreaming(false)` unblocks it so the disconnect wait completes without timing out.
- **Reconnect regression test** (`TestReconnectAfterMidPeriodDisconnect`): verifies that disconnecting mid-period and reconnecting resets the per-period counters/flags correctly, instead of deadlocking on the next streaming session due to leftover dirty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA6kJDFXW3FD4qW2TP2naq