### PR TITLE
Extracted interaction with GOSoundOrganEngine from GOSoundSystem to the new class GOSoundCallbackConnector

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -237,6 +237,7 @@ sound/tasks/GOSoundReleaseTask.cpp
 sound/tasks/GOSoundTouchTask.cpp
 sound/tasks/GOSoundTremulantTask.cpp
 sound/tasks/GOSoundWindchestTask.cpp
+sound/GOSoundCallbackConnector.cpp
 sound/GOSoundDevInfo.cpp
 sound/GOSoundOrganEngine.cpp
 sound/GOSoundSystem.cpp

--- a/src/grandorgue/sound/GOSoundCallbackConnector.cpp
+++ b/src/grandorgue/sound/GOSoundCallbackConnector.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSoundCallbackConnector.h"
+
+#include <wx/intl.h>
+#include <wx/log.h>
+
+#include "buffer/GOSoundBufferMutable.h"
+#include "threading/GOMutexLocker.h"
+
+#include "GOSoundOrganEngine.h"
+
+void GOSoundCallbackConnector::ConnectToEngine(GOSoundOrganEngine &engine) {
+  OnBeforeConnectToEngine();
+  assert(engine.IsWorking());
+
+  engine.SetUsed(true);
+  m_NCallbacksEntered.store(0);
+  engine.SetStreaming(true);
+  p_OrganEngine.store(&engine);
+}
+
+void GOSoundCallbackConnector::DisconnectFromEngine(
+  GOSoundOrganEngine &engine) {
+  // Signal callbacks to stop by clearing the engine pointer
+  p_OrganEngine.store(nullptr);
+
+  // Unblock any callbacks waiting at [W1] and prevent new ones from blocking
+  engine.SetStreaming(false);
+
+  // wait for all started callbacks to finish
+  {
+    GOMutexLocker lock(m_CallbackMutex);
+
+    while (m_NCallbacksEntered.load() > 0)
+      m_CallbackCondition.WaitOrStop(
+        "GOSoundCallbackConnector::DisconnectFromEngine waits for all "
+        "callbacks to finish",
+        nullptr);
+  }
+
+  engine.SetUsed(false);
+  OnAfterDisconnectFromEngine();
+}
+
+bool GOSoundCallbackConnector::AudioCallback(
+  unsigned devIndex, GOSoundBufferMutable &outBuffer) {
+  bool wasEntered = false;
+  const unsigned nSamples = outBuffer.GetNFrames();
+
+  if (p_OrganEngine.load()) {
+    if (nSamples == m_SamplesPerBuffer) {
+      m_NCallbacksEntered.fetch_add(1);
+      wasEntered = true;
+    } else
+      wxLogError(
+        _("No sound output will happen. Samples per buffer has been "
+          "changed by the sound driver to %d"),
+        nSamples);
+  }
+  // assure that p_OrganEngine has not yet been changed after
+  // m_NCallbacksEntered.fetch_add, otherwise the control thread may not wait
+  GOSoundOrganEngine *pOrganEngine
+    = wasEntered ? p_OrganEngine.load() : nullptr;
+
+  if (pOrganEngine) {
+    if (pOrganEngine->ProcessAudioCallback(devIndex, outBuffer))
+      OnNewAudioPeriod();
+  } else
+    outBuffer.FillWithSilence();
+  if (
+    wasEntered && m_NCallbacksEntered.fetch_sub(1) <= 1
+    && !p_OrganEngine.load()) {
+    // ensure that the control thread enters into m_NCallbackCondition.Wait()
+    GOMutexLocker lk(m_CallbackMutex);
+
+    // notify the control thread
+    m_CallbackCondition.Broadcast();
+  }
+  return true;
+}

