### PR TITLE
Added GOOrganModel::GetUsedWindchestGroupPairs() and related const accessors

### DIFF
--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -355,7 +355,7 @@ std::set<std::pair<unsigned, unsigned>> GOOrganModel::
   GetUsedWindchestGroupPairs() const {
   std::set<std::pair<unsigned, unsigned>> pairs;
 
-  for (unsigned n = GetODFRankCount(), rankI = 0; rankI < n; rankI++) {
+  for (unsigned n = GetRankCount(), rankI = 0; rankI < n; rankI++) {
     const GORank *pRank = GetRank(rankI);
 
     for (unsigned m = pRank->GetPipeCount(), pipeI = 0; pipeI < m; pipeI++) {

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -21,6 +21,7 @@
 #include "GOManual.h"
 #include "GORank.h"
 #include "GOReferencingObject.h"
+#include "GOSoundingPipe.h"
 #include "GOSwitch.h"
 #include "GOTremulant.h"
 #include "GOWindchest.h"
@@ -345,13 +346,28 @@ int GOOrganModel::FindTremulantByName(const wxString &name) const {
   return resIndex;
 }
 
-GORank *GOOrganModel::GetRank(unsigned index) { return m_ranks[index]; }
-
-unsigned GOOrganModel::GetODFRankCount() { return m_ODFRankCount; }
-
 void GOOrganModel::AddRank(GORank *rank) {
   rank->SetContext(&MIDI_CONTEXT_RANKS);
   m_ranks.push_back(rank);
+}
+
+std::set<std::pair<unsigned, unsigned>> GOOrganModel::
+  GetUsedWindchestGroupPairs() const {
+  std::set<std::pair<unsigned, unsigned>> pairs;
+
+  for (unsigned n = GetODFRankCount(), rankI = 0; rankI < n; rankI++) {
+    const GORank *pRank = GetRank(rankI);
+
+    for (unsigned m = pRank->GetPipeCount(), pipeI = 0; pipeI < m; pipeI++) {
+      const GOSoundingPipe *pPipe
+        = dynamic_cast<const GOSoundingPipe *>(pRank->GetPipe(pipeI));
+
+      if (pPipe)
+        pairs.insert({pPipe->GetWindchestN(), pPipe->GetAudioGroupId()});
+    }
+  }
+
+  return pairs;
 }
 
 unsigned GOOrganModel::GetNumberOfReversiblePistons() {

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -190,7 +190,15 @@ public:
   unsigned GetFirstManualIndex();
   GOManual *GetManual(unsigned index);
 
+  /** @return the number of ranks declared in the ODF [Ranks] section only;
+   * excludes ranks added later via AddRank(), such as inline stop ranks and
+   * the metronome rank */
   unsigned GetODFRankCount() const { return m_ODFRankCount; }
+
+  /** @return the total number of ranks, including ODF ranks and ranks added
+   * later via AddRank() */
+  unsigned GetRankCount() const { return m_ranks.size(); }
+
   const GORank *GetRank(unsigned index) const { return m_ranks[index]; }
   GORank *GetRank(unsigned index) { return m_ranks[index]; }
   void AddRank(GORank *rank);

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -190,9 +190,20 @@ public:
   unsigned GetFirstManualIndex();
   GOManual *GetManual(unsigned index);
 
-  GORank *GetRank(unsigned index);
-  unsigned GetODFRankCount();
+  unsigned GetODFRankCount() const { return m_ODFRankCount; }
+  const GORank *GetRank(unsigned index) const { return m_ranks[index]; }
+  GORank *GetRank(unsigned index) { return m_ranks[index]; }
   void AddRank(GORank *rank);
+
+  /**
+   * Scans every sounding pipe of every rank and collects the distinct
+   * (windchestN, audioGroupId) pairs actually used - the pairs the sound
+   * engine needs a GOSoundWindchestGroupTask for. Tremulant-only samplers
+   * are not pipes, so they are not part of this scan.
+   * @return the distinct (windchestN, audioGroupId) pairs used by the
+   *   organ's pipes
+   */
+  std::set<std::pair<unsigned, unsigned>> GetUsedWindchestGroupPairs() const;
 
   unsigned GetNumberOfReversiblePistons();
   GOPistonControl *GetPiston(unsigned index);

--- a/src/grandorgue/model/GORank.cpp
+++ b/src/grandorgue/model/GORank.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -172,8 +172,6 @@ void GORank::SetPipeState(int pipeIndex, unsigned velocity, unsigned stopID) {
 }
 
 GOPipe *GORank::GetPipe(unsigned index) { return m_Pipes[index]; }
-
-unsigned GORank::GetPipeCount() { return m_Pipes.size(); }
 
 GOPipeConfigNode &GORank::GetPipeConfig() { return m_PipeConfig; }
 

--- a/src/grandorgue/model/GORank.h
+++ b/src/grandorgue/model/GORank.h
@@ -79,7 +79,8 @@ public:
   unsigned RegisterStop(GOStop *stop);
   void SetPipeState(int pipeIndex, unsigned velocity, unsigned stopID);
   GOPipe *GetPipe(unsigned index);
-  unsigned GetPipeCount();
+  unsigned GetPipeCount() const { return m_Pipes.size(); }
+  const GOPipe *GetPipe(unsigned index) const { return m_Pipes[index]; }
   GOPipeConfigNode &GetPipeConfig();
   void SetTemperament(const GOTemperament &temperament);
 

--- a/src/grandorgue/model/GOSoundingPipe.h
+++ b/src/grandorgue/model/GOSoundingPipe.h
@@ -126,6 +126,12 @@ public:
     const wxString &filename);
   void Load(GOConfigReader &cfg, const wxString &group, const wxString &prefix)
     override;
+
+  /** @return the 1-based windchest index this pipe belongs to */
+  unsigned GetWindchestN() const { return m_WindchestN; }
+
+  /** @return the audio group id this pipe's sound is routed to */
+  unsigned GetAudioGroupId() const { return m_AudioGroupID; }
 };
 
 #endif


### PR DESCRIPTION
## Summary
- Add `GOOrganModel::GetUsedWindchestGroupPairs()`, which scans all sounding pipes and returns the distinct `(windchestN, audioGroupId)` pairs actually used by the organ.
- Add const overloads of `GOOrganModel::GetRank()`/`GetODFRankCount()` and `GORank::GetPipe()`/`GetPipeCount()`, needed so the new method can be `const`.
- Add public `GOSoundingPipe::GetWindchestN()`/`GetAudioGroupId()` getters (previously private).

This is a standalone extraction of the model-layer groundwork for an upcoming sound-engine change that needs to build per-`(windchest, audio group)` state without the engine reaching into rank/pipe internals itself. No behavior change to existing code paths - `GetUsedWindchestGroupPairs()` has no caller yet in this PR.

## Test plan
- [x] `cmake -DGO_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug` build succeeds
- [x] `./bin/GOTestExe --no-perf` passes (all existing tests)