### PR TITLE
Renamed class members and local variables according to the convention: gain is measured in dB and amplitude is a linear coefficient

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -293,7 +293,7 @@ void GOOrganController::LoadOrganCoreData(GOConfigReader &cfg) {
   int volume = cfg.ReadInteger(
     CMBSetting, WX_ORGAN, wxT("Volume"), -120, 100, false, m_config.Volume());
 
-  m_SoundEngine.SetVolume(volume > 20 ? 0 : volume);
+  m_SoundEngine.SetGain(volume > 20 ? 0 : volume);
   m_Temperament
     = cfg.ReadString(CMBSetting, WX_ORGAN, wxT("Temperament"), false);
 
@@ -699,7 +699,7 @@ void GOOrganController::SaveOrganCoreData(GOConfigWriter &cfg) {
     cfg.WriteString(
       WX_ORGAN, wxT("ArchiveID"), m_ConfiguredOrgan.GetArchiveID());
   cfg.WriteString(WX_ORGAN, WX_GRANDORGUE_VERSION, wxT(APP_VERSION));
-  cfg.WriteInteger(WX_ORGAN, wxT("Volume"), m_SoundEngine.GetVolume());
+  cfg.WriteInteger(WX_ORGAN, wxT("Volume"), m_SoundEngine.GetGain());
   cfg.WriteString(WX_ORGAN, wxT("Temperament"), m_Temperament);
 
   GOEventDistributor::Save(cfg);

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -265,9 +265,9 @@ public:
     const wxString &filename,
     const GOConfig::MidiChannelMappingChooser &chooseMapping);
 
-  int GetVolume() const { return m_SoundEngine.GetVolume(); }
-  /** Sets the master volume and forwards it to the sound engine. */
-  void SetVolume(int volume) { m_SoundEngine.SetVolume(volume); }
+  int GetGain() const { return m_SoundEngine.GetGain(); }
+  /** Sets the master gain and forwards it to the sound engine. */
+  void SetGain(int gain) { m_SoundEngine.SetGain(gain); }
 
   /** Returns true if the sound engine is running. */
   bool IsStarted() const { return m_SoundEngine.IsWorking(); }

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -66,7 +66,7 @@ GOOrganController *GOGuiOrgan::LoadOrgan(
     cfg.Flush();
     {
       wxCommandEvent event(wxEVT_SETVALUE, ID_METER_AUDIO_SPIN);
-      event.SetInt(m_OrganController->GetVolume());
+      event.SetInt(m_OrganController->GetGain());
       wxTheApp->GetTopWindow()->GetEventHandler()->AddPendingEvent(event);
     }
 

--- a/src/grandorgue/gui/frames/GOAppWindow.cpp
+++ b/src/grandorgue/gui/frames/GOAppWindow.cpp
@@ -1290,7 +1290,7 @@ void GOAppWindow::OnSettingsVolume(wxCommandEvent &event) {
   long n = m_Volume->GetValue();
 
   if (p_OrganController)
-    p_OrganController->SetVolume(n);
+    p_OrganController->SetGain(n);
   for (unsigned i = 0; i < m_VolumeGauge.size(); i++)
     m_VolumeGauge[i]->ResetClip();
 }

--- a/src/grandorgue/model/GOWindchest.cpp
+++ b/src/grandorgue/model/GOWindchest.cpp
@@ -19,7 +19,7 @@
 GOWindchest::GOWindchest(GOOrganModel &organModel)
   : r_OrganModel(organModel),
     m_Name(),
-    m_Volume(1),
+    m_amplitude(1),
     m_enclosure(0),
     m_tremulant(0),
     m_ranks(0),
@@ -84,10 +84,8 @@ void GOWindchest::UpdateVolume() {
   float f = 1.0f;
   for (unsigned i = 0; i < m_enclosure.size(); i++)
     f *= m_enclosure[i]->GetAttenuation();
-  m_Volume = f;
+  m_amplitude = f;
 }
-
-float GOWindchest::GetVolume() { return m_Volume; }
 
 unsigned GOWindchest::GetTremulantCount() { return m_tremulant.size(); }
 

--- a/src/grandorgue/model/GOWindchest.h
+++ b/src/grandorgue/model/GOWindchest.h
@@ -31,7 +31,7 @@ private:
   // used
   wxString m_HardName;
 
-  float m_Volume;
+  float m_amplitude;
   std::vector<GOEnclosure *> m_enclosure;
   std::vector<unsigned> m_tremulant;
   std::vector<GORank *> m_ranks;
@@ -50,7 +50,7 @@ public:
   void Load(GOConfigReader &cfg, wxString group, unsigned index);
   void UpdateTremulant(GOTremulant *tremulant);
   void UpdateVolume();
-  float GetVolume();
+  float GetAmplitude() const { return m_amplitude; }
   unsigned GetTremulantCount();
   unsigned GetTremulantId(unsigned index);
   unsigned GetRankCount();

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -118,7 +118,7 @@ GOSoundOrganEngine::GOSoundOrganEngine(
     p_AudioRecorder(nullptr),
     m_NCallbacksEnteredCurrPeriod(0),
     m_NCallbacksFinishedCurrPeriod(0) {
-  SetVolume(-15);
+  SetGain(-15);
   mp_ReleaseTask
     = std::make_unique<GOSoundReleaseTask>(m_SamplerPlayer, mp_AudioGroupTasks);
 }
@@ -133,10 +133,9 @@ GOSoundOrganEngine::~GOSoundOrganEngine() {}
  * Configuration getters and setters
  */
 
-// TODO: rename to SetGain(int gain), m_volume → m_gain, m_gain → m_amplitude
-void GOSoundOrganEngine::SetVolume(int volume) {
-  m_volume = volume;
-  m_gain = powf(10.0f, m_volume * 0.05f);
+void GOSoundOrganEngine::SetGain(int gain) {
+  m_gain = gain;
+  m_amplitude = powf(10.0f, m_gain * 0.05f);
 }
 
 void GOSoundOrganEngine::SetFromConfig(GOConfig &config) {

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -145,12 +145,8 @@ private:
   unsigned m_NAuxThreads;
   bool m_IsDownmix;
   unsigned m_NReleaseRepeats;
-  // TODO: rename to m_gain (stores gain in dB; in GrandOrgue "gain" means dB)
-  int m_volume;
-  // TODO: rename to m_amplitude (stores the linear amplitude coefficient
-  //       derived from m_volume; in GrandOrgue "amplitude" means a linear
-  //       coefficient)
-  float m_gain;
+  int m_gain;
+  float m_amplitude;
   GOSoundReverb::ReverbConfig m_ReverbConfig;
 
   /*
@@ -295,13 +291,10 @@ public:
     m_ReverbConfig = config;
   }
 
-  // TODO: rename to GetAmplitude() (returns linear amplitude coefficient)
-  float GetGain() const { return m_gain; }
+  float GetAmplitude() const { return m_amplitude; }
 
-  // TODO: rename to GetGain() (returns gain in dB)
-  int GetVolume() const { return m_volume; }
-  // TODO: rename to SetGain(int gain)
-  void SetVolume(int volume);
+  int GetGain() const { return m_gain; }
+  void SetGain(int gain);
 
   unsigned GetHardPolyphony() const {
     return m_SamplerPlayer.GetHardPolyphony();

--- a/src/grandorgue/sound/playing/GOSoundSamplerPlayer.cpp
+++ b/src/grandorgue/sound/playing/GOSoundSamplerPlayer.cpp
@@ -308,7 +308,7 @@ void GOSoundSamplerPlayer::CreateReleaseSampler(GOSoundSampler *handle) {
 
   int taskId = handle->m_SamplerTaskId;
   float vol = isWindchestTask(taskId)
-    ? r_WindchestTasks[windchestTaskToIndex(taskId)]->GetWindchestVolume()
+    ? r_WindchestTasks[windchestTaskToIndex(taskId)]->GetWindchestAmplitude()
     : 1.0f;
 
   // FIXME: this is wrong... the intention is to not create a release for a

--- a/src/grandorgue/sound/tasks/GOSoundGroupTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundGroupTask.cpp
@@ -61,7 +61,7 @@ void GOSoundGroupTask::ProcessList(
     if (
       windchest
       && r_SamplerPlayer.ProcessSampler(
-        *sampler, windchest->GetVolume(), outBuffer))
+        *sampler, windchest->GetAmplitude(), outBuffer))
       Add(sampler);
   }
 }

--- a/src/grandorgue/sound/tasks/GOSoundTremulantTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundTremulantTask.cpp
@@ -14,7 +14,7 @@
 GOSoundTremulantTask::GOSoundTremulantTask(
   GOSoundSamplerPlayer &samplerPlayer, unsigned nFramesPerBuffer)
   : r_SamplerPlayer(samplerPlayer),
-    m_Volume(0),
+    m_amplitude(0),
     m_SamplesPerBuffer(nFramesPerBuffer),
     m_Done(false) {}
 
@@ -38,7 +38,7 @@ void GOSoundTremulantTask::Run(GOSchedulerThread *pThread) {
 
   m_Samplers.Move();
   if (m_Samplers.Peek() == NULL) {
-    m_Volume = 1;
+    m_amplitude = 1;
     m_Done = true;
     return;
   }
@@ -52,6 +52,6 @@ void GOSoundTremulantTask::Run(GOSchedulerThread *pThread) {
     if (r_SamplerPlayer.ProcessSampler(*pSampler, 1.0f, outputBuffer))
       m_Samplers.Put(pSampler);
   }
-  m_Volume = outputBuffer.GetData()[2 * m_SamplesPerBuffer - 1];
+  m_amplitude = outputBuffer.GetData()[2 * m_SamplesPerBuffer - 1];
   m_Done = true;
 }

--- a/src/grandorgue/sound/tasks/GOSoundTremulantTask.h
+++ b/src/grandorgue/sound/tasks/GOSoundTremulantTask.h
@@ -21,7 +21,7 @@ private:
   GOSoundSamplerPlayer &r_SamplerPlayer;
   GOSoundSamplerList m_Samplers;
   GOMutex m_Mutex;
-  float m_Volume;
+  float m_amplitude;
   unsigned m_SamplesPerBuffer;
   bool m_Done;
 
@@ -39,10 +39,10 @@ public:
   void DiscardContent() override { m_Samplers.Clear(); }
   void Add(GOSoundSampler *sampler);
 
-  float GetVolume() {
+  float GetAmplitude() {
     if (!m_Done)
       Run();
-    return m_Volume;
+    return m_amplitude;
   }
 };
 

--- a/src/grandorgue/sound/tasks/GOSoundWindchestTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundWindchestTask.cpp
@@ -15,7 +15,7 @@
 GOSoundWindchestTask::GOSoundWindchestTask(
   GOSoundOrganEngine &soundEngine, GOWindchest *pWindchest)
   : r_engine(soundEngine),
-    m_volume(0),
+    m_amplitude(0),
     m_done(false),
     p_windchest(pWindchest) {}
 
@@ -39,14 +39,14 @@ void GOSoundWindchestTask::Run(GOSchedulerThread *pThread) {
     GOMutexLocker locker(m_mutex);
 
     if (!m_done.load()) {
-      float volume = r_engine.GetGain();
+      float amplitude = r_engine.GetAmplitude();
 
       if (p_windchest) {
-        volume *= p_windchest->GetVolume();
+        amplitude *= p_windchest->GetAmplitude();
         for (unsigned i = 0; i < m_pTremulantTasks.size(); i++)
-          volume *= m_pTremulantTasks[i]->GetVolume();
+          amplitude *= m_pTremulantTasks[i]->GetAmplitude();
       }
-      m_volume = volume;
+      m_amplitude = amplitude;
       m_done.store(true);
     }
   }

--- a/src/grandorgue/sound/tasks/GOSoundWindchestTask.h
+++ b/src/grandorgue/sound/tasks/GOSoundWindchestTask.h
@@ -25,7 +25,7 @@ class GOSoundWindchestTask : public GOSoundTaskBase {
 private:
   GOSoundOrganEngine &r_engine;
   GOMutex m_mutex;
-  float m_volume;
+  float m_amplitude;
   std::atomic_bool m_done;
   GOWindchest *p_windchest;
   std::vector<GOSoundTremulantTask *> m_pTremulantTasks;
@@ -44,14 +44,14 @@ public:
   void NewRound() override;
   void Init(ptr_vector<GOSoundTremulantTask> &tremulantTasks);
 
-  float GetWindchestVolume() const {
-    return p_windchest ? p_windchest->GetVolume() : 1;
+  float GetWindchestAmplitude() const {
+    return p_windchest ? p_windchest->GetAmplitude() : 1;
   }
 
-  float GetVolume() {
+  float GetAmplitude() {
     if (!m_done.load())
       Run();
-    return m_volume;
+    return m_amplitude;
   }
 };
 

--- a/src/tests/testing/model/GOTestWindchest.cpp
+++ b/src/tests/testing/model/GOTestWindchest.cpp
@@ -43,7 +43,7 @@ void GOTestWindchest::run() {
   message = "Windchest name should be void (no configuration set)";
   this->GOAssert(name == "", message);
 
-  // Check enclosure volume values from midi ones
+  // Check enclosure amplitude values from midi ones
   GOEnclosure *enclosure = new GOEnclosure(*this->controller);
   // windchest->AddEnclosure() only registers enclosure in a non-owning
   // std::vector (GOWindchest::m_enclosure) for volume grouping; ownership
@@ -53,23 +53,23 @@ void GOTestWindchest::run() {
   windchest->AddEnclosure(enclosure);
 
   enclosure->SetEnclosureValue(127);
-  float volume = windchest->GetVolume();
-  message = "The Windchest volume is not 1 but ";
-  message = message + std::to_string(volume);
-  this->GOAssert(volume == 1, message);
+  float amplitude = windchest->GetAmplitude();
+  message = "The Windchest amplitude is not 1 but ";
+  message = message + std::to_string(amplitude);
+  this->GOAssert(amplitude == 1, message);
 
   enclosure->SetEnclosureValue(0);
-  volume = windchest->GetVolume();
-  message = "The Windchest volume is not 0 but ";
-  message = message + std::to_string(volume);
-  this->GOAssert(volume == 0, message);
+  amplitude = windchest->GetAmplitude();
+  message = "The Windchest amplitude is not 0 but ";
+  message = message + std::to_string(amplitude);
+  this->GOAssert(amplitude == 0, message);
 
   // Check a MIDI value of 50 (50/127)
   enclosure->SetEnclosureValue(50);
-  volume = windchest->GetVolume();
-  message = "The Windchest volume is not 0.393701 but ";
-  message = message + std::to_string(volume);
-  this->GOAssert(volume == 0.393700778f, message);
+  amplitude = windchest->GetAmplitude();
+  message = "The Windchest amplitude is not 0.393701 but ";
+  message = message + std::to_string(amplitude);
+  this->GOAssert(amplitude == 0.393700778f, message);
 
   // Check Tremulants
   int tremulant_count = windchest->GetTremulantCount();

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -119,7 +119,7 @@ void GOPerfTestApp::RunTest(
           true);
         pipes.push_back(w);
       }
-      engine.SetVolume(10);
+      engine.SetGain(10);
       engine.SetPolyphonyLimiting(false);
       engine.SetHardPolyphony(10000);
       engine.SetScaledReleases(true);


### PR DESCRIPTION
## Summary
- Resolves several long-standing `TODO` comments in `GOSoundOrganEngine` (and downstream users) asking for exactly this rename: `m_volume`/`GetVolume()`/`SetVolume()` → `m_gain`/`GetGain()`/`SetGain()` (dB value), and `m_gain`/`GetGain()` → `m_amplitude`/`GetAmplitude()` (linear coefficient derived from gain).
- Propagates the renamed accessors through call sites in `GOOrganController`, `GOGuiOrgan`, `GOAppWindow`, `GOWindchest`, `GOSoundSamplerPlayer`, `GOSoundGroupTask`, `GOSoundTremulantTask`, and `GOSoundWindchestTask`.
- Pure rename — no behavior change.

## Test plan
- [x] `cmake -DCMAKE_BUILD_TYPE=Debug -DGO_BUILD_TESTING=ON -DGO_BUILD_ASAN=ON ...` then `make -k -j16` — builds cleanly
- [x] `ASAN_OPTIONS=detect_leaks=1 ./bin/GOTestExe --no-perf` — all tests pass, no leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)