### PR TITLE
Moved owning GOMidiSystem from GOSoundSystem to GOGuiApp

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -804,7 +804,8 @@ void GOOrganController::PreconfigRecorder() {
   }
 }
 
-void GOOrganController::StartOrgan(GOSoundSystem &soundSystem) {
+void GOOrganController::StartOrgan(
+  GOSoundSystem &soundSystem, GOMidiSystem &midi) {
   const std::vector<GOSoundOrganEngine::AudioOutputConfig> audioOutputConfigs
     = GOSoundOrganEngine::createAudioOutputConfigs(
       m_config, m_config.GetAudioGroups().size());
@@ -817,8 +818,6 @@ void GOOrganController::StartOrgan(GOSoundSystem &soundSystem) {
     soundSystem.GetAudioRecorder());
   m_SoundEngine.StartEngine();
   soundSystem.ConnectToEngine(m_SoundEngine);
-
-  GOMidiSystem &midi = soundSystem.GetMidi();
 
   m_midi = &midi;
   m_MidiRecorder->SetOutputDevice(m_config.MidiRecorderOutputDevice());

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -200,7 +200,7 @@ public:
    * Starts the organ sound engine: builds audio tasks, connects to the sound
    * system, and begins MIDI and audio playback.
    */
-  void StartOrgan(GOSoundSystem &soundSystem);
+  void StartOrgan(GOSoundSystem &soundSystem, GOMidiSystem &midi);
 
   /**
    * Stops the organ sound engine: aborts playback, disconnects from the sound

--- a/src/grandorgue/gui/GOGuiApp.cpp
+++ b/src/grandorgue/gui/GOGuiApp.cpp
@@ -18,6 +18,7 @@
 
 #include "config/GOConfig.h"
 #include "frames/GOAppWindow.h"
+#include "midi/GOMidiSystem.h"
 #include "sound/GOSoundSystem.h"
 
 #include "GOCrashHandler.h"
@@ -184,6 +185,7 @@ bool GOGuiApp::OnInit() {
     GOStdPath::GetGrandOrgueSubDir(wxT("CrashReports")));
 
   mp_SoundSystem = std::make_unique<GOSoundSystem>(*mp_config);
+  mp_MidiSystem = std::make_unique<GOMidiSystem>(*mp_config);
 
   p_AppWindow = new GOAppWindow(
     *this,
@@ -194,7 +196,9 @@ bool GOGuiApp::OnInit() {
     wxDefaultSize,
     wxMINIMIZE_BOX | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX
       | wxCLIP_CHILDREN | wxFULL_REPAINT_ON_RESIZE,
-    *mp_SoundSystem);
+    *mp_config,
+    *mp_SoundSystem,
+    *mp_MidiSystem);
   SetTopWindow(p_AppWindow);
   mp_log = std::make_unique<GOGuiLog>(p_AppWindow);
   // SetActiveTarget returns the previous logger (TemporaryLog, released from

--- a/src/grandorgue/gui/GOGuiApp.h
+++ b/src/grandorgue/gui/GOGuiApp.h
@@ -29,6 +29,7 @@
 class GOConfig;
 class GOAppWindow;
 class GOGuiLog;
+class GOMidiSystem;
 class GOSoundSystem;
 
 class GOGuiApp : public wxApp {
@@ -59,6 +60,7 @@ protected:
   wxLocale m_locale;
   std::unique_ptr<GOConfig> mp_config;
   std::unique_ptr<GOSoundSystem> mp_SoundSystem;
+  std::unique_ptr<GOMidiSystem> mp_MidiSystem;
   std::unique_ptr<GOGuiLog> mp_log;
   wxString m_FileName;
   std::string m_InstanceName;

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -20,8 +20,8 @@
 #include "gui/panels/GOGUIPanelView.h"
 #include "gui/size/GOResizable.h"
 #include "loader/GOProgressMonitor.h"
+#include "midi/GOMidiSystem.h"
 #include "midi/events/GOMidiEvent.h"
-#include "sound/GOSoundSystem.h"
 #include "threading/GOMutexLocker.h"
 
 #include "GOEvent.h"
@@ -29,13 +29,15 @@
 #include "GOOrganController.h"
 #include "go_ids.h"
 
-GOGuiOrgan::GOGuiOrgan(GOResizable *pMainWindow, GOSoundSystem *sound)
+GOGuiOrgan::GOGuiOrgan(
+  GOResizable *pMainWindow, GOConfig &config, GOMidiSystem &midi)
   : p_MainWindow(pMainWindow),
-    m_sound(*sound),
+    r_config(config),
+    r_MidiSystem(midi),
     m_OrganFileReady(false),
     m_OrganController(NULL),
     m_listener() {
-  m_listener.Register(&m_sound.GetMidi());
+  m_listener.Register(&r_MidiSystem);
 }
 
 GOGuiOrgan::~GOGuiOrgan() {
@@ -53,7 +55,7 @@ GOOrganController *GOGuiOrgan::LoadOrgan(
   bool isGuiOnly,
   GOProgressMonitor &monitor) {
   wxBusyCursor busy;
-  GOConfig &cfg = m_sound.GetSettings();
+  GOConfig &cfg = r_config;
 
   CloseOrgan();
   m_OrganController = new GOOrganController(cfg, true);

--- a/src/grandorgue/gui/GOGuiOrgan.h
+++ b/src/grandorgue/gui/GOGuiOrgan.h
@@ -15,18 +15,20 @@
 #include "midi/events/GOMidiCallback.h"
 #include "threading/GOMutex.h"
 
+class GOConfig;
 class GOMidiDialogListener;
 class GOMidiObject;
+class GOMidiSystem;
 class GOOrganController;
 class GOOrgan;
 class GOProgressMonitor;
 class GOResizable;
-class GOSoundSystem;
 
 class GOGuiOrgan : public GODocumentBase, protected GOMidiCallback {
 private:
   GOResizable *p_MainWindow;
-  GOSoundSystem &m_sound;
+  GOConfig &r_config;
+  GOMidiSystem &r_MidiSystem;
 
   GOMutex m_lock;
   bool m_OrganFileReady;
@@ -40,7 +42,7 @@ private:
   void CloseOrgan();
 
 public:
-  GOGuiOrgan(GOResizable *pMainWindow, GOSoundSystem *sound);
+  GOGuiOrgan(GOResizable *pMainWindow, GOConfig &config, GOMidiSystem &midi);
   ~GOGuiOrgan();
 
   GOOrganController *GetOrganController() const { return m_OrganController; }

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -151,13 +151,15 @@ GOAppWindow::GOAppWindow(
   const wxPoint &pos,
   const wxSize &size,
   const long type,
-  GOSoundSystem &sound)
+  GOConfig &config,
+  GOSoundSystem &sound,
+  GOMidiSystem &midi)
   : wxFrame(pParentFrame, id, title, pos, size, type),
     GOHelpRequestor(this),
     r_app(app),
-    r_config(sound.GetSettings()),
+    r_config(config),
     r_SoundSystem(sound),
-    r_MidiSystem(sound.GetMidi()),
+    r_MidiSystem(midi),
     m_file_menu(NULL),
     m_panel_menu(NULL),
     m_favorites_menu(NULL),
@@ -536,7 +538,7 @@ void GOAppWindow::Init(const wxString &filename, bool isGuiOnly) {
 
   r_SoundSystem.SetLogSoundErrorMessages(false);
 
-  bool soundProblems = !r_SoundSystem.AssureSoundIsOpen();
+  bool soundProblems = !EnsureSoundMidiOpen();
 
   if (soundProblems)
     settingsReasons.push_back(GOSettingsReason(
@@ -592,11 +594,24 @@ void GOAppWindow::Init(const wxString &filename, bool isGuiOnly) {
 
 void GOAppWindow::OnBeforeSoundClose() { EnsureOrganStopped(); }
 
+bool GOAppWindow::EnsureSoundMidiOpen() {
+  const bool wasOpen = r_SoundSystem.IsOpen();
+  const bool isOpen = r_SoundSystem.AssureSoundIsOpen();
+
+  if (!wasOpen && isOpen)
+    r_MidiSystem.Open();
+  return isOpen;
+}
+
+void GOAppWindow::EnsureSoundMidiClosed() {
+  r_SoundSystem.AssureSoundIsClosed();
+}
+
 void GOAppWindow::EnsureOrganStartedIfReady() {
   if (
     p_OrganController && r_SoundSystem.IsOpen()
     && !p_OrganController->IsOrganStarted())
-    p_OrganController->StartOrgan(r_SoundSystem);
+    p_OrganController->StartOrgan(r_SoundSystem, r_MidiSystem);
 }
 
 void GOAppWindow::EnsureOrganStopped() {
@@ -661,7 +676,7 @@ void GOAppWindow::Open(const GOOrgan &organ) {
     GOMutexLocker m_locker(m_mutex, true);
 
     if (m_locker.IsLocked()) {
-      mp_organ = std::make_unique<GOGuiOrgan>(this, &r_SoundSystem);
+      mp_organ = std::make_unique<GOGuiOrgan>(this, r_config, r_MidiSystem);
       LoadOrgan(organ);
     }
   }
@@ -1128,8 +1143,8 @@ void GOAppWindow::OnProperties(wxCommandEvent &event) {
 
 void GOAppWindow::OnAudioPanic(wxCommandEvent &WXUNUSED(event)) {
   // EnsureOrganStopped() is called via OnBeforeSoundClose callback
-  r_SoundSystem.AssureSoundIsClosed();
-  r_SoundSystem.AssureSoundIsOpen();
+  EnsureSoundMidiClosed();
+  EnsureSoundMidiOpen();
   EnsureOrganStartedIfReady();
 }
 
@@ -1198,7 +1213,7 @@ void GOAppWindow::OnSettings(wxCommandEvent &event) {
     // because the sound settings might be changed, close sound.
     // EnsureOrganStopped() is called via OnBeforeSoundClose callback.
     // It will reopened later
-    r_SoundSystem.AssureSoundIsClosed();
+    EnsureSoundMidiClosed();
 
     r_config.Flush();
     if (
@@ -1232,7 +1247,7 @@ void GOAppWindow::OnSettings(wxCommandEvent &event) {
   // The sound might be closed in the settings dialog (for obtaining the list of
   // devices) or later if the settings were changed
   if (isToContinue) {
-    r_SoundSystem.AssureSoundIsOpen();
+    EnsureSoundMidiOpen();
     EnsureOrganStartedIfReady();
   }
 

--- a/src/grandorgue/gui/frames/GOAppWindow.h
+++ b/src/grandorgue/gui/frames/GOAppWindow.h
@@ -27,6 +27,7 @@ class GOConfig;
 class GOGuiApp;
 class GOGuiOrgan;
 class GOMidiEvent;
+class GOMidiSystem;
 class GOOrgan;
 class GOOrganController;
 class GOProgressDialog;
@@ -98,6 +99,19 @@ private:
 
   /** GOSoundCloseListener: stops the organ before the sound system closes. */
   void OnBeforeSoundClose() override;
+
+  /**
+   * Opens the sound system. If the sound system transitions from closed to
+   * open, also opens the MIDI system. Returns true if the sound system is
+   * open after the call, false otherwise.
+   */
+  bool EnsureSoundMidiOpen();
+
+  /**
+   * Closes the sound system. The organ is stopped first via the
+   * OnBeforeSoundClose callback.
+   */
+  void EnsureSoundMidiClosed();
 
   /**
    * Starts the organ if a controller is present, the sound system is open,
@@ -205,7 +219,9 @@ public:
     const wxPoint &pos,
     const wxSize &size,
     const long type,
-    GOSoundSystem &sound);
+    GOConfig &config,
+    GOSoundSystem &sound,
+    GOMidiSystem &midi);
   virtual ~GOAppWindow(void);
 
   void Init(const wxString &filename, bool isGuiOnly);

--- a/src/grandorgue/midi/GOMidiSystem.cpp
+++ b/src/grandorgue/midi/GOMidiSystem.cpp
@@ -14,6 +14,7 @@
 #include "midi/events/GOMidiWxEvent.h"
 #include "ports/GOMidiInPort.h"
 #include "ports/GOMidiOutPort.h"
+#include "ports/GOMidiPortFactory.h"
 
 BEGIN_EVENT_TABLE(GOMidiSystem, wxEvtHandler)
 EVT_MIDI(GOMidiSystem::OnMidiEvent)
@@ -30,6 +31,8 @@ void GOMidiSystem::UpdateDevices(const GOPortsConfig &portsConfig) {
 GOMidiSystem::~GOMidiSystem() {
   m_midi_in_devices.clear();
   m_midi_out_devices.clear();
+
+  GOMidiPortFactory::terminate();
 }
 
 void GOMidiSystem::Open() {

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -23,7 +23,6 @@
 
 GOSoundSystem::GOSoundSystem(GOConfig &settings)
   : m_config(settings),
-    m_midi(settings),
     p_OrganEngine(nullptr),
     p_CloseListener(nullptr),
     m_open(false),
@@ -38,7 +37,6 @@ GOSoundSystem::GOSoundSystem(GOConfig &settings)
 GOSoundSystem::~GOSoundSystem() {
   AssureSoundIsClosed();
 
-  GOMidiPortFactory::terminate();
   GOSoundPortFactory::terminate();
 }
 
@@ -90,7 +88,6 @@ void GOSoundSystem::OpenSoundSystem() {
     // m_IsRunning is set to true only in StartSoundSystem(), called after
     // OpenSoundSystem() completes.
     StartStreams();
-    OpenMidi();
     m_AudioRecorder.SetSampleRate(m_SampleRate);
     m_open = true;
   } catch (wxString &msg) {

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -14,7 +14,6 @@
 
 #include <wx/string.h>
 
-#include "midi/GOMidiSystem.h"
 #include "tasks/GOSoundRecorderTask.h"
 #include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
@@ -39,7 +38,6 @@ class GOSoundSystem {
 private:
   GOConfig &m_config;
 
-  GOMidiSystem m_midi;
   GOSoundRecorderTask m_AudioRecorder;
   std::atomic<GOSoundOrganEngine *> p_OrganEngine;
 
@@ -68,7 +66,6 @@ private:
   unsigned meter_counter;
 
   void StartStreams();
-  void OpenMidi() { m_midi.Open(); }
 
   void UpdateMeter();
   void ResetMeters();
@@ -84,9 +81,6 @@ public:
 
   GOSoundSystem(GOConfig &settings);
   ~GOSoundSystem();
-
-  GOConfig &GetSettings() { return m_config; }
-  GOMidiSystem &GetMidi() { return m_midi; }
 
   std::vector<GOSoundDevInfo> GetAudioDevices(const GOPortsConfig &portsConfig);
   const GOSoundDevInfo &GetDefaultAudioDevice(const GOPortsConfig &portsConfig);

--- a/src/tests/testing/sound/playing/GOTestSoundStream.cpp
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.cpp
@@ -251,10 +251,10 @@ void GOTestSoundStream::TestLoopTransitionAcrossDifferentEndPos() {
     GOSoundResample::GO_LINEAR_INTERPOLATION,
     SAMPLE_RATE_ADJUSTMENT);
 
-  float buffer[N_BUFFER_ITEMS];
+  GO_DECLARE_LOCAL_SOUND_BUFFER(buffer, 2, N_FRAMES_PER_BLOCK)
 
   for (unsigned iterI = 0; iterI < N_ITERATIONS; iterI++) {
-    const bool result = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+    const bool result = stream.ReadBlock(buffer);
 
     GOAssert(
       result,

--- a/src/tests/testing/sound/playing/GOTestSoundStream.cpp
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.cpp
@@ -251,10 +251,10 @@ void GOTestSoundStream::TestLoopTransitionAcrossDifferentEndPos() {
     GOSoundResample::GO_LINEAR_INTERPOLATION,
     SAMPLE_RATE_ADJUSTMENT);
 
-  GO_DECLARE_LOCAL_SOUND_BUFFER(buffer, 2, N_FRAMES_PER_BLOCK)
+  float buffer[N_BUFFER_ITEMS];
 
   for (unsigned iterI = 0; iterI < N_ITERATIONS; iterI++) {
-    const bool result = stream.ReadBlock(buffer);
+    const bool result = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
 
     GOAssert(
       result,


### PR DESCRIPTION
## Summary
- Moved ownership of `GOMidiSystem` from `GOSoundSystem` to `GOGuiApp`, so the sound subsystem no longer owns MIDI setup/lifecycle.

## Test plan
- [x] Builds cleanly (`GrandOrgue`, `GrandOrguePerfTest`)