### PR TITLE
Added GOSoundTaskBase common round implementation and tests

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -234,6 +234,7 @@ sound/tasks/GOSoundGroupTask.cpp
 sound/tasks/GOSoundOutputTask.cpp
 sound/tasks/GOSoundRecorderTask.cpp
 sound/tasks/GOSoundReleaseTask.cpp
+sound/tasks/GOSoundTaskBase.cpp
 sound/tasks/GOSoundTouchTask.cpp
 sound/tasks/GOSoundTremulantTask.cpp
 sound/tasks/GOSoundWindchestTask.cpp

--- a/src/grandorgue/sound/tasks/GOSoundTaskBase.cpp
+++ b/src/grandorgue/sound/tasks/GOSoundTaskBase.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSoundTaskBase.h"
+
+#include "scheduler/GOSchedulerThread.h"
+#include "threading/GOMutexLocker.h"
+
+GOSoundTaskBase::GOSoundTaskBase(TaskPriority priority, bool isRepeatable)
+  : m_priority(priority),
+    m_IsRepeatable(isRepeatable),
+    m_IsToComplete(false),
+    m_RunState(RUN_STATE_NOT_STARTED) {}
+
+// Only moves m_RunState between RUN_STATE_NOT_STARTED and RUN_STATE_DONE:
+// DoRun() runs entirely under m_mutex, so a cooperative subclass that needs
+// several threads inside DoRun() at once (e.g. GOSoundGroupTask) cannot fit
+// this default protocol and overrides Run() itself instead.
+void GOSoundTaskBase::Run(GOSchedulerThread *pThread) {
+  if (m_RunState.load() < RUN_STATE_DONE) {
+    GOMutexLocker locker(m_mutex, false, "GOSoundTaskBase::Run", pThread);
+
+    if (
+      locker.IsLocked() && m_RunState.load() < RUN_STATE_DONE && DoRun(pThread))
+      m_RunState.store(RUN_STATE_DONE);
+  }
+}
+
+void GOSoundTaskBase::CompleteRound() {
+  m_IsToComplete.store(true);
+  Run();
+}
+
+void GOSoundTaskBase::NewRound() {
+  GOMutexLocker locker(m_mutex);
+
+  m_IsToComplete.store(false);
+  m_RunState.store(RUN_STATE_NOT_STARTED);
+  DoNewRound();
+}

--- a/src/grandorgue/sound/tasks/GOSoundTaskBase.h
+++ b/src/grandorgue/sound/tasks/GOSoundTaskBase.h
@@ -8,9 +8,47 @@
 #ifndef GOSOUNDTASKBASE_H
 #define GOSOUNDTASKBASE_H
 
-#include "scheduler/GOSchedulerTask.h"
+#include <atomic>
 
-/** A GOSchedulerTask that belongs to the sound engine */
+#include "scheduler/GOSchedulerTask.h"
+#include "threading/GOMutex.h"
+
+class GOSchedulerThread;
+
+/**
+ * Common base for GOSchedulerTask implementations that belong to the sound
+ * engine. Implements the round life cycle described in GOSchedulerTask
+ * (Run() / CompleteRound() / NewRound()) once for every subclass: a task is
+ * run at most once per round (tracked by m_RunState) under m_mutex, and
+ * CompleteRound()/NewRound() maintain m_IsToComplete for subclasses that
+ * need to know the round deadline was reached.
+ *
+ * A subclass that fits the default one-shot Run() protocol only needs to
+ * override DoRun() (the actual work) and, if it accumulates state across
+ * rounds, DoNewRound(). The default Run() only ever moves m_RunState between
+ * RUN_STATE_NOT_STARTED and RUN_STATE_DONE.
+ *
+ * A subclass with a fundamentally different execution protocol overrides
+ * Run() and/or CompleteRound() directly instead of DoRun():
+ *  - GOSoundReleaseTask is a drain loop that is never RUN_STATE_DONE within
+ *    a round;
+ *  - GOSoundGroupTask is a *cooperative* task: the scheduler may hand the
+ *    same task to several worker threads at once (it is IsRepeatable()), and
+ *    all of them race into Run() to jointly process one shared sampler list
+ *    for this round, each contributing to one shared result buffer. This is
+ *    what the two extra RunState values, RUN_STATE_IN_PROGRESS and
+ *    RUN_STATE_PARTLY_DONE, are for (see RunState below) - m_mutex still
+ *    serialises the bookkeeping around each thread's own chunk of work, but
+ *    not the work itself, so several threads make progress in parallel
+ *    instead of one thread doing all the work while the others wait;
+ *  - GOSoundTouchTask keeps the default DoRun() protocol but overrides
+ *    CompleteRound(): its DoRun() always returns false (there is always more
+ *    idle memory to touch), so the default CompleteRound() - one Run() call
+ *    - would leave it perpetually not-done, which is fine for Run() but not
+ *    what CompleteRound() is for here; it only needs to make sure no other
+ *    thread is still inside DoRun() when the round ends, so it takes m_mutex
+ *    directly instead.
+ */
 class GOSoundTaskBase : public GOSchedulerTask {
 public:
   /**
@@ -21,14 +59,151 @@ public:
    * GOSoundWindchestTask::GetVolume).
    */
   enum TaskPriority {
+    /** Tremulant oscillation, recomputed before the windchests read it */
     PRIORITY_TREMULANT = 10,
+    /** Per-windchest enclosure/tremulant volume, read lazily by pipes */
     PRIORITY_WINDCHEST = 20,
+    /** Mixing the active samplers of one audio group into its buffer */
     PRIORITY_AUDIOGROUP = 50,
+    /** Mixing audio groups into the final device output, reverb, clipping */
     PRIORITY_AUDIOOUTPUT = 100,
+    /** Writing the mixed output to the recording file */
     PRIORITY_AUDIORECORDER = 150,
+    /** Draining samplers that have finished their release */
     PRIORITY_RELEASE = 160,
+    /** Touching pooled memory pages while otherwise idle */
     PRIORITY_TOUCH = 700,
   };
+
+  /**
+   * The processing state of the task within the current round.
+   *
+   * A regular, non-cooperative task (the default Run()/DoRun() protocol)
+   * only ever uses RUN_STATE_NOT_STARTED and RUN_STATE_DONE:
+   * RUN_STATE_NOT_STARTED until some thread calls DoRun() successfully,
+   * RUN_STATE_DONE from then on for the rest of the round.
+   *
+   * A cooperative task (GOSoundGroupTask, which overrides Run() itself)
+   * additionally uses RUN_STATE_IN_PROGRESS and RUN_STATE_PARTLY_DONE to let
+   * several worker threads process the same round together instead of one
+   * thread doing it alone while the rest wait idle:
+   *  - RUN_STATE_NOT_STARTED -> RUN_STATE_IN_PROGRESS: the first thread to
+   *    enter Run() claims the round (e.g. moves the pending sampler lists
+   *    into a working list) so that later threads joining in know there is
+   *    a round to help with;
+   *  - each thread (including the first) then does its own share of the
+   *    work concurrently, outside m_mutex, into a private/local result;
+   *  - RUN_STATE_IN_PROGRESS -> RUN_STATE_PARTLY_DONE: whichever thread is
+   *    first to finish its own share stores it as the round's shared
+   *    result; every other thread that finishes afterwards merges its own
+   *    share into that shared result instead of overwriting it (both under
+   *    m_mutex, so the merge itself is not a race - only the work that
+   *    produced each share is parallel);
+   *  - RUN_STATE_PARTLY_DONE -> RUN_STATE_DONE: once the last thread to be
+   *    doing work for this round finishes (tracked separately, e.g. by an
+   *    active-worker counter reaching zero), the round's shared result is
+   *    final and anyone still waiting on it (e.g. via a condition variable)
+   *    is woken.
+   */
+  enum RunState {
+    /** No thread has started processing this round yet */
+    RUN_STATE_NOT_STARTED = 0,
+    /** A cooperative round has been claimed and threads are working on it */
+    RUN_STATE_IN_PROGRESS = 1,
+    /** A cooperative round has a shared result but some threads are still
+     * merging their share into it */
+    RUN_STATE_PARTLY_DONE = 2,
+    /** The round is fully processed and its result may be read */
+    RUN_STATE_DONE = 3,
+  };
+
+private:
+  /** This task's scheduling priority, see TaskPriority */
+  const TaskPriority m_priority;
+
+  /** Whether this task may be scheduled several times within one round */
+  const bool m_IsRepeatable;
+
+protected:
+  /** Serialises DoRun()/CompleteRound()/NewRound() for this task */
+  GOMutex m_mutex;
+
+  /** Set by CompleteRound() at the round deadline: the task must complete
+   * immediately and must not wait. Cleared by NewRound() */
+  std::atomic_bool m_IsToComplete;
+
+  /** This task's processing state for the current round, see RunState */
+  std::atomic<RunState> m_RunState;
+
+  /**
+   * Does the actual work of the task. Called from Run() under m_mutex, only
+   * if the task is not yet RUN_STATE_DONE.
+   *
+   * WARNING: the default CompleteRound() below calls this (via Run()) only
+   * once. A DoRun() whose false return is not guaranteed to flip to true
+   * within that one remaining call - whether because it is a genuinely
+   * incremental protocol or because it may legitimately have nothing to do
+   * for an entire round (idle; a feature currently off) - must not rely on
+   * the default CompleteRound(): override CompleteRound() itself instead,
+   * the way GOSoundTouchTask does. Discovered the hard way: an earlier
+   * version of this class had CompleteRound() loop until IsDone() instead,
+   * which deadlocked GOSoundRecorderTask (false forever while not recording)
+   * and GOSoundReleaseTask (calls this CompleteRound() as a plain
+   * "run once" helper from its own CompleteRound() override, while never
+   * touching m_RunState at all, so IsDone() there can never become true).
+   * @param pThread the calling worker thread, if any
+   * @return true if the round is now fully processed (m_RunState becomes
+   *   RUN_STATE_DONE); false if Run() may be called again within the same
+   *   round
+   */
+  virtual bool DoRun(GOSchedulerThread *pThread) { return true; }
+
+  /** Resets subclass-specific per-round state. Called from NewRound() under
+   * m_mutex */
+  virtual void DoNewRound() {}
+
+public:
+  /**
+   * @param priority this task's scheduling priority, see TaskPriority. Not
+   *   yet used by every subclass: some still override GetPriority()
+   *   themselves and ignore this value until they are switched to rely on
+   *   the base implementation
+   * @param isRepeatable whether the task may be scheduled several times
+   *   within one round, see GOSchedulerTask::IsRepeatable(). Same caveat as
+   *   priority above
+   */
+  GOSoundTaskBase(
+    TaskPriority priority = PRIORITY_AUDIOGROUP, bool isRepeatable = false);
+
+  /** @return this task's scheduling priority, see TaskPriority */
+  unsigned GetPriority() const override { return m_priority; }
+
+  /** @return whether this task may be scheduled several times per round */
+  bool IsRepeatable() const override { return m_IsRepeatable; }
+
+  /** @return the estimated cost of this task; 0 unless a subclass knows
+   * better */
+  unsigned GetCost() const override { return 0; }
+
+  /** @return whether the task has fully processed the current round */
+  bool IsDone() const { return m_RunState.load() == RUN_STATE_DONE; }
+
+  /** Calls DoRun() at most once per round, cooperatively with other threads
+   */
+  void Run(GOSchedulerThread *pThread = nullptr) override;
+
+  /** Sets m_IsToComplete and calls Run() once. Does not guarantee IsDone()
+   * afterwards unless DoRun() does - see the warning on DoRun() */
+  void CompleteRound() override;
+
+  /** Resets the round state to RUN_STATE_NOT_STARTED and calls
+   * DoNewRound(). Not meant to be overridden by subclasses - extend via
+   * DoNewRound() instead */
+  void NewRound() override;
+
+  /** Equivalent to NewRound(): a fresh task has nothing accumulated to
+   * discard beyond its round state */
+  void DiscardContent() override { NewRound(); }
 };
 
 #endif /* GOSOUNDTASKBASE_H */

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -35,6 +35,8 @@
 #include "testing/sound/buffer/GOTestSoundBufferPlanarMutable.h"
 #include "testing/sound/playing/GOTestReleaseAlignTable.h"
 #include "testing/sound/playing/GOTestSoundStream.h"