--- a/src/grandorgue/sound/GOSoundCallbackConnector.h
+++ b/src/grandorgue/sound/GOSoundCallbackConnector.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDCALLBACKCONNECTOR_H
+#define GOSOUNDCALLBACKCONNECTOR_H
+
+#include <atomic>
+
+#include "threading/GOCondition.h"
+#include "threading/GOMutex.h"
+
+class GOSoundBufferMutable;
+class GOSoundOrganEngine;
+
+/**
+ * Base class that manages the connection between audio ports and a
+ * GOSoundOrganEngine. Responsible for routing real-time audio callbacks
+ * to the currently connected engine and synchronizing engine
+ * connect/disconnect with the audio callback thread.
+ *
+ * GOSoundSystem inherits from this class and adds audio hardware
+ * management (ports, MIDI, recording).
+ */
+class GOSoundCallbackConnector {
+private:
+  std::atomic<GOSoundOrganEngine *> p_OrganEngine{nullptr};
+
+  // counter of audio callbacks that have been entered but have not yet been
+  // exited
+  std::atomic_uint m_NCallbacksEntered{0};
+
+  // For waiting for and notifying when m_NCallbacksEntered becomes 0
+  GOMutex m_CallbackMutex;
+  GOCondition m_CallbackCondition{m_CallbackMutex};
+
+  unsigned m_SamplesPerBuffer = 0;
+  unsigned m_SampleRate = 0;
+
+  /*
+   * Virtual hooks
+   */
+
+  /**
+   * Called by ConnectToEngine() before the engine pointer is stored.
+   * Override to add subclass-specific precondition checks.
+   */
+  virtual void OnBeforeConnectToEngine() {}
+
+  /**
+   * Called by DisconnectFromEngine() after all callbacks have exited
+   * and the engine has been fully disconnected.
+   * Override to perform cleanup in subclasses.
+   */
+  virtual void OnAfterDisconnectFromEngine() {}
+
+  /**
+   * Called by AudioCallback() each time a new audio period begins
+   * (i.e. when ProcessAudioCallback returns true for the last output).
+   * Override to update meters or perform other per-period tasks.
+   */
+  virtual void OnNewAudioPeriod() {}
+
+public:
+  /** Returns the number of audio frames per buffer used by the connected ports.
+   */
+  unsigned GetSamplesPerBuffer() const { return m_SamplesPerBuffer; }
+  void SetSamplesPerBuffer(unsigned nSamplesPerBuffer) {
+    m_SamplesPerBuffer = nSamplesPerBuffer;
+  }
+
+  /** Returns the audio sample rate in Hz used by the connected ports. */
+  unsigned GetSampleRate() const { return m_SampleRate; }
+  void SetSampleRate(unsigned sampleRate) { m_SampleRate = sampleRate; }
+
+  /** Returns true if an engine is currently connected. */
+  bool IsEngineConnected() const { return p_OrganEngine.load(); }
+
+  /*
+   * Engine connection
+   */
+
+  /**
+   * Connects the given engine to receive audio callbacks.
+   * The engine must be in the WORKING state (built but not yet used).
+   * Calls OnBeforeConnectToEngine() to allow subclasses to validate
+   * preconditions before the connection is established.
+   */
+  void ConnectToEngine(GOSoundOrganEngine &engine);
+
+  /**
+   * Disconnects the engine from audio callbacks and waits for all
+   * in-flight callbacks to finish before returning.
+   * Calls OnAfterDisconnectFromEngine() once all callbacks have exited.
+   */
+  void DisconnectFromEngine(GOSoundOrganEngine &engine);
+
+  /*
+   * Audio callback
+   */
+
+  /**
+   * Routes an audio callback from a sound port to the connected engine.
+   * If no engine is connected, fills the output buffer with silence.
+   * Thread-safe: may be called concurrently from multiple audio port
+   * callback threads.
+   * @return always true (keep the audio stream running)
+   */
+  bool AudioCallback(unsigned devIndex, GOSoundBufferMutable &outBuffer);
+};
+
+#endif

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -15,7 +15,6 @@
 #include "config/GOConfig.h"
 #include "config/GOPortsConfig.h"
 #include "ports/GOSoundPortFactory.h"
-#include "threading/GOMutexLocker.h"
 
 #include "GOEvent.h"
 #include "GOSoundDefs.h"
@@ -23,15 +22,10 @@
 
 GOSoundSystem::GOSoundSystem(GOConfig &settings)
   : m_config(settings),
-    p_OrganEngine(nullptr),
     p_CloseListener(nullptr),
     m_open(false),
     logSoundErrors(true),
-    m_SampleRate(0),
-    m_SamplesPerBuffer(0),
     m_DefaultAudioDevice(GOSoundDevInfo::getInvalideDeviceInfo()),
