### PR TITLE
PR B: split GOOrganController::Load()/Export()/~GOOrganController() into core/GUI/objects phases

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -84,6 +84,9 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
     m_ConfiguredOrgan(wxEmptyString),
     m_FileStore(config),
     m_Cacheable(false),
+    m_IsOrganCoreDataLoaded(false),
+    m_IsOrganGuiLoaded(false),
+    m_IsObjectsLoaded(false),
     m_setter(0),
     m_AudioRecorder(NULL),
     m_MidiPlayer(NULL),
@@ -100,9 +103,13 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
     m_PitchLabel(*this),
     m_TemperamentLabel(*this),
     m_MainWindowData(*this, wxT("MainWindow")) {
+  // GOTimer needs no live wx event loop to construct (only to fire), so it
+  // is created unconditionally: GOAudioRecorder/GOMidiPlayer/GOMidiRecorder/
+  // GOMetronome (created by LoadOrganCoreData(), independent of
+  // isAppInitialized) all assume GetTimer() is non-null.
+  m_timer = new GOTimer();
   if (isAppInitialized) {
     // Load here objects that needs App (wx) to be loaded
-    m_timer = new GOTimer();
     mp_ImageCache = new GOGuiImageCache(m_FileStore);
   }
   GOOrganModel::SetModelModificationListener(this);
@@ -111,24 +118,66 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
 }
 
 GOOrganController::~GOOrganController() {
-  p_OnStateButton = nullptr;
+  // Clear() runs m_elementcreators.clear() (via ClearOrganCoreData), which
+  // may reference m_timer, so we respect the deletion order and delete
+  // m_timer only afterward.
+  Clear();
   m_FileStore.CloseArchives();
-  GOEventHandlerList::Cleanup();
-  // Just to be sure, that the sound providers are freed before the pool
-  m_manuals.clear();
-  m_tremulants.clear();
-  m_ranks.clear();
-  m_VirtualCouplers.Cleanup();
-  GOOrganModel::Cleanup();
-  GOOrganModel::SetModelModificationListener(nullptr);
-  GOOrganModel::SetCombinationController(nullptr);
-  m_elementcreators.clear();
-  // some elementcreator may reference to m_timer so we respect the deletion
-  // order
   if (mp_ImageCache)
     delete mp_ImageCache;
   if (m_timer)
     delete m_timer;
+}
+
+void GOOrganController::ClearObjects() {
+  if (m_IsObjectsLoaded) {
+    m_Cacheable = false;
+    m_IsObjectsLoaded = false;
+  }
+}
+
+void GOOrganController::ClearOrganGui() {
+  if (m_IsOrganGuiLoaded) {
+    m_panels.clear();
+    m_panelcreators.clear();
+    m_IsOrganGuiLoaded = false;
+  }
+}
+
+void GOOrganController::ClearOrganCoreData() {
+  if (m_IsOrganCoreDataLoaded) {
+    p_OnStateButton = nullptr;
+
+    // Just to be sure, that the sound providers are freed before the pool
+    GOOrganModel::Cleanup();
+
+    m_VirtualCouplers.Cleanup();
+    GOOrganModel::SetModelModificationListener(nullptr);
+    GOOrganModel::SetCombinationController(nullptr);
+
+    // m_elementcreators (a ptr_vector) is the sole owner of m_setter,
+    // m_DivisionalSetter, m_AudioRecorder, m_MidiRecorder, m_MidiPlayer, and
+    // the anonymous GOMetronome pushed onto it in LoadOrganCoreData().
+    // ptr_vector::clear() deletes every contained pointer (see
+    // ptrvector.h:59-68), so this single call is what actually frees all
+    // six objects; the raw-pointer members below are then only reset to
+    // nullptr to avoid leaving them dangling, not separately deleted.
+    m_elementcreators.clear();
+
+    m_setter = nullptr;
+    m_DivisionalSetter = nullptr;
+    m_AudioRecorder = nullptr;
+    m_MidiRecorder = nullptr;
+    m_MidiPlayer = nullptr;
+
+    m_IsOrganCoreDataLoaded = false;
+  }
+}
+
+void GOOrganController::Clear() {
+  ClearObjects();
+  ClearOrganGui();
+  ClearOrganCoreData();
 }
 
 void GOOrganController::SetOrganModified(bool modified) {
@@ -178,7 +227,9 @@ GOHashType GOOrganController::GenerateCacheHash() {
   return hash.getHash();
 }
 
-void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
+void GOOrganController::LoadOrganCoreData(GOConfigReader &cfg) {
+  m_IsOrganCoreDataLoaded = true;
+
   /* load church info */
   cfg.ReadString(
     ODFSetting, WX_ORGAN, wxT("HauptwerkOrganFileFormatVersion"), false);
@@ -217,8 +268,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   }
 
   /* load basic organ information */
-  unsigned NumberOfPanels = cfg.ReadInteger(
-    ODFSetting, WX_ORGAN, wxT("NumberOfPanels"), 0, 100, false);
   cfg.ReadString(CMBSetting, WX_ORGAN, WX_GRANDORGUE_VERSION, false);
 
   int volume = cfg.ReadInteger(
@@ -248,15 +297,6 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
   m_elementcreators.push_back(m_MidiPlayer);
   m_elementcreators.push_back(m_MidiRecorder);
   m_elementcreators.push_back(new GOMetronome(this));
-  m_panelcreators.push_back(new GOGUICouplerPanel(this, m_VirtualCouplers));
-  m_panelcreators.push_back(new GOGUICouplerManualsAndVolumePanel(this));
-  m_panelcreators.push_back(new GOGUIMetronomePanel(this));
-  m_panelcreators.push_back(new GOGUICrescendoPanel(this));
-  m_panelcreators.push_back(new GOGUIDivisionalsPanel(this));
-  m_panelcreators.push_back(new GOGUIBankedGeneralsPanel(this));
-  m_panelcreators.push_back(new GOGUISequencerPanel(this));
-  m_panelcreators.push_back(new GOGUIMasterPanel(this));
-  m_panelcreators.push_back(new GOGUIRecorderPanel(this));
 
   for (unsigned i = 0; i < m_elementcreators.size(); i++)
     m_elementcreators[i]->Load(cfg);
@@ -269,34 +309,9 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
     UnRegisterLifecycleListener(p_OnStateButton);
   }
 
-  m_PitchLabel.Load(cfg, wxT("SetterMasterPitch"), _("organ pitch"));
-  m_TemperamentLabel.Load(
-    cfg, wxT("SetterMasterTemperament"), _("temperament"));
-  m_MainWindowData.Load(cfg);
-
   // Load dialog sizes
   if (GODialogSizeSet::isPresentInCfg(cfg, CMBSetting))
     m_config.m_DialogSizes.Load(cfg, CMBSetting);
-
-  m_panels.resize(0);
-  m_panels.push_back(new GOGUIPanel(this));
-  m_panels[0]->Load(cfg, wxT(""));
-
-  wxString buffer;
-
-  for (unsigned i = 0; i < NumberOfPanels; i++) {
-    buffer.Printf(wxT("Panel%03d"), i + 1);
-    m_panels.push_back(new GOGUIPanel(this));
-    m_panels[i + 1]->Load(cfg, buffer);
-  }
-
-  m_StopWindowSizeKeeper.Load(cfg, wxT("Stops"));
-
-  for (unsigned i = 0; i < m_panelcreators.size(); i++)
-    m_panelcreators[i]->CreatePanels(cfg);
-
-  for (unsigned i = 0; i < m_panels.size(); i++)
-    m_panels[i]->Layout();
 
   const wxString &organName = GetOrganName();
 
@@ -319,14 +334,181 @@ void GOOrganController::ReadOrganFile(GOConfigReader &cfg) {
     | (result.hash[7] & 0x7F);
 }
 
+void GOOrganController::LoadOrganGui(GOConfigReader &cfg) {
+  m_IsOrganGuiLoaded = true;
+
+  unsigned NumberOfPanels = cfg.ReadInteger(
+    ODFSetting, WX_ORGAN, wxT("NumberOfPanels"), 0, 100, false);
+
+  m_panelcreators.push_back(new GOGUICouplerPanel(this, m_VirtualCouplers));
+  m_panelcreators.push_back(new GOGUICouplerManualsAndVolumePanel(this));
+  m_panelcreators.push_back(new GOGUIMetronomePanel(this));
+  m_panelcreators.push_back(new GOGUICrescendoPanel(this));
+  m_panelcreators.push_back(new GOGUIDivisionalsPanel(this));
+  m_panelcreators.push_back(new GOGUIBankedGeneralsPanel(this));
+  m_panelcreators.push_back(new GOGUISequencerPanel(this));
+  m_panelcreators.push_back(new GOGUIMasterPanel(this));
+  m_panelcreators.push_back(new GOGUIRecorderPanel(this));
+
+  m_PitchLabel.Load(cfg, wxT("SetterMasterPitch"), _("organ pitch"));
+  m_TemperamentLabel.Load(
+    cfg, wxT("SetterMasterTemperament"), _("temperament"));
+  m_MainWindowData.Load(cfg);
+
+  m_panels.resize(0);
+  m_panels.push_back(new GOGUIPanel(this));
+  m_panels[0]->Load(cfg, wxT(""));
+
+  wxString buffer;
+
+  for (unsigned i = 0; i < NumberOfPanels; i++) {
+    buffer.Printf(wxT("Panel%03d"), i + 1);
+    m_panels.push_back(new GOGUIPanel(this));
+    m_panels[i + 1]->Load(cfg, buffer);
+  }
+
+  m_StopWindowSizeKeeper.Load(cfg, wxT("Stops"));
+
+  for (unsigned i = 0; i < m_panelcreators.size(); i++)
+    m_panelcreators[i]->CreatePanels(cfg);
+
+  for (unsigned i = 0; i < m_panels.size(); i++)
+    m_panels[i]->Layout();
+}
+
 class GOLoadAborted : public std::exception {};
+
+void GOOrganController::LoadObjects(GOProgressMonitor &monitor) {
+  m_IsObjectsLoaded = true;
+
+  GOBuffer<char> dummy;
+
+  try {
+    bool cache_ok = false;
+
+    dummy.resize(1024 * 1024 * 50);
+    ResolveReferences();
+
+    /* Figure out list of pipes to load */
+    GOCacheObjectDistributor objectDistributor(GetCacheObjects());
+
+    monitor.Reset(objectDistributor.GetNObjects());
+
+    GOCacheObject *obj = nullptr;
+
+    /* Load pipes */
+    if (wxFileExists(m_LoadedOrganInfo.cacheFilePath)) {
+      wxFile cache_file(m_LoadedOrganInfo.cacheFilePath);
+      GOCache reader(cache_file, m_pool);
+      cache_ok = cache_file.IsOpened();
+
+      if (cache_ok) {
+        GOHashType hash1, hash2;
+        if (!reader.ReadHeader()) {
+          cache_ok = false;
+          wxLogWarning(_("Cache file had bad magic bypassing cache."));
+        }
+        hash1 = GenerateCacheHash();
+        if (
+          !reader.Read(&hash2, sizeof(hash2))
+          || memcmp(&hash1, &hash2, sizeof(hash1))) {
+          cache_ok = false;
+          reader.FreeCacheFile();
+          wxLogWarning(_("Cache file had diffent hash bypassing cache."));
+        }
+      }
+
+      GOCacheObject *obj = nullptr;
+
+      if (cache_ok) {
+        while ((obj = objectDistributor.FetchNext())) {
+          if (!obj->LoadFromCacheWithoutExc(m_pool, reader)) {
+            wxLogWarning(_("Cache load failure: %s"), obj->GetLoadError());
+            break;
+          }
+          if (!monitor.Update(objectDistributor.GetPos(), obj->GetLoadTitle()))
+            throw GOLoadAborted(); // Skip the rest of the loading code
+        }
+        if (!obj)
+          m_Cacheable = true;
+        else
+          // obj points to an object with a load error. We will try to load
+          // it from the file later
+          cache_ok = false;
+      }
+
+      if (!cache_ok && !m_config.ManageCache())
+        wxLogWarning(_("The cache for this organ is outdated. Please update "
+                       "or delete it."));
+
+      reader.Close();
+    }
+
+    if (!cache_ok) {
+      GOLoadWorker thisWorker(m_FileStore, m_pool, objectDistributor);
+      ptr_vector<GOLoadThread> threads;
+
+      // Create and run additional worker threads
+      for (unsigned i = 0; i < m_config.LoadConcurrency(); i++)
+        threads.push_back(
+          new GOLoadThread(m_FileStore, m_pool, objectDistributor));
+      for (unsigned i = 0; i < threads.size(); i++)
+        threads[i]->Run();
+
+      // try to load the object that we could not load from cache
+      if (obj)
+        thisWorker.LoadObjectNoExc(obj);
+
+      while (thisWorker.LoadNextObject(obj))
+        // show the progress and process possible Cancel
+        if (!monitor.Update(objectDistributor.GetPos(), obj->GetLoadTitle()))
+          throw GOLoadAborted(); // skip the rest of loading code
+      // rethrow exception if any occurred in thisWorker.LoadNextObject
+      bool wereExceptions = thisWorker.WereExceptions();
+
+      for (unsigned i = 0; i < threads.size(); i++)
+        wereExceptions |= threads[i]->CheckExceptions();
+      if (wereExceptions) {
+        for (auto obj : GetCacheObjects()) {
+          if (!obj->IsReady())
+            wxLogError(obj->GetLoadError());
+        }
+        GOMessageBox(
+          _("There are errors while loading the organ. See Log Messages."),
+          _("Load error"),
+          wxOK | wxICON_ERROR,
+          NULL);
+      } else {
+        if (objectDistributor.IsComplete())
+          m_Cacheable = true;
+        if (m_config.ManageCache() && m_Cacheable)
+          UpdateCache(m_config.CompressCache(), monitor);
+      }
+
+      // Despite a possible exception automatic calling ~GOLoadThread from
+      // ~ptr_vector stops all additional worker threads
+    }
+  } catch (const GOOutOfMemory &e) {
+    GOMessageBox(
+      _("Out of memory - only parts of the organ are loaded. Please "
+        "reduce memory footprint via the sample loading settings."),
+      _("Load error"),
+      wxOK | wxICON_ERROR,
+      NULL);
+  } catch (const GOLoadAborted &) {
+    GOMessageBox(
+      _("Load aborted by the user - only parts of the organ are loaded."),
+      _("Load error"),
+      wxOK | wxICON_ERROR,
+      NULL);
+  }
+}
 
 wxString GOOrganController::Load(
   const GOOrgan &organ,
   const wxString &file2,
   bool isGuiOnly,
   GOProgressMonitor &monitor) {
-  GOBuffer<char> dummy;
   wxString errMsg;
 
   try {
@@ -336,133 +518,12 @@ wxString GOOrganController::Load(
     m_LoadedOrganInfo = organReader.GetLoadedOrganInfo();
     m_Cacheable = false;
 
-    ReadOrganFile(organReader.GetConfigReader());
+    LoadOrganCoreData(organReader.GetConfigReader());
+    LoadOrganGui(organReader.GetConfigReader());
     organReader.ReportUnused();
 
-    if (!isGuiOnly) {
-      try {
-        bool cache_ok = false;
-
-        dummy.resize(1024 * 1024 * 50);
-        ResolveReferences();
-
-        /* Figure out list of pipes to load */
-        GOCacheObjectDistributor objectDistributor(GetCacheObjects());
-
-        monitor.Reset(objectDistributor.GetNObjects());
-
-        GOCacheObject *obj = nullptr;
-
-        /* Load pipes */
-        if (wxFileExists(m_LoadedOrganInfo.cacheFilePath)) {
-          wxFile cache_file(m_LoadedOrganInfo.cacheFilePath);
-          GOCache reader(cache_file, m_pool);
-          cache_ok = cache_file.IsOpened();
-
-          if (cache_ok) {
-            GOHashType hash1, hash2;
-            if (!reader.ReadHeader()) {
-              cache_ok = false;
-              wxLogWarning(_("Cache file had bad magic bypassing cache."));
-            }
-            hash1 = GenerateCacheHash();
-            if (
-              !reader.Read(&hash2, sizeof(hash2))
-              || memcmp(&hash1, &hash2, sizeof(hash1))) {
-              cache_ok = false;
-              reader.FreeCacheFile();
-              wxLogWarning(_("Cache file had diffent hash bypassing cache."));
-            }
-          }
-
-          GOCacheObject *obj = nullptr;
-
-          if (cache_ok) {
-            while ((obj = objectDistributor.FetchNext())) {
-              if (!obj->LoadFromCacheWithoutExc(m_pool, reader)) {
-                wxLogWarning(_("Cache load failure: %s"), obj->GetLoadError());
-                break;
-              }
-              if (!monitor.Update(
-                    objectDistributor.GetPos(), obj->GetLoadTitle()))
-                throw GOLoadAborted(); // Skip the rest of the loading code
-            }
-            if (!obj)
-              m_Cacheable = true;
-            else
-              // obj points to an object with a load error. We will try to load
-              // it from the file later
-              cache_ok = false;
-          }
-
-          if (!cache_ok && !m_config.ManageCache())
-            wxLogWarning(
-              _("The cache for this organ is outdated. Please update "
-                "or delete it."));
-
-          reader.Close();
-        }
-
-        if (!cache_ok) {
-          GOLoadWorker thisWorker(m_FileStore, m_pool, objectDistributor);
-          ptr_vector<GOLoadThread> threads;
-
-          // Create and run additional worker threads
-          for (unsigned i = 0; i < m_config.LoadConcurrency(); i++)
-            threads.push_back(
-              new GOLoadThread(m_FileStore, m_pool, objectDistributor));
-          for (unsigned i = 0; i < threads.size(); i++)
-            threads[i]->Run();
-
-          // try to load the object that we could not load from cache
-          if (obj)
-            thisWorker.LoadObjectNoExc(obj);
-
-          while (thisWorker.LoadNextObject(obj))
-            // show the progress and process possible Cancel
-            if (!monitor.Update(
-                  objectDistributor.GetPos(), obj->GetLoadTitle()))
-              throw GOLoadAborted(); // skip the rest of loading code
-          // rethrow exception if any occurred in thisWorker.LoadNextObject
-          bool wereExceptions = thisWorker.WereExceptions();
-
-          for (unsigned i = 0; i < threads.size(); i++)
-            wereExceptions |= threads[i]->CheckExceptions();
-          if (wereExceptions) {
-            for (auto obj : GetCacheObjects()) {
-              if (!obj->IsReady())
-                wxLogError(obj->GetLoadError());
-            }
-            GOMessageBox(
-              _("There are errors while loading the organ. See Log Messages."),
-              _("Load error"),
-              wxOK | wxICON_ERROR,
-              NULL);
-          } else {
-            if (objectDistributor.IsComplete())
-              m_Cacheable = true;
-            if (m_config.ManageCache() && m_Cacheable)
-              UpdateCache(m_config.CompressCache(), monitor);
-          }
-
-          // Despite a possible exception automatic calling ~GOLoadThread from
-          // ~ptr_vector stops all additional worker threads
-        }
-      } catch (const GOOutOfMemory &e) {
-        GOMessageBox(
-          _("Out of memory - only parts of the organ are loaded. Please "
-            "reduce memory footprint via the sample loading settings."),
-          _("Load error"),
-          wxOK | wxICON_ERROR,
-          NULL);
-      } catch (const GOLoadAborted &) {
-        GOMessageBox(
-          _("Load aborted by the user - only parts of the organ are loaded."),
-          _("Load error"),
-          wxOK | wxICON_ERROR,
-          NULL);
-      }
-    }
+    if (!isGuiOnly)
+      LoadObjects(monitor);
   } catch (const wxString &error_) {
     errMsg = error_;
   } catch (const std::exception &e) {
@@ -470,7 +531,6 @@ wxString GOOrganController::Load(
   } catch (...) { // We must not allow unhandled exceptions here
     errMsg.Printf("Unknown exception");
   }
-  dummy.free();
   m_FileStore.CloseArchives();
   if (errMsg.IsEmpty())
     SetTemperament(m_Temperament);
@@ -617,10 +677,7 @@ bool GOOrganController::Save() {
   return true;
 }
 
-bool GOOrganController::Export(const wxString &cmb) {
-  GOConfigFileWriter cfg_file;
-  GOConfigWriter cfg(cfg_file, false);
-
+void GOOrganController::SaveOrganCoreData(GOConfigWriter &cfg) {
   m_LoadedOrganInfo.isCustomized = true;
   cfg.WriteString(WX_ORGAN, wxT("ODFHash"), m_LoadedOrganInfo.odfHash);
   cfg.WriteString(WX_ORGAN, wxT("ChurchName"), GetOrganName());
@@ -635,8 +692,19 @@ bool GOOrganController::Export(const wxString &cmb) {
 
   GOEventDistributor::Save(cfg);
   GetDialogSizeSet().Save(cfg);
-  m_StopWindowSizeKeeper.Save(cfg);
   m_VirtualCouplers.Save(cfg);
+}
+
+void GOOrganController::SaveOrganGui(GOConfigWriter &cfg) {
+  m_StopWindowSizeKeeper.Save(cfg);
+}
+
+bool GOOrganController::Export(const wxString &cmb) {
+  GOConfigFileWriter cfg_file;
+  GOConfigWriter cfg(cfg_file, false);
+
+  SaveOrganCoreData(cfg);
+  SaveOrganGui(cfg);
 
   wxString tmp_name = cmb + wxT(".new");
 

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -36,6 +36,7 @@ class GOArchive;
 class GOAudioRecorder;
 class GOButtonControl;
 class GOCache;
+class GOConfigWriter;
 class GODialogSizeSet;
 class GODivisionalSetter;
 class GOElementCreator;
@@ -59,12 +60,20 @@ typedef struct _GOHashType GOHashType;
 class GOOrganController : public GOEventDistributor,
                           public GOOrganModel,
                           public GOModificationProxy {
+  // Exercises LoadOrganCoreData()/LoadObjects()/SaveOrganCoreData()/
+  // ClearObjects()/ClearOrganCoreData() directly, bypassing Load()'s
+  // unconditional call to LoadOrganGui() (which needs a real GUI display).
+  friend class GOTestOrganController;
+
 private:
   GOConfig &m_config;
   GOOrgan m_ConfiguredOrgan;
   GOLoadedOrganInfo m_LoadedOrganInfo;
   GOFileStore m_FileStore;
   bool m_Cacheable;
+  bool m_IsOrganCoreDataLoaded;
+  bool m_IsOrganGuiLoaded;
+  bool m_IsObjectsLoaded;
   GOSetter *m_setter;
   GODivisionalSetter *m_DivisionalSetter;
   GOAudioRecorder *m_AudioRecorder;
@@ -109,7 +118,26 @@ private:
   // if modified then sets m_IsOrganModified
   void OnIsModifiedChanged(bool modified);
 
-  void ReadOrganFile(GOConfigReader &cfg);
+  /** Reads the non-GUI ODF/CMB data (church info, model, element creators,
+   * combinations) into this controller. Sets m_IsOrganCoreDataLoaded. */
+  void LoadOrganCoreData(GOConfigReader &cfg);
+  /** Reads the GUI ODF/CMB data (panel creators, panels, stops-window size,
+   * main-window data) and builds the panels. Sets m_IsOrganGuiLoaded. */
+  void LoadOrganGui(GOConfigReader &cfg);
+  /** Loads pipe/sample data from the cache or, failing that, from the
+   * sample files in parallel worker threads. Sets m_IsObjectsLoaded. */
+  void LoadObjects(GOProgressMonitor &monitor);
+  /** Writes the non-GUI organ state (church info, volume, temperament,
+   * saveable objects, virtual couplers) to cfg. */
+  void SaveOrganCoreData(GOConfigWriter &cfg);
+  /** Writes the GUI organ state (stops-window size) to cfg. */
+  void SaveOrganGui(GOConfigWriter &cfg);
+  /** Undoes LoadObjects if it ran. Idempotent. */
+  void ClearObjects();
+  /** Undoes LoadOrganGui if it ran. Idempotent. */
+  void ClearOrganGui();
+  /** Undoes LoadOrganCoreData if it ran. Idempotent. */
+  void ClearOrganCoreData();
   GOHashType GenerateCacheHash();
   void SetTemperament(const GOTemperament &temperament);
   void PreconfigRecorder();
@@ -144,6 +172,9 @@ public:
     const wxString &cmb,
     bool isGuiOnly,
     GOProgressMonitor &monitor);
+  /** Undoes whatever Load() built (core data, GUI, cached objects), in
+   * reverse order. Idempotent - safe to call any number of times. */
+  void Clear();
   /**
    * Exports organ combinations in the yaml file
    * @param fileName - the path to the yaml file to export

--- a/src/grandorgue/model/GOOrganModel.cpp
+++ b/src/grandorgue/model/GOOrganModel.cpp
@@ -244,6 +244,19 @@ void GOOrganModel::LoadCmbButtons(GOConfigReader &cfg) {
     m_manuals[i]->LoadDivisionals(cfg);
 }
 
+void GOOrganModel::Cleanup() {
+  GOEventHandlerList::Cleanup();
+  m_windchests.clear();
+  m_manuals.clear();
+  m_enclosures.clear();
+  m_switches.clear();
+  m_tremulants.clear();
+  m_ranks.clear();
+  m_pistons.clear();
+  m_DivisionalCoupler.clear();
+  m_generals.clear();
+}
+
 void GOOrganModel::SetOrganModelModified(bool modified) {
   if (modified != m_OrganModelModified)
     m_OrganModelModified = modified;

--- a/src/grandorgue/model/GOOrganModel.h
+++ b/src/grandorgue/model/GOOrganModel.h
@@ -82,6 +82,11 @@ protected:
   unsigned m_ODFManualCount;
   unsigned m_ODFRankCount;
 
+  /** Undoes Load()/LoadCmbButtons(): clears the windchest/manual/enclosure/
+   * switch/tremulant/rank/piston/divisional-coupler/general elements they
+   * populated, plus the inherited GOEventHandlerList registrations. */
+  void Cleanup();
+
   /**
    * Update all generals buttons light.
    * @param buttonToLight - the button that should be lighted on. All other

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -11,6 +11,7 @@
 
 #include "common/GOTestCollection.h"
 #include "testing/GOTestNameMap.h"
+#include "testing/GOTestOrganController.h"
 #include "testing/combinations/GOTestDivisionalSetter.h"
 #include "testing/loader/GOTestOrganReader.h"
 #include "testing/model/GOTestDrawStop.h"
@@ -50,6 +51,7 @@ int main(int argc, char *argv[]) {
   /* Instantiate all the test classes here */
   GOTestDivisionalSetter testDivisionalSetter;
   GOTestOrganReader testOrganReader;
+  GOTestOrganController testOrganController;
   GOTestDrawStop testDrawStop;
   GOTestOrganModel testOrganModel;
   GOTestSwitch testSwitch;

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -15,9 +15,12 @@ set(go_tests
     sound/playing/GOTestReleaseAlignTable.cpp
     sound/playing/GOTestSoundStream.cpp
     GOTestNameMap.cpp
+    GOTestOrganController.cpp
 )
 add_library(GOTests STATIC ${go_tests})
 
 target_link_libraries(GOTests GOTestLib)
 target_compile_definitions(GOTests PUBLIC
     GOTEST_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/combinations/fixtures")
+target_compile_definitions(GOTests PRIVATE
+    GO_TEST_RESOURCES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/resources")

--- a/src/tests/testing/GOTestOrganController.cpp
+++ b/src/tests/testing/GOTestOrganController.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestOrganController.h"
+
+#include "config/GOConfig.h"
+#include "config/GOConfigFileWriter.h"
+#include "config/GOConfigWriter.h"
+#include "loader/GOOrganReader.h"
+#include "loader/GOProgressMonitor.h"
+
+#include "GOOrgan.h"
+#include "GOOrganController.h"
+
+// Smallest ODF that survives LoadOrganCoreData() to completion: one
+// windchest group, one manual, no stops/couplers/tremulants/switches/ranks
+// (all optional, default to 0). Checked into src/tests/testing/resources
+// rather than generated at runtime.
+static const wxString MINIMAL_ODF_PATH
+  = wxT(GO_TEST_RESOURCES_DIR "/minimal.organ");
+
+static class GOTestProgressMonitor : public GOProgressMonitor {
+public:
+  void Setup(long max, const wxString &title, const wxString &msg) override {}
+  void Reset(long max, const wxString &msg) override {}
+  bool Update(unsigned value, const wxString &msg) override { return true; }
+} s_ProgressMonitor;
+
+GOTestOrganController::~GOTestOrganController() {}
+
+std::string GOTestOrganController::GetName() { return name; }
+
+void GOTestOrganController::run() {
+  try {
+    runImpl();
+  } catch (const wxString &e) {
+    throw GOTestException(
+      std::string("Unexpected wxString exception: ") + e.ToStdString());
+  }
+}
+
+// Deliberately does not go through the public Load()/Clear(), since those
+// unconditionally call LoadOrganGui()/ClearOrganGui() (which build real
+// panels needing a live GUI display) and LoadObjects() (whose error path
+// pops up a GOMessageBox, also needing a display, when GOMetronome's sound
+// files aren't installed in this environment). GOTestOrganController is a
+// friend of GOOrganController precisely so this test can call the
+// non-GUI, non-cache phase methods (LoadOrganCoreData/SaveOrganCoreData/
+// ClearOrganCoreData) directly, skipping the other phases entirely.
+void GOTestOrganController::runImpl() {
+  const GOOrgan organ(MINIMAL_ODF_PATH);
+
+  GOOrganReader organReader(
+    controller->m_config,
+    organ,
+    wxEmptyString,
+    controller->m_FileStore,
+    s_ProgressMonitor);
+
+  controller->LoadOrganCoreData(organReader.GetConfigReader());
+  organReader.ReportUnused();
+
+  GOAssert(
+    controller->GetOrganName() == wxT("Test Organ"),
+    "LoadOrganCoreData() should populate the organ name from the ODF");
+  GOAssert(
+    controller->GetPanelCount() == 0,
+    "LoadOrganCoreData() alone must not build any panels "
+    "(that's LoadOrganGui's job, not exercised here)");
+  // 1 windchest group from the ODF (NumberOfWindchestGroups=1) plus 1 more
+  // that GOMetronome::Load() creates for itself via AddWindchest() to route
+  // its own sound (GOMetronome.cpp), regardless of the ODF's own count.
+  GOAssert(
+    controller->GetWindchestCount() == 2,
+    "LoadOrganCoreData() should populate the ODF's windchest group plus "
+    "GOMetronome's own, got: "
+      + std::to_string(controller->GetWindchestCount()));
+
+  // SaveOrganCoreData() round-trip.
+  GOConfigFileWriter cfgFile;
+  GOConfigWriter cfgWriter(cfgFile, false);
+
+  controller->SaveOrganCoreData(cfgWriter);
+
+  const wxString cmbPath
+    = wxString::Format(wxT("%s/test.cmb"), organ_directory);
+
+  GOAssert(
+    cfgFile.Save(cmbPath), "SaveOrganCoreData() output should be writable");
+  GOAssert(wxFileExists(cmbPath), "The .cmb file should have been created");
+
+  // ClearOrganCoreData() idempotency: calling it multiple times must not
+  // crash, and a second call must be a safe no-op (this is exactly what
+  // the m_IsOrganCoreDataLoaded flag is for).
+  controller->ClearOrganCoreData();
+  GOAssert(
+    controller->GetWindchestCount() == 0,
+    "ClearOrganCoreData() should remove the windchest group");
+  controller->ClearOrganCoreData();
+  GOAssert(
+    controller->GetWindchestCount() == 0,
+    "A second ClearOrganCoreData() call should be a safe no-op");
+}

--- a/src/tests/testing/GOTestOrganController.h
+++ b/src/tests/testing/GOTestOrganController.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTORGANCONTROLLER_H
+#define GOTESTORGANCONTROLLER_H
+
+#include <string>
+
+#include "GOTest.h"
+
+class GOTestOrganController : public GOCommonControllerTest {
+
+private:
+  std::string name = "GOTestOrganController";
+
+public:
+  GOTestOrganController() { name = "GOTestOrganController"; }
+  virtual ~GOTestOrganController();
+  virtual void run();
+  std::string GetName();
+
+private:
+  void runImpl();
+};
+
+#endif /* GOTESTORGANCONTROLLER_H */

--- a/src/tests/testing/resources/minimal.organ
+++ b/src/tests/testing/resources/minimal.organ
@@ -1,0 +1,27 @@
+[Organ]
+ChurchName=Test Organ
+ChurchAddress=Test Address
+DivisionalsStoreIntermanualCouplers=N
+DivisionalsStoreIntramanualCouplers=N
+DivisionalsStoreTremulants=N
+GeneralsStoreDivisionalCouplers=N
+NumberOfWindchestGroups=1
+NumberOfManuals=1
+HasPedals=N
+NumberOfEnclosures=0
+NumberOfTremulants=0
+NumberOfReversiblePistons=0
+NumberOfDivisionalCouplers=0
+NumberOfGenerals=0
+
+[Manual001]
+Name=Test Manual
+NumberOfLogicalKeys=32
+FirstAccessibleKeyLogicalKeyNumber=1
+FirstAccessibleKeyMIDINoteNumber=60
+NumberOfAccessibleKeys=32
+NumberOfStops=0
+
+[WindchestGroup001]
+NumberOfEnclosures=0
+NumberOfTremulants=0


### PR DESCRIPTION
PR B: split GOOrganController::Load()/Export()/~GOOrganController() into core/GUI/objects phases

Splits the monolithic Load()/ReadOrganFile() (already trimmed of ODF/CMB
resolution by PR A's GOOrganReader) into three phases mirrored across
load, save, and teardown:

- LoadOrganCoreData()/SaveOrganCoreData()/ClearOrganCoreData(): non-GUI
  ODF/CMB data - church info, GOOrganModel::Load, element creators,
  combinations.
- LoadOrganGui()/SaveOrganGui()/ClearOrganGui(): GUI-only data - panel
  creators, panels, stops-window size. Named identically to their future
  GOGuiOrgan counterparts so that a later PR can move these bodies out
  wholesale as a pure cut-and-paste.
- LoadObjects(): pipe/sample cache loading, extracted from Load()'s
  isGuiOnly-guarded block.

Load()/Export() become thin orchestrators calling their three phases in
sequence; Clear() (new, public, mirrors Load()/Export()) calls the three
Clear* phases in reverse order and replaces the old destructor body.
Each phase is guarded by its own idempotency flag
(m_IsOrganCoreDataLoaded/m_IsOrganGuiLoaded/m_IsObjectsLoaded), set at
the start of its Load* method and cleared at the end of its Clear*
method, so Clear() (and thus ~GOOrganController()) is safe to call any
number of times regardless of how far a Load() got.

GOOrganModel gains its own Cleanup(), mirroring Load()/LoadCmbButtons(),
so GOOrganController no longer reaches into GOOrganModel's protected
ptr_vectors directly - it was previously an incomplete, ad-hoc partial
clear duplicated with GOEventHandlerList::Cleanup().

GOTestOrganController exercises the split (LoadOrganCoreData,
SaveOrganCoreData, ClearOrganCoreData) end-to-end against a minimal
synthetic ODF (checked into src/tests/testing/resources/minimal.organ),
using a friend-class grant on GOOrganController to call these private,
non-GUI phase methods directly - bypassing Load()/Clear()'s calls into
LoadOrganGui()/ClearOrganGui() (which build real panels needing a live
GUI display) and LoadObjects() (whose error path pops up a GUI-dependent
GOMessageBox when GOMetronome's sound files aren't installed).

The test also exposed a latent bug, fixed here: GOOrganController's
constructor only created m_timer when isAppInitialized was true, but
GOAudioRecorder/GOMidiPlayer/GOMidiRecorder/GOMetronome (created by
LoadOrganCoreData() regardless of isAppInitialized) all assume
GetTimer() is non-null and crash otherwise. GOTimer needs no live wx
event loop to construct (only to fire), so it is now created
unconditionally.

No GUI ownership moves to GOGuiOrgan yet - that starts once
LoadOrganGui/SaveOrganGui/ClearOrganGui's bodies physically move there in
a later PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

