### PR TITLE
Widen flaky perf test baselines for mutable buffer operations

### DIFF
--- a/src/tests/testing/sound/buffer/GOTestPerfSoundBufferMutable.cpp
+++ b/src/tests/testing/sound/buffer/GOTestPerfSoundBufferMutable.cpp
@@ -43,8 +43,9 @@ static constexpr Baseline BASELINE_FILL_WITH_SILENCE[] = {
   {512, 4840}, // 4840 Mframes/sec (lowered: min observed 5382.5, -10% margin)
   {2048, 8600} // 8600 Mframes/sec (lowered: min observed 9653.4, -10% margin)
 #else
-  {32,
-   2330}, // 2330 Mframes/sec (debug, lowered: min observed 2590.4, -10% margin)
+  {32, 2000}, // 2000 Mframes/sec (debug, widened to -20% margin: CI runner
+              // variance exceeds 10%, observed as low as 2132.7 on
+              // 2026-08-26/28)
   {128,
    4050}, // 4050 Mframes/sec (debug, lowered: min observed 4507.3, -10% margin)
   {512,
@@ -173,8 +174,9 @@ static constexpr Baseline BASELINE_MONO_COPY_ADD_FROM_COEFF[] = {
 #else
   {32,
    450}, // 450 Mframes/sec (debug, lowered: min observed 502.5, -10% margin)
-  {128,
-   590}, // 590 Mframes/sec (debug, raised: min observed 659.3, -10% margin)
+  {128, 500}, // 500 Mframes/sec (debug, widened to -20% margin: CI runner
+              // variance exceeds 10%, observed as low as 547.8 on
+              // 2026-08-26/28)
   {512,
    640}, // 640 Mframes/sec (debug, raised: min observed 724.3, -10% margin)
   {2048,


### PR DESCRIPTION
## Summary
- CI Build runs over 2026-08-26..08-28 (both upstream and a fork's runners) repeatedly failed or nearly failed a couple of Debug-build `GOTestPerfSoundBufferMutable` perf baselines that were tuned from only 5 CI runs on 2026-08-19..08-24.
- Runner-to-runner variance turns out to exceed the assumed 10% margin for these entries, so this widens them to -20%:
  - `BASELINE_FILL_WITH_SILENCE{32}` (Debug): 2330 → 2000 (observed as low as 2132.7)
  - `BASELINE_MONO_COPY_ADD_FROM_COEFF{128}` (Debug): 590 → 500 (observed as low as 547.8)

## Test plan
- [ ] CI `Build` workflow (tests job, `perf` matrix, Debug) is green on this branch across a few runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MneZKkoA7k2xscuZSZZFMk