### PR TITLE
Moved ownership of the SoundRecorderTask from GOSoundSystem to GOSoundEngine

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -816,14 +816,13 @@ void GOOrganController::StartOrgan(
   m_SoundEngine.BuildEngine(
     audioOutputConfigs,
     soundSystem.GetSamplesPerBuffer(),
-    soundSystem.GetSampleRate(),
-    soundSystem.GetAudioRecorder());
+    soundSystem.GetSampleRate());
   m_SoundEngine.StartEngine();
   soundSystem.ConnectToEngine(m_SoundEngine);
 
   m_midi = &midi;
   m_MidiRecorder->SetOutputDevice(m_config.MidiRecorderOutputDevice());
-  m_AudioRecorder->SetAudioRecorder(&soundSystem.GetAudioRecorder());
+  m_AudioRecorder->SetAudioRecorder(&m_SoundEngine.GetRecorderTask());
 
   m_MidiRecorder->Clear();
   PreconfigRecorder();

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -16,7 +16,6 @@
 #include "scheduler/GOSchedulerThread.h"
 #include "tasks/GOSoundGroupTask.h"
 #include "tasks/GOSoundOutputTask.h"
-#include "tasks/GOSoundRecorderTask.h"
 #include "tasks/GOSoundReleaseTask.h"
 #include "tasks/GOSoundTouchTask.h"
 #include "tasks/GOSoundTremulantTask.h"
