### PR TITLE
Fixed memory leak of GOCallbackButtonControl in GOVirtualCouplerController

### DIFF
--- a/src/grandorgue/GOVirtualCouplerController.cpp
+++ b/src/grandorgue/GOVirtualCouplerController.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,6 +14,17 @@
 #include "model/GOCoupler.h"
 #include "model/GOManual.h"
 #include "model/GOOrganModel.h"
+
+// The (defaulted) constructor and destructor can't be left implicit in the
+// header: GOCallbackButtonControl is only forward-declared there, and any
+// other translation unit implicitly constructing/destroying a
+// GOVirtualCouplerController (e.g. GOOrganController.cpp, which holds one as
+// a by-value member) would need std::unique_ptr<GOCallbackButtonControl>'s
+// constructor/deleter instantiated with an incomplete type. Declaring them
+// here and defining them in this .cpp, where the type is complete, keeps
+// that instantiation confined to this file.
+GOVirtualCouplerController::GOVirtualCouplerController() = default;
+GOVirtualCouplerController::~GOVirtualCouplerController() = default;
 
 static GOVirtualCouplerController::CouplerSetKey make_key(
   unsigned srcManualN, unsigned dstManualN) {
@@ -137,8 +148,11 @@ void GOVirtualCouplerController::Init(
         wxT("S%dM%dCM"),
         _("MEL"));
 
-      couplers.m_ButtonCoupleThrough
-        = new GOCallbackButtonControl(organModel, this, false, false);
+      // Not std::make_unique: it would convert `this` to GOButtonCallback*
+      // inside library code, outside this class's own scope, which fails
+      // since GOButtonCallback is a private base here.
+      couplers.m_ButtonCoupleThrough = std::unique_ptr<GOCallbackButtonControl>(
+        new GOCallbackButtonControl(organModel, this, false, false));
       couplers.m_ButtonCoupleThrough->SetContext(
         couplers.m_CouplersContext.get());
       couplers.m_ButtonCoupleThrough->Init(
@@ -156,7 +170,8 @@ void GOVirtualCouplerController::Load(
   GOOrganModel &organModel, GOConfigReader &cfg) {
   Init(organModel, cfg);
   for (auto &e : m_CouplerSets) {
-    GOCallbackButtonControl *pCoupleThrough = e.second.m_ButtonCoupleThrough;
+    GOCallbackButtonControl *pCoupleThrough
+      = e.second.m_ButtonCoupleThrough.get();
     bool isCoupleThrough = cfg.ReadBoolean(
       CMBSetting, pCoupleThrough->GetGroup(), WX_COUPLE_THROUGH, false, false);
 
@@ -166,7 +181,8 @@ void GOVirtualCouplerController::Load(
 
 void GOVirtualCouplerController::Save(GOConfigWriter &cfg) {
   for (auto &e : m_CouplerSets) {
-    GOCallbackButtonControl *pCoupleThrough = e.second.m_ButtonCoupleThrough;
+    GOCallbackButtonControl *pCoupleThrough
+      = e.second.m_ButtonCoupleThrough.get();
 
     cfg.WriteBoolean(
       pCoupleThrough->GetGroup(),
@@ -174,6 +190,10 @@ void GOVirtualCouplerController::Save(GOConfigWriter &cfg) {
       pCoupleThrough->IsEngaged());
   }
 }
+
+// Can't be inline in the header: m_CouplerSets.clear() destroys
+// m_ButtonCoupleThrough, needing the complete GOCallbackButtonControl type.
+void GOVirtualCouplerController::Cleanup() { m_CouplerSets.clear(); }
 
 GOCoupler *GOVirtualCouplerController::GetCoupler(
   unsigned fromManual, unsigned toManual, CouplerType type) const {
@@ -187,14 +207,14 @@ GOButtonControl *GOVirtualCouplerController::GetCouplerThrough(
   unsigned fromManual, unsigned toManual) const {
   const auto iter = m_CouplerSets.find(make_key(fromManual, toManual));
 
-  return iter != m_CouplerSets.end() ? iter->second.m_ButtonCoupleThrough
+  return iter != m_CouplerSets.end() ? iter->second.m_ButtonCoupleThrough.get()
                                      : nullptr;
 }
 
 void GOVirtualCouplerController::ButtonStateChanged(
   GOButtonControl *button, bool newState) {
   for (auto &e : m_CouplerSets)
-    if (e.second.m_ButtonCoupleThrough == button)
+    if (e.second.m_ButtonCoupleThrough.get() == button)
       for (auto pCoupler : e.second.m_CouplerPtrs) {
         pCoupler->SetRecursive(newState);
         pCoupler->RefreshState();

--- a/src/grandorgue/GOVirtualCouplerController.h
+++ b/src/grandorgue/GOVirtualCouplerController.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -44,13 +44,16 @@ public:
     std::unique_ptr<GOMidiObjectContext> m_CouplersContext;
     // indexed by CouplerType
     std::vector<GOCoupler *> m_CouplerPtrs;
-    GOCallbackButtonControl *m_ButtonCoupleThrough;
+    std::unique_ptr<GOCallbackButtonControl> m_ButtonCoupleThrough;
   };
 
 private:
   std::map<CouplerSetKey, CouplerSet> m_CouplerSets;
 
 public:
+  GOVirtualCouplerController();
+  ~GOVirtualCouplerController();
+
   void ButtonStateChanged(GOButtonControl *button, bool newState) override;
 
 public:
@@ -60,8 +63,10 @@ public:
   void Load(GOOrganModel &organModel, GOConfigReader &cfg);
   void Save(GOConfigWriter &cfg);
 
-  // Clears the couplers
-  void Cleanup() { m_CouplerSets.clear(); }
+  // Clears the couplers. Defined in the .cpp: destroying m_CouplerSets
+  // needs the complete GOCallbackButtonControl type, same reason as the
+  // destructor above.
+  void Cleanup();
 
   // Returns the coupler pointer
   GOCoupler *GetCoupler(


### PR DESCRIPTION
## Summary
- `ASAN_OPTIONS=detect_leaks=1 ./bin/GOTestExe --no-perf` reported 3520 bytes leaked in 15 allocations, all originating in `GOVirtualCouplerController::Init()`.
- `CouplerSet::m_ButtonCoupleThrough` was a raw `GOCallbackButtonControl *` with no owner, so it was never freed when the coupler sets were cleared or the controller destroyed.
- Changed it to `std::unique_ptr<GOCallbackButtonControl>`, matching the sibling `m_CouplersContext` field in the same struct. `GOCallbackButtonControl` stays forward-declared in the header, so the constructor, destructor, and `Cleanup()` are declared there and defined in the `.cpp` where the type is complete.

## Test plan
- [x] Built with `-DGO_BUILD_ASAN=ON -DGO_BUILD_TESTING=ON`
- [x] `ASAN_OPTIONS=detect_leaks=1 ./bin/GOTestExe --no-perf` — was reporting the leak above, now exits 0 with all 22 tests passing and no leak report
- [x] `ctest` — GOTestFunctional passes; GOTestPerf fails on throughput thresholds only, an expected artifact of ASAN instrumentation slowdown, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129Jz7ajVdYJf5Fs7zVNK5n