### PR TITLE
Fixed RPM package shipping cpptrace/libdwarf headers and static libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed Linux packages including unnecessary cpptrace/libdwarf headers and static libraries, causing RPM install conflicts with elfutils https://github.com/GrandOrgue/grandorgue/issues/2596
 - Added Belarusian, Lithuanian, Russian, and Ukrainian UI translations
 - Added capability of building GrandOrgue natively on Windows via MSYS2, without needing a Linux machine for cross-compiling https://github.com/GrandOrgue/grandorgue/issues/2378
 # 3.17.3 (2026-08-10)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ if(USE_INTERNAL_CPPTRACE)
     # Use system zstd to avoid a FetchContent download at build time
     set(CPPTRACE_USE_EXTERNAL_ZSTD      ON  CACHE BOOL "" FORCE)
   endif()
-  add_subdirectory(${CPPTRACE_SRC_DIR})
+  add_subdirectory(${CPPTRACE_SRC_DIR} EXCLUDE_FROM_ALL)
   if(NOT TARGET cpptrace::cpptrace)
     add_library(cpptrace::cpptrace ALIAS cpptrace)
   endif()


### PR DESCRIPTION
## Summary
- The CppTrace submodule (added for printing stack traces on assertion failures in debug builds) was pulled in via `add_subdirectory()` without `EXCLUDE_FROM_ALL`, so its own `install()` rules (headers + `libcpptrace.a`) and those of its vendored libdwarf (`libdwarf.a` + headers, including `dwarf.h`) became part of the default install/CPack tree.
- Since component-based RPM install is off by default, CPack packaged everything in the install tree, so the RPM shipped unnecessary headers and static libraries, and `dwarf.h` conflicted with the one from the system `elfutils` package, breaking installation.
- Fix: add `EXCLUDE_FROM_ALL` to the `add_subdirectory(${CPPTRACE_SRC_DIR})` call in `CMakeLists.txt`. cpptrace still builds and links into GrandOrgue normally; only its own install rules (and libdwarf's) are suppressed.

Fixes #2596

## Test plan
- [x] Reconfigured and rebuilt a Debug build (`USE_INTERNAL_CPPTRACE=ON`) — build succeeds, `GrandOrgue` links against cpptrace normally
- [x] `make install DESTDIR=...` no longer produces any `cpptrace`/`dwarf` headers or `.a` files
- [x] `./bin/GOTestExe` — all 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vU6fNPoV4EZkxL39LBMkV