-    m_NCallbacksEntered(0),
-    m_CallbackCondition(m_CallbackMutex),
     meter_counter(0) {}
 
 GOSoundSystem::~GOSoundSystem() {
@@ -48,8 +42,8 @@ void GOSoundSystem::OpenSoundSystem() {
     = m_config.GetAudioDeviceConfig();
 
   m_LastErrorMessage = wxEmptyString;
-  m_SampleRate = m_config.SampleRate();
-  m_SamplesPerBuffer = m_config.SamplesPerBuffer();
+  SetSampleRate(m_config.SampleRate());
+  SetSamplesPerBuffer(m_config.SamplesPerBuffer());
   m_AudioRecorder.SetBytesPerSample(m_config.WaveFormatBytesPerSample());
 
   mp_SoundPorts.resize(audio_config.size());
@@ -69,7 +63,7 @@ void GOSoundSystem::OpenSoundSystem() {
       }
 
       GOSoundPort *pPort
-        = GOSoundPortFactory::create(portsConfig, this, *pNamePattern);
+        = GOSoundPortFactory::create(portsConfig, *this, *pNamePattern);
 
       if (!pPort)
         throw wxString::Format(
@@ -78,8 +72,8 @@ void GOSoundSystem::OpenSoundSystem() {
       mp_SoundPorts[i].reset(pPort);
       pPort->Init(
         deviceConfig.GetChannels(),
-        m_SampleRate,
-        m_SamplesPerBuffer,
+        GetSampleRate(),
+        GetSamplesPerBuffer(),
         deviceConfig.GetDesiredLatency(),
         i);
     }
@@ -88,7 +82,7 @@ void GOSoundSystem::OpenSoundSystem() {
     // m_IsRunning is set to true only in StartSoundSystem(), called after
     // OpenSoundSystem() completes.
     StartStreams();
-    m_AudioRecorder.SetSampleRate(m_SampleRate);
+    m_AudioRecorder.SetSampleRate(GetSampleRate());
     m_open = true;
   } catch (wxString &msg) {
     if (logSoundErrors)
@@ -117,7 +111,7 @@ void GOSoundSystem::StartStreams() {
   for (auto &pPort : mp_SoundPorts)
     pPort->Open();
 
-  if (m_SamplesPerBuffer > MAX_FRAME_SIZE)
+  if (GetSamplesPerBuffer() > MAX_FRAME_SIZE)
     throw wxString::Format(
       _("Cannot use buffer size above %d samples; "
         "unacceptable quantization would occur."),
@@ -138,7 +132,7 @@ void GOSoundSystem::AssureSoundIsClosed() {
     if (p_CloseListener) // The callback must call to DisconnectFromEngine()
       p_CloseListener->OnBeforeSoundClose();
 
-    assert(!p_OrganEngine.load());
+    assert(!IsEngineConnected());
 
     CloseSoundSystem();
   }
@@ -192,7 +186,7 @@ void GOSoundSystem::ResetMeters() {
 
 void GOSoundSystem::UpdateMeter() {
   /* Update meters */
-  meter_counter += m_SamplesPerBuffer;
+  meter_counter += GetSamplesPerBuffer();
   if (meter_counter >= 6144) // update 44100 / (N / 2) = ~14 times per second
   {
     wxCommandEvent event(wxEVT_METERS, 0);
@@ -203,81 +197,20 @@ void GOSoundSystem::UpdateMeter() {
   }
 }
 
-bool GOSoundSystem::AudioCallback(
-  unsigned devIndex, GOSoundBufferMutable &outBuffer) {
-  bool wasEntered = false;
-  const unsigned nSamples = outBuffer.GetNFrames();
-
-  if (p_OrganEngine.load()) {
-    if (nSamples == m_SamplesPerBuffer) {
-      m_NCallbacksEntered.fetch_add(1);
-      wasEntered = true;
-    } else
-      wxLogError(
-        _("No sound output will happen. Samples per buffer has been "
-          "changed by the sound driver to %d"),
-        nSamples);
-  }
-  // assure that p_OrganEngine has not yet been changed after
-  // m_NCallbacksEntered.fetch_add, otherwise the control thread may not wait
-  GOSoundOrganEngine *pOrganEngine
-    = wasEntered ? p_OrganEngine.load() : nullptr;
-
-  if (pOrganEngine) {
-    if (pOrganEngine->ProcessAudioCallback(devIndex, outBuffer))
-      UpdateMeter();
-  } else
-    outBuffer.FillWithSilence();
-  if (
-    wasEntered && m_NCallbacksEntered.fetch_sub(1) <= 1
-    && !p_OrganEngine.load()) {
-    // ensure that the control thread enters into m_NCallbackCondition.Wait()
-    GOMutexLocker lk(m_CallbackMutex);
-
-    // notify the control thread
-    m_CallbackCondition.Broadcast();
-  }
-  return true;
-}
-
 wxString GOSoundSystem::getState() {
   if (!mp_SoundPorts.size())
     return _("No sound output occurring");
   wxString result = wxString::Format(
-    _("%d samples per buffer, %d Hz\n"), m_SamplesPerBuffer, m_SampleRate);
+    _("%d samples per buffer, %d Hz\n"),
+    GetSamplesPerBuffer(),
+    GetSampleRate());
 
   for (auto &pPort : mp_SoundPorts)
     result = result + _("\n") + pPort->getPortState();
   return result;
 }
 
-void GOSoundSystem::ConnectToEngine(GOSoundOrganEngine &engine) {
+void GOSoundSystem::OnBeforeConnectToEngine() {
   assert(m_open);
   assert(p_CloseListener);
-  assert(engine.IsWorking());
-
-  engine.SetUsed(true);
-  m_NCallbacksEntered.store(0);
-  engine.SetStreaming(true);
-  p_OrganEngine.store(&engine);
-}
-
-void GOSoundSystem::DisconnectFromEngine(GOSoundOrganEngine &engine) {
-  // Signal callbacks to stop by clearing the engine pointer
-  p_OrganEngine.store(nullptr);
-
-  // Unblock any callbacks waiting at [W1] and prevent new ones from blocking
-  engine.SetStreaming(false);
-
-  // wait for all started callbacks to finish
-  {
-    GOMutexLocker lock(m_CallbackMutex);
-
-    while (m_NCallbacksEntered.load() > 0)
-      m_CallbackCondition.WaitOrStop(
-        "GOSoundSystem::DisconnectFromEngine waits for all callbacks to finish",
-        nullptr);
-  }
-
-  engine.SetUsed(false);
 }

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -8,25 +8,21 @@
 #ifndef GOSOUNDSYSTEM_H
 #define GOSOUNDSYSTEM_H
 
-#include <atomic>
 #include <memory>
 #include <vector>
 
 #include <wx/string.h>
 
 #include "tasks/GOSoundRecorderTask.h"
-#include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
 
+#include "GOSoundCallbackConnector.h"
 #include "GOSoundCloseListener.h"
 #include "GOSoundDevInfo.h"
-
-class GOSoundOrganEngine;
 
 class GOConfig;
 class GODeviceNamePattern;
 class GOPortsConfig;
-class GOSoundBufferMutable;
 class GOSoundPort;
 
 /**
@@ -34,32 +30,21 @@ class GOSoundPort;
  * without a loaded organ
  */
 
-class GOSoundSystem {
+class GOSoundSystem : public GOSoundCallbackConnector {
 private:
   GOConfig &m_config;
 
   GOSoundRecorderTask m_AudioRecorder;
-  std::atomic<GOSoundOrganEngine *> p_OrganEngine;
 
   GOSoundCloseListener *p_CloseListener;
 
   bool m_open;
   bool logSoundErrors;
-  unsigned m_SampleRate;
-  unsigned m_SamplesPerBuffer;
   std::vector<std::unique_ptr<GOSoundPort>> mp_SoundPorts;
 
   wxString m_LastErrorMessage;
 
   GOSoundDevInfo m_DefaultAudioDevice;
-
-  // counter of audio callbacks that have been entered but have not yet been
-  // exited
-  std::atomic_uint m_NCallbacksEntered;
-
-  // For waiting for and notifying when m_NCallbacksEntered bacomes 0
-  GOMutex m_CallbackMutex;
-  GOCondition m_CallbackCondition;
 
   GOMutex m_lock;
 
@@ -74,6 +59,10 @@ private:
   void OpenSoundSystem();
   /** Close and delete audio ports, reset meters, mark system as closed */
   void CloseSoundSystem();
+
+protected:
+  void OnBeforeConnectToEngine() override;
+  void OnNewAudioPeriod() override { UpdateMeter(); }
 
 public:
   static void FillDeviceNamePattern(
@@ -93,8 +82,6 @@ public:
   /** Returns the audio recorder associated with this sound system. */
   GOSoundRecorderTask &GetAudioRecorder() { return m_AudioRecorder; }
 
-  unsigned GetSampleRate() const { return m_SampleRate; }
-  unsigned GetSamplesPerBuffer() const { return m_SamplesPerBuffer; }
   wxString getState();
 
   void SetLogSoundErrorMessages(bool isVisible) { logSoundErrors = isVisible; }
@@ -110,11 +97,6 @@ public:
 
   bool AssureSoundIsOpen();
   void AssureSoundIsClosed();
-
-  bool AudioCallback(unsigned devIndex, GOSoundBufferMutable &outBuffer);
-
-  void ConnectToEngine(GOSoundOrganEngine &engine);
-  void DisconnectFromEngine(GOSoundOrganEngine &engine);
 };
 
 #endif

--- a/src/grandorgue/sound/ports/GOSoundJackPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundJackPort.cpp
@@ -16,8 +16,9 @@
 
 const wxString GOSoundJackPort::PORT_NAME = wxT("Jack");
 
-GOSoundJackPort::GOSoundJackPort(GOSoundSystem *sound, wxString name)
-  : GOSoundPort(sound, name) {}
+GOSoundJackPort::GOSoundJackPort(
+  GOSoundCallbackConnector &callbackConnector, const wxString &name)
+  : GOSoundPort(callbackConnector, name) {}
 
 GOSoundJackPort::~GOSoundJackPort() { Close(); }
 
@@ -170,7 +171,7 @@ static const wxString OLD_STYLE_NAME = wxT("Jack Output");
 
 GOSoundPort *GOSoundJackPort::create(
   const GOPortsConfig &portsConfig,
-  GOSoundSystem *sound,
+  GOSoundCallbackConnector &callbackConnector,
   GODeviceNamePattern &pattern) {
   GOSoundPort *pPort = nullptr;
 #if defined(GO_USE_JACK)
@@ -183,7 +184,7 @@ GOSoundPort *GOSoundJackPort::create(
       || pattern.DoesMatch(devName + GOPortFactory::c_NameDelim)
       || pattern.DoesMatch(OLD_STYLE_NAME))) {
     pattern.SetPhysicalName(devName);
-    pPort = new GOSoundJackPort(sound, devName);
+    pPort = new GOSoundJackPort(callbackConnector, devName);
   }
 #endif
   return pPort;

--- a/src/grandorgue/sound/ports/GOSoundJackPort.h
+++ b/src/grandorgue/sound/ports/GOSoundJackPort.h
@@ -29,7 +29,8 @@ class GOSoundJackPort : public GOSoundPort {
 public:
   static const wxString PORT_NAME;
 
-  GOSoundJackPort(GOSoundSystem *sound, wxString name);
+  GOSoundJackPort(
+    GOSoundCallbackConnector &callbackConnector, const wxString &name);
   ~GOSoundJackPort();
 
 #if defined(GO_USE_JACK)
@@ -60,7 +61,7 @@ public:
   }
   static GOSoundPort *create(
     const GOPortsConfig &portsConfig,
-    GOSoundSystem *sound,
+    GOSoundCallbackConnector &callbackConnector,
     GODeviceNamePattern &pattern);
   static void addDevices(
     const GOPortsConfig &portsConfig, std::vector<GOSoundDevInfo> &list);

--- a/src/grandorgue/sound/ports/GOSoundPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundPort.cpp
@@ -10,11 +10,12 @@
 #include <wx/intl.h>
 #include <wx/thread.h>
 
-#include "sound/GOSoundSystem.h"
+#include "sound/GOSoundCallbackConnector.h"
 #include "sound/buffer/GOSoundBufferMutable.h"
 
-GOSoundPort::GOSoundPort(GOSoundSystem *sound, wxString name)
-  : m_Sound(sound),
+GOSoundPort::GOSoundPort(
+  GOSoundCallbackConnector &callbackConnector, const wxString &name)
+  : r_CallbackConnector(callbackConnector),
     m_Index(0),
     m_IsOpen(false),
     m_Name(name),
@@ -48,7 +49,7 @@ void GOSoundPort::SetActualLatency(double latency) {
 }
 
 bool GOSoundPort::AudioCallback(GOSoundBufferMutable &outputBuffer) {
-  return m_Sound->AudioCallback(m_Index, outputBuffer);
+  return r_CallbackConnector.AudioCallback(m_Index, outputBuffer);
 }
 
 const wxString &GOSoundPort::GetName() { return m_Name; }

--- a/src/grandorgue/sound/ports/GOSoundPort.h
+++ b/src/grandorgue/sound/ports/GOSoundPort.h
@@ -15,11 +15,11 @@
 #include "config/GOPortsConfig.h"
 
 class GOSoundBufferMutable;
-class GOSoundSystem;
+class GOSoundCallbackConnector;
 
 class GOSoundPort {
 protected:
-  GOSoundSystem *m_Sound;
+  GOSoundCallbackConnector &r_CallbackConnector;
   unsigned m_Index;
   bool m_IsOpen;
   wxString m_Name;
@@ -33,7 +33,8 @@ protected:
   bool AudioCallback(GOSoundBufferMutable &outputBuffer);
 
 public:
-  GOSoundPort(GOSoundSystem *sound, wxString name);
+  GOSoundPort(
+    GOSoundCallbackConnector &callbackConnector, const wxString &name);
   virtual ~GOSoundPort();
 
   void Init(

--- a/src/grandorgue/sound/ports/GOSoundPortFactory.cpp
+++ b/src/grandorgue/sound/ports/GOSoundPortFactory.cpp
@@ -43,7 +43,7 @@ enum { SUBSYS_PA_BIT = 1, SUBSYS_RT_BIT = 2, SUBSYS_JACK_BIT = 4 };
 
 GOSoundPort *GOSoundPortFactory::create(
   const GOPortsConfig &portsConfig,
-  GOSoundSystem *sound,
+  GOSoundCallbackConnector &callbackConnector,
   GODeviceNamePattern &pattern) {
   GOSoundPort *port = NULL;
   const wxString &patternPort = pattern.GetPortName();
@@ -68,15 +68,16 @@ GOSoundPort *GOSoundPortFactory::create(
   if (
     port == NULL && (portMask & SUBSYS_PA_BIT)
     && portsConfig.IsEnabled(GOSoundPortaudioPort::PORT_NAME))
-    port = GOSoundPortaudioPort::create(portsConfig, sound, pattern);
+    port
+      = GOSoundPortaudioPort::create(portsConfig, callbackConnector, pattern);
   if (
     port == NULL && (portMask & SUBSYS_RT_BIT)
     && portsConfig.IsEnabled(GOSoundRtPort::PORT_NAME))
-    port = GOSoundRtPort::create(portsConfig, sound, pattern);
+    port = GOSoundRtPort::create(portsConfig, callbackConnector, pattern);
   if (
     port == NULL && (portMask & SUBSYS_JACK_BIT)
     && portsConfig.IsEnabled(GOSoundJackPort::PORT_NAME))
-    port = GOSoundJackPort::create(portsConfig, sound, pattern);
+    port = GOSoundJackPort::create(portsConfig, callbackConnector, pattern);
   return port;
 }
 

--- a/src/grandorgue/sound/ports/GOSoundPortFactory.h
+++ b/src/grandorgue/sound/ports/GOSoundPortFactory.h
@@ -15,6 +15,7 @@
 
 class GODeviceNamePattern;
 class GOPortsConfig;
+class GOSoundCallbackConnector;
 class GOSoundPort;
 
 class GOSoundPortFactory : public GOPortFactory {
@@ -26,7 +27,7 @@ public:
     const GOPortsConfig &portsConfig);
   static GOSoundPort *create(
     const GOPortsConfig &portsConfig,
-    GOSoundSystem *sound,
+    GOSoundCallbackConnector &callbackConnector,
     GODeviceNamePattern &name);
 
   static GOSoundPortFactory &getInstance();

--- a/src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundPortaudioPort.cpp
@@ -38,8 +38,12 @@ wxString GOSoundPortaudioPort::getLastError(PaError error) {
 }
 
 GOSoundPortaudioPort::GOSoundPortaudioPort(
-  GOSoundSystem *sound, unsigned paDevIndex, const wxString &name)
-  : GOSoundPort(sound, name), m_PaDevIndex(paDevIndex), m_stream(nullptr) {}
+  GOSoundCallbackConnector &callbackConnector,
+  unsigned paDevIndex,
+  const wxString &name)
+  : GOSoundPort(callbackConnector, name),
+    m_PaDevIndex(paDevIndex),
+    m_stream(nullptr) {}
 
 GOSoundPortaudioPort::~GOSoundPortaudioPort() { Close(); }
 
@@ -147,7 +151,7 @@ void GOSoundPortaudioPort::terminate() {
 
 GOSoundPort *GOSoundPortaudioPort::create(
   const GOPortsConfig &portsConfig,
-  GOSoundSystem *sound,
+  GOSoundCallbackConnector &callbackConnector,
   GODeviceNamePattern &pattern) {
   GOSoundPort *pPort = nullptr;
 
@@ -165,7 +169,7 @@ GOSoundPort *GOSoundPortaudioPort::create(
 	  || pattern.DoesMatch(get_oldstyle_name(i))
 	  || pattern.DoesMatch(compose_device_name(PORT_NAME_OLD, pInfo)))) {
         pattern.SetPhysicalName(devName);
-        pPort = new GOSoundPortaudioPort(sound, i, devName);
+        pPort = new GOSoundPortaudioPort(callbackConnector, i, devName);
         break;
       }
     }

--- a/src/grandorgue/sound/ports/GOSoundPortaudioPort.h
+++ b/src/grandorgue/sound/ports/GOSoundPortaudioPort.h
@@ -32,7 +32,9 @@ public:
   static const wxString PORT_NAME_OLD;
 
   GOSoundPortaudioPort(
-    GOSoundSystem *sound, unsigned paDevIndex, const wxString &name);
+    GOSoundCallbackConnector &callbackConnector,
+    unsigned paDevIndex,
+    const wxString &name);
   virtual ~GOSoundPortaudioPort();
 
   void Open();
@@ -45,7 +47,7 @@ public:
 
   static GOSoundPort *create(
     const GOPortsConfig &portsConfig,
-    GOSoundSystem *sound,
+    GOSoundCallbackConnector &callbackConnector,
     GODeviceNamePattern &pattern);
   static void addDevices(
     const GOPortsConfig &portsConfig, std::vector<GOSoundDevInfo> &list);

--- a/src/grandorgue/sound/ports/GOSoundRtPort.cpp
+++ b/src/grandorgue/sound/ports/GOSoundRtPort.cpp
@@ -18,8 +18,11 @@ const wxString GOSoundRtPort::PORT_NAME = wxT("RtAudio");
 const wxString GOSoundRtPort::PORT_NAME_OLD = wxT("Rt");
 
 GOSoundRtPort::GOSoundRtPort(
-  GOSoundSystem *sound, RtAudio *rtApi, unsigned rtDevId, const wxString &name)
-  : GOSoundPort(sound, name),
+  GOSoundCallbackConnector &callbackConnector,
+  RtAudio *rtApi,
+  unsigned rtDevId,
+  const wxString &name)
+  : GOSoundPort(callbackConnector, name),
     m_rtApi(rtApi),
     m_RtDevId(rtDevId),
     m_nBuffers(0) {}
@@ -205,7 +208,7 @@ const std::vector<wxString> &GOSoundRtPort::getApis() {
 
 GOSoundPort *GOSoundRtPort::create(
   const GOPortsConfig &portsConfig,
-  GOSoundSystem *sound,
+  GOSoundCallbackConnector &callbackConnector,
   GODeviceNamePattern &pattern) {
   GOSoundRtPort *port = NULL;
 
@@ -248,7 +251,8 @@ GOSoundPort *GOSoundRtPort::create(
                // usb)
             info.outputChannels > 0) {
             pattern.SetPhysicalName(devName);
-            port = new GOSoundRtPort(sound, rtApi, deviceId, devName);
+            port
+              = new GOSoundRtPort(callbackConnector, rtApi, deviceId, devName);
             break;
           }
         }

--- a/src/grandorgue/sound/ports/GOSoundRtPort.h
+++ b/src/grandorgue/sound/ports/GOSoundRtPort.h
@@ -33,7 +33,7 @@ private:
   bool processRtResult(RtAudioErrorType rtResult, bool isToThrowOnError = true);
 
   GOSoundRtPort(
-    GOSoundSystem *sound,
+    GOSoundCallbackConnector &callbackConnector,
     RtAudio *rtApi,
     unsigned rtDevIndex,
     const wxString &name);
@@ -52,7 +52,7 @@ public:
   static const std::vector<wxString> &getApis();
   static GOSoundPort *create(
     const GOPortsConfig &portsConfig,
-    GOSoundSystem *sound,
+    GOSoundCallbackConnector &callbackConnector,
     GODeviceNamePattern &pattern);
   static void addDevices(
     const GOPortsConfig &portsConfig, std::vector<GOSoundDevInfo> &list);

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -20,7 +20,9 @@
 #include "testing/model/GOTestOrganModel.h"
 #include "testing/model/GOTestSwitch.h"
 #include "testing/model/GOTestWindchest.h"
+#include "testing/sound/GOTestSoundCallbackConnector.h"
 #include "testing/sound/GOTestSoundOrganEngine.h"
+#include "testing/sound/GOTestSoundOrganEngineStress.h"
 #include "testing/sound/buffer/GOTestPerfSoundBufferMutable.h"
 #include "testing/sound/buffer/GOTestSoundBuffer.h"
 #include "testing/sound/buffer/GOTestSoundBufferManaged.h"
@@ -70,6 +72,8 @@ int main(int argc, char *argv[]) {
   GOTestReleaseAlignTable testReleaseAlignTable;
   GOTestSoundStream testSoundStream;
   GOTestSoundOrganEngine testSoundOrganEngine;
+  GOTestSoundCallbackConnector testSoundCallbackConnector;
+  GOTestSoundOrganEngineStress testSoundOrganEngineStress;
   /* end of instanciation */
   GOTestResultCollection test_result_collection;
   test_result_collection = GOTestCollection::Instance()->Run(categoryFilter);

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -18,6 +18,8 @@ set(go_tests
     sound/playing/GOTestSoundStream.cpp
     sound/GOTestSoundOrganEngineBase.cpp
     sound/GOTestSoundOrganEngine.cpp
+    sound/GOTestSoundCallbackConnector.cpp
+    sound/GOTestSoundOrganEngineStress.cpp
     GOTestNameMap.cpp
     GOTestOrganController.cpp
 )

--- a/src/tests/testing/sound/GOTestSoundCallbackConnector.cpp
+++ b/src/tests/testing/sound/GOTestSoundCallbackConnector.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundCallbackConnector.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "sound/GOSoundCallbackConnector.h"
+#include "sound/GOSoundOrganEngine.h"
+#include "sound/buffer/GOSoundBufferMutable.h"
+
+const std::string GOTestSoundCallbackConnector::TEST_NAME
+  = "GOTestSoundCallbackConnector";
+
+static struct TestConnector : public GOSoundCallbackConnector {
+  std::atomic_uint m_NConnects{0};
+  std::atomic_uint m_NDisconnects{0};
+  std::atomic_uint m_NNewPeriods{0};
+
+  void OnBeforeConnectToEngine() override { m_NConnects.fetch_add(1); }
+  void OnAfterDisconnectFromEngine() override { m_NDisconnects.fetch_add(1); }
+  void OnNewAudioPeriod() override { m_NNewPeriods.fetch_add(1); }
+
+  void Setup(unsigned nSamplesPerBuffer, unsigned sampleRate) {
+    m_NConnects.store(0);
+    m_NDisconnects.store(0);
+    m_NNewPeriods.store(0);
+    SetSamplesPerBuffer(nSamplesPerBuffer);
+    SetSampleRate(sampleRate);
+  }
+} testConnector;
+
+void GOTestSoundCallbackConnector::TestSilenceWithoutEngine() {
+  std::atomic_bool isRunning{true};
+
+  auto threadBody = [&]() {
+    for (unsigned iterI = 0; iterI < 100; ++iterI) {
+      GO_DECLARE_LOCAL_SOUND_BUFFER(
+        buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+      m_connector.AudioCallback(0, buf);
+
+      const float *pData = buf.GetData();
+      const unsigned nItems = buf.GetNItems();
+      bool isSilent = true;
+
+      for (unsigned itemI = 0; itemI < nItems; ++itemI) {
+        if (pData[itemI] != 0.0f) {
+          isSilent = false;
+          break;
+        }
+      }
+
+      GOAssert(isSilent, "AudioCallback without engine should produce silence");
+    }
+  };
+
+  std::thread t1(threadBody);
+  std::thread t2(threadBody);
+  std::thread t3(threadBody);
+  std::thread t4(threadBody);
+
+  t1.join();
+  t2.join();
+  t3.join();
+  t4.join();
+}
+
+void GOTestSoundCallbackConnector::TestConnectDisconnectLifecycle() {
+  testConnector.Setup(N_SAMPLES_PER_BUFFER, SAMPLE_RATE);
+
+  GOSoundOrganEngine &engine = BuildAndStartEngine(
+    /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 2);
+
+  for (unsigned cycleI = 0; cycleI < 2; ++cycleI) {
+    testConnector.ConnectToEngine(engine);
+
+    GOAssert(
+      testConnector.m_NConnects.load() == cycleI + 1,
+      "OnBeforeConnectToEngine should be called once per connect");
+
+    testConnector.DisconnectFromEngine(engine);
+
+    GOAssert(
+      testConnector.m_NDisconnects.load() == cycleI + 1,
+      "OnAfterDisconnectFromEngine should be called once per disconnect");
+  }
+
+  StopAndDestroyEngine();
+}
+
+void GOTestSoundCallbackConnector::TestAsyncCallbacksXrun() {
+  GOSoundOrganEngine &engine = BuildAndStartEngine(
+    /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 1);
+
+  m_connector.ConnectToEngine(engine);
+
+  std::atomic_bool isRunning{true};
+
+  auto threadBody = [&]() {
+    while (isRunning.load()) {
+      GO_DECLARE_LOCAL_SOUND_BUFFER(
+        buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+      m_connector.AudioCallback(0, buf);
+    }
+  };
+
+  std::thread t1(threadBody);
+  std::thread t2(threadBody);
+  std::thread t3(threadBody);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  m_connector.DisconnectFromEngine(engine);
+
+  isRunning.store(false);
+  t1.join();
+  t2.join();
+  t3.join();
+
+  StopAndDestroyEngine();
+}
+
+void GOTestSoundCallbackConnector::TestConnectDisconnectCyclesAsyncCallbacks() {
+  GOSoundOrganEngine &engine = BuildAndStartEngine(
+    /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 2);
+
+  std::atomic_bool isRunning{true};
+
+  auto threadBody = [&]() {
+    while (isRunning.load()) {
+      GO_DECLARE_LOCAL_SOUND_BUFFER(
+        buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+      m_connector.AudioCallback(0, buf);
+    }
+  };
+
+  std::thread t1(threadBody);
+  std::thread t2(threadBody);
+
+  for (unsigned cycleI = 0; cycleI < 30; ++cycleI) {
+    m_connector.ConnectToEngine(engine);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    m_connector.DisconnectFromEngine(engine);
+  }
+
+  isRunning.store(false);
+  t1.join();
+  t2.join();
+
+  StopAndDestroyEngine();
+}
+
+void GOTestSoundCallbackConnector::TestDisconnectWaitsAsyncCallbacks() {
+  GOSoundOrganEngine &engine = BuildAndStartEngine(
+    /* nAudioGroups */ 1, /* nAuxThreads */ 0, /* nOutputs */ 2);
+
+  m_connector.ConnectToEngine(engine);
+
+  std::atomic_bool isRunning{true};
+
+  auto threadBody = [&]() {
+    while (isRunning.load()) {
+      GO_DECLARE_LOCAL_SOUND_BUFFER(
+        buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+      m_connector.AudioCallback(0, buf);
+    }
+  };
+
+  std::thread t1(threadBody);
+  std::thread t2(threadBody);
+  std::thread t3(threadBody);
+  std::thread t4(threadBody);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+  m_connector.DisconnectFromEngine(engine);
+
+  isRunning.store(false);
+  t1.join();
+  t2.join();
+  t3.join();
+  t4.join();
+
+  StopAndDestroyEngine();
+}
+
+void GOTestSoundCallbackConnector::run() {
+  TestSilenceWithoutEngine();
+  TestConnectDisconnectLifecycle();
+  TestAsyncCallbacksXrun();
+  TestConnectDisconnectCyclesAsyncCallbacks();
+  TestDisconnectWaitsAsyncCallbacks();
+}

--- a/src/tests/testing/sound/GOTestSoundCallbackConnector.h
+++ b/src/tests/testing/sound/GOTestSoundCallbackConnector.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDCALLBACKCONNECTOR_H
+#define GOTESTSOUNDCALLBACKCONNECTOR_H
+
+#include "GOTestSoundOrganEngineBase.h"
+
+class GOTestSoundCallbackConnector : public GOTestSoundOrganEngineBase {
+private:
+  static const std::string TEST_NAME;
+
+  void TestSilenceWithoutEngine();
+  void TestConnectDisconnectLifecycle();
+  void TestAsyncCallbacksXrun();
+  void TestConnectDisconnectCyclesAsyncCallbacks();
+  void TestDisconnectWaitsAsyncCallbacks();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTSOUNDCALLBACKCONNECTOR_H */

--- a/src/tests/testing/sound/GOTestSoundOrganEngineBase.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineBase.cpp
@@ -11,6 +11,11 @@
 
 #include "sound/GOSoundOrganEngine.h"
 
+GOTestSoundOrganEngineBase::GOTestSoundOrganEngineBase() {
+  m_connector.SetSamplesPerBuffer(N_SAMPLES_PER_BUFFER);
+  m_connector.SetSampleRate(SAMPLE_RATE);
+}
+
 GOSoundOrganEngine &GOTestSoundOrganEngineBase::BuildAndStartEngine(
   unsigned nAudioGroups, unsigned nAuxThreads, unsigned nOutputs) {
   GOSoundOrganEngine &engine = controller->GetSoundEngine();

--- a/src/tests/testing/sound/GOTestSoundOrganEngineBase.h
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineBase.h
@@ -10,6 +10,7 @@
 
 #include "GOTest.h"
 
+#include "sound/GOSoundCallbackConnector.h"
 #include "sound/tasks/GOSoundRecorderTask.h"
 
 class GOSoundOrganEngine;
@@ -34,6 +35,10 @@ private:
   GOSoundRecorderTask m_recorder;
 
 protected:
+  GOSoundCallbackConnector m_connector;
+
+  GOTestSoundOrganEngineBase();
+
   /*
    * Configures and starts the engine with the given parameters.
    * Asserts that the engine is WORKING and not USED after start.

--- a/src/tests/testing/sound/GOTestSoundOrganEngineStress.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineStress.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundOrganEngineStress.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "sound/GOSoundCallbackConnector.h"
+#include "sound/GOSoundOrganEngine.h"
+#include "sound/buffer/GOSoundBufferMutable.h"
+
+const std::string GOTestSoundOrganEngineStress::TEST_NAME
+  = "GOTestSoundOrganEngineStress";
+
+void GOTestSoundOrganEngineStress::RunCallbackThreads(
+  std::atomic_bool &isRunning, std::vector<std::thread> &outThreads) {
+  auto makeThread = [&](unsigned outputI) {
+    return std::thread([&, outputI]() {
+      while (isRunning.load()) {
+        GO_DECLARE_LOCAL_SOUND_BUFFER(
+          buf, N_OUTPUT_CHANNELS, N_SAMPLES_PER_BUFFER);
+
+        m_connector.AudioCallback(outputI, buf);
+      }
+    });
+  };
+
+  outThreads.push_back(makeThread(0));
+  outThreads.push_back(makeThread(0));
+  outThreads.push_back(makeThread(1));
+  outThreads.push_back(makeThread(2));
+  outThreads.push_back(makeThread(2));
+}
+
+void GOTestSoundOrganEngineStress::TestConnectDisconnectCycles() {
+  GOSoundOrganEngine &engine = BuildAndStartEngine(
+    /* nAudioGroups */ 2, /* nAuxThreads */ 3, /* nOutputs */ 3);
+
+  std::atomic_bool isRunning{true};
+  std::vector<std::thread> threads;
+
+  RunCallbackThreads(isRunning, threads);
+
+  for (unsigned cycleI = 0; cycleI < 100; ++cycleI) {
+    m_connector.ConnectToEngine(engine);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    m_connector.DisconnectFromEngine(engine);
+  }
+
+  isRunning.store(false);
+  for (std::thread &t : threads)
+    t.join();
+
+  StopAndDestroyEngine();
+}
+
+void GOTestSoundOrganEngineStress::TestBuildStopCycles() {
+  std::atomic_bool isRunning{true};
+  std::vector<std::thread> threads;
+
+  RunCallbackThreads(isRunning, threads);
+
+  for (unsigned cycleI = 0; cycleI < 100; ++cycleI) {
+    GOSoundOrganEngine &engine = BuildAndStartEngine(
+      /* nAudioGroups */ 2, /* nAuxThreads */ 3, /* nOutputs */ 3);
+
+    m_connector.ConnectToEngine(engine);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    m_connector.DisconnectFromEngine(engine);
+
+    StopAndDestroyEngine();
+  }
+
+  isRunning.store(false);
+  for (std::thread &t : threads)
+    t.join();
+}
+
+void GOTestSoundOrganEngineStress::run() {
+  TestConnectDisconnectCycles();
+  TestBuildStopCycles();
+}

--- a/src/tests/testing/sound/GOTestSoundOrganEngineStress.h
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineStress.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDORGANENGINESTRESS_H
+#define GOTESTSOUNDORGANENGINESTRESS_H
+
+#include "GOTestSoundOrganEngineBase.h"
+
+class GOTestSoundOrganEngineStress : public GOTestSoundOrganEngineBase {
+private:
+  static const std::string TEST_NAME;
+
+  /*
+   * Starts 5 callback threads via m_Connector:
+   *   threads 0, 1 → output 0 (xrun)
+   *   thread 2     → output 1
+   *   threads 3, 4 → output 2 (xrun)
+   * Threads run until isRunning is set to false.
+   */
+  void RunCallbackThreads(
+    std::atomic_bool &isRunning, std::vector<std::thread> &outThreads);
+
+  /*
+   * Builds engine once (3out/2g/3aux), then runs 100 connect/disconnect cycles
+   * with 2ms sleep under xrun load from 5 threads.
+   */
+  void TestConnectDisconnectCycles();
+
+  /*
+   * Runs 100 build/connect/disconnect/stop cycles with 2ms sleep
+   * under xrun load from 5 threads.
+   */
+  void TestBuildStopCycles();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTSOUNDORGANENGINESTRESS_H */


### PR DESCRIPTION
## Summary
- Extracted the audio-callback routing and engine connect/disconnect synchronization logic from `GOSoundSystem` into a new base class `GOSoundCallbackConnector` (`src/grandorgue/sound/GOSoundCallbackConnector.{h,cpp}`).
- `GOSoundSystem` now inherits from `GOSoundCallbackConnector` instead of owning this logic directly, keeping port management and MIDI/audio device concerns separate from the engine-connection concern.
- Added `GOTestSoundCallbackConnector` covering the new class in isolation.

## Test plan
- [x] `cmake -DCMAKE_BUILD_TYPE=Debug -DGO_BUILD_TESTING=ON -DGO_BUILD_ASAN=ON ...` then `make -k -j16` — builds cleanly
- [x] `ASAN_OPTIONS=detect_leaks=1 ./bin/GOTestExe --no-perf` — all 22 tests pass, no leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)