### PR TITLE
Started using GOSoundBufferMutable in GOSoundStream and its call sites

### DIFF
--- a/src/grandorgue/sound/playing/GOSoundFader.cpp
+++ b/src/grandorgue/sound/playing/GOSoundFader.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,6 +8,8 @@
 #include "GOSoundFader.h"
 
 #include <algorithm>
+
+#include "sound/buffer/GOSoundBufferMutable.h"
 
 void GOSoundFader::Setup(
   float targetVolume, float velocityVolume, unsigned nFramesToIncreaseIn) {
@@ -29,7 +31,10 @@ void GOSoundFader::Setup(
 static constexpr unsigned EXTERNAL_VOLUME_CHANGE_FRAMES = 1024;
 
 void GOSoundFader::Process(
-  unsigned nFrames, float *buffer, float externalVolume) {
+  float externalAmplitude, GOSoundBufferMutable &outBuffer) {
+  float *pData = outBuffer.GetData();
+  const unsigned nFrames = outBuffer.GetNFrames();
+
   // setup process
 
   float startTargetVolumePoint = m_LastTargetVolumePoint;
@@ -78,7 +83,7 @@ void GOSoundFader::Process(
   }
 
   // Calculate the external volume
-  float targetExternalVolume = m_VelocityVolume * externalVolume;
+  float targetExternalVolume = m_VelocityVolume * externalAmplitude;
 
   if (m_LastExternalVolumePoint < 0.0f)
     m_LastExternalVolumePoint = targetExternalVolume;
@@ -102,9 +107,9 @@ void GOSoundFader::Process(
     (m_LastTargetVolumePoint == startTargetVolumePoint)
     && (m_LastExternalVolumePoint == startExternalVolumePoint)) {
     // Adjust the buffer by frameTotalVolume
-    for (unsigned int i = 0; i < nFrames; i++, buffer += 2) {
-      buffer[0] *= frameTotalVolume;
-      buffer[1] *= frameTotalVolume;
+    for (unsigned int i = nFrames; i > 0; i--) {
+      *pData++ *= frameTotalVolume;
+      *pData++ *= frameTotalVolume;
     }
   } else {
     // Adjust the buffer smoothly from frameTotalVolume to
@@ -113,9 +118,9 @@ void GOSoundFader::Process(
       = (m_LastTargetVolumePoint * m_LastExternalVolumePoint - frameTotalVolume)
       / nFrames;
 
-    for (unsigned int i = 0; i < nFrames; i++, buffer += 2) {
-      buffer[0] *= frameTotalVolume;
-      buffer[1] *= frameTotalVolume;
+    for (unsigned int i = nFrames; i > 0; i--) {
+      *pData++ *= frameTotalVolume;
+      *pData++ *= frameTotalVolume;
       frameTotalVolume += frameTotalVolumeDelta;
     }
   }

--- a/src/grandorgue/sound/playing/GOSoundFader.h
+++ b/src/grandorgue/sound/playing/GOSoundFader.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -9,6 +9,8 @@
 #define GOSOUNDFADER_H_
 
 #include <assert.h>
+
+class GOSoundBufferMutable;
 
 /**
  * This class is responsible for smoothly changing a volume of samples.
@@ -92,7 +94,7 @@ public:
   inline float GetVelocityVolume() const { return m_VelocityVolume; }
   inline void SetVelocityVolume(float volume) { m_VelocityVolume = volume; }
 
-  void Process(unsigned nFrames, float *buffer, float externalVolume);
+  void Process(float externalAmplitude, GOSoundBufferMutable &outBuffer);
 
   bool IsSilent() const { return (m_LastTargetVolumePoint <= 0.0f); }
 };

--- a/src/grandorgue/sound/playing/GOSoundFilter.h
+++ b/src/grandorgue/sound/playing/GOSoundFilter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,6 +10,8 @@
 
 #include <cmath>
 #include <cstdint>
+
+#include "sound/buffer/GOSoundBufferMutable.h"
 
 class GOSoundFilter {
 public:
@@ -25,16 +27,19 @@ public:
     FilterState() { Init(nullptr); }
     void Init(const GOSoundFilter *filter);
     bool IsToApply() { return p_filter && p_filter->IsToApply(); }
-    inline void ProcessBuffer(unsigned n_blocks, float *buffer) {
+    inline void ProcessBuffer(GOSoundBufferMutable &outBuffer) {
+      float *pData = outBuffer.GetData();
+      const unsigned nFrames = outBuffer.GetNFrames();
       float out[2];
-      for (unsigned int i = 0; i < n_blocks; i++, buffer += 2) {
-        out[0] = p_filter->m_B0 * buffer[0] + m_state[0];
-        out[1] = p_filter->m_B0 * buffer[1] + m_state[1];
-        m_state[0] = p_filter->m_B1 * buffer[0] - p_filter->m_A1 * out[0];
-        m_state[1] = p_filter->m_B1 * buffer[1] - p_filter->m_A1 * out[1];
 
-        buffer[0] = out[0];
-        buffer[1] = out[1];
+      for (unsigned int i = 0; i < nFrames; i++, pData += 2) {
+        out[0] = p_filter->m_B0 * pData[0] + m_state[0];
+        out[1] = p_filter->m_B0 * pData[1] + m_state[1];
+        m_state[0] = p_filter->m_B1 * pData[0] - p_filter->m_A1 * out[0];
+        m_state[1] = p_filter->m_B1 * pData[1] - p_filter->m_A1 * out[1];
+
+        pData[0] = out[0];
+        pData[1] = out[1];
       }
     }
 

--- a/src/grandorgue/sound/playing/GOSoundSamplerPlayer.cpp
+++ b/src/grandorgue/sound/playing/GOSoundSamplerPlayer.cpp
@@ -12,13 +12,15 @@
 #include <cmath>
 #include <cstdlib>
 
-#include "GOSoundReleaseAlignTable.h"
-#include "GOSoundSampler.h"
+#include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/providers/GOSoundProvider.h"
 #include "sound/tasks/GOSoundGroupTask.h"
 #include "sound/tasks/GOSoundReleaseTask.h"
 #include "sound/tasks/GOSoundTremulantTask.h"
 #include "sound/tasks/GOSoundWindchestTask.h"
+
+#include "GOSoundReleaseAlignTable.h"
+#include "GOSoundSampler.h"
 
 /*
  * Constructor
@@ -126,55 +128,47 @@ void GOSoundSamplerPlayer::StartSampler(GOSoundSampler *sampler) {
 }
 
 bool GOSoundSamplerPlayer::ProcessSampler(
-  float *output_buffer,
-  GOSoundSampler *sampler,
-  unsigned n_frames,
-  float volume) {
-  float temp[n_frames * 2];
-  const bool process_sampler = (sampler->time <= m_CurrentTime);
+  GOSoundSampler &sampler, float amplitude, GOSoundBufferMutable &outBuffer) {
+  const bool process_sampler = (sampler.time <= m_CurrentTime);
 
   if (process_sampler) {
-    if (sampler->is_release &&
+    if (sampler.is_release &&
         ((m_IsPolyphonyLimiting &&
           m_SamplerPool.UsedSamplerCount() >= m_PolyphonySoftLimit &&
-          m_CurrentTime - sampler->time > 172 * 16) ||
-         sampler->drop_counter > 1))
-      sampler->fader.StartDecreasingVolume(MsToSamples(370));
+          m_CurrentTime - sampler.time > 172 * 16) ||
+         sampler.drop_counter > 1))
+      sampler.fader.StartDecreasingVolume(MsToSamples(370));
 
     /* The decoded sampler frame will contain values containing
-     * sampler->pipe_section->sample_bits worth of significant bits.
+     * sampler.pipe_section->sample_bits worth of significant bits.
      * It is the responsibility of the fade engine to bring these bits
      * back into a sensible state. This is achieved during setup of the
      * fade parameters. The gain target should be:
      *
-     *     playback gain * (2 ^ -sampler->pipe_section->sample_bits)
+     *     playback gain * (2 ^ -sampler.pipe_section->sample_bits)
      */
-    if (!sampler->stream.ReadBlock(temp, n_frames))
-      sampler->p_SoundProvider = NULL;
+    GO_DECLARE_LOCAL_SOUND_BUFFER(tmpBuffer, 2, outBuffer.GetNFrames())
 
-    sampler->fader.Process(n_frames, temp, volume);
-    if (sampler->toneBalanceFilterState.IsToApply())
-      sampler->toneBalanceFilterState.ProcessBuffer(n_frames, temp);
+    if (!sampler.stream.ReadBlock(tmpBuffer))
+      sampler.p_SoundProvider = NULL;
 
-    /* Add these samples to the current output buffer shifting
-     * right by the necessary amount to bring the sample gain back
-     * to unity (this value is computed in GOPipe.cpp)
-     */
-    for (unsigned i = 0; i < n_frames * 2; i++)
-      output_buffer[i] += temp[i];
+    sampler.fader.Process(amplitude, tmpBuffer);
+    if (sampler.toneBalanceFilterState.IsToApply())
+      sampler.toneBalanceFilterState.ProcessBuffer(tmpBuffer);
+
+    outBuffer.AddFrom(tmpBuffer);
 
     if (
-      (sampler->stop && sampler->stop <= m_CurrentTime)
-      || (sampler->new_attack && sampler->new_attack <= m_CurrentTime)) {
-      rp_ReleaseTask->Add(sampler);
+      (sampler.stop && sampler.stop <= m_CurrentTime)
+      || (sampler.new_attack && sampler.new_attack <= m_CurrentTime)) {
+      rp_ReleaseTask->Add(&sampler);
       return false;
     }
   }
 
   if (
-    !sampler->p_SoundProvider
-    || (sampler->fader.IsSilent() && process_sampler)) {
-    ReturnSampler(sampler);
+    !sampler.p_SoundProvider || (sampler.fader.IsSilent() && process_sampler)) {
+    ReturnSampler(&sampler);
     return false;
   } else
     return true;

--- a/src/grandorgue/sound/playing/GOSoundSamplerPlayer.h
+++ b/src/grandorgue/sound/playing/GOSoundSamplerPlayer.h
@@ -19,6 +19,7 @@
 
 #include "ptrvector.h"
 
+class GOSoundBufferMutable;
 class GOSoundGroupTask;
 class GOSoundReleaseTask;
 class GOSoundTremulantTask;
@@ -267,17 +268,13 @@ public:
   /**
    * @brief Processes one period of audio for a single sampler.
    *
-   * @param output_buffer  Interleaved stereo buffer to mix into.
-   * @param sampler        The sampler to process.
-   * @param n_frames       Number of frames.
-   * @param volume         Windchest/tremulant volume factor.
+   * @param sampler    The sampler to process.
+   * @param amplitude  Windchest/tremulant amplitude factor.
+   * @param outBuffer  Interleaved stereo buffer to mix into.
    * @return true if the sampler should be kept alive for the next period.
    */
   bool ProcessSampler(
-    float *output_buffer,
-    GOSoundSampler *sampler,
-    unsigned n_frames,
-    float volume);
+    GOSoundSampler &sampler, float amplitude, GOSoundBufferMutable &outBuffer);
 
   /**
    * @brief Processes a release or attack-switch event for a sampler.

--- a/src/grandorgue/sound/playing/GOSoundStream.cpp
+++ b/src/grandorgue/sound/playing/GOSoundStream.cpp
@@ -9,6 +9,8 @@
 
 #include <wx/log.h>
 
+#include "sound/buffer/GOSoundBufferMutable.h"
+
 #include "GOSoundAudioSection.h"
 #include "GOSoundReleaseAlignTable.h"
 
@@ -354,10 +356,12 @@ void GOSoundStream::InitAlignedStream(
     &pExistingStream->m_ResamplingPos);
 }
 
-bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
+bool GOSoundStream::ReadBlock(GOSoundBufferMutable &outBuffer) {
+  float *pData = outBuffer.GetData();
+  unsigned nFrames = outBuffer.GetNFrames();
   bool res = true;
 
-  while (n_blocks > 0) {
+  while (nFrames > 0) {
     unsigned currSrcOffset = m_ResamplingPos.GetIndex();
 
     if (currSrcOffset < end_pos) { // the loop has not yet fully played
@@ -365,12 +369,12 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
       bool isToPlayMain = currSrcOffset < transition_position;
       unsigned finishPos = isToPlayMain ? transition_position : end_pos;
       unsigned targetSamples
-        = std::min(m_ResamplingPos.AvailableTargetSamples(finishPos), n_blocks);
+        = std::min(m_ResamplingPos.AvailableTargetSamples(finishPos), nFrames);
 
       assert(targetSamples > 0);
       if (isToPlayMain) {
         assert(decode_call);
-        (this->*decode_call)(buffer, targetSamples);
+        (this->*decode_call)(pData, targetSamples);
       } else {
         assert(end_decode_call);
 
@@ -378,11 +382,11 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
         GoToEndSegment();
         // we continue to use the same position as before because end_ptr is a
         // "virtual" pointer: end_data - transition_offset
-        (this->*end_decode_call)(buffer, targetSamples);
+        (this->*end_decode_call)(pData, targetSamples);
       }
-      buffer += 2 * targetSamples;
-      n_blocks -= targetSamples;
-      assert(!n_blocks || m_ResamplingPos.GetIndex() >= finishPos);
+      pData += 2 * targetSamples;
+      nFrames -= targetSamples;
+      assert(!nFrames || m_ResamplingPos.GetIndex() >= finishPos);
     } else if (m_NextStartSegmentIndex >= 0) {
       // switch to the start of the loop.
       // overflowOffset must be computed BEFORE GoToStartSegment(): it
@@ -404,12 +408,9 @@ bool GOSoundStream::ReadBlock(float *buffer, unsigned int n_blocks) {
         m_NextStartSegmentIndex = -1;
       }
     } else { // no loop available
-      // fill the buffer with zeros
-      float *p = buffer;
-
-      for (unsigned i = n_blocks * 2; i > 0; i--)
-        *(p++) = 0.0f;
-      n_blocks = 0;
+      outBuffer.GetSubBuffer(outBuffer.GetNFrames() - nFrames, nFrames)
+        .FillWithSilence();
+      nFrames = 0;
       res = false;
     }
   }

--- a/src/grandorgue/sound/playing/GOSoundStream.h
+++ b/src/grandorgue/sound/playing/GOSoundStream.h
@@ -12,6 +12,7 @@
 #include "GOSoundResample.h"
 
 class GOSoundAudioSection;
+class GOSoundBufferMutable;
 
 class GOSoundStream {
 private:
@@ -131,7 +132,7 @@ public:
     const GOSoundStream *pExistingStream);
 
   /* Read an audio buffer from an audio section stream */
-  bool ReadBlock(float *buffer, unsigned int n_blocks);
+  bool ReadBlock(GOSoundBufferMutable &outBuffer);
 };
 
 #endif /* GOSOUNDSTREAM_H */

--- a/src/grandorgue/sound/tasks/GOSoundGroupTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundGroupTask.cpp
@@ -42,12 +42,12 @@ void GOSoundGroupTask::Add(GOSoundSampler *sampler) {
 }
 
 void GOSoundGroupTask::ProcessList(
-  GOSoundSamplerList &list, bool toDropOld, float *output_buffer) {
+  GOSoundSamplerList &list, bool isToDropOld, GOSoundBufferMutable &outBuffer) {
   GOSoundSampler *sampler;
 
   while ((sampler = list.Get())) {
     if (
-      toDropOld && m_IsToComplete.load()
+      isToDropOld && m_IsToComplete.load()
       && sampler->time + 2000 < r_SamplerPlayer.GetTime()) {
       if (sampler->drop_counter++ > 3) {
         r_SamplerPlayer.ReturnSampler(sampler);
@@ -61,7 +61,7 @@ void GOSoundGroupTask::ProcessList(
     if (
       windchest
       && r_SamplerPlayer.ProcessSampler(
-        output_buffer, sampler, GetNFrames(), windchest->GetVolume()))
+        *sampler, windchest->GetVolume(), outBuffer))
       Add(sampler);
   }
 }
@@ -97,8 +97,8 @@ void GOSoundGroupTask::Run(GOSchedulerThread *pThread) {
   GO_DECLARE_LOCAL_SOUND_BUFFER(localBuffer, 2, GetNFrames())
 
   localBuffer.FillWithSilence();
-  ProcessList(m_Active, false, localBuffer.GetData());
-  ProcessList(m_Release, true, localBuffer.GetData());
+  ProcessList(m_Active, false, localBuffer);
+  ProcessList(m_Release, true, localBuffer);
 
   {
     GOMutexLocker locker(

--- a/src/grandorgue/sound/tasks/GOSoundGroupTask.h
+++ b/src/grandorgue/sound/tasks/GOSoundGroupTask.h
@@ -17,6 +17,7 @@
 #include "GOSoundBufferTaskBase.h"
 
 class GOSchedulerThread;
+class GOSoundBufferMutable;
 class GOSoundSamplerPlayer;
 
 class GOSoundGroupTask : public GOSoundBufferTaskBase {
@@ -39,7 +40,9 @@ private:
   std::atomic_bool m_IsToComplete;
 
   void ProcessList(
-    GOSoundSamplerList &list, bool toDropOld, float *output_buffer);
+    GOSoundSamplerList &list,
+    bool isToDropOld,
+    GOSoundBufferMutable &outBuffer);
 
 public:
   GOSoundGroupTask(

--- a/src/grandorgue/sound/tasks/GOSoundTremulantTask.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundTremulantTask.cpp
@@ -7,6 +7,7 @@
 
 #include "GOSoundTremulantTask.h"
 
+#include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/playing/GOSoundSamplerPlayer.h"
 #include "threading/GOMutexLocker.h"
 
@@ -42,18 +43,15 @@ void GOSoundTremulantTask::Run(GOSchedulerThread *pThread) {
     return;
   }
 
-  float output_buffer[m_SamplesPerBuffer * 2];
-  std::fill(output_buffer, output_buffer + m_SamplesPerBuffer * 2, 0.0f);
-  output_buffer[2 * m_SamplesPerBuffer - 1] = 1.0f;
-  for (GOSoundSampler *sampler = m_Samplers.Get(); sampler;
-       sampler = m_Samplers.Get()) {
-    bool keep;
-    keep = r_SamplerPlayer.ProcessSampler(
-      output_buffer, sampler, m_SamplesPerBuffer, 1);
+  GO_DECLARE_LOCAL_SOUND_BUFFER(outputBuffer, 2, m_SamplesPerBuffer)
 
-    if (keep)
-      m_Samplers.Put(sampler);
+  outputBuffer.FillWithSilence();
+  outputBuffer.GetData()[2 * m_SamplesPerBuffer - 1] = 1.0f;
+  for (GOSoundSampler *pSampler = m_Samplers.Get(); pSampler;
+       pSampler = m_Samplers.Get()) {
+    if (r_SamplerPlayer.ProcessSampler(*pSampler, 1.0f, outputBuffer))
+      m_Samplers.Put(pSampler);
   }
-  m_Volume = output_buffer[2 * m_SamplesPerBuffer - 1];
+  m_Volume = outputBuffer.GetData()[2 * m_SamplesPerBuffer - 1];
   m_Done = true;
 }

--- a/src/tests/testing/sound/playing/GOTestSoundStream.cpp
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.cpp
@@ -25,7 +25,6 @@ static constexpr float SAMPLE_RATE_ADJUSTMENT = 1.0f / SECTION_RATE;
 static constexpr unsigned N_FRAMES = 500;
 static constexpr unsigned N_ATTACK_FRAMES = 100;
 static constexpr unsigned N_FRAMES_PER_BLOCK = 50;
-static constexpr unsigned N_BUFFER_ITEMS = N_FRAMES_PER_BLOCK * 2;
 
 std::unique_ptr<GOSoundAudioSection> GOTestSoundStream::CreateAudioSection(
   unsigned nChannels,
@@ -82,10 +81,10 @@ void GOTestSoundStream::TestReadBlock(
   stream.InitStream(
     &resample, pSection.get(), interpolationType, SAMPLE_RATE_ADJUSTMENT);
 
-  float buffer[N_BUFFER_ITEMS];
+  GO_DECLARE_LOCAL_SOUND_BUFFER(buffer, 2, N_FRAMES_PER_BLOCK)
 
   for (unsigned frameI = 0; frameI < N_FRAMES; frameI += N_FRAMES_PER_BLOCK) {
-    const bool result = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+    const bool result = stream.ReadBlock(buffer);
 
     GOAssert(
       result,
@@ -94,21 +93,23 @@ void GOTestSoundStream::TestReadBlock(
   }
 
   // ReadBlock should return false after exhaustion
-  const bool resultAfterEnd = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+  const bool resultAfterEnd = stream.ReadBlock(buffer);
 
   GOAssert(
     !resultAfterEnd,
     std::format("ReadBlock should return false after exhaustion ({})", label));
 
   // Buffer should be filled with zeros after end
-  for (unsigned i = 0; i < N_BUFFER_ITEMS; i++)
+  const float *pData = buffer.GetData();
+
+  for (unsigned n = buffer.GetNItems(), i = 0; i < n; i++)
     GOAssert(
-      buffer[i] == 0.0f,
+      pData[i] == 0.0f,
       std::format(
         "Buffer[{}] should be 0.0f after end ({}, got: {})",
         i,
         label,
-        buffer[i]));
+        pData[i]));
 
   // TODO: verify decoded frame values
 }
@@ -126,10 +127,10 @@ void GOTestSoundStream::TestLoopedStreamAlwaysReturnsTrue() {
     GOSoundResample::GO_LINEAR_INTERPOLATION,
     SAMPLE_RATE_ADJUSTMENT);
 
-  float buffer[N_BUFFER_ITEMS];
+  GO_DECLARE_LOCAL_SOUND_BUFFER(buffer, 2, N_FRAMES_PER_BLOCK)
 
   for (unsigned iterI = 0; iterI < N_ITERATIONS; iterI++) {
-    const bool result = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+    const bool result = stream.ReadBlock(buffer);
 
     GOAssert(
       result,
@@ -154,18 +155,18 @@ void GOTestSoundStream::TestInitAlignedStream() {
     GOSoundResample::GO_LINEAR_INTERPOLATION,
     SAMPLE_RATE_ADJUSTMENT);
 
-  float buffer[N_BUFFER_ITEMS];
+  GO_DECLARE_LOCAL_SOUND_BUFFER(buffer, 2, N_FRAMES_PER_BLOCK)
 
   for (unsigned frameI = 0; frameI < N_ATTACK_FRAMES;
        frameI += N_FRAMES_PER_BLOCK)
-    attackStream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+    attackStream.ReadBlock(buffer);
 
   GOSoundStream releaseStream;
 
   releaseStream.InitAlignedStream(
     pRelease.get(), GOSoundResample::GO_LINEAR_INTERPOLATION, &attackStream);
 
-  const bool result = releaseStream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+  const bool result = releaseStream.ReadBlock(buffer);
 
   GOAssert(result, "ReadBlock should return true after InitAlignedStream");
 }
@@ -251,10 +252,10 @@ void GOTestSoundStream::TestLoopTransitionAcrossDifferentEndPos() {
     GOSoundResample::GO_LINEAR_INTERPOLATION,
     SAMPLE_RATE_ADJUSTMENT);
 
-  float buffer[N_BUFFER_ITEMS];
+  GO_DECLARE_LOCAL_SOUND_BUFFER(buffer, 2, N_FRAMES_PER_BLOCK)
 
   for (unsigned iterI = 0; iterI < N_ITERATIONS; iterI++) {
-    const bool result = stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
+    const bool result = stream.ReadBlock(buffer);
 
     GOAssert(
       result,
@@ -309,19 +310,25 @@ void GOTestSoundStream::TestCompressedLoopWrapMatchesUncompressed() {
       GOSoundResample::GO_LINEAR_INTERPOLATION,
       SAMPLE_RATE_ADJUSTMENT);
 
-    std::vector<float> captured(N_ITERATIONS * N_BUFFER_ITEMS);
-    float buffer[N_BUFFER_ITEMS];
+    // GOSoundStream::ReadBlock always writes interleaved stereo output,
+    // regardless of the source section's channel count.
+    const unsigned nBufferItems
+      = GOSoundBuffer::getNItems(2, N_FRAMES_PER_BLOCK);
+    std::vector<float> captured(N_ITERATIONS * nBufferItems);
+
+    GO_DECLARE_LOCAL_SOUND_BUFFER(buffer, 2, N_FRAMES_PER_BLOCK)
 
     for (unsigned iterI = 0; iterI < N_ITERATIONS; iterI++) {
-      stream.ReadBlock(buffer, N_FRAMES_PER_BLOCK);
-      for (unsigned i = 0; i < N_BUFFER_ITEMS; i++)
-        captured[iterI * N_BUFFER_ITEMS + i] = buffer[i];
+      stream.ReadBlock(buffer);
+      for (unsigned i = 0; i < nBufferItems; i++)
+        captured[iterI * nBufferItems + i] = buffer.GetData()[i];
     }
     return captured;
   };
 
   const std::vector<float> uncompressed = runCapture(false);
   const std::vector<float> compressed = runCapture(true);
+  const unsigned nBufferItems = GOSoundBuffer::getNItems(2, N_FRAMES_PER_BLOCK);
 
   for (unsigned i = 0; i < uncompressed.size(); i++)
     GOAssert(
@@ -330,8 +337,8 @@ void GOTestSoundStream::TestCompressedLoopWrapMatchesUncompressed() {
         "compressed/uncompressed mismatch at output sample {} (iteration {}, "
         "offset {}): compressed={} uncompressed={}",
         i,
-        i / N_BUFFER_ITEMS,
-        i % N_BUFFER_ITEMS,
+        i / nBufferItems,
+        i % nBufferItems,
         compressed[i],
         uncompressed[i]));
 }


### PR DESCRIPTION
## Summary
- Cherry-picked from a downstream branch: switches `GOSoundTremulantTask` and `GOSoundGroupTask` (via `GOSoundSamplerPlayer::ProcessSampler`) from raw `float*` buffers to `GOSoundBufferMutable`.
- Updated `GOSoundStream`, `GOSoundFader`, `GOSoundFilter` call sites accordingly.
- Updated `GOTestSoundStream` tests to match.

## Test plan
- [x] `make -k -j16` builds cleanly
- [x] `./bin/GOTestExe` — all functional tests pass (the pre-existing `GOTestPerfSoundBufferMutable` performance test fails on this machine regardless of this change, due to hardware-dependent throughput baselines)