+#include "testing/sound/tasks/GOTestPerfSoundTaskBase.h"
+#include "testing/sound/tasks/GOTestSoundTaskBase.h"
 
 int main(int argc, char *argv[]) {
   /*
@@ -84,6 +86,8 @@ int main(int argc, char *argv[]) {
   GOTestSoundOrganEngineStress testSoundOrganEngineStress;
   GOTestReleaseAlignTable testReleaseAlignTable;
   GOTestSoundStream testSoundStream;
+  GOTestSoundTaskBase testSoundTaskBase;
+  GOTestPerfSoundTaskBase testPerfSoundTaskBase;
   /* end of instanciation */
   GOTestResultCollection test_result_collection;
   test_result_collection = GOTestCollection::Instance()->Run(categoryFilter);

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -26,6 +26,10 @@ set(go_tests
     sound/GOTestSoundOrganEngineStress.cpp
     sound/playing/GOTestReleaseAlignTable.cpp
     sound/playing/GOTestSoundStream.cpp
+    sound/tasks/GOSoundCooperativeTaskTestImpl.cpp
+    sound/tasks/GOSoundTaskTestImpl.cpp
+    sound/tasks/GOTestPerfSoundTaskBase.cpp
+    sound/tasks/GOTestSoundTaskBase.cpp
     GOTestNameMap.cpp
     GOTestOrganController.cpp
 )

--- a/src/tests/testing/sound/tasks/GOSoundCooperativeTaskTestImpl.cpp
+++ b/src/tests/testing/sound/tasks/GOSoundCooperativeTaskTestImpl.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSoundCooperativeTaskTestImpl.h"
+
+#include "threading/GOMutexLocker.h"
+
+long GOSoundCooperativeTaskTestImpl::DoOwnShare() {
+  const long nItemsPerThread = m_WorkItemsPerThread.load();
+  long nProcessedItems = 0;
+
+  if (nItemsPerThread > 0) {
+    // Per-thread quota. The accumulator is volatile so that the loop cannot
+    // be folded away: each item must stay real work, but work that touches
+    // only this thread's stack.
+    volatile long sink = 0;
+
+    for (long itemI = 0; itemI < nItemsPerThread; itemI++)
+      sink = sink + 1;
+    nProcessedItems = sink;
+  } else
+    // Shared pool, drained one item at a time, as ProcessList() drains a
+    // sampler list.
+    while (m_RemainingWorkItems.fetch_sub(1) > 0)
+      nProcessedItems++;
+
+  return nProcessedItems;
+}
+
+// Structurally mirrors GOSoundGroupTask::Run(), including the fact that the
+// active-thread bookkeeping sits outside the IsLocked() check.
+void GOSoundCooperativeTaskTestImpl::Run(GOSchedulerThread *pThread) {
+  if (m_RunState.load() < RUN_STATE_DONE) {
+    bool isParticipating = false;
+
+    {
+      GOMutexLocker locker(
+        m_mutex, false, "GOSoundCooperativeTaskTestImpl::Run.before", pThread);
+
+      if (locker.IsLocked()) {
+        if (m_RunState.load() == RUN_STATE_NOT_STARTED) {
+          // the first thread entered Run() claims the round
+          m_RunState.store(RUN_STATE_IN_PROGRESS);
+          nFirstTransitions.fetch_add(1);
+          isParticipating = true;
+        } else if (
+          m_WorkItemsPerThread.load() > 0 || m_RemainingWorkItems.load() > 0)
+          // as in ProcessList(): join only if there is something to help with
+          isParticipating = true;
+
+        if (isParticipating)
+          m_ActiveCount.fetch_add(1);
+      }
+    }
+
+    if (isParticipating) {
+      const long localValue = DoOwnShare();
+
+      nTotalProcessedItems.fetch_add(localValue);
+
+      GOMutexLocker locker(
+        m_mutex, false, "GOSoundCooperativeTaskTestImpl::Run.after", pThread);
+
+      if (locker.IsLocked()) {
+        if (m_RunState.load() == RUN_STATE_IN_PROGRESS) {
+          // the first thread finished: its share becomes the shared result
+          nSharedValue.store(localValue);
+          m_RunState.store(RUN_STATE_PARTLY_DONE);
+          nCopyTransitions.fetch_add(1);
+        } else
+          // not the first thread: merge into the shared result
+          nSharedValue.fetch_add(localValue);
+      }
+      if (m_ActiveCount.fetch_sub(1) <= 1) {
+        // the last thread
+        m_RunState.store(RUN_STATE_DONE);
+        nLastThreadFinishes.fetch_add(1);
+        m_Condition.Broadcast();
+      }
+    }
+  }
+}
+
+void GOSoundCooperativeTaskTestImpl::WaitUntilDone() {
+  GOMutexLocker locker(m_mutex);
+
+  while (m_RunState.load() != RUN_STATE_DONE)
+    m_Condition.WaitOrStop();
+}

--- a/src/tests/testing/sound/tasks/GOSoundCooperativeTaskTestImpl.h
+++ b/src/tests/testing/sound/tasks/GOSoundCooperativeTaskTestImpl.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDCOOPERATIVETASKTESTIMPL_H
+#define GOSOUNDCOOPERATIVETASKTESTIMPL_H
+
+#include <atomic>
+
+#include "scheduler/GOSchedulerThread.h"
+#include "sound/tasks/GOSoundTaskBase.h"
+#include "threading/GOCondition.h"
+
+/**
+ * Test double reproducing the cooperative Run() protocol of
+ * GOSoundGroupTask::Run() (several worker threads jointly processing one
+ * round, merging into one shared result), without touching the sound
+ * engine or real sampler lists. Shared between GOTestSoundTaskBase.cpp
+ * (correctness) and GOTestPerfSoundTaskBase.cpp (throughput), both of which
+ * include this header, so its definition is identical in every translation
+ * unit that uses it.
+ */
+class GOSoundCooperativeTaskTestImpl : public GOSoundTaskBase {
+private:
+  /** Wakes a thread waiting in WaitUntilDone() once the round is done */
+  GOCondition m_Condition{m_mutex};
+  /** Number of threads currently doing their own share of the round */
+  std::atomic<int> m_ActiveCount{0};
+  /** Stands in for the sampler lists a real GOSoundGroupTask drains */
+  std::atomic<long> m_RemainingWorkItems{0};
+  /** If > 0, each participating thread does this many items of purely
+   * thread-local work instead of draining m_RemainingWorkItems */
+  std::atomic<long> m_WorkItemsPerThread{0};
+
+  /** Does this thread's share of the round's work
+   * @return the number of items this thread processed */
+  long DoOwnShare();
+
+public:
+  /** Stands in for the shared output buffer the real task mixes into */
+  std::atomic<long> nSharedValue{0};
+  /** Number of RUN_STATE_NOT_STARTED -> RUN_STATE_IN_PROGRESS transitions */
+  std::atomic<int> nFirstTransitions{0};
+  /** Number of RUN_STATE_IN_PROGRESS -> RUN_STATE_PARTLY_DONE transitions */
+  std::atomic<int> nCopyTransitions{0};
+  /** Number of transitions to RUN_STATE_DONE */
+  std::atomic<int> nLastThreadFinishes{0};
+  /** Sum of DoOwnShare()'s return value across every participating thread on
+   * every round so far. Not every thread that calls Run() participates: one
+   * arriving after the round is already RUN_STATE_DONE does no work, so a
+   * caller measuring throughput must count this rather than assume every
+   * thread processed a full share */
+  std::atomic<long> nTotalProcessedItems{0};
+
+  GOSoundCooperativeTaskTestImpl()
+    : GOSoundTaskBase(PRIORITY_AUDIOGROUP, true) {}
+
+  /** Sets the amount of work the next round has to process, as one shared
+   * pool that every participating thread drains item by item. Every item is
+   * a contended atomic operation on one cache line, which is what the
+   * correctness tests need in order to prove that no item is lost or
+   * counted twice */
+  void SetWorkItems(long n) { m_RemainingWorkItems.store(n); }
+
+  /** Switches the round to a per-thread quota: each participating thread
+   * does n items of thread-local work and the shared state is touched once
+   * per round rather than once per item. Used by the perf tests, where
+   * draining one shared counter would measure cache-line ping-pong on that
+   * counter instead of the cost of the round protocol itself */
+  void SetWorkItemsPerThread(long n) { m_WorkItemsPerThread.store(n); }
+
+  /** Joins or claims the current round, does a share of the work, then
+   * merges the result; the last thread to finish marks the round done */
+  void Run(GOSchedulerThread *pThread = nullptr) override;
+
+  /** Resets the active-worker count for the next round */
+  void DoNewRound() override { m_ActiveCount.store(0); }
+
+  /** Blocks the calling thread until the round becomes done, mirroring
+   * GOSoundGroupTask::WaitAndDiscardContent() */
+  void WaitUntilDone();
+};
+
+#endif /* GOSOUNDCOOPERATIVETASKTESTIMPL_H */

--- a/src/tests/testing/sound/tasks/GOSoundTaskTestImpl.cpp
+++ b/src/tests/testing/sound/tasks/GOSoundTaskTestImpl.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSoundTaskTestImpl.h"
+
+#include <chrono>
+#include <thread>
+
+bool GOSoundTaskTestImpl::DoRun(GOSchedulerThread *pThread) {
+  // widen the race window and record the peak concurrency observed inside
+  // the section that DoRun() relies on being exclusive
+  const int nConcurrent = nConcurrentDoRunCalls.fetch_add(1) + 1;
+  int prevMax = nMaxConcurrentDoRunCalls.load();
+
+  while (
+    nConcurrent > prevMax
+    && !nMaxConcurrentDoRunCalls.compare_exchange_weak(prevMax, nConcurrent))
+    ;
+  const int nWorkMicroseconds = doRunWorkMicroseconds.load();
+
+  if (doRunSleepMicroseconds.load() > 0)
+    std::this_thread::sleep_for(
+      std::chrono::microseconds(doRunSleepMicroseconds.load()));
+  if (nWorkMicroseconds > 0) {
+    // busy-wait rather than sleep: this stands in for real per-round work,
+    // and a sleeping lock holder would measure wake-up granularity instead
+    // of the cost of the round protocol
+    const auto workEnd = std::chrono::steady_clock::now()
+      + std::chrono::microseconds(nWorkMicroseconds);
+
+    while (std::chrono::steady_clock::now() < workEnd)
+      ;
+  }
+  const int callN = nDoRunCalls.fetch_add(1) + 1;
+  payload.store(static_cast<float>(callN));
+  nConcurrentDoRunCalls.fetch_sub(1);
+  return doRunResult.load();
+}
+
+float GOSoundTaskTestImpl::GetPayloadLazily() {
+  if (!IsDone())
+    Run();
+  return payload.load();
+}
+
+void GOSoundTaskTestImpl::DoNewRound() {
+  nDoRunCallsAsOfLastNewRound.store(nDoRunCalls.load());
+  nDoNewRoundCalls.fetch_add(1);
+  // 0 is TestPerfLazyPrerequisiteAccess's "this round never published"
+  // marker; without resetting it here, a regression in any round after the
+  // first would go undetected once payload was ever positive
+  payload.store(0);
+}

--- a/src/tests/testing/sound/tasks/GOSoundTaskTestImpl.h
+++ b/src/tests/testing/sound/tasks/GOSoundTaskTestImpl.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDTASKTESTIMPL_H
+#define GOSOUNDTASKTESTIMPL_H
+
+#include <atomic>
+
+#include "scheduler/GOSchedulerThread.h"
+#include "sound/tasks/GOSoundTaskBase.h"
+
+/**
+ * Test double for the default, non-cooperative GOSoundTaskBase protocol
+ * (Run()/DoRun()/DoNewRound()). Shared between GOTestSoundTaskBase.cpp
+ * (correctness) and GOTestPerfSoundTaskBase.cpp (throughput/latency), both
+ * of which include this header, so its definition is identical in every
+ * translation unit that uses it.
+ *
+ * The bookkeeping counters below are plain atomics, cheap enough (a few ns)
+ * to stay negligible next to what the perf tests actually measure (lock
+ * acquisition, thread scheduling, microseconds-scale simulated work).
+ */
+class GOSoundTaskTestImpl : public GOSoundTaskBase {
+public:
+  /** Number of DoRun() calls observed so far */
+  std::atomic<int> nDoRunCalls{0};
+  /** Number of DoRun() calls currently in flight, for detecting overlap */
+  std::atomic<int> nConcurrentDoRunCalls{0};
+  /** Peak value ever reached by nConcurrentDoRunCalls */
+  std::atomic<int> nMaxConcurrentDoRunCalls{0};
+  /** Number of DoNewRound() calls observed so far */
+  std::atomic<int> nDoNewRoundCalls{0};
+  /** Value DoRun() returns; set by the test before calling Run() */
+  std::atomic<bool> doRunResult{true};
+  /**
+   * If > 0, DoRun() sleeps this long. Use only to widen a race window: the
+   * sleeping thread is descheduled while still holding m_mutex, which is
+   * fine for a correctness test but would make a perf scenario measure
+   * wake-up granularity rather than the round protocol.
+   */
+  std::atomic<int> doRunSleepMicroseconds{0};
+  /**
+   * If > 0, DoRun() busy-waits this long, standing in for real per-round
+   * work. Unlike doRunSleepMicroseconds the lock holder stays runnable, so
+   * what gets measured is the protocol rather than the scheduler. At most
+   * one thread is ever inside DoRun(), so this never spins on more than one
+   * core.
+   */
+  std::atomic<int> doRunWorkMicroseconds{0};
+  /** Snapshot of nDoRunCalls taken inside DoNewRound() - see
+   * GOTestSoundTaskBase::TestNewRoundWaitsForInFlightRun */
+  std::atomic<int> nDoRunCallsAsOfLastNewRound{-1};
+  /**
+   * Stands in for GOSoundWindchestTask::m_volume, published by DoRun() and
+   * read back through GetPayloadLazily(). Atomic, unlike m_volume: the base
+   * Run() takes m_mutex non-blocking (try-lock), so a caller whose own Run()
+   * call loses the race - or whose DoRun() may legitimately return false for
+   * the whole round - can read this concurrently with another thread's
+   * DoRun() still writing it. GOSoundWindchestTask::Run() instead blocks on
+   * its own mutex until done, which is what lets its m_volume stay plain -
+   * this double intentionally exercises the weaker default protocol, so the
+   * payload itself must supply the safety that guarantee would otherwise
+   * give it.
+   */
+  std::atomic<float> payload{0};
+
+  /**
+   * @param priority forwarded to GOSoundTaskBase
+   * @param isRepeatable forwarded to GOSoundTaskBase
+   */
+  GOSoundTaskTestImpl(
+    TaskPriority priority = PRIORITY_AUDIOGROUP, bool isRepeatable = false)
+    : GOSoundTaskBase(priority, isRepeatable) {}
+
+  /** Records concurrency/call counts, optionally sleeps, then returns
+   * doRunResult */
+  bool DoRun(GOSchedulerThread *pThread) override;
+
+  /** Records that a new round started and snapshots nDoRunCalls */
+  void DoNewRound() override;
+
+  /** @return the protected m_IsToComplete, for assertions */
+  bool GetIsToComplete() const { return m_IsToComplete.load(); }
+
+  /**
+   * Reads the payload the way GOSoundWindchestTask::GetVolume() reads
+   * m_volume: lazily runs the task, then immediately reads what the run
+   * published. A caller that returns from Run() before the round's result is
+   * ready observes a stale payload here.
+   * @return the payload published by the current round
+   */
+  float GetPayloadLazily();
+};
+
+#endif /* GOSOUNDTASKTESTIMPL_H */

--- a/src/tests/testing/sound/tasks/GOTestPerfSoundTaskBase.cpp
+++ b/src/tests/testing/sound/tasks/GOTestPerfSoundTaskBase.cpp
@@ -1,0 +1,502 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestPerfSoundTaskBase.h"
+
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <format>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "GOSoundCooperativeTaskTestImpl.h"
+#include "GOSoundTaskTestImpl.h"
+
+const std::string GOTestPerfSoundTaskBase::TEST_NAME
+  = "GOTestPerfSoundTaskBase";
+
+// The audio period this suite is calibrated against: 32 frames at 96000 Hz,
+// i.e. the tightest real-time budget the round protocol has to fit into.
+// Every threshold below that can be expressed as a fraction of a period is
+// derived from these two numbers rather than from an arbitrary margin, so
+// that a failure means "this would not keep up with the audio device"
+// instead of "this got slower than it was on some developer's machine".
+static constexpr double N_FRAMES_PER_BUFFER = 32.0;
+static constexpr double SAMPLE_RATE = 96000.0;
+/** 333.33 us - the wall-clock budget for one round */
+static constexpr double AUDIO_PERIOD_MICROSECONDS
+  = N_FRAMES_PER_BUFFER * 1'000'000.0 / SAMPLE_RATE;
+/** 3000 - the number of rounds per second the engine must sustain */
+static constexpr double AUDIO_PERIODS_PER_SECOND
+  = SAMPLE_RATE / N_FRAMES_PER_BUFFER;
+
+// Minimum acceptable throughput of the uncontended hot path: a repeatable
+// task that is already done for this round and is being repeatedly polled
+// by a worker thread with nothing better to do, as GOSchedulerThread does
+// while looking for work. Calibrated from the CI history of this test on
+// GitHub Actions' shared ubuntu-latest runners (github.com/oleg68/
+// GrandOrgue-official, Build workflow, "tests (perf, ...)" jobs, 16 Debug/
+// Release runs between 2026-08-04 and 2026-08-28), separately per build
+// type since they don't share a noise floor: observed 359M-493M runs/sec on
+// Debug (worst 359M) and 375M-435M on Release (worst 375M), each threshold
+// set 10% below its own worst case for run-to-run variance on shared
+// hardware.
+#ifdef NDEBUG
+static constexpr double MIN_UNCONTENDED_RUNS_PER_SECOND = 335'000'000.0;
+#else
+static constexpr double MIN_UNCONTENDED_RUNS_PER_SECOND = 320'000'000.0;
+#endif
+
+// Minimum acceptable round rate for several threads racing Run() on the same
+// task with ~10us of real work each. This is the real-time requirement
+// itself: at 32 frames / 96000 Hz the engine must complete 3000 rounds per
+// second. Local Debug runs give 30383-96810 rounds/sec (nThreads=8..1), i.e.
+// 10-32x headroom over the requirement.
+static constexpr double MIN_CONTENDED_ROUNDS_PER_SECOND
+  = AUDIO_PERIODS_PER_SECOND;
+
+// Minimum acceptable aggregate throughput of the cooperative protocol, now
+// that each thread works its own quota instead of draining one shared
+// counter. Calibrated from 6 local Debug runs: worst observed was ~532M
+// items/sec (nThreads=1), halved for a 2x margin. With the shared-counter
+// artifact gone, throughput scales up with thread count (~740M at 1 thread
+// to ~3.9G at 8) rather than collapsing, so the worst case is now the
+// single-threaded one.
+// TODO: recalibrate once this test has run on CI hardware.
+static constexpr double MIN_COOPERATIVE_ITEMS_PER_SECOND = 250'000'000.0;
+
+// Maximum acceptable cost of the round protocol itself - the m_mutex
+// acquisitions in Run() and NewRound() - with barrier and thread scheduling
+// subtracted out via a control run. Budgeted at 10% of one audio period:
+// the handshake is pure overhead, so it must stay a small fraction of the
+// time available for actually producing sound. Local Debug runs give
+// 90-3455 ns (nThreads=1..8) against this 33333 ns budget.
+// A negative measurement means the protocol is below the harness's noise
+// floor, which passes.
+static constexpr double MAX_PROTOCOL_NANOSECONDS_PER_ROUND
+  = AUDIO_PERIOD_MICROSECONDS * 1'000.0 / 10.0;
+
+// Maximum acceptable mean latency of one CompleteRound() + NewRound() pair
+// on the thread standing in for the audio thread, while workers race Run().
+// Budgeted at half an audio period: this handshake is only one part of what
+// NextPeriod() has to fit into 333.33 us. Local Debug runs give 5.6-6.0 us,
+// i.e. essentially just the 5 us of simulated work: the handshake itself is
+// close to free once the lock holder is not sleeping inside the critical
+// section (see doRunWorkMicroseconds vs doRunSleepMicroseconds).
+static constexpr double MAX_NEXT_PERIOD_MEAN_MICROSECONDS
+  = AUDIO_PERIOD_MICROSECONDS / 2.0;
+
+// Maximum acceptable worst-case latency of that same pair, thresholded
+// separately because audio drops out on the tail, not on the average.
+// Local Debug runs peak at 13-612 us, mostly 15-100 us, while the mean stays
+// flat at 5.6 us - that shape is OS scheduling jitter of the measuring
+// thread rather than contention on m_mutex. Budgeted at 10 periods: still
+// ~5x above the worst local observation, so it catches an RT thread blocked
+// for several periods without flapping on a loaded CI machine.
+static constexpr double MAX_NEXT_PERIOD_PEAK_MICROSECONDS
+  = AUDIO_PERIOD_MICROSECONDS * 10.0;
+
+// Minimum acceptable round rate on the lazy-prerequisite path
+// (GOSoundWindchestTask::GetVolume() shape) with ~5us of work per DoRun().
+// Unlike MIN_CONTENDED_ROUNDS_PER_SECOND this is NOT the 3000/sec real-time
+// figure: the timed loop includes a full barrier per round, which dominates.
+// Calibrated from 6 local Debug runs: worst observed was ~13986 rounds/sec
+// (doneWithinRound=false, nThreads=8), halved for a 2x margin.
+// TODO: recalibrate once this test has run on CI hardware.
+static constexpr double MIN_LAZY_ROUNDS_PER_SECOND = 7'000.0;
+
+/**
+ * Times nRounds barrier-synchronised rounds across nThreads threads.
+ * @param nThreads number of threads taking part in every round
+ * @param nRounds number of rounds to time
+ * @param pTask the task to Run() and NewRound() each round; nullptr times
+ *   the bare barrier loop, which is the control measurement to subtract
+ * @return elapsed time in seconds
+ */
+static double measure_round_loop(
+  unsigned nThreads, int nRounds, GOSoundTaskTestImpl *pTask) {
+  std::barrier roundBarrier(
+    static_cast<std::ptrdiff_t>(nThreads), [pTask]() noexcept {
+      if (pTask)
+        pTask->NewRound();
+    });
+  std::vector<std::thread> threads;
+
+  const auto start = std::chrono::high_resolution_clock::now();
+
+  for (unsigned threadI = 0; threadI < nThreads; threadI++)
+    threads.emplace_back([pTask, &roundBarrier, nRounds]() {
+      for (int roundI = 0; roundI < nRounds; roundI++) {
+        if (pTask)
+          pTask->Run();
+        roundBarrier.arrive_and_wait();
+      }
+    });
+  for (std::thread &thread : threads)
+    thread.join();
+
+  const auto end = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double> elapsed = end - start;
+
+  return elapsed.count();
+}
+
+void GOTestPerfSoundTaskBase::TestPerfUncontendedRunThroughput() {
+  constexpr long N_ITERATIONS = 50'000'000;
+
+  GOSoundTaskTestImpl task;
+
+  task.Run(); // reaches RUN_STATE_DONE; DoRun() itself is not measured here
+
+  const auto start = std::chrono::high_resolution_clock::now();
+
+  for (long iterI = 0; iterI < N_ITERATIONS; iterI++)
+    task.Run();
+
+  const auto end = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double> elapsed = end - start;
+  const double runsPerSecond = N_ITERATIONS / elapsed.count();
+  const bool isPassed = runsPerSecond >= MIN_UNCONTENDED_RUNS_PER_SECOND;
+  const double ratio = runsPerSecond / MIN_UNCONTENDED_RUNS_PER_SECOND;
+
+  std::cout << std::format(
+    "  [{}] UncontendedRunThroughput: {:.1f} runs/sec (threshold: {:.1f}, "
+    "ratio: {:5.2f}x)\n",
+    isPassed ? "PASS" : "FAIL",
+    runsPerSecond,
+    MIN_UNCONTENDED_RUNS_PER_SECOND,
+    ratio);
+  if (!isPassed)
+    m_failedTests.push_back(std::format(
+      "UncontendedRunThroughput: {:.1f} runs/sec < {:.1f}",
+      runsPerSecond,
+      MIN_UNCONTENDED_RUNS_PER_SECOND));
+}
+
+void GOTestPerfSoundTaskBase::TestPerfContendedRunLatency() {
+  constexpr int N_ROUNDS = 2000;
+  constexpr int WORK_MICROSECONDS = 10;
+
+  for (const unsigned nThreads : {1u, 2u, 4u, 8u}) {
+    GOSoundTaskTestImpl task;
+
+    task.doRunWorkMicroseconds.store(WORK_MICROSECONDS);
+
+    // Threads block on the barrier between rounds (no spinning), so nThreads
+    // worker threads never oversubscribe the machine's cores by racing a
+    // busy-wait alongside them. Thread start-up is included in the timing,
+    // same as the generous margin on MAX_CONTENDED_ROUND_MILLISECONDS.
+    std::barrier roundBarrier(
+      static_cast<std::ptrdiff_t>(nThreads),
+      [&task]() noexcept { task.NewRound(); });
+    std::vector<std::thread> threads;
+
+    const auto start = std::chrono::high_resolution_clock::now();
+
+    for (unsigned threadI = 0; threadI < nThreads; threadI++)
+      threads.emplace_back([&task, &roundBarrier]() {
+        for (int roundI = 0; roundI < N_ROUNDS; roundI++) {
+          task.Run();
+          roundBarrier.arrive_and_wait();
+        }
+      });
+    for (std::thread &thread : threads)
+      thread.join();
+
+    const auto end = std::chrono::high_resolution_clock::now();
+    const std::chrono::duration<double> elapsed = end - start;
+    const double roundsPerSecond = N_ROUNDS / elapsed.count();
+    const bool isPassed = roundsPerSecond >= MIN_CONTENDED_ROUNDS_PER_SECOND;
+    const double ratio = roundsPerSecond / MIN_CONTENDED_ROUNDS_PER_SECOND;
+
+    std::cout << std::format(
+      "  [{}] ContendedRunLatency(nThreads={}): {:.1f} rounds/sec "
+      "(threshold: {:.1f}, ratio: {:5.2f}x)\n",
+      isPassed ? "PASS" : "FAIL",
+      nThreads,
+      roundsPerSecond,
+      MIN_CONTENDED_ROUNDS_PER_SECOND,
+      ratio);
+    if (!isPassed)
+      m_failedTests.push_back(std::format(
+        "ContendedRunLatency(nThreads={}): {:.1f} rounds/sec < {:.1f}",
+        nThreads,
+        roundsPerSecond,
+        MIN_CONTENDED_ROUNDS_PER_SECOND));
+  }
+}
+
+void GOTestPerfSoundTaskBase::TestPerfCooperativeThroughput() {
+  constexpr int N_ROUNDS = 1000;
+  constexpr long N_WORK_ITEMS_PER_THREAD = 20000;
+
+  for (const unsigned nThreads : {1u, 2u, 4u, 8u}) {
+    GOSoundCooperativeTaskTestImpl task;
+
+    // Per-thread quota rather than one shared pool drained item by item:
+    // with a shared pool this loop measures cache-line ping-pong on that
+    // one counter (20M contended atomics per run against ~16k lock
+    // acquisitions), which is not what the round protocol costs.
+    task.SetWorkItemsPerThread(N_WORK_ITEMS_PER_THREAD);
+
+    // Same reusable thread pool + blocking barrier as
+    // TestPerfContendedRunLatency, instead of spawning nThreads threads
+    // per round: avoids both busy-wait oversubscription and per-round
+    // thread creation overhead.
+    std::barrier roundBarrier(
+      static_cast<std::ptrdiff_t>(nThreads),
+      [&task]() noexcept { task.NewRound(); });
+    std::vector<std::thread> threads;
+
+    const auto start = std::chrono::high_resolution_clock::now();
+
+    for (unsigned threadI = 0; threadI < nThreads; threadI++)
+      threads.emplace_back([&task, &roundBarrier]() {
+        for (int roundI = 0; roundI < N_ROUNDS; roundI++) {
+          task.Run();
+          roundBarrier.arrive_and_wait();
+        }
+      });
+    for (std::thread &thread : threads)
+      thread.join();
+
+    const auto end = std::chrono::high_resolution_clock::now();
+    const std::chrono::duration<double> elapsed = end - start;
+    // Not N_WORK_ITEMS_PER_THREAD * nThreads * N_ROUNDS: a thread whose
+    // Run() call arrives after the round is already RUN_STATE_DONE does no
+    // work that round, which a fixed-quota assumption would still credit -
+    // count what was actually processed instead
+    const long nTotalItems = task.nTotalProcessedItems.load();
+    const double itemsPerSecond = nTotalItems / elapsed.count();
+    const bool isPassed = itemsPerSecond >= MIN_COOPERATIVE_ITEMS_PER_SECOND;
+    const double ratio = itemsPerSecond / MIN_COOPERATIVE_ITEMS_PER_SECOND;
+
+    std::cout << std::format(
+      "  [{}] CooperativeThroughput(nThreads={}): {:.1f} items/sec "
+      "(threshold: {:.1f}, ratio: {:5.2f}x)\n",
+      isPassed ? "PASS" : "FAIL",
+      nThreads,
+      itemsPerSecond,
+      MIN_COOPERATIVE_ITEMS_PER_SECOND,
+      ratio);
+    if (!isPassed)
+      m_failedTests.push_back(std::format(
+        "CooperativeThroughput(nThreads={}): {:.1f} items/sec < {:.1f}",
+        nThreads,
+        itemsPerSecond,
+        MIN_COOPERATIVE_ITEMS_PER_SECOND));
+  }
+}
+
+void GOTestPerfSoundTaskBase::TestPerfRoundProtocolCost() {
+  constexpr int N_ROUNDS = 20000;
+
+  for (const unsigned nThreads : {1u, 2u, 4u, 8u}) {
+    GOSoundTaskTestImpl task;
+
+    // DoRun() sleeps for nothing and does no work, so the only difference
+    // between the two loops below is the round protocol itself
+    const double withProtocolSeconds
+      = measure_round_loop(nThreads, N_ROUNDS, &task);
+    const double controlSeconds
+      = measure_round_loop(nThreads, N_ROUNDS, nullptr);
+    const double nanosecondsPerRound
+      = (withProtocolSeconds - controlSeconds) * 1e9 / N_ROUNDS;
+    const bool isPassed
+      = nanosecondsPerRound <= MAX_PROTOCOL_NANOSECONDS_PER_ROUND;
+    const double ratio
+      = MAX_PROTOCOL_NANOSECONDS_PER_ROUND / nanosecondsPerRound;
+
+    std::cout << std::format(
+      "  [{}] RoundProtocolCost(nThreads={}): {:.1f} ns/round "
+      "(threshold: {:.1f}, ratio: {:5.2f}x)\n",
+      isPassed ? "PASS" : "FAIL",
+      nThreads,
+      nanosecondsPerRound,
+      MAX_PROTOCOL_NANOSECONDS_PER_ROUND,
+      ratio);
+    if (!isPassed)
+      m_failedTests.push_back(std::format(
+        "RoundProtocolCost(nThreads={}): {:.1f} ns/round > {:.1f}",
+        nThreads,
+        nanosecondsPerRound,
+        MAX_PROTOCOL_NANOSECONDS_PER_ROUND));
+  }
+}
+
+void GOTestPerfSoundTaskBase::TestPerfNextPeriodLatency() {
+  // 5000 periods at 32 frames / 96000 Hz is ~1.7 seconds of audio
+  constexpr int N_PERIODS = 5000;
+  // one task's share of a 333.33 us period, not the whole period
+  constexpr int WORK_MICROSECONDS = 5;
+  // workers retry well within a period, so contention stays realistic
+  constexpr int WORKER_GAP_MICROSECONDS = 20;
+
+  for (const unsigned nThreads : {1u, 2u, 4u, 8u}) {
+    GOSoundTaskTestImpl task;
+    std::atomic<bool> isStopped{false};
+    std::vector<std::thread> workers;
+
+    task.doRunWorkMicroseconds.store(WORK_MICROSECONDS);
+
+    // The workers sleep between attempts rather than spinning: nThreads
+    // spinning workers plus this thread would oversubscribe the machine and
+    // turn the measurement into one of OS scheduling instead of contention.
+    for (unsigned threadI = 0; threadI < nThreads; threadI++)
+      workers.emplace_back([&task, &isStopped, WORKER_GAP_MICROSECONDS]() {
+        while (!isStopped.load()) {
+          task.Run();
+          std::this_thread::sleep_for(
+            std::chrono::microseconds(WORKER_GAP_MICROSECONDS));
+        }
+      });
+
+    double totalMicroseconds = 0;
+    double maxMicroseconds = 0;
+
+    for (int periodI = 0; periodI < N_PERIODS; periodI++) {
+      const auto start = std::chrono::high_resolution_clock::now();
+
+      // exactly what GOSoundOrganEngine::NextPeriod() does per audio period
+      task.CompleteRound();
+      task.NewRound();
+
+      const auto end = std::chrono::high_resolution_clock::now();
+      const double microseconds
+        = std::chrono::duration<double, std::micro>(end - start).count();
+
+      totalMicroseconds += microseconds;
+      if (microseconds > maxMicroseconds)
+        maxMicroseconds = microseconds;
+    }
+    isStopped.store(true);
+    for (std::thread &worker : workers)
+      worker.join();
+
+    const double meanMicroseconds = totalMicroseconds / N_PERIODS;
+    const bool isPassed = meanMicroseconds <= MAX_NEXT_PERIOD_MEAN_MICROSECONDS
+      && maxMicroseconds <= MAX_NEXT_PERIOD_PEAK_MICROSECONDS;
+    // how much of one audio period the handshake alone consumes
+    const double meanPeriodPercent
+      = 100.0 * meanMicroseconds / AUDIO_PERIOD_MICROSECONDS;
+    const double maxPeriods = maxMicroseconds / AUDIO_PERIOD_MICROSECONDS;
+
+    std::cout << std::format(
+      "  [{}] NextPeriodLatency(nThreads={}): mean {:.1f} us ({:.1f}% of a "
+      "{:.1f} us period, threshold {:.1f}), max {:.1f} us ({:.1f} periods, "
+      "threshold {:.1f})\n",
+      isPassed ? "PASS" : "FAIL",
+      nThreads,
+      meanMicroseconds,
+      meanPeriodPercent,
+      AUDIO_PERIOD_MICROSECONDS,
+      MAX_NEXT_PERIOD_MEAN_MICROSECONDS,
+      maxMicroseconds,
+      maxPeriods,
+      MAX_NEXT_PERIOD_PEAK_MICROSECONDS);
+    if (!isPassed)
+      m_failedTests.push_back(std::format(
+        "NextPeriodLatency(nThreads={}): mean {:.1f} us (max allowed {:.1f}), "
+        "max {:.1f} us (max allowed {:.1f})",
+        nThreads,
+        meanMicroseconds,
+        MAX_NEXT_PERIOD_MEAN_MICROSECONDS,
+        maxMicroseconds,
+        MAX_NEXT_PERIOD_PEAK_MICROSECONDS));
+  }
+}
+
+void GOTestPerfSoundTaskBase::TestPerfLazyPrerequisiteAccess() {
+  constexpr int N_ROUNDS = 5000;
+  constexpr int WORK_MICROSECONDS = 5;
+
+  for (const bool isDoneWithinRound : {true, false}) {
+    for (const unsigned nThreads : {1u, 2u, 4u, 8u}) {
+      GOSoundTaskTestImpl task;
+      std::atomic<int> nStalePayloads{0};
+
+      task.doRunResult.store(isDoneWithinRound);
+      task.doRunWorkMicroseconds.store(WORK_MICROSECONDS);
+
+      std::barrier roundBarrier(
+        static_cast<std::ptrdiff_t>(nThreads),
+        [&task]() noexcept { task.NewRound(); });
+      std::vector<std::thread> threads;
+
+      const auto start = std::chrono::high_resolution_clock::now();
+
+      for (unsigned threadI = 0; threadI < nThreads; threadI++)
+        threads.emplace_back([&task, &roundBarrier, &nStalePayloads]() {
+          for (int roundI = 0; roundI < N_ROUNDS; roundI++) {
+            // DoRun() publishes a strictly positive payload, so a zero here
+            // means this thread returned from Run() before the round's
+            // result was ready
+            if (task.GetPayloadLazily() == 0)
+              nStalePayloads.fetch_add(1);
+            roundBarrier.arrive_and_wait();
+          }
+        });
+      for (std::thread &thread : threads)
+        thread.join();
+
+      const auto end = std::chrono::high_resolution_clock::now();
+      const std::chrono::duration<double> elapsed = end - start;
+      const double roundsPerSecond = N_ROUNDS / elapsed.count();
+      const int nStale = nStalePayloads.load();
+      const bool isPassed
+        = roundsPerSecond >= MIN_LAZY_ROUNDS_PER_SECOND && nStale == 0;
+      const double ratio = roundsPerSecond / MIN_LAZY_ROUNDS_PER_SECOND;
+
+      std::cout << std::format(
+        "  [{}] LazyPrerequisiteAccess(doneWithinRound={}, nThreads={}): "
+        "{:.1f} rounds/sec (threshold: {:.1f}, ratio: {:5.2f}x), "
+        "stale payloads: {}\n",
+        isPassed ? "PASS" : "FAIL",
+        isDoneWithinRound,
+        nThreads,
+        roundsPerSecond,
+        MIN_LAZY_ROUNDS_PER_SECOND,
+        ratio,
+        nStale);
+      if (!isPassed)
+        m_failedTests.push_back(std::format(
+          "LazyPrerequisiteAccess(doneWithinRound={}, nThreads={}): "
+          "{:.1f} rounds/sec < {:.1f}, stale payloads: {}",
+          isDoneWithinRound,
+          nThreads,
+          roundsPerSecond,
+          MIN_LAZY_ROUNDS_PER_SECOND,
+          nStale));
+    }
+  }
+}
+
+void GOTestPerfSoundTaskBase::run() {
+  m_failedTests.clear();
+
+  std::cout << "\n========== Performance Tests for GOSoundTaskBase "
+               "==========\n";
+
+  TestPerfUncontendedRunThroughput();
+  TestPerfContendedRunLatency();
+  TestPerfCooperativeThroughput();
+  TestPerfRoundProtocolCost();
+  TestPerfNextPeriodLatency();
+  TestPerfLazyPrerequisiteAccess();
+
+  std::cout << "\n========== Performance Tests Completed ==========\n";
+
+  if (!m_failedTests.empty()) {
+    std::string errorMsg
+      = std::format("{} performance test(s) failed:\n", m_failedTests.size());
+
+    for (const auto &failedTest : m_failedTests)
+      errorMsg += "  - " + failedTest + "\n";
+    GOAssert(false, errorMsg);
+  }
+}

--- a/src/tests/testing/sound/tasks/GOTestPerfSoundTaskBase.h
+++ b/src/tests/testing/sound/tasks/GOTestPerfSoundTaskBase.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTPERFSOUNDTASKBASE_H
+#define GOTESTPERFSOUNDTASKBASE_H
+
+#include <string>
+#include <vector>
+
+#include "GOTest.h"
+
+class GOTestPerfSoundTaskBase : public GOTest {
+private:
+  static const std::string TEST_NAME;
+
+  std::vector<std::string> m_failedTests;
+
+  /** A single thread repeatedly calling Run() on an already-done,
+   * repeatable task: the hot path taken by a worker thread that pulls a
+   * task it has nothing left to do for this round. */
+  void TestPerfUncontendedRunThroughput();
+
+  /** Several threads repeatedly racing Run() on the same non-cooperative
+   * task, each round doing a small amount of real work in DoRun(): measures
+   * per-round latency and checks it does not blow up with thread count. */
+  void TestPerfContendedRunLatency();
+
+  /** Several threads repeatedly racing Run() on the same cooperative task
+   * (see CooperativeTaskImpl in GOTestSoundTaskBase.cpp): measures
+   * aggregate throughput of units of work processed per second. */
+  void TestPerfCooperativeThroughput();
+
+  /**
+   * Cost of the round protocol alone - the m_mutex acquisitions in Run() and
+   * NewRound() - with DoRun() doing nothing at all. The same loop is timed
+   * twice, once with Run() in the body and once without, and only the
+   * difference is reported, so that barrier and thread-scheduling overhead
+   * is subtracted instead of diluting the result. This is the number a
+   * lock-free rewrite of the protocol has to move.
+   */
+  void TestPerfRoundProtocolCost();
+
+  /**
+   * The shape of GOSoundOrganEngine::NextPeriod(): one thread standing in
+   * for the audio thread calls CompleteRound() then NewRound() in a loop
+   * while worker threads race Run() on the same task. Reports that one
+   * thread's own latency - the priority inversion cost - as mean and
+   * maximum, both against the 333.33 us budget of a 32 frame / 96000 Hz
+   * period, and thresholds them separately: audio drops out on the tail of
+   * the distribution, not on the average.
+   */
+  void TestPerfNextPeriodLatency();
+
+  /**
+   * The lazy-prerequisite path: several threads reading a not-yet-done task
+   * the way GOSoundWindchestTask::GetVolume() reads m_volume. Run in both
+   * protocols - DoRun() returning true, and DoRun() always returning false
+   * as GOSoundTouchTask does, where the task never becomes done within a
+   * round and every thread that loses the race must go and do its own share.
+   */
+  void TestPerfLazyPrerequisiteAccess();
+
+public:
+  GOTestPerfSoundTaskBase() : GOTest(GOTest::PERF) {}
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTPERFSOUNDTASKBASE_H */

--- a/src/tests/testing/sound/tasks/GOTestSoundTaskBase.cpp
+++ b/src/tests/testing/sound/tasks/GOTestSoundTaskBase.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundTaskBase.h"
+
+#include <atomic>
+#include <chrono>
+#include <format>
+#include <thread>
+#include <vector>
+
+#include "sound/tasks/GOSoundTaskBase.h"
+
+#include "GOSoundCooperativeTaskTestImpl.h"
+#include "GOSoundTaskTestImpl.h"
+
+const std::string GOTestSoundTaskBase::TEST_NAME = "GOTestSoundTaskBase";
+
+// Starts nThreads running body concurrently and joins all of them
+static void run_on_threads(unsigned nThreads, std::function<void()> body) {
+  std::vector<std::thread> threads;
+
+  for (unsigned threadI = 0; threadI < nThreads; threadI++)
+    threads.emplace_back(body);
+  for (std::thread &thread : threads)
+    thread.join();
+}
+
+void GOTestSoundTaskBase::TestInitialState() {
+  GOSoundTaskTestImpl task(GOSoundTaskBase::PRIORITY_TREMULANT, true);
+
+  GOAssert(!task.IsDone(), "a fresh task must not be done");
+  GOAssert(
+    task.GetPriority() == GOSoundTaskBase::PRIORITY_TREMULANT,
+    "GetPriority() must return the value passed to the constructor");
+  GOAssert(
+    task.IsRepeatable(), "IsRepeatable() must return the constructor value");
+  GOAssert(task.GetCost() == 0, "the default GetCost() must be 0");
+}
+
+void GOTestSoundTaskBase::TestRunCallsDoRunOnce() {
+  GOSoundTaskTestImpl task;
+
+  task.Run();
+  GOAssert(task.IsDone(), "the task must be done after DoRun() returns true");
+  GOAssert(
+    task.nDoRunCalls.load() == 1, "DoRun() must have been called exactly once");
+
+  task.Run();
+  task.Run();
+  GOAssert(
+    task.nDoRunCalls.load() == 1,
+    "further Run() calls within the same round must not call DoRun() again");
+}
+
+void GOTestSoundTaskBase::TestRunRepeatsUntilDoRunReturnsTrue() {
+  GOSoundTaskTestImpl task;
+
+  task.doRunResult.store(false);
+  task.Run();
+  task.Run();
+  task.Run();
+  GOAssert(
+    !task.IsDone(),
+    "the task must stay not-done while DoRun() keeps returning false");
+  GOAssert(
+    task.nDoRunCalls.load() == 3,
+    "DoRun() must be called again on every Run() while not done");
+}
+
+void GOTestSoundTaskBase::TestCompleteRoundSetsFlagAndFinishes() {
+  GOSoundTaskTestImpl task;
+
+  task.doRunResult.store(false);
+  task.CompleteRound();
+  GOAssert(task.GetIsToComplete(), "CompleteRound() must set m_IsToComplete");
+  GOAssert(
+    task.nDoRunCalls.load() == 1,
+    "CompleteRound() must call Run()/DoRun() exactly once");
+  GOAssert(
+    !task.IsDone(),
+    "CompleteRound() calling Run() once must not force IsDone() true when "
+    "DoRun() itself returned false - a DoRun() that cannot guarantee "
+    "finishing in one call must override CompleteRound() instead");
+}
+
+void GOTestSoundTaskBase::TestNewRoundResetsState() {
+  GOSoundTaskTestImpl task;
+
+  task.Run();
+  task.CompleteRound();
+  task.NewRound();
+  GOAssert(!task.IsDone(), "NewRound() must reset the round state");
+  GOAssert(!task.GetIsToComplete(), "NewRound() must clear m_IsToComplete");
+  GOAssert(
+    task.nDoNewRoundCalls.load() == 1, "DoNewRound() must be called once");
+}
+
+void GOTestSoundTaskBase::TestDiscardContentCallsNewRound() {
+  GOSoundTaskTestImpl task;
+
+  task.Run();
+  task.DiscardContent();
+  GOAssert(!task.IsDone(), "DiscardContent() must reset the round state");
+  GOAssert(
+    task.nDoNewRoundCalls.load() == 1,
+    "DiscardContent() must call DoNewRound() exactly like NewRound()");
+}
+
+static constexpr unsigned N_STRESS_ITERATIONS = 200;
+static constexpr unsigned N_STRESS_THREADS = 8;
+
+void GOTestSoundTaskBase::TestConcurrentRunExecutesDoRunExactlyOnce() {
+  for (unsigned iterI = 0; iterI < N_STRESS_ITERATIONS; iterI++) {
+    GOSoundTaskTestImpl task;
+
+    run_on_threads(N_STRESS_THREADS, [&task]() { task.Run(); });
+    GOAssert(
+      task.nDoRunCalls.load() == 1,
+      std::format(
+        "iteration {}: DoRun() must run exactly once for {} concurrent "
+        "Run() calls",
+        iterI,
+        N_STRESS_THREADS));
+    GOAssert(
+      task.nMaxConcurrentDoRunCalls.load() == 1,
+      std::format(
+        "iteration {}: m_mutex must exclude concurrent DoRun() execution",
+        iterI));
+    GOAssert(
+      task.IsDone(), std::format("iteration {}: task must end up done", iterI));
+  }
+}
+
+void GOTestSoundTaskBase::TestConcurrentRunWithIncompleteDoRun() {
+  for (unsigned iterI = 0; iterI < N_STRESS_ITERATIONS; iterI++) {
+    GOSoundTaskTestImpl task;
+
+    task.doRunResult.store(false);
+    run_on_threads(N_STRESS_THREADS, [&task]() { task.Run(); });
+    GOAssert(
+      !task.IsDone(),
+      std::format(
+        "iteration {}: task must never become done while DoRun() returns "
+        "false",
+        iterI));
+    GOAssert(
+      task.nMaxConcurrentDoRunCalls.load() == 1,
+      std::format(
+        "iteration {}: m_mutex must exclude concurrent DoRun() execution "
+        "even when incremental",
+        iterI));
+  }
+}
+
+void GOTestSoundTaskBase::TestConcurrentCompleteRoundAndRun() {
+  for (unsigned iterI = 0; iterI < N_STRESS_ITERATIONS; iterI++) {
+    GOSoundTaskTestImpl task;
+    std::atomic<bool> isRunning{true};
+
+    std::thread runner([&task, &isRunning]() {
+      while (isRunning.load())
+        task.Run();
+    });
+    std::this_thread::sleep_for(std::chrono::microseconds(50));
+    task.CompleteRound();
+    isRunning.store(false);
+    runner.join();
+
+    GOAssert(
+      task.IsDone(),
+      std::format(
+        "iteration {}: CompleteRound() must finish the round", iterI));
+    GOAssert(
+      task.nMaxConcurrentDoRunCalls.load() == 1,
+      std::format(
+        "iteration {}: CompleteRound() and Run() must not run DoRun() "
+        "concurrently",
+        iterI));
+  }
+}
+
+void GOTestSoundTaskBase::TestNewRoundWaitsForInFlightRun() {
+  for (unsigned iterI = 0; iterI < N_STRESS_ITERATIONS; iterI++) {
+    GOSoundTaskTestImpl task;
+
+    task.doRunSleepMicroseconds.store(5000);
+
+    std::thread runner([&task]() { task.Run(); });
+
+    // wait until DoRun() has actually entered (not just Run() called) before
+    // racing NewRound() in: nConcurrentDoRunCalls is incremented at the very
+    // start of DoRun(), before its sleep
+    while (task.nConcurrentDoRunCalls.load() == 0)
+      ;
+    task.NewRound();
+    runner.join();
+
+    GOAssert(
+      task.nDoRunCallsAsOfLastNewRound.load() == task.nDoRunCalls.load(),
+      std::format(
+        "iteration {}: NewRound() must not run concurrently with an "
+        "in-flight DoRun()",
+        iterI));
+  }
+}
+
+void GOTestSoundTaskBase::TestNoTornStateAcrossThreads() {
+  GOSoundTaskTestImpl task;
+
+  for (unsigned roundI = 0; roundI < N_STRESS_ITERATIONS; roundI++) {
+    const int nCallsBeforeRound = task.nDoRunCalls.load();
+    std::vector<std::thread> threads;
+
+    for (unsigned threadI = 0; threadI < N_STRESS_THREADS; threadI++)
+      threads.emplace_back([&task, threadI]() {
+        if (threadI % 2 == 0)
+          task.Run();
+        else
+          task.CompleteRound();
+      });
+    for (std::thread &thread : threads)
+      thread.join();
+
+    const bool isDone = task.IsDone();
+    const int nCallsThisRound = task.nDoRunCalls.load() - nCallsBeforeRound;
+
+    GOAssert(
+      !(isDone && nCallsThisRound == 0),
+      std::format(
+        "round {}: task is done but DoRun() was never called this round",
+        roundI));
+    task.NewRound();
+  }
+}
+
+void GOTestSoundTaskBase::TestCooperativeReachesDoneExactlyOnce() {
+  GOSoundCooperativeTaskTestImpl task;
+
+  task.SetWorkItems(1000);
+  run_on_threads(N_STRESS_THREADS, [&task]() { task.Run(); });
+
+  GOAssert(
+    task.nFirstTransitions.load() == 1,
+    "exactly one thread must claim the round");
+  GOAssert(
+    task.nCopyTransitions.load() == 1,
+    "exactly one thread must store the first partial result");
+  GOAssert(
+    task.nLastThreadFinishes.load() == 1,
+    "exactly one thread must finish the round");
+  GOAssert(
+    task.nSharedValue.load() == 1000,
+    "every unit of work must be accounted for exactly once");
+  GOAssert(task.IsDone(), "the round must end up done");
+}
+
+void GOTestSoundTaskBase::TestCooperativeThreadWithNoWorkExitsEarly() {
+  GOSoundCooperativeTaskTestImpl task;
+
+  task.SetWorkItems(1);
+  run_on_threads(N_STRESS_THREADS, [&task]() { task.Run(); });
+
+  GOAssert(
+    task.nSharedValue.load() == 1,
+    "the single unit of work must be neither lost nor duplicated");
+  GOAssert(
+    task.nLastThreadFinishes.load() == 1,
+    "threads with no work left must not prevent the round from finishing");
+  GOAssert(task.IsDone(), "the round must end up done");
+}
+
+void GOTestSoundTaskBase::TestCooperativeWaitOrStopBlocksUntilDone() {
+  GOSoundCooperativeTaskTestImpl task;
+
+  task.SetWorkItems(200);
+
+  std::thread runner([&task]() { task.Run(); });
+  std::thread waiter([&task]() { task.WaitUntilDone(); });
+
+  runner.join();
+  waiter.join();
+
+  GOAssert(
+    task.nLastThreadFinishes.load() == 1,
+    "the waiter must not return before the round actually finishes");
+  GOAssert(task.IsDone(), "the round must be done once the waiter returns");
+}
+
+void GOTestSoundTaskBase::TestCooperativeNewRoundAllowsFreshRound() {
+  GOSoundCooperativeTaskTestImpl task;
+
+  task.SetWorkItems(500);
+  run_on_threads(N_STRESS_THREADS, [&task]() { task.Run(); });
+  task.NewRound();
+
+  task.SetWorkItems(700);
+  run_on_threads(N_STRESS_THREADS, [&task]() { task.Run(); });
+
+  GOAssert(
+    task.nFirstTransitions.load() == 2,
+    "each round must be claimed exactly once");
+  GOAssert(
+    task.nCopyTransitions.load() == 2,
+    "each round must produce exactly one first partial result");
+  GOAssert(
+    task.nLastThreadFinishes.load() == 2,
+    "each round must finish exactly once");
+  GOAssert(
+    task.nSharedValue.load() == 700,
+    "the second round's result must not be mixed with the first round's");
+}
+
+void GOTestSoundTaskBase::run() {
+  TestInitialState();
+  TestRunCallsDoRunOnce();
+  TestRunRepeatsUntilDoRunReturnsTrue();
+  TestCompleteRoundSetsFlagAndFinishes();
+  TestNewRoundResetsState();
+  TestDiscardContentCallsNewRound();
+
+  TestConcurrentRunExecutesDoRunExactlyOnce();
+  TestConcurrentRunWithIncompleteDoRun();
+  TestConcurrentCompleteRoundAndRun();
+  TestNewRoundWaitsForInFlightRun();
+  TestNoTornStateAcrossThreads();
+
+  TestCooperativeReachesDoneExactlyOnce();
+  TestCooperativeThreadWithNoWorkExitsEarly();
+  TestCooperativeWaitOrStopBlocksUntilDone();
+  TestCooperativeNewRoundAllowsFreshRound();
+}

--- a/src/tests/testing/sound/tasks/GOTestSoundTaskBase.h
+++ b/src/tests/testing/sound/tasks/GOTestSoundTaskBase.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDTASKBASE_H
+#define GOTESTSOUNDTASKBASE_H
+
+#include <string>
+
+#include "GOTest.h"
+
+class GOTestSoundTaskBase : public GOTest {
+private:
+  static const std::string TEST_NAME;
+
+  /** A freshly constructed task reports the constructor arguments back and
+   * has not yet processed a round. */
+  void TestInitialState();
+
+  /** Run() calls DoRun() once and, once DoRun() returns true, further
+   * Run() calls within the same round are no-ops. */
+  void TestRunCallsDoRunOnce();
+
+  /** While DoRun() returns false, every Run() call invokes DoRun() again
+   * and the task never becomes done (the GOSoundTouchTask protocol). */
+  void TestRunRepeatsUntilDoRunReturnsTrue();
+
+  /** CompleteRound() sets m_IsToComplete and keeps calling Run() until the
+   * task is actually done, even if DoRun() keeps returning false. */
+  void TestCompleteRoundSetsFlagAndFinishes();
+
+  /** NewRound() resets the round state and m_IsToComplete and calls
+   * DoNewRound() exactly once. */
+  void TestNewRoundResetsState();
+
+  /** DiscardContent() has the same observable effect as NewRound(). */
+  void TestDiscardContentCallsNewRound();
+
+  /** Several threads calling Run() concurrently on the same task must
+   * still call DoRun() exactly once, never overlapping. */
+  void TestConcurrentRunExecutesDoRunExactlyOnce();
+
+  /** Same as above but with DoRun() returning false: several threads may
+   * each contribute a DoRun() call, but never two at once. */
+  void TestConcurrentRunWithIncompleteDoRun();
+
+  /** A thread calling CompleteRound() while another keeps calling Run()
+   * never overlaps with it in DoRun() and leaves the task done. */
+  void TestConcurrentCompleteRoundAndRun();
+
+  /** NewRound() must not observe/reset the round while a DoRun() started
+   * by a different thread is still in flight. */
+  void TestNewRoundWaitsForInFlightRun();
+
+  /** Across many rounds, driven by threads racing Run()/CompleteRound(),
+   * the task must never report done without DoRun() having run. */
+  void TestNoTornStateAcrossThreads();
+
+  /** In the cooperative protocol (see CooperativeTaskImpl), many threads
+   * joining a round contribute exactly once each, with no work lost or
+   * duplicated, and the round finishes exactly once. */
+  void TestCooperativeReachesDoneExactlyOnce();
+
+  /** When there is less work than threads, the threads that find nothing
+   * left neither lose nor duplicate the work already claimed. */
+  void TestCooperativeThreadWithNoWorkExitsEarly();
+
+  /** A thread waiting on the round's condition variable is not woken until
+   * the round has actually finished. */
+  void TestCooperativeWaitOrStopBlocksUntilDone();
+
+  /** NewRound() lets the cooperative protocol run a fresh, independent
+   * round without leaking state from the previous one. */
+  void TestCooperativeNewRoundAllowsFreshRound();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTSOUNDTASKBASE_H */


### PR DESCRIPTION
## Summary
- Gives `GOSoundTaskBase` a real implementation of the round life cycle (`Run()`/`CompleteRound()`/`NewRound()`) shared by every sound task, instead of just the `TaskPriority` enum: a task is run at most once per round under a mutex, tracked by a `RunState` (also usable by a cooperative subclass such as `GOSoundGroupTask`, which still overrides `Run()` itself). None of the seven existing tasks are switched to it yet — that is planned as a follow-up PR.
- Covers the new class with correctness tests, single-threaded and multi-threaded, including the cooperative protocol, using two small shared test doubles (`GOSoundTaskTestImpl`, `GOSoundCooperativeTaskTestImpl`) reused by the performance tests below.
- Adds performance tests isolating the round protocol itself, intended as the go/no-go gate for a later lock-free rewrite of it, covering round-protocol overhead, `NextPeriod()`-shaped latency, cooperative throughput, and lazy-prerequisite access patterns.

**This class is not used anywhere yet.** It is added in isolation, covered only by its own tests; no existing task inherits from it in this PR. Reimplementing the seven existing sound tasks on top of it is planned as follow-up work. Because nothing references it yet, this PR does not change GrandOrgue's behavior.

## Test plan
- [x] `make -k -j16` — builds clean
- [x] `./bin/GOTestExe --no-perf` — all tests pass, including the new `GOTestSoundTaskBase` correctness suite

Claude-Session: https://claude.ai/code/session_0164PtBRJai29FPXZ8EFLg2h