### PR TITLE
Fix autotag.sh not tagging the future release when CHANGELOG.md still starts with a release header

### DIFF
--- a/build-scripts/for-github/autotag.sh
+++ b/build-scripts/for-github/autotag.sh
@@ -32,14 +32,17 @@ if [[ "$(echo "$CHANGELOG_HEAD" | cut -d\  -f1)" == "#" ]]; then
   # release
   CHANGELOG_TAG=$(assure_full_version "$(echo "$CHANGELOG_HEAD" | cut -d\  -f2)" 1)
 fi
-if [[ -n "$CHANGELOG_TAG" ]] && version_ge "$CHANGELOG_TAG" "$GIT_TAG"; then
+# the version we are preparing for a release in the future
+FUTURE_RELEASE_TAG=$(assure_full_version "$(cat "$VERSION_TXT")" 0)
+
+if [[ -n "$CHANGELOG_TAG" ]] && version_ge "$CHANGELOG_TAG" "$GIT_TAG" \
+  && version_ge "$CHANGELOG_TAG" "$FUTURE_RELEASE_TAG"; then
   # a new release. Push the release tag and make the relnotes
   NEW_TAG=$CHANGELOG_TAG
-  sed '0,/^#/d;/^#/Q' CHANGELOG.md >$RELEASE_NOTES
-else
-  # No release. May be we are preparing for a new release in the future
-  FUTURE_RELEASE_TAG=$(assure_full_version "$(cat "$VERSION_TXT")" 0)
-  version_gt "$FUTURE_RELEASE_TAG" "$GIT_TAG" && NEW_TAG=$FUTURE_RELEASE_TAG
+  sed '0,/^#/d;/^#/Q' $CHANGELOG >$RELEASE_NOTES
+elif version_gt "$FUTURE_RELEASE_TAG" "$GIT_TAG"; then
+  # No release. We are preparing for a new release in the future
+  NEW_TAG=$FUTURE_RELEASE_TAG
 fi
 echo "NEW_TAG=$NEW_TAG"
 if [[ -n "$NEW_TAG" ]]; then


### PR DESCRIPTION
After merging #2579 ("Started a new release", `version.txt`: 3.17.3 → 3.18.0) the tag `3.18.0-0` was not created, and it was not created on the subsequent merges either. Builds on master are still numbered `3.17.3-1.N`.

From the [workflow log](https://github.com/GrandOrgue/grandorgue/actions/runs/31699877350), step `calc_ver / Set git tags and compose RELNOTES.md`:

```
release
NEW_TAG=3.17.3-1
Release 3.17.3-1 is already published, skipping tag push.
...
full_ver=3.17.3-1.2   release_flag=OFF
```

`autotag.sh` chose between the "release" and the "future release" branches by looking at the first line of `CHANGELOG.md` only. At that moment the first line was still `# 3.17.3 (2026-08-10)` (no new unreleased items had been added on top yet), so `CHANGELOG_TAG` was `3.17.3-1`, equal to the current git tag. The script took the release branch, and the guard added in #2446 (the release is already published, do not move its tag) cleared `NEW_TAG`. `version.txt` was never read, because it was only used in the `else` branch.

Now both candidate tags are computed and the greater one wins: the release branch is taken only if the tag derived from `CHANGELOG.md` is not lower than the one derived from `version.txt`. The result no longer depends on whether new unreleased items have already been added on top of `CHANGELOG.md`.

Checked against the tag-selection scenarios:

| Situation | GIT_TAG | CHANGELOG_TAG | version.txt tag | NEW_TAG |
|---|---|---|---|---|
| master now (broken before) | 3.17.3-1 | 3.17.3-1 | 3.18.0-0 | 3.18.0-0 |
| development after 3.18.0-0 | 3.18.0-0 | 3.17.3-1 | 3.18.0-0 | *(none)* |
| release PR | 3.18.0-0 | 3.18.0-1 | 3.18.0-0 | 3.18.0-1 |
| rerun while the release is still a draft | 3.18.0-1 | 3.18.0-1 | 3.18.0-0 | 3.18.0-1 |
| preparing 3.19.0 | 3.18.0-1 | 3.18.0-1 | 3.19.0-0 | 3.19.0-0 |

The last row failed with the old code too, so the same problem would have repeated in the next cycle.

The missing `3.18.0-0` tag has to be pushed manually on `c90b9b87` (the commit that bumped `version.txt`), the way the previous `-0` tags are placed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw2HA8JkBk5gkMsLV9AGc4