### PR TITLE
Detect memory leaks via LeakSanitizer in the functional tests CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - actions: "functional coverage"
+          - actions: "functional coverage asan"
             build_type: Debug
             coverage: "ON"
+            asan: "asan"
           - actions: "perf"
             build_type: Debug
             coverage: "OFF"
@@ -38,7 +39,7 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}
-        run: ${{github.workspace}}/build-scripts/for-linux/build-for-tests.sh amd64 ${{ matrix.build_type }} ${{ matrix.coverage }}
+        run: ${{github.workspace}}/build-scripts/for-linux/build-for-tests.sh amd64 ${{ matrix.build_type }} ${{ matrix.coverage }} ${{ matrix.asan }}
 
       - name: Run tests
         working-directory: ${{github.workspace}}

--- a/build-scripts/for-linux/do-tests.sh
+++ b/build-scripts/for-linux/do-tests.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# $@ - optional list of actions: functional, perf, tests, coverage, all (default: all)
+# $@ - optional list of actions: functional, perf, tests, coverage, asan, all (default: all)
 # Actions:
 #   functional - run functional tests (-R GOTestFunctional)
 #   perf       - run performance tests (-R GOTestPerf)
 #   tests      - run all tests without filter (no coverage)
 #   coverage   - run coverage steps (ctest -T coverage + gcovr)
+#   asan       - enable LeakSanitizer while running the tests above
 #   all        - run all tests without filter + coverage (default when no args)
 
 set -e
@@ -18,6 +19,7 @@ if [ "$1" = "--help" ] || [ "$1" = "-?" ]; then
     echo "  perf        Run performance tests (-R GOTestPerf)"
     echo "  tests       Run all tests without filter (no coverage)"
     echo "  coverage    Run coverage steps (ctest -T coverage + gcovr)"
+    echo "  asan        Enable LeakSanitizer while running the tests above"
     echo "  all         Run all tests + coverage (default when no args)"
     exit 0
 fi
@@ -31,6 +33,7 @@ IS_TESTS=false
 IS_FUNCTIONAL=false
 IS_PERF=false
 IS_COVERAGE=false
+IS_ASAN=false
 
 for ACTION in $ACTIONS; do
     case $ACTION in
@@ -39,8 +42,13 @@ for ACTION in $ACTIONS; do
         functional) IS_FUNCTIONAL=true ;;
         perf)       IS_PERF=true ;;
         coverage)   IS_COVERAGE=true ;;
+        asan)       IS_ASAN=true ;;
     esac
 done
+
+if $IS_ASAN; then
+    export ASAN_OPTIONS=detect_leaks=1
+fi
 
 # Print system information for performance test comparison
 echo "=========================================="


### PR DESCRIPTION
## Summary
- The `functional coverage` matrix entry of the `tests` job now also builds with `GO_BUILD_ASAN=ON` and runs with `ASAN_OPTIONS=detect_leaks=1`, so a leak like the one fixed in `GOVirtualCouplerController` (#2587) fails CI instead of only being caught by someone running ASAN locally.
- `do-tests.sh` gains an `asan` action token that exports `ASAN_OPTIONS=detect_leaks=1` before the `ctest` run, keeping that concern in the script rather than the workflow YAML.
- No other build script/CMake changes needed: `GO_BUILD_ASAN` (CMake) and the 4th `asan` arg to `build-for-tests.sh` already existed but were never wired up in the `tests` job.

## Test plan
- [x] Locally ran `build-scripts/for-linux/build-for-tests.sh amd64 Debug ON asan` — builds cleanly with coverage + ASAN combined
- [x] Locally ran `build-scripts/for-linux/do-tests.sh "functional coverage asan"` — exits 0, 20 tests succeeded, no LeakSanitizer report, `ASAN_OPTIONS` now set inside the script
- [ ] Confirm the new CI matrix entry runs green in GitHub Actions on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129Jz7ajVdYJf5Fs7zVNK5n