@@ -115,7 +114,6 @@ GOSoundOrganEngine::GOSoundOrganEngine(
     m_ReverbConfig(GOSoundReverb::CONFIG_REVERB_DISABLED),
     m_NSamplesPerBuffer(1),
     m_LifecycleState(LifecycleState::IDLE),
-    p_AudioRecorder(nullptr),
     m_NCallbacksEnteredCurrPeriod(0),
     m_NCallbacksFinishedCurrPeriod(0) {
   SetVolume(-15);
@@ -152,6 +150,7 @@ void GOSoundOrganEngine::SetFromConfig(GOConfig &config) {
   SetRandomizeSpeaking(config.RandomizeSpeaking());
   SetInterpolationType(config.m_InterpolationType());
   SetReverbConfig(GOSoundReverb::createReverbConfig(config));
+  SetNBytesPerSoundItem(config.WaveFormatBytesPerSample());
 }
 
 /*
@@ -161,15 +160,13 @@ void GOSoundOrganEngine::SetFromConfig(GOConfig &config) {
 void GOSoundOrganEngine::BuildEngine(
   const std::vector<AudioOutputConfig> &audioOutputConfigs,
   unsigned nSamplesPerBuffer,
-  unsigned sampleRate,
-  GOSoundRecorderTask &recorder) {
+  unsigned sampleRate) {
   GOMutexLocker locker(m_LifecycleMutex);
 
   assert(m_LifecycleState.load() == LifecycleState::IDLE);
 
-  // Fill out thr start parameters
+  // Fill out the start parameters
   m_NSamplesPerBuffer = nSamplesPerBuffer;
-  p_AudioRecorder = &recorder;
 
   // [B1] Build audio group tasks
   std::vector<GOSoundBufferTaskBase *> groupOutputs;
@@ -245,7 +242,8 @@ void GOSoundOrganEngine::BuildEngine(
     else
       for (OutputState &state : m_OutputStates)
         recorderOutputs.push_back(state.mp_task.get());
-    p_AudioRecorder->SetOutputs(recorderOutputs, m_NSamplesPerBuffer);
+    m_RecorderTask.SetSampleRate(sampleRate);
+    m_RecorderTask.SetOutputs(recorderOutputs, m_NSamplesPerBuffer);
   }
 
   // [B6] Set up reverb
@@ -287,7 +285,7 @@ void GOSoundOrganEngine::BuildEngine(
     m_scheduler.Add(mp_DownmixTask.get());
   for (OutputState &state : m_OutputStates)
     m_scheduler.Add(state.mp_task.get());
-  m_scheduler.Add(p_AudioRecorder);
+  m_scheduler.Add(&m_RecorderTask);
   m_scheduler.Add(mp_ReleaseTask.get());
   m_scheduler.Add(mp_TouchTask.get());
 

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -15,6 +15,7 @@
 #include "playing/GOSoundSamplerPlayer.h"
 #include "reverb/GOSoundReverb.h"
 #include "scheduler/GOScheduler.h"
+#include "tasks/GOSoundRecorderTask.h"
 #include "threading/GOCondition.h"
 #include "threading/GOMutex.h"
 
@@ -26,7 +27,6 @@ class GOSchedulerThread;
 class GOSoundBufferMutable;
 class GOSoundGroupTask;
 class GOSoundOutputTask;
-class GOSoundRecorderTask;
 class GOSoundReleaseTask;
 class GOSoundTouchTask;
 class GOSoundTremulantTask;
@@ -132,6 +132,7 @@ private:
   // mp_TouchTask references r_MemoryPool; created in constructor,
   // added to m_scheduler in BuildEngine [B8]
   std::unique_ptr<GOSoundTouchTask> mp_TouchTask;
+  GOSoundRecorderTask m_RecorderTask;
   // m_SamplerPlayer is declared after mp_ReleaseTask so that mp_ReleaseTask
   // is already a valid (though null) unique_ptr when passed by reference to
   // the player constructor.
@@ -183,7 +184,7 @@ private:
   // [B2] m_OutputStates: created from audioOutputConfigs (per-device
   // tasks + callback sync state)
   //   — uses mp_AudioGroupTasks [B1] via SetOutputs()
-  //   — referenced by: m_MeterInfo [B3], p_AudioRecorder [B5], reverb [B6]
+  //   — referenced by: m_MeterInfo [B3], m_RecorderTask [B5], reverb [B6]
   std::vector<OutputState> m_OutputStates;
   // [B3] m_MeterInfo: per-channel peak levels for the meter display
   //   — uses nTotalChannels accumulated over m_OutputStates [B2]
@@ -192,11 +193,10 @@ private:
   std::vector<std::atomic<float>> m_MeterInfo;
   // [B4] mp_DownmixTask: optional stereo downmix task (only when m_IsDownmix)
   //   — uses mp_AudioGroupTasks [B1] via SetOutputs()
-  //   — referenced by: p_AudioRecorder [B5], reverb setup [B6]
+  //   — referenced by: m_RecorderTask [B5], reverb setup [B6]
   std::unique_ptr<GOSoundOutputTask> mp_DownmixTask;
-  // [B5] p_AudioRecorder: non-owning pointer to the recorder passed in
+  // [B5] recorder: set up sample rate and outputs on m_RecorderTask
   //   — uses mp_DownmixTask [B4] or m_OutputStates [B2]
-  GOSoundRecorderTask *p_AudioRecorder;
   // [B6] reverb: set up inline on mp_DownmixTask [B4] and m_OutputStates [B2]
   //   — uses m_ReverbConfig, sampleRate (BuildEngine parameter),
   //     m_NSamplesPerBuffer
@@ -336,6 +336,14 @@ public:
     m_SamplerPlayer.SetInterpolationType(type);
   }
 
+  unsigned GetNBytesPerSoundItem() const {
+    return m_RecorderTask.GetBytesPerSample();
+  }
+  void SetNBytesPerSoundItem(unsigned nBytes) {
+    m_RecorderTask.SetBytesPerSample(nBytes);
+  }
+  GOSoundRecorderTask &GetRecorderTask() { return m_RecorderTask; }
+
   /** Reads parameters from GOConfig and stores them via setters. */
   void SetFromConfig(GOConfig &config);
 
@@ -400,14 +408,11 @@ public:
    * @param audioOutputConfigs  Output configurations; must not be empty.
    * @param nSamplesPerBuffer   Buffer size in samples (from audio system).
    * @param sampleRate          Sample rate in Hz (from audio system).
-   * @param recorder            Recorder (non-owning, must be a
-   * GOSoundRecorderTask).
    */
   void BuildEngine(
     const std::vector<AudioOutputConfig> &audioOutputConfigs,
     unsigned nSamplesPerBuffer,
-    unsigned sampleRate,
-    GOSoundRecorderTask &recorder);
+    unsigned sampleRate);
 
   /**
    * @brief Destroys every task built by BuildEngine() and reclaims the

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -44,8 +44,6 @@ void GOSoundSystem::OpenSoundSystem() {
   m_LastErrorMessage = wxEmptyString;
   SetSampleRate(m_config.SampleRate());
   SetSamplesPerBuffer(m_config.SamplesPerBuffer());
-  m_AudioRecorder.SetBytesPerSample(m_config.WaveFormatBytesPerSample());
-
   mp_SoundPorts.resize(audio_config.size());
 
   const GOPortsConfig &portsConfig(m_config.GetSoundPortsConfig());
@@ -82,7 +80,6 @@ void GOSoundSystem::OpenSoundSystem() {
     // m_IsRunning is set to true only in StartSoundSystem(), called after
     // OpenSoundSystem() completes.
     StartStreams();
-    m_AudioRecorder.SetSampleRate(GetSampleRate());
     m_open = true;
   } catch (wxString &msg) {
     if (logSoundErrors)

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -13,7 +13,6 @@
 
 #include <wx/string.h>
 
-#include "tasks/GOSoundRecorderTask.h"
 #include "threading/GOMutex.h"
 
 #include "GOSoundCallbackConnector.h"
@@ -33,8 +32,6 @@ class GOSoundPort;
 class GOSoundSystem : public GOSoundCallbackConnector {
 private:
   GOConfig &m_config;
-
-  GOSoundRecorderTask m_AudioRecorder;
 
   GOSoundCloseListener *p_CloseListener;
 
@@ -78,9 +75,6 @@ public:
   /** Returns true if the sound system is currently open (audio ports active).
    */
   bool IsOpen() const { return m_open; }
-
-  /** Returns the audio recorder associated with this sound system. */
-  GOSoundRecorderTask &GetAudioRecorder() { return m_AudioRecorder; }
 
   wxString getState();
 

--- a/src/tests/testing/sound/GOTestSoundOrganEngineBase.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineBase.cpp
@@ -35,7 +35,7 @@ GOSoundOrganEngine &GOTestSoundOrganEngineBase::BuildAndStartEngine(
       N_OUTPUT_CHANNELS,
       defaultConfigs[0].channels));
 
