### PR TITLE
Fixed stereo downmix left/right channel mixup with multiple audio groups

### DIFF
--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -29,6 +29,29 @@
  * Factory functions
  */
 
+std::vector<float> GOSoundOrganEngine::createDownmixGains(
+  unsigned nAudioGroups) {
+  // GOSoundOutputTask::DoRun() reads the linear form of this (see
+  // convertGainToScaleFactor()) as a row-major [outChannelI][groupI * 2 +
+  // groupChannelI] matrix with row stride nAudioGroups * 2 (not a fixed 4,
+  // which only matches that row stride when nAudioGroups == 1): row 0 (L)
+  // takes each group's left channel (even groupChannelI), row 1 (R),
+  // starting at the row-1 offset nOutputCount, takes each group's right
+  // channel.
+  const unsigned nOutputCount = nAudioGroups * 2;
+  std::vector<float> gains(nOutputCount * 2, GOAudioDeviceConfig::MUTE_VOLUME);
+
+  for (unsigned groupI = 0; groupI < nAudioGroups; groupI++) {
+    gains[groupI * 2] = 0.0f;
+    gains[nOutputCount + groupI * 2 + 1] = 0.0f;
+  }
+  return gains;
+}
+
+float GOSoundOrganEngine::convertGainToScaleFactor(float gain) {
+  return gain >= -120 && gain < 40 ? powf(10.0f, gain * 0.05f) : 0.0f;
+}
+
 std::vector<GOSoundOrganEngine::AudioOutputConfig> GOSoundOrganEngine::
   createAudioOutputConfigs(GOConfig &config, unsigned nAudioGroups) {
   std::vector<GOAudioDeviceConfig> &audioDeviceConfig
@@ -71,19 +94,16 @@ std::vector<GOSoundOrganEngine::AudioOutputConfig> GOSoundOrganEngine::
 
 std::vector<GOSoundOrganEngine::AudioOutputConfig> GOSoundOrganEngine::
   createDefaultOutputConfigs(unsigned nAudioGroups) {
+  const std::vector<float> gains = createDownmixGains(nAudioGroups);
+  const unsigned nOutputCount = nAudioGroups * 2;
   AudioOutputConfig config;
 
   config.channels = 2;
   config.scaleFactors.resize(2);
-  config.scaleFactors[0].resize(
-    nAudioGroups * 2, GOAudioDeviceConfig::MUTE_VOLUME);
-  config.scaleFactors[1].resize(
-    nAudioGroups * 2, GOAudioDeviceConfig::MUTE_VOLUME);
-
-  for (unsigned groupI = 0; groupI < nAudioGroups; groupI++) {
-    config.scaleFactors[0][groupI * 2] = 0.0f;
-    config.scaleFactors[1][groupI * 2 + 1] = 0.0f;
-  }
+  for (unsigned channelI = 0; channelI < 2; channelI++)
+    config.scaleFactors[channelI].assign(
+      gains.begin() + channelI * nOutputCount,
+      gains.begin() + (channelI + 1) * nOutputCount);
   return {config};
 }
 
@@ -198,12 +218,8 @@ void GOSoundOrganEngine::BuildEngine(
       for (unsigned k = 0; k < devConfig.scaleFactors[channelI].size(); k++) {
         if (k >= m_NAudioGroups * 2)
           break;
-        float factor = devConfig.scaleFactors[channelI][k];
-        if (factor >= -120 && factor < 40)
-          factor = powf(10.0f, factor * 0.05f);
-        else
-          factor = 0;
-        scaleFactors[channelI * m_NAudioGroups * 2 + k] = factor;
+        scaleFactors[channelI * m_NAudioGroups * 2 + k]
+          = convertGainToScaleFactor(devConfig.scaleFactors[channelI][k]);
       }
     }
     outputState.mp_task = std::make_unique<GOSoundOutputTask>(
@@ -223,14 +239,12 @@ void GOSoundOrganEngine::BuildEngine(
 
   // [B4] Build downmix task (optional stereo mix for recorder)
   if (m_IsDownmix) {
-    std::vector<float> scaleFactors;
+    const std::vector<float> gains = createDownmixGains(m_NAudioGroups);
+    std::vector<float> scaleFactors(gains.size());
 
-    scaleFactors.resize(m_NAudioGroups * 2 * 2);
-    std::fill(scaleFactors.begin(), scaleFactors.end(), 0.0f);
-    for (unsigned groupI = 0; groupI < m_NAudioGroups; groupI++) {
-      scaleFactors[groupI * 4] = 1;
-      scaleFactors[groupI * 4 + 3] = 1;
-    }
+    for (unsigned i = 0, n = gains.size(); i < n; i++)
+      scaleFactors[i] = convertGainToScaleFactor(gains[i]);
+
     mp_DownmixTask = std::make_unique<GOSoundOutputTask>(
       2, scaleFactors, m_NSamplesPerBuffer);
     mp_DownmixTask->SetOutputs(groupOutputs);

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -74,6 +74,32 @@ public:
    */
 
   /**
+   * @brief Creates gains, in dB (like every other gain in this class), for
+   * the row-major [outChannelI][groupI * 2 + groupChannelI] pattern where
+   * each audio group's left channel feeds output channel 0 and right
+   * channel feeds output channel 1: 0.0f dB (pass-through) at the selected
+   * position, GOAudioDeviceConfig::MUTE_VOLUME elsewhere.
+   *
+   * The row stride is nAudioGroups * 2 - matching what
+   * GOSoundOutputTask::DoRun() reads once converted to linear scale
+   * factors via convertGainToScaleFactor() - not a fixed 4, which only
+   * coincides with the real row stride when nAudioGroups == 1.
+   *
+   * Shared by createDefaultOutputConfigs() (used as dB, split per channel)
+   * and BuildEngine()'s downmix task (converted to a linear scale factor at
+   * the call site, same as any other device's scaleFactors).
+   */
+  static std::vector<float> createDownmixGains(unsigned nAudioGroups);
+
+  /**
+   * @brief Converts a gain in dB to a linear scale factor, the same rule
+   * BuildEngine() applies to every device's AudioOutputConfig::scaleFactors:
+   * gains outside [-120, 40) dB (e.g. GOAudioDeviceConfig::MUTE_VOLUME) are
+   * treated as silence (0.0f) rather than converted.
+   */
+  static float convertGainToScaleFactor(float gain);
+
+  /**
    * @brief Creates output configurations from GOConfig.
    */
   static std::vector<AudioOutputConfig> createAudioOutputConfigs(

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -22,6 +22,7 @@
 #include "testing/model/GOTestWindchest.h"
 #include "testing/sound/GOTestSoundCallbackConnector.h"
 #include "testing/sound/GOTestSoundOrganEngine.h"
+#include "testing/sound/GOTestSoundOrganEngineFactories.h"
 #include "testing/sound/GOTestSoundOrganEngineStress.h"
 #include "testing/sound/buffer/GOTestPerfSoundBufferMutable.h"
 #include "testing/sound/buffer/GOTestPerfSoundBufferPlanarMutable.h"
@@ -77,11 +78,12 @@ int main(int argc, char *argv[]) {
   GOTestSoundBufferPlanarManaged testSoundBufferPlanarManaged;
   GOTestPerfSoundBufferMutable testPerfSoundBufferMutable;
   GOTestPerfSoundBufferPlanarMutable testPerfSoundBufferPlanarMutable;
-  GOTestReleaseAlignTable testReleaseAlignTable;
-  GOTestSoundStream testSoundStream;
   GOTestSoundOrganEngine testSoundOrganEngine;
+  GOTestSoundOrganEngineFactories testSoundOrganEngineFactories;
   GOTestSoundCallbackConnector testSoundCallbackConnector;
   GOTestSoundOrganEngineStress testSoundOrganEngineStress;
+  GOTestReleaseAlignTable testReleaseAlignTable;
+  GOTestSoundStream testSoundStream;
   /* end of instanciation */
   GOTestResultCollection test_result_collection;
   test_result_collection = GOTestCollection::Instance()->Run(categoryFilter);

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -19,12 +19,13 @@ set(go_tests
     sound/buffer/GOTestSoundBufferPlanar.cpp
     sound/buffer/GOTestSoundBufferPlanarManaged.cpp
     sound/buffer/GOTestSoundBufferPlanarMutable.cpp
+    sound/GOTestSoundCallbackConnector.cpp
+    sound/GOTestSoundOrganEngine.cpp
+    sound/GOTestSoundOrganEngineBase.cpp
+    sound/GOTestSoundOrganEngineFactories.cpp
+    sound/GOTestSoundOrganEngineStress.cpp
     sound/playing/GOTestReleaseAlignTable.cpp
     sound/playing/GOTestSoundStream.cpp
-    sound/GOTestSoundOrganEngineBase.cpp
-    sound/GOTestSoundOrganEngine.cpp
-    sound/GOTestSoundCallbackConnector.cpp
-    sound/GOTestSoundOrganEngineStress.cpp
     GOTestNameMap.cpp
     GOTestOrganController.cpp
 )

--- a/src/tests/testing/sound/GOTestSoundOrganEngineFactories.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineFactories.cpp
@@ -31,14 +31,14 @@ public:
     }
   }
 
-  unsigned GetGroup() override { return AUDIOGROUP; }
-  unsigned GetCost() override { return 0; }
-  bool GetRepeat() override { return false; }
-  void Run(GOSoundThread *) override {}
-  void Exec() override {}
-  void Finish(bool, GOSoundThread *) override {}
-  void Clear() override {}
-  void Reset() override {}
+  unsigned GetPriority() const override { return PRIORITY_AUDIOGROUP; }
+  unsigned GetCost() const override { return 0; }
+  bool IsRepeatable() const override { return false; }
+  void Run(GOSchedulerThread * = nullptr) override {}
+  void CompleteRound() override {}
+  void EnsureBufferReady(bool, GOSchedulerThread * = nullptr) override {}
+  void NewRound() override {}
+  void DiscardContent() override {}
 };
 
 std::vector<float> convertGainsToScaleFactors(const std::vector<float> &gains) {

--- a/src/tests/testing/sound/GOTestSoundOrganEngineFactories.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineFactories.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundOrganEngineFactories.h"
+
+#include <format>
+#include <vector>
+
+#include "config/GOAudioDeviceConfig.h"
+#include "sound/GOSoundOrganEngine.h"
+#include "sound/tasks/GOSoundBufferTaskBase.h"
+#include "sound/tasks/GOSoundOutputTask.h"
+
+const std::string GOTestSoundOrganEngineFactories::TEST_NAME
+  = "GOTestSoundOrganEngineFactories";
+
+namespace {
+
+// A stub 2-channel group-task input, filled with a known constant per
+// channel, standing in for a real GOSoundGroupTask.
+class StubGroupTask : public GOSoundBufferTaskBase {
+public:
+  StubGroupTask(unsigned nFrames, float leftValue, float rightValue)
+    : GOSoundBufferTaskBase(2, nFrames) {
+    for (unsigned frameI = 0; frameI < nFrames; frameI++) {
+      GetData()[GetItemIndex(frameI, 0)] = leftValue;
+      GetData()[GetItemIndex(frameI, 1)] = rightValue;
+    }
+  }
+
+  unsigned GetGroup() override { return AUDIOGROUP; }
+  unsigned GetCost() override { return 0; }
+  bool GetRepeat() override { return false; }
+  void Run(GOSoundThread *) override {}
+  void Exec() override {}
+  void Finish(bool, GOSoundThread *) override {}
+  void Clear() override {}
+  void Reset() override {}
+};
+
+std::vector<float> convertGainsToScaleFactors(const std::vector<float> &gains) {
+  std::vector<float> scaleFactors(gains.size());
+
+  for (unsigned i = 0, n = gains.size(); i < n; i++)
+    scaleFactors[i] = GOSoundOrganEngine::convertGainToScaleFactor(gains[i]);
+  return scaleFactors;
+}
+
+} // namespace
+
+void GOTestSoundOrganEngineFactories::TestDownmixGainsWithOneGroup() {
+  const std::vector<float> gains = GOSoundOrganEngine::createDownmixGains(1);
+
+  GOAssert(gains.size() == 4, "1 group: gains should have 4 entries");
+  GOAssert(gains[0] == 0.0f, "1 group: L should take group0.left");
+  GOAssert(
+    gains[1] == GOAudioDeviceConfig::MUTE_VOLUME,
+    "1 group: L should not take group0.right");
+  GOAssert(
+    gains[2] == GOAudioDeviceConfig::MUTE_VOLUME,
+    "1 group: R should not take group0.left");
+  GOAssert(gains[3] == 0.0f, "1 group: R should take group0.right");
+}
+
+void GOTestSoundOrganEngineFactories::TestDownmixGainsWithTwoGroups() {
+  static constexpr unsigned N_FRAMES = 4;
+  static constexpr float GROUP0_LEFT = 0.1f;
+  static constexpr float GROUP0_RIGHT = 0.2f;
+  static constexpr float GROUP1_LEFT = 0.4f;
+  static constexpr float GROUP1_RIGHT = 0.8f;
+
+  StubGroupTask group0(N_FRAMES, GROUP0_LEFT, GROUP0_RIGHT);
+  StubGroupTask group1(N_FRAMES, GROUP1_LEFT, GROUP1_RIGHT);
+
+  GOSoundOutputTask downmixTask(
+    2,
+    convertGainsToScaleFactors(GOSoundOrganEngine::createDownmixGains(2)),
+    N_FRAMES);
+
+  downmixTask.SetOutputs({&group0, &group1});
+  downmixTask.Run();
+
+  const float *pData = downmixTask.GetData();
+  const float expectedLeft = GROUP0_LEFT + GROUP1_LEFT;
+  const float expectedRight = GROUP0_RIGHT + GROUP1_RIGHT;
+
+  for (unsigned frameI = 0; frameI < N_FRAMES; frameI++) {
+    GOAssert(
+      pData[downmixTask.GetItemIndex(frameI, 0)] == expectedLeft,
+      std::format(
+        "2 groups, frame {}: downmix L should be group0.left + group1.left, "
+        "not a group0.left + group1.right mixup",
+        frameI));
+    GOAssert(
+      pData[downmixTask.GetItemIndex(frameI, 1)] == expectedRight,
+      std::format(
+        "2 groups, frame {}: downmix R should be group0.right + "
+        "group1.right, not a group0.left + group1.right mixup",
+        frameI));
+  }
+}
+
+void GOTestSoundOrganEngineFactories::TestDefaultOutputConfigs() {
+  for (unsigned nAudioGroups = 1; nAudioGroups <= 2; nAudioGroups++) {
+    const std::vector<GOSoundOrganEngine::AudioOutputConfig> configs
+      = GOSoundOrganEngine::createDefaultOutputConfigs(nAudioGroups);
+
+    GOAssert(
+      configs.size() == 1,
+      std::format(
+        "{} group(s): should produce exactly one output", nAudioGroups));
+
+    const GOSoundOrganEngine::AudioOutputConfig &config = configs[0];
+
+    GOAssert(
+      config.channels == 2,
+      std::format("{} group(s): output should be stereo", nAudioGroups));
+    GOAssert(
+      config.scaleFactors.size() == 2,
+      std::format(
+        "{} group(s): scaleFactors should have one entry per channel",
+        nAudioGroups));
+
+    for (unsigned groupI = 0; groupI < nAudioGroups; groupI++) {
+      GOAssert(
+        config.scaleFactors[0][groupI * 2] == 0.0f,
+        std::format(
+          "{} group(s): L should pass through group {}'s left channel",
+          nAudioGroups,
+          groupI));
+      GOAssert(
+        config.scaleFactors[0][groupI * 2 + 1]
+          == GOAudioDeviceConfig::MUTE_VOLUME,
+        std::format(
+          "{} group(s): L should mute group {}'s right channel",
+          nAudioGroups,
+          groupI));
+      GOAssert(
+        config.scaleFactors[1][groupI * 2] == GOAudioDeviceConfig::MUTE_VOLUME,
+        std::format(
+          "{} group(s): R should mute group {}'s left channel",
+          nAudioGroups,
+          groupI));
+      GOAssert(
+        config.scaleFactors[1][groupI * 2 + 1] == 0.0f,
+        std::format(
+          "{} group(s): R should pass through group {}'s right channel",
+          nAudioGroups,
+          groupI));
+    }
+  }
+}
+
+void GOTestSoundOrganEngineFactories::
+  TestDefaultOutputConfigsMatchesDownmixGains() {
+  for (unsigned nAudioGroups = 1; nAudioGroups <= 2; nAudioGroups++) {
+    const std::vector<GOSoundOrganEngine::AudioOutputConfig> configs
+      = GOSoundOrganEngine::createDefaultOutputConfigs(nAudioGroups);
+    const GOSoundOrganEngine::AudioOutputConfig &config = configs[0];
+    const std::vector<float> gains
+      = GOSoundOrganEngine::createDownmixGains(nAudioGroups);
+    const unsigned nOutputCount = nAudioGroups * 2;
+
+    for (unsigned channelI = 0; channelI < 2; channelI++)
+      for (unsigned k = 0; k < nOutputCount; k++)
+        GOAssert(
+          config.scaleFactors[channelI][k]
+            == gains[channelI * nOutputCount + k],
+          std::format(
+            "{} group(s), channel {}, index {}: createDefaultOutputConfigs() "
+            "must reuse createDownmixGains()'s pattern, not a diverging copy "
+            "of it",
+            nAudioGroups,
+            channelI,
+            k));
+  }
+}
+
+void GOTestSoundOrganEngineFactories::run() {
+  TestDownmixGainsWithOneGroup();
+  TestDownmixGainsWithTwoGroups();
+  TestDefaultOutputConfigs();
+  TestDefaultOutputConfigsMatchesDownmixGains();
+}

--- a/src/tests/testing/sound/GOTestSoundOrganEngineFactories.h
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineFactories.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDORGANENGINEFACTORIES_H
+#define GOTESTSOUNDORGANENGINEFACTORIES_H
+
+#include <string>
+
+#include "GOTest.h"
+
+/**
+ * Exercises GOSoundOrganEngine's static factory functions - the parts of
+ * BuildEngine() that can be tested without constructing a full engine.
+ */
+class GOTestSoundOrganEngineFactories : public GOTest {
+private:
+  static const std::string TEST_NAME;
+
+  /** With one audio group, createDownmixGains() must keep the pre-fix
+   * behaviour: L = group0.left, R = group0.right (0.0f dB at those
+   * positions, GOAudioDeviceConfig::MUTE_VOLUME everywhere else). */
+  void TestDownmixGainsWithOneGroup();
+
+  /** Regression test for the stereo-downmix scale-factor bug: with two or
+   * more audio groups, the gains layout createDownmixGains() returns - once
+   * converted to linear via convertGainToScaleFactor() and run through a
+   * real GOSoundOutputTask - must match the row-major
+   * [outChannelI][groupI * 2 + groupChannelI] indexing
+   * GOSoundOutputTask::DoRun() actually reads (row stride nAudioGroups * 2),
+   * not a fixed stride of 4 per group - otherwise the downmix's left and
+   * right channels end up reading each other's groups' channels instead of
+   * summing every group's own left/right channel. */
+  void TestDownmixGainsWithTwoGroups();
+
+  /** createDefaultOutputConfigs() must reflect its documented per-group
+   * layout: scaleFactors[0][i*2] = 0.0f (L), scaleFactors[1][i*2+1] = 0.0f
+   * (R), MUTE_VOLUME everywhere else - for both one and two audio groups. */
+  void TestDefaultOutputConfigs();
+
+  /** createDefaultOutputConfigs() must reuse the same group-selection
+   * pattern as createDownmixGains(): its two per-channel scaleFactors
+   * vectors, concatenated, must equal createDownmixGains()'s flat result -
+   * pins the two factory functions together so they cannot silently drift
+   * apart the way the pre-fix downmix code once did. */
+  void TestDefaultOutputConfigsMatchesDownmixGains();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTSOUNDORGANENGINEFACTORIES_H */


### PR DESCRIPTION
## Summary
- `GOSoundOrganEngine::BuildEngine()`'s downmix `scaleFactors` used a fixed stride of 4 per audio group, but `GOSoundOutputTask::DoRun()` reads them as a row-major matrix with row stride `nAudioGroups * 2`. The two only agreed when `nAudioGroups == 1`, so with 2+ audio groups the downmix's left and right outputs both ended up as `group0.left + group1.right` — a silent, doubled/wrong stereo image in recordings, not a crash.
- Introduced in #2525 ("Refactored GOSoundOrganEngine API: AudioOutputConfig, lifecycle state, factory methods", commit 764a5435), which added the downmix task using the `groupI*4` stride while `GOSoundOutputTask::DoRun()` already used the `nAudioGroups*2` row-major layout.
- Extracted the scaleFactors construction into `GOSoundOrganEngine::createDownmixGains()` (dB-valued, matching this class's existing gain units) and unified it with `createDefaultOutputConfigs()`, which independently implemented the same group-selection pattern — removing the duplication that let the two drift apart in the first place. Also extracted the shared dB→linear conversion into `convertGainToScaleFactor()`, used by both the downmix task and the per-device output loop.

## Test plan
- [x] `GOTestExe --no-perf`: all 20 functional tests pass, including new `GOTestSoundOrganEngine` tests (`TestDownmixGainsWithOneGroup/WithTwoGroups`, `TestDefaultOutputConfigs`, `TestDefaultOutputConfigsMatchesDownmixGains`)
- [x] Confirmed `TestDownmixGainsWithTwoGroups` fails with the pre-fix `groupI*4` indexing (reproduced the exact "L == R, both group0.left + group1.right" failure by reverting locally) and passes with the fix
- [x] Debug + ASAN build: no leaks/UB in the new/touched code (a dangling-reference bug in my own new test was caught and fixed this way)
- [ ] Manual smoke test with a real multi-audio-group organ and downmix-enabled recording (not available in this environment)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01P1mBv1HHY4xvAEnNTM2XAw