### PR TITLE
Fix memory leaks found by AddressSanitizer in the test suite

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -107,6 +107,11 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
   }
   GOOrganModel::SetModelModificationListener(this);
   m_setter = new GOSetter(this);
+  // Register m_setter for ownership immediately: m_elementcreators.clear()
+  // in the destructor is what frees it, and Load() (which used to be the
+  // only place registering it) may never run (e.g. in tests, or if loading
+  // fails before reaching that point), which would otherwise leak it.
+  m_elementcreators.push_back(m_setter);
   m_pool.SetMemoryLimit(m_config.MemoryLimit() * 1024 * 1024);
 }
 
@@ -231,7 +236,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   // It must be created before GOOrganModel::Load because lots of objects
   // reference to it
   GOOrganModel::SetCombinationController(m_setter);
-  m_elementcreators.push_back(m_setter);
 
   GOOrganModel::Load(cfg);
 

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -64,9 +64,9 @@ int main(int argc, char *argv[]) {
 
   // Display tests results
   std::cout << "==================== TESTS RESULTS ====================\n";
-  for (GOTestResult *pResult : test_result_collection.get_results()) {
+  for (GOTestResult &result : test_result_collection.get_results()) {
     std::cout << "-------------------------------------------------------\n";
-    std::cout << pResult->GetMessage() << "\n";
+    std::cout << result.GetMessage() << "\n";
   }
 
   const int failed_count = GOTestCollection::Instance()->get_failed_count();

--- a/src/tests/common/GOTestCollection.cpp
+++ b/src/tests/common/GOTestCollection.cpp
@@ -40,7 +40,7 @@ GOTestResultCollection GOTestCollection::Run(
       This iterates on tests_ vector, run them one by one, then collects
       the tests results and display them at the end.
   */
-  GOTestResultCollection *test_result_collection = new GOTestResultCollection();
+  GOTestResultCollection test_result_collection;
 
   run_number_ = 0;
   for (auto current = tests_.begin(); current != tests_.end();
@@ -57,37 +57,37 @@ GOTestResultCollection GOTestCollection::Run(
             isRunSucceeded = true;
           } catch (GOTestException &e) {
             fail_count_++;
-            test_result_collection->add_result(
-              new GOTestResult(test->GetName() + " failed: " + e.what(), true));
+            test_result_collection.add_result(
+              GOTestResult(test->GetName() + " failed: " + e.what(), true));
             test->tearDown();
           } catch (std::exception &e) {
             fail_count_++;
-            test_result_collection->add_result(
-              new GOTestResult(test->GetName() + " failed: " + e.what(), true));
+            test_result_collection.add_result(
+              GOTestResult(test->GetName() + " failed: " + e.what(), true));
             test->tearDown();
           }
           if (isRunSucceeded) {
-            test_result_collection->add_result(
-              new GOTestResult(test->GetName() + " succeeded"));
+            test_result_collection.add_result(
+              GOTestResult(test->GetName() + " succeeded"));
             success_count_++;
             test->tearDown();
           }
         } else {
-          test_result_collection->add_result(new GOTestResult(
+          test_result_collection.add_result(GOTestResult(
             "The setUp() of test '" + test->GetName() + "' has failed."));
         }
       } catch (std::exception &e) {
-        test_result_collection->add_result(new GOTestResult(
+        test_result_collection.add_result(GOTestResult(
           "An exception occurred during test '" + test->GetName() + "'."));
       } catch (...) {
         fail_count_++;
-        test_result_collection->add_result(
-          new GOTestResult("Unknown exception", true));
+        test_result_collection.add_result(
+          GOTestResult("Unknown exception", true));
         test->tearDown();
       }
     }
   }
-  return *test_result_collection;
+  return test_result_collection;
 }
 
 GOTestCollection *GOTestCollection::go_test_collection = nullptr;

--- a/src/tests/common/GOTestResult.cpp
+++ b/src/tests/common/GOTestResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -20,5 +20,5 @@ GOTestResult::GOTestResult(std::string message) : m_result_message(message) {
 
 GOTestResult::GOTestResult(std::string message, bool failed)
   : m_result_message(message) {
-  failed = failed;
+  this->failed = failed;
 }

--- a/src/tests/common/GOTestResultCollection.cpp
+++ b/src/tests/common/GOTestResultCollection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,14 +10,14 @@
 
 GOTestResultCollection::GOTestResultCollection() {}
 
-void GOTestResultCollection::add_result(GOTestResult *test_result) {
+void GOTestResultCollection::add_result(GOTestResult test_result) {
   /*
       This method allows to add tests results.
   */
   test_results.push_back(test_result);
 }
 
-std::vector<GOTestResult *> GOTestResultCollection::get_results() {
+std::vector<GOTestResult> GOTestResultCollection::get_results() {
 
   return test_results;
 }

--- a/src/tests/common/GOTestResultCollection.h
+++ b/src/tests/common/GOTestResultCollection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,12 +13,12 @@
 class GOTestResultCollection {
 
 private:
-  std::vector<GOTestResult *> test_results;
+  std::vector<GOTestResult> test_results;
 
 public:
   GOTestResultCollection();
-  void add_result(GOTestResult *test);
-  std::vector<GOTestResult *> get_results();
+  void add_result(GOTestResult test);
+  std::vector<GOTestResult> get_results();
 };
 
 #endif

--- a/src/tests/testing/model/GOTestSwitch.cpp
+++ b/src/tests/testing/model/GOTestSwitch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2024-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -13,12 +13,12 @@ void GOTestSwitch::run() {
   std::string message;
 
   // Check global Switch
-  GOSwitch *go_switch = new GOSwitch(*this->controller);
+  GOSwitch goSwitch(*this->controller);
   message = "The associated manual should be -1 as it is a global switch!";
-  this->GOAssert(go_switch->GetAssociatedManualN() == -1, message);
+  this->GOAssert(goSwitch.GetAssociatedManualN() == -1, message);
 
   message = "The switch index in manual should be 0!";
-  this->GOAssert(go_switch->GetIndexInManual() == 0, message);
+  this->GOAssert(goSwitch.GetIndexInManual() == 0, message);
 }
 
 std::string GOTestSwitch::GetName() { return name; }


### PR DESCRIPTION
## Summary
- `GOOrganController::m_setter` was only registered for ownership inside `Load()`, so it leaked whenever `Load()` never ran (e.g. in unit tests); registration moved to the constructor right after `m_setter` is created.
- `GOTestSwitch::run()` leaked a heap-allocated `GOSwitch`; switched to a stack-allocated local.
- `GOTestCollection::Run()` heap-allocated its `GOTestResultCollection` and each `GOTestResult` but never freed them; both are now small copyable value types instead.
- Fixed `GOTestResult(message, failed)` constructor, which did `failed = failed;` (parameter shadowing member) instead of `this->failed = failed;`.

Found by building with `-DGO_BUILD_ASAN=ON -DGO_BUILD_TESTING=ON` and running `GOTestExe` under LeakSanitizer — no memory-corruption issues, only these leaks.

## Test plan
- [x] `cmake -DCMAKE_BUILD_TYPE=Debug -DGO_BUILD_TESTING=ON -DGO_BUILD_ASAN=ON ...` then `make -k -j16`
- [x] `ASAN_OPTIONS=detect_leaks=1 ./bin/GOTestExe --no-perf` — all 12 functional tests pass with no ASAN/LeakSanitizer reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM9695qbmyuMvajvutHrdq