### PR TITLE
Uniffied GOOrganController::Save()/Export() into a single Save(path)

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -670,13 +670,6 @@ void GOOrganController::DeleteSettings() {
   wxRemoveFile(m_LoadedOrganInfo.settingsFilePath);
 }
 
-bool GOOrganController::Save() {
-  if (!Export(m_LoadedOrganInfo.settingsFilePath))
-    return false;
-  ResetOrganModified();
-  return true;
-}
-
 void GOOrganController::SaveOrganCoreData(GOConfigWriter &cfg) {
   m_LoadedOrganInfo.isCustomized = true;
   cfg.WriteString(WX_ORGAN, wxT("ODFHash"), m_LoadedOrganInfo.odfHash);
@@ -699,26 +692,35 @@ void GOOrganController::SaveOrganGui(GOConfigWriter &cfg) {
   m_StopWindowSizeKeeper.Save(cfg);
 }
 
-bool GOOrganController::Export(const wxString &cmb) {
-  GOConfigFileWriter cfg_file;
-  GOConfigWriter cfg(cfg_file, false);
+static bool write_config_file(
+  GOConfigFileWriter &cfgFile, const wxString &path) {
+  wxString tmpName = path + wxT(".new");
+  bool isOk = !::wxFileExists(tmpName) || ::wxRemoveFile(tmpName);
+
+  if (!isOk)
+    wxLogError(_("Could not write to '%s'"), tmpName);
+  else {
+    isOk = cfgFile.Save(tmpName);
+    if (!isOk)
+      wxLogError(_("Could not write to '%s'"), tmpName);
+    else
+      isOk = go_rename_file(tmpName, path);
+  }
+  return isOk;
+}
+
+bool GOOrganController::Save(const wxString &path) {
+  GOConfigFileWriter cfgFile;
+  GOConfigWriter cfg(cfgFile, false);
 
   SaveOrganCoreData(cfg);
   SaveOrganGui(cfg);
 
-  wxString tmp_name = cmb + wxT(".new");
-
-  if (::wxFileExists(tmp_name) && !::wxRemoveFile(tmp_name)) {
-    wxLogError(_("Could not write to '%s'"), tmp_name);
-    return false;
-  }
-  if (!cfg_file.Save(tmp_name)) {
-    wxLogError(_("Could not write to '%s'"), tmp_name);
-    return false;
-  }
-  if (!go_rename_file(tmp_name, cmb))
-    return false;
-  return true;
+  bool isOk = write_config_file(
+    cfgFile, path.IsEmpty() ? m_LoadedOrganInfo.settingsFilePath : path);
+  if (isOk && path.IsEmpty())
+    ResetOrganModified();
+  return isOk;
 }
 
 GOEnclosure *GOOrganController::GetEnclosure(

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -182,8 +182,17 @@ public:
    */
   wxString ExportCombination(const wxString &fileName);
   void LoadCombination(const wxString &cmb);
-  bool Save();
-  bool Export(const wxString &cmb);
+  /**
+   * Writes the organ's core and GUI data to a config file.
+   * @param path the file to write to; empty (the default) means the path
+   *   this organ was loaded from (m_LoadedOrganInfo.settingsFilePath) - a
+   *   default member expression can't be used here since default arguments
+   *   can't reference `this`, so the sentinel is resolved in the body.
+   *   An explicit non-empty path is treated as an export to a copy and does
+   *   not reset the modified flag.
+   * @return true if the file was written successfully
+   */
+  bool Save(const wxString &path = wxEmptyString);
   bool CachePresent() const {
     return wxFileExists(m_LoadedOrganInfo.cacheFilePath);
   }

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -120,14 +120,9 @@ void GOGuiOrgan::SyncState() {
   GODocumentBase::SyncState();
 }
 
-bool GOGuiOrgan::Save() {
+bool GOGuiOrgan::Save(const wxString &path) {
   SyncState();
-  return m_OrganController->Save();
-}
-
-bool GOGuiOrgan::Export(const wxString &cmb) {
-  SyncState();
-  return m_OrganController->Export(cmb);
+  return m_OrganController->Save(path);
 }
 
 void GOGuiOrgan::CloseOrgan() {

--- a/src/grandorgue/gui/GOGuiOrgan.h
+++ b/src/grandorgue/gui/GOGuiOrgan.h
@@ -51,8 +51,7 @@ public:
   void ShowMidiList();
   void ShowStops();
 
-  bool Save();
-  bool Export(const wxString &cmb);
+  bool Save(const wxString &path = wxEmptyString);
   // Returns the loaded organ controller, or nullptr on failure.
   // Note: on failure CloseOrgan() is called, which also clears
   // m_OrganController.

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -1012,7 +1012,7 @@ void GOAppWindow::OnExport(wxCommandEvent &event) {
       wxString exportedFilePath = dlg.GetPath();
       if (!exportedFilePath.EndsWith(wxT(".cmb"), NULL))
         exportedFilePath += wxT(".cmb");
-      if (!mp_organ->Export(exportedFilePath))
+      if (!mp_organ->Save(exportedFilePath))
         GOMessageBox(
           wxString::Format(
             _("Failed to export settings to '%s'"), exportedFilePath.c_str()),


### PR DESCRIPTION
Both did near-identical work (write core+GUI data to a file, differing
only in the destination path and whether the modified flag was reset
afterward). A single method with a default-valued path parameter covers
both cases; the file-write sequence is extracted into a static
write_config_file() helper. Prepares for moving GUI ownership out of
GOOrganController in a later step.