### PR TITLE
Renamed GOSoundFilter to GOSoundOnePoleFilter and relocated it to sound/

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -212,7 +212,6 @@ scheduler/GOSchedulerThread.cpp
 sound/interfaces/GOSoundCallbackConnector.cpp
 sound/playing/GOSoundAudioSection.cpp
 sound/playing/GOSoundFader.cpp
-sound/playing/GOSoundFilter.cpp
 sound/playing/GOSoundReleaseAlignTable.cpp
 sound/playing/GOSoundResample.cpp
 sound/playing/GOSoundSamplerPlayer.cpp
@@ -239,6 +238,7 @@ sound/tasks/GOSoundTouchTask.cpp
 sound/tasks/GOSoundTremulantTask.cpp
 sound/tasks/GOSoundWindchestTask.cpp
 sound/GOSoundDevInfo.cpp
+sound/GOSoundOnePoleFilter.cpp
 sound/GOSoundOrganEngine.cpp
 sound/GOSoundSystem.cpp
 updater/GOUpdateChecker.cpp

--- a/src/grandorgue/sound/GOSoundOnePoleFilter.cpp
+++ b/src/grandorgue/sound/GOSoundOnePoleFilter.cpp
@@ -1,24 +1,24 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#include "GOSoundFilter.h"
+#include "GOSoundOnePoleFilter.h"
 
