### PR TITLE
Turned GOOrganController's GUI phase methods into private virtual hooks

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -8,6 +8,7 @@
 #include "GOOrganController.h"
 
 #include <algorithm>
+#include <cassert>
 
 #include <wx/filename.h>
 #include <wx/log.h>
@@ -123,10 +124,11 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
 }
 
 GOOrganController::~GOOrganController() {
-  // Clear() runs m_elementcreators.clear() (via ClearOrganCoreData), which
-  // may reference m_timer, so we respect the deletion order and delete
-  // m_timer only afterward.
-  Clear();
+  // Callers must call Clear() explicitly before destroying this object (see
+  // the doc-comment on Clear()) - it cannot be called from here, since by
+  // now any subclass part of the object is already gone and OnClear() would
+  // not dispatch to a subclass override.
+  assert(!m_IsOrganCoreDataLoaded && !m_IsOrganGuiLoaded && !m_IsObjectsLoaded);
   m_FileStore.CloseArchives();
   if (mp_ImageCache)
     delete mp_ImageCache;

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -141,7 +141,7 @@ void GOOrganController::ClearObjects() {
   }
 }
 
-void GOOrganController::ClearOrganGui() {
+void GOOrganController::OnClear() {
   if (m_IsOrganGuiLoaded) {
     m_panels.clear();
     m_panelcreators.clear();
@@ -181,7 +181,7 @@ void GOOrganController::ClearOrganCoreData() {
 
 void GOOrganController::Clear() {
   ClearObjects();
-  ClearOrganGui();
+  OnClear();
   ClearOrganCoreData();
 }
 
@@ -338,7 +338,7 @@ void GOOrganController::LoadOrganCoreData(GOConfigReader &cfg) {
     | (result.hash[7] & 0x7F);
 }
 
-void GOOrganController::LoadOrganGui(GOConfigReader &cfg) {
+void GOOrganController::OnLoad(GOConfigReader &cfg) {
   m_IsOrganGuiLoaded = true;
 
   unsigned NumberOfPanels = cfg.ReadInteger(
@@ -523,7 +523,7 @@ wxString GOOrganController::Load(
     m_Cacheable = false;
 
     LoadOrganCoreData(organReader.GetConfigReader());
-    LoadOrganGui(organReader.GetConfigReader());
+    OnLoad(organReader.GetConfigReader());
     organReader.ReportUnused();
 
     if (!isGuiOnly)
@@ -692,7 +692,7 @@ void GOOrganController::SaveOrganCoreData(GOConfigWriter &cfg) {
   m_VirtualCouplers.Save(cfg);
 }
 
-void GOOrganController::SaveOrganGui(GOConfigWriter &cfg) {
+void GOOrganController::OnSave(GOConfigWriter &cfg) {
   m_StopWindowSizeKeeper.Save(cfg);
 }
 
@@ -718,7 +718,7 @@ bool GOOrganController::Save(const wxString &path) {
   GOConfigWriter cfg(cfgFile, false);
 
   SaveOrganCoreData(cfg);
-  SaveOrganGui(cfg);
+  OnSave(cfg);
 
   bool isOk = write_config_file(
     cfgFile, path.IsEmpty() ? m_LoadedOrganInfo.settingsFilePath : path);

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -125,10 +125,23 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
 
 GOOrganController::~GOOrganController() {
   // Callers must call Clear() explicitly before destroying this object (see
-  // the doc-comment on Clear()) - it cannot be called from here, since by
-  // now any subclass part of the object is already gone and OnClear() would
-  // not dispatch to a subclass override.
-  assert(!m_IsOrganCoreDataLoaded && !m_IsOrganGuiLoaded && !m_IsObjectsLoaded);
+  // its doc-comment): OnClear() is virtual, and a call made from here would
+  // never reach a subclass override, since by now the object's dynamic
+  // type has already unwound to GOOrganController.
+  //
+  // ClearObjects() must run before OnClear() (Clear()'s own order), so by
+  // the time we get here it is already too late to call it - OnClear() is
+  // expected to have already run (by the caller) with ClearObjects()
+  // having already preceded it. We only assert that it did.
+  //
+  // ClearOrganCoreData() is different: it is non-virtual, idempotent, and
+  // has no ordering dependency on OnClear() having actually reached a
+  // subclass override, so it is safe - and necessary - to (re-)run it here
+  // unconditionally, regardless of NDEBUG: it frees m_elementcreators,
+  // which must happen before m_timer is deleted below.
+  assert(!m_IsObjectsLoaded);
+  assert(!m_IsOrganGuiLoaded);
+  ClearOrganCoreData();
   m_FileStore.CloseArchives();
   if (mp_ImageCache)
     delete mp_ImageCache;

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -183,13 +183,15 @@ public:
     GOProgressMonitor &monitor);
   /** Undoes whatever Load() built (core data, GUI, cached objects), in
    * reverse order. Idempotent - safe to call any number of times.
-   * Callers must call this explicitly before destroying the object
-   * (stack, member, or heap) - the destructor does not call it itself and
-   * instead asserts that it already ran. This is because Clear() calls the
-   * virtual OnClear(), and a call made from within ~GOOrganController()
-   * would only ever reach GOOrganController::OnClear(), never a subclass
-   * override, since C++ virtual dispatch during base-class destruction is
-   * restricted to the base class. */
+   * Callers must call this explicitly before destroying the object (stack,
+   * member, or heap): Clear() calls the virtual OnClear(), and a call made
+   * from within ~GOOrganController() would only ever reach
+   * GOOrganController::OnClear(), never a subclass override, since C++
+   * virtual dispatch during base-class destruction is restricted to the
+   * base class. The destructor only asserts that ClearObjects()/OnClear()
+   * already ran; it still re-runs the non-virtual ClearOrganCoreData() on
+   * its own as a safety net regardless of whether the caller called
+   * Clear(). */
   void Clear();
   /**
    * Exports organ combinations in the yaml file

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -62,7 +62,7 @@ class GOOrganController : public GOEventDistributor,
                           public GOModificationProxy {
   // Exercises LoadOrganCoreData()/LoadObjects()/SaveOrganCoreData()/
   // ClearObjects()/ClearOrganCoreData() directly, bypassing Load()'s
-  // unconditional call to LoadOrganGui() (which needs a real GUI display).
+  // unconditional call to OnLoad() (which needs a real GUI display).
   friend class GOTestOrganController;
 
 private:
@@ -121,21 +121,30 @@ private:
   /** Reads the non-GUI ODF/CMB data (church info, model, element creators,
    * combinations) into this controller. Sets m_IsOrganCoreDataLoaded. */
   void LoadOrganCoreData(GOConfigReader &cfg);
-  /** Reads the GUI ODF/CMB data (panel creators, panels, stops-window size,
-   * main-window data) and builds the panels. Sets m_IsOrganGuiLoaded. */
-  void LoadOrganGui(GOConfigReader &cfg);
+  /** Hook for a subclass to load GUI-only data, called after
+   * LoadOrganCoreData() and before the ODF/CMB unused-key report. Empty by
+   * default - a bare GOOrganController has no GUI.
+   * @param cfg the config reader for the ODF/CMB currently being loaded,
+   *   the same one passed to LoadOrganCoreData() */
+  virtual void OnLoad(GOConfigReader &cfg);
   /** Loads pipe/sample data from the cache or, failing that, from the
    * sample files in parallel worker threads. Sets m_IsObjectsLoaded. */
   void LoadObjects(GOProgressMonitor &monitor);
   /** Writes the non-GUI organ state (church info, volume, temperament,
    * saveable objects, virtual couplers) to cfg. */
   void SaveOrganCoreData(GOConfigWriter &cfg);
-  /** Writes the GUI organ state (stops-window size) to cfg. */
-  void SaveOrganGui(GOConfigWriter &cfg);
+  /** Hook for a subclass to save GUI-only data, called after
+   * SaveOrganCoreData() and before the file is written. Empty by default.
+   * @param cfg the config writer Save() is assembling; core data has
+   *   already been written to it by the time this runs */
+  virtual void OnSave(GOConfigWriter &cfg);
   /** Undoes LoadObjects if it ran. Idempotent. */
   void ClearObjects();
-  /** Undoes LoadOrganGui if it ran. Idempotent. */
-  void ClearOrganGui();
+  /** Hook for a subclass to clear GUI-only data, called after
+   * ClearObjects() and before ClearOrganCoreData() (GUI data may reference
+   * core model objects that ClearOrganCoreData() frees). Empty by default.
+   * Undoes OnLoad() if it ran. Idempotent. */
+  virtual void OnClear();
   /** Undoes LoadOrganCoreData if it ran. Idempotent. */
   void ClearOrganCoreData();
   GOHashType GenerateCacheHash();

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -182,7 +182,14 @@ public:
     bool isGuiOnly,
     GOProgressMonitor &monitor);
   /** Undoes whatever Load() built (core data, GUI, cached objects), in
-   * reverse order. Idempotent - safe to call any number of times. */
+   * reverse order. Idempotent - safe to call any number of times.
+   * Callers must call this explicitly before destroying the object
+   * (stack, member, or heap) - the destructor does not call it itself and
+   * instead asserts that it already ran. This is because Clear() calls the
+   * virtual OnClear(), and a call made from within ~GOOrganController()
+   * would only ever reach GOOrganController::OnClear(), never a subclass
+   * override, since C++ virtual dispatch during base-class destruction is
+   * restricted to the base class. */
   void Clear();
   /**
    * Exports organ combinations in the yaml file

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -136,6 +136,7 @@ void GOGuiOrgan::CloseOrgan() {
   m_OrganFileReady = false;
   GOMutexLocker locker(m_lock);
   if (m_OrganController) {
+    m_OrganController->Clear();
     delete m_OrganController;
     m_OrganController = 0;
   }

--- a/src/tests/common/GOTest.cpp
+++ b/src/tests/common/GOTest.cpp
@@ -48,6 +48,7 @@ bool GOCommonControllerTest::setUp() {
 bool GOCommonControllerTest::tearDown() {
   // Delete controller before resetting mp_config: ~GOOrganController() may
   // still read m_config, so mp_config must outlive it.
+  this->controller->Clear();
   delete this->controller;
   this->controller = nullptr;
   mp_config.reset();

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -187,6 +187,7 @@ void GOPerfTestApp::RunTest(
       wxLogError(wxT("Error: %s"), msg.c_str());
     }
 
+    organController->Clear();
     delete organController;
   } catch (wxString msg) {
     wxLogError(wxT("Error: %s"), msg.c_str());


### PR DESCRIPTION
Rename `LoadOrganGui`/`SaveOrganGui`/`ClearOrganGui` to `OnLoad`/`OnSave`/`OnClear` and make them virtual.

Bodies are unchanged and nothing overrides them yet, so this is a pure mechanical step with no behavior change - it prepares `GOOrganController` for a subclass to override the GUI phase via ordinary virtual dispatch, including through `GOSetter`'s direct `Save()` call which has no `GOGuiOrgan` in scope.