-  engine.BuildEngine(configs, N_SAMPLES_PER_BUFFER, SAMPLE_RATE, m_recorder);
+  engine.BuildEngine(configs, N_SAMPLES_PER_BUFFER, SAMPLE_RATE);
   engine.StartEngine();
 
   GOAssert(engine.IsWorking(), "Engine should be WORKING after BuildEngine");

--- a/src/tests/testing/sound/GOTestSoundOrganEngineBase.h
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineBase.h
@@ -11,15 +11,13 @@
 #include "GOTest.h"
 
 #include "sound/GOSoundCallbackConnector.h"
-#include "sound/tasks/GOSoundRecorderTask.h"
 
 class GOSoundOrganEngine;
 
 /*
  * Base class for GOSoundOrganEngine tests.
  *
- * Provides helpers for building and stopping the engine and owns the recorder
- * passed to BuildAndStart.
+ * Provides helpers for building and stopping the engine.
  */
 class GOTestSoundOrganEngineBase : public GOCommonControllerTest {
 public:
@@ -30,9 +28,6 @@ public:
 
   static constexpr unsigned N_SAMPLES_PER_BUFFER = 128;
   static constexpr unsigned SAMPLE_RATE = 96000;
-
-private:
-  GOSoundRecorderTask m_recorder;
 
 protected:
   GOSoundCallbackConnector m_connector;

--- a/src/tools/GOPerfTest.cpp
+++ b/src/tools/GOPerfTest.cpp
@@ -17,7 +17,6 @@
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/playing/GOSoundSamplerPlayer.h"
 #include "sound/providers/GOSoundProviderWave.h"
-#include "sound/tasks/GOSoundRecorderTask.h"
 
 #include "GOOrganController.h"
 #include "GOStdPath.h"
@@ -79,7 +78,6 @@ void GOPerfTestApp::RunTest(
     organController->InitOrganDirectory(testsDir);
     organController->AddWindchest(new GOWindchest(*organController));
 
-    GOSoundRecorderTask recorder;
     GOSoundOrganEngine &engine = organController->GetSoundEngine();
 
     try {
@@ -127,8 +125,7 @@ void GOPerfTestApp::RunTest(
       engine.BuildEngine(
         GOSoundOrganEngine::createDefaultOutputConfigs(),
         samples_per_frame,
-        sample_rate,
-        recorder);
+        sample_rate);
       engine.StartEngine();
       engine.SetUsed(true);
       engine.SetStreaming(true);


### PR DESCRIPTION
## Summary
- Moved the GOSoundRecorderTask instance out of GOSoundSystem into GOSoundOrganEngine, which now owns and configures it (sample rate, bytes per sample)
- Updated call sites in GOOrganController, tests, and GOPerfTest accordingly

## Test plan
- [x] Built cleanly with `cmake . && make -k -j16`
- [x] `./bin/GOTestExe` — all 23 tests pass