-GOSoundFilter::GOSoundFilter() {
-  m_type = FilterType::TYPE_NONE;
+GOSoundOnePoleFilter::GOSoundOnePoleFilter() {
+  m_type = Type::TYPE_NONE;
   m_samplerate = 0;
   m_B0 = 0;
   m_B1 = 0;
   m_A1 = 0;
 }
 
-void GOSoundFilter::Init(FilterType type, double frequency, double gain) {
+void GOSoundOnePoleFilter::Init(Type type, double frequency, double gain) {
   // if for any reason m_samlerate is not set, don't even try using filter
   if (m_samplerate == 0) {
-    m_type = FilterType::TYPE_NONE;
+    m_type = Type::TYPE_NONE;
     return;
   }
   m_type = type;
@@ -33,25 +33,25 @@ void GOSoundFilter::Init(FilterType type, double frequency, double gain) {
   double sinW0 = sin(w0);
 
   switch (m_type) {
-  case FilterType::TYPE_LPF:
+  case Type::TYPE_LPF:
     b0 = sinW0;
     b1 = sinW0;
     a0 = sinW0 + cosW0 + 1.0;
     a1 = (sinW0 - cosW0 - 1.0);
     break;
-  case FilterType::TYPE_HPF:
+  case Type::TYPE_HPF:
     b0 = 1.0 + cosW0;
     b1 = -(1.0 + cosW0);
     a0 = sinW0 + cosW0 + 1.0;
     a1 = (sinW0 - cosW0 - 1.0);
     break;
-  case FilterType::TYPE_LOW_SHELF:
+  case Type::TYPE_LOW_SHELF:
     b0 = amp * sinW0 + cosW0 + 1.0;
     b1 = amp * sinW0 - cosW0 - 1.0;
     a0 = 1.0 / amp * sinW0 + cosW0 + 1.0;
     a1 = 1.0 / amp * sinW0 - cosW0 - 1.0;
     break;
-  case FilterType::TYPE_HIGH_SHELF:
+  case Type::TYPE_HIGH_SHELF:
     b0 = sinW0 + amp + amp * cosW0;
     b1 = sinW0 - amp - amp * cosW0;
     a0 = sinW0 + 1.0 / amp + 1.0 / amp * cosW0;
@@ -65,7 +65,8 @@ void GOSoundFilter::Init(FilterType type, double frequency, double gain) {
   m_A1 = a1 / a0;
 }
 
-void GOSoundFilter::FilterState::Init(const GOSoundFilter *filter) {
+void GOSoundOnePoleFilter::FilterState::Init(
+  const GOSoundOnePoleFilter *filter) {
   p_filter = filter;
   for (int i = 0; i < 2; i++)
     m_state[i] = 0;

--- a/src/grandorgue/sound/GOSoundOnePoleFilter.h
+++ b/src/grandorgue/sound/GOSoundOnePoleFilter.h
@@ -5,17 +5,17 @@
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
-#ifndef GOSOUNDFILTER_H_
-#define GOSOUNDFILTER_H_
+#ifndef GOSOUNDONEPOLEFILTER_H_
+#define GOSOUNDONEPOLEFILTER_H_
 
 #include <cmath>
 #include <cstdint>
 
 #include "sound/buffer/GOSoundBufferMutable.h"
 
-class GOSoundFilter {
+class GOSoundOnePoleFilter {
 public:
-  enum class FilterType : uint8_t {
+  enum class Type : uint8_t {
     TYPE_NONE = 0,
     TYPE_LPF,
     TYPE_HPF,
@@ -25,7 +25,7 @@ public:
   class FilterState {
   public:
     FilterState() { Init(nullptr); }
-    void Init(const GOSoundFilter *filter);
+    void Init(const GOSoundOnePoleFilter *filter);
     bool IsToApply() { return p_filter && p_filter->IsToApply(); }
     inline void ProcessBuffer(GOSoundBufferMutable &outBuffer) {
       float *pData = outBuffer.GetData();
@@ -45,11 +45,11 @@ public:
 
   private:
     float m_state[2];
-    const GOSoundFilter *p_filter;
+    const GOSoundOnePoleFilter *p_filter;
   };
 
 private:
-  FilterType m_type;
+  Type m_type;
   unsigned m_samplerate;
 
   // Calculated filter coefficients
@@ -58,13 +58,13 @@ private:
   double m_A1;
 
 public:
-  GOSoundFilter();
-  void Init(FilterType type, double frequency, double gain = 0);
+  GOSoundOnePoleFilter();
+  void Init(Type type, double frequency, double gain = 0);
   bool IsToApply() const { return static_cast<bool>(m_type); }
   void SetSamplerate(unsigned samplerate) {
     m_samplerate = samplerate;
-    m_type = FilterType::TYPE_NONE;
+    m_type = Type::TYPE_NONE;
   }
 };
 
-#endif /* GOSOUNDFILTER_H_ */
+#endif /* GOSOUNDONEPOLEFILTER_H_ */

--- a/src/grandorgue/sound/playing/GOSoundSampler.h
+++ b/src/grandorgue/sound/playing/GOSoundSampler.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,9 +8,10 @@
 #ifndef GOSOUNDSAMPLER_H_
 #define GOSOUNDSAMPLER_H_
 
+#include "sound/GOSoundOnePoleFilter.h"
+
 #include "GOBool3.h"
 #include "GOSoundFader.h"
-#include "GOSoundFilter.h"
 #include "GOSoundStream.h"
 
 class GOSoundProvider;
@@ -24,7 +25,7 @@ struct GOSoundSampler {
   unsigned m_AudioGroupId;
   GOSoundStream stream;
   GOSoundFader fader;
-  GOSoundFilter::FilterState toneBalanceFilterState;
+  GOSoundOnePoleFilter::FilterState toneBalanceFilterState;
   uint64_t time;
   unsigned velocity;
   unsigned delay;

--- a/src/grandorgue/sound/playing/GOSoundToneBalanceFilter.cpp
+++ b/src/grandorgue/sound/playing/GOSoundToneBalanceFilter.cpp
@@ -11,16 +11,16 @@
 
 void GOSoundToneBalanceFilter::Init(int8_t value) {
   if (value == 0)
-    m_filter.Init(GOSoundFilter::FilterType::TYPE_NONE, 0);
+    m_filter.Init(GOSoundOnePoleFilter::Type::TYPE_NONE, 0);
   else {
     double hz;
-    GOSoundFilter::FilterType type;
+    GOSoundOnePoleFilter::Type type;
 
     if (value < 0) {
-      type = GOSoundFilter::FilterType::TYPE_LPF;
+      type = GOSoundOnePoleFilter::Type::TYPE_LPF;
       hz = 16000 * pow(20.0 / 16000.0, abs(value) / 99.0);
     } else {
-      type = GOSoundFilter::FilterType::TYPE_HPF;
+      type = GOSoundOnePoleFilter::Type::TYPE_HPF;
       hz = 20 * pow(800.0, value / 99.0);
     }
 

--- a/src/grandorgue/sound/playing/GOSoundToneBalanceFilter.h
+++ b/src/grandorgue/sound/playing/GOSoundToneBalanceFilter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -8,18 +8,18 @@
 #ifndef GOSOUNDTONEBALANCEFILTER_H_
 #define GOSOUNDTONEBALANCEFILTER_H_
 
-#include "GOSoundFilter.h"
+#include "sound/GOSoundOnePoleFilter.h"
 
 class GOSoundToneBalanceFilter {
 public:
   void Init(int8_t value);
-  const GOSoundFilter *GetFilter() const { return &m_filter; }
+  const GOSoundOnePoleFilter *GetFilter() const { return &m_filter; }
   void SetFilterSamplerate(unsigned samplerate) {
     m_filter.SetSamplerate(samplerate);
   }
 
 private:
-  GOSoundFilter m_filter;
+  GOSoundOnePoleFilter m_filter;
 };
 
 #endif /* GOSOUNDTONEBALANCE_H_ */


### PR DESCRIPTION
## Summary
- Pure rename+move, no logic changes: `sound/playing/GOSoundFilter.{h,cpp}` -> `sound/GOSoundOnePoleFilter.{h,cpp}`, `FilterType` -> `Type`.
- `GOSoundFilter` is performance-critical, per-sampler shared code used only by `GOSoundToneBalanceFilter`, but lived under `sound/playing/` as if it were sampler-specific. Moving it to `sound/` reflects that it's shared infrastructure, and sets up a follow-up change that turns it into a genuinely shared one-pole filter core reused by a future windchest shelf-EQ effect alongside the existing tone-balance filter.
- All call sites updated for the new name/path: `GOSoundToneBalanceFilter.h/.cpp`, `GOSoundSampler.h`. `CMakeLists.txt` path updated.

## Test plan
- [x] `cmake -DGO_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug ...` build succeeds
- [x] `./bin/GOTestExe` run: all functional tests pass (only unrelated performance-threshold benchmarks fail, calibrated for faster reference hardware)