### PR TITLE
Modified GOGUIPanel and the 9 panel creators to take GOGuiOrgan&

### DIFF
--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -31,17 +31,7 @@
 #include "files/GOOpenedFile.h"
 #include "gui/GOGuiImageCache.h"
 #include "gui/dialogs/go-message-boxes.h"
-#include "gui/panels/GOGUIBankedGeneralsPanel.h"
-#include "gui/panels/GOGUICouplerManualsAndVolumePanel.h"
-#include "gui/panels/GOGUICouplerPanel.h"
-#include "gui/panels/GOGUICrescendoPanel.h"
-#include "gui/panels/GOGUIDivisionalsPanel.h"
-#include "gui/panels/GOGUIMasterPanel.h"
-#include "gui/panels/GOGUIMetronomePanel.h"
 #include "gui/panels/GOGUIPanel.h"
-#include "gui/panels/GOGUIPanelCreator.h"
-#include "gui/panels/GOGUIRecorderPanel.h"
-#include "gui/panels/GOGUISequencerPanel.h"
 #include "loader/GOLoadThread.h"
 #include "loader/GOLoaderFilename.h"
 #include "loader/GOOrganReader.h"
@@ -156,10 +146,9 @@ void GOOrganController::ClearObjects() {
   }
 }
 
-void GOOrganController::OnClear() {
+void GOOrganController::ClearOrganGuiData() {
   if (m_IsOrganGuiLoaded) {
     m_panels.clear();
-    m_panelcreators.clear();
     m_IsOrganGuiLoaded = false;
   }
 }
@@ -353,21 +342,11 @@ void GOOrganController::LoadOrganCoreData(GOConfigReader &cfg) {
     | (result.hash[7] & 0x7F);
 }
 
-void GOOrganController::OnLoad(GOConfigReader &cfg) {
+void GOOrganController::LoadOrganGuiData(GOConfigReader &cfg) {
   m_IsOrganGuiLoaded = true;
 
   unsigned NumberOfPanels = cfg.ReadInteger(
     ODFSetting, WX_ORGAN, wxT("NumberOfPanels"), 0, 100, false);
-
-  m_panelcreators.push_back(new GOGUICouplerPanel(this, m_VirtualCouplers));
-  m_panelcreators.push_back(new GOGUICouplerManualsAndVolumePanel(this));
-  m_panelcreators.push_back(new GOGUIMetronomePanel(this));
-  m_panelcreators.push_back(new GOGUICrescendoPanel(this));
-  m_panelcreators.push_back(new GOGUIDivisionalsPanel(this));
-  m_panelcreators.push_back(new GOGUIBankedGeneralsPanel(this));
-  m_panelcreators.push_back(new GOGUISequencerPanel(this));
-  m_panelcreators.push_back(new GOGUIMasterPanel(this));
-  m_panelcreators.push_back(new GOGUIRecorderPanel(this));
 
   m_PitchLabel.Load(cfg, wxT("SetterMasterPitch"), _("organ pitch"));
   m_TemperamentLabel.Load(
@@ -375,24 +354,18 @@ void GOOrganController::OnLoad(GOConfigReader &cfg) {
   m_MainWindowData.Load(cfg);
 
   m_panels.resize(0);
-  m_panels.push_back(new GOGUIPanel(this));
+  m_panels.push_back(new GOGUIPanel(this, GetImageCache(), GetMouseState()));
   m_panels[0]->Load(cfg, wxT(""));
 
   wxString buffer;
 
   for (unsigned i = 0; i < NumberOfPanels; i++) {
     buffer.Printf(wxT("Panel%03d"), i + 1);
-    m_panels.push_back(new GOGUIPanel(this));
+    m_panels.push_back(new GOGUIPanel(this, GetImageCache(), GetMouseState()));
     m_panels[i + 1]->Load(cfg, buffer);
   }
 
   m_StopWindowSizeKeeper.Load(cfg, wxT("Stops"));
-
-  for (unsigned i = 0; i < m_panelcreators.size(); i++)
-    m_panelcreators[i]->CreatePanels(cfg);
-
-  for (unsigned i = 0; i < m_panels.size(); i++)
-    m_panels[i]->Layout();
 }
 
 class GOLoadAborted : public std::exception {};

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -40,11 +40,9 @@ class GOConfigWriter;
 class GODialogSizeSet;
 class GODivisionalSetter;
 class GOElementCreator;
-class GOGUICouplerPanel;
 class GOGuiImageCache;
 class GOGuiOrgan;
 class GOGUIPanel;
-class GOGUIPanelCreator;
 class GOMidiEvent;
 class GOMidiPlayer;
 class GOMidiRecorder;
@@ -97,7 +95,6 @@ private:
   GOVirtualCouplerController m_VirtualCouplers;
 
   ptr_vector<GOGUIPanel> m_panels;
-  ptr_vector<GOGUIPanelCreator> m_panelcreators;
   ptr_vector<GOElementCreator> m_elementcreators;
 
   GOMidiSystem *m_midi;
@@ -123,10 +120,12 @@ private:
   void LoadOrganCoreData(GOConfigReader &cfg);
   /** Hook for a subclass to load GUI-only data, called after
    * LoadOrganCoreData() and before the ODF/CMB unused-key report. Empty by
-   * default - a bare GOOrganController has no GUI.
+   * default - a bare GOOrganController has no GUI. Overridden by
+   * GOGuiOrgan::Controller, which calls LoadOrganGuiData() below (still
+   * owned by this class) before building its own panel creators.
    * @param cfg the config reader for the ODF/CMB currently being loaded,
    *   the same one passed to LoadOrganCoreData() */
-  virtual void OnLoad(GOConfigReader &cfg);
+  virtual void OnLoad(GOConfigReader &cfg) {}
   /** Loads pipe/sample data from the cache or, failing that, from the
    * sample files in parallel worker threads. Sets m_IsObjectsLoaded. */
   void LoadObjects(GOProgressMonitor &monitor);
@@ -143,13 +142,30 @@ private:
   /** Hook for a subclass to clear GUI-only data, called after
    * ClearObjects() and before ClearOrganCoreData() (GUI data may reference
    * core model objects that ClearOrganCoreData() frees). Empty by default.
-   * Undoes OnLoad() if it ran. Idempotent. */
-  virtual void OnClear();
+   * Overridden by GOGuiOrgan::Controller, which calls ClearOrganGuiData()
+   * below (still owned by this class) to clear its own panel creators. */
+  virtual void OnClear() {}
   /** Undoes LoadOrganCoreData if it ran. Idempotent. */
   void ClearOrganCoreData();
   GOHashType GenerateCacheHash();
   void SetTemperament(const GOTemperament &temperament);
   void PreconfigRecorder();
+
+protected:
+  /**
+   * Loads the GUI-only data still owned by this class (panels, image
+   * cache, main-window data, stop-window size) - everything OnLoad() used
+   * to do except building/running the panel creators, which
+   * GOGuiOrgan::Controller now owns and runs after this returns. Called
+   * from GOGuiOrgan::Controller::OnLoad(). Temporary: GOGuiOrgan will take
+   * over this data too once the ownership move is complete, at which point
+   * this method goes away.
+   * @param cfg the config reader for the ODF/CMB currently being loaded
+   */
+  void LoadOrganGuiData(GOConfigReader &cfg);
+  /** Undoes LoadOrganGuiData(). Called from
+   * GOGuiOrgan::Controller::OnClear(). Temporary, see LoadOrganGuiData(). */
+  void ClearOrganGuiData();
 
 public:
   GOOrganController(GOConfig &config, bool isAppInitialized = false);
@@ -255,6 +271,12 @@ public:
   GOLabelControl *GetPitchLabel() { return &m_PitchLabel; }
   GOLabelControl *GetTemperamentLabel() { return &m_TemperamentLabel; }
   GOMainWindowData *GetMainWindowData() { return &m_MainWindowData; }
+
+  /** @return the virtual coupler configuration for this organ, used by
+   * GOGUICouplerPanel when building the coupler panel. */
+  const GOVirtualCouplerController &GetVirtualCouplers() const {
+    return m_VirtualCouplers;
+  }
 
   /**
    * Loads a MIDI file for playback via the MIDI player.

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -10,14 +10,24 @@
 #include <wx/app.h>
 
 #include "config/GOConfig.h"
+#include "config/GOConfigReader.h"
 #include "document-base/GODocumentView.h"
 #include "frames/GOAppWindow.h"
 #include "gui/dialogs/GOMidiObjectstDialog.h"
 #include "gui/dialogs/midi-event/GOMidiEventDialog.h"
 #include "gui/dialogs/organ-settings/GOOrganSettingsDialog.h"
 #include "gui/frames/GOStopsWindow.h"
+#include "gui/panels/GOGUIBankedGeneralsPanel.h"
+#include "gui/panels/GOGUICouplerManualsAndVolumePanel.h"
+#include "gui/panels/GOGUICouplerPanel.h"
+#include "gui/panels/GOGUICrescendoPanel.h"
+#include "gui/panels/GOGUIDivisionalsPanel.h"
+#include "gui/panels/GOGUIMasterPanel.h"
+#include "gui/panels/GOGUIMetronomePanel.h"
 #include "gui/panels/GOGUIPanel.h"
 #include "gui/panels/GOGUIPanelView.h"
+#include "gui/panels/GOGUIRecorderPanel.h"
+#include "gui/panels/GOGUISequencerPanel.h"
 #include "gui/size/GOResizable.h"
 #include "loader/GOProgressMonitor.h"
 #include "midi/GOMidiSystem.h"
@@ -49,6 +59,18 @@ bool GOGuiOrgan::IsModified() const {
   return m_OrganController && m_OrganController->IsOrganModified();
 }
 
+GOGuiImageCache &GOGuiOrgan::GetImageCache() {
+  return m_OrganController->GetImageCache();
+}
+
+GOGUIMouseState &GOGuiOrgan::GetMouseState() {
+  return m_OrganController->GetMouseState();
+}
+
+void GOGuiOrgan::AddPanel(GOGUIPanel *panel) {
+  m_OrganController->AddPanel(panel);
+}
+
 GOOrganController *GOGuiOrgan::LoadOrgan(
   const GOOrgan &organ,
   const wxString &cmb,
@@ -58,7 +80,7 @@ GOOrganController *GOGuiOrgan::LoadOrgan(
   GOConfig &cfg = r_config;
 
   CloseOrgan();
-  m_OrganController = new GOOrganController(cfg, true);
+  m_OrganController = new Controller(cfg, *this);
   wxString error = m_OrganController->Load(organ, cmb, isGuiOnly, monitor);
 
   if (error.IsEmpty()) {
@@ -126,6 +148,27 @@ bool GOGuiOrgan::Save(const wxString &path) {
   SyncState();
   return m_OrganController->Save(path);
 }
+
+void GOGuiOrgan::LoadOrganGui(GOConfigReader &cfg) {
+  m_PanelCreators.push_back(
+    new GOGUICouplerPanel(*this, m_OrganController->GetVirtualCouplers()));
+  m_PanelCreators.push_back(new GOGUICouplerManualsAndVolumePanel(*this));
+  m_PanelCreators.push_back(new GOGUIMetronomePanel(*this));
+  m_PanelCreators.push_back(new GOGUICrescendoPanel(*this));
+  m_PanelCreators.push_back(new GOGUIDivisionalsPanel(*this));
+  m_PanelCreators.push_back(new GOGUIBankedGeneralsPanel(*this));
+  m_PanelCreators.push_back(new GOGUISequencerPanel(*this));
+  m_PanelCreators.push_back(new GOGUIMasterPanel(*this));
+  m_PanelCreators.push_back(new GOGUIRecorderPanel(*this));
+
+  for (unsigned i = 0; i < m_PanelCreators.size(); i++)
+    m_PanelCreators[i]->CreatePanels(cfg);
+
+  for (unsigned i = 0; i < m_OrganController->GetPanelCount(); i++)
+    m_OrganController->GetPanel(i)->Layout();
+}
+
+void GOGuiOrgan::ClearOrganGui() { m_PanelCreators.clear(); }
 
 void GOGuiOrgan::CloseOrgan() {
   m_listener.SetCallback(NULL);

--- a/src/grandorgue/gui/GOGuiOrgan.h
+++ b/src/grandorgue/gui/GOGuiOrgan.h
@@ -10,22 +10,63 @@
 
 #include <wx/string.h>
 
+#include "ptrvector.h"
+
+#include "GOOrganController.h"
 #include "document-base/GODocumentBase.h"
 #include "midi/GOMidiListener.h"
 #include "midi/events/GOMidiCallback.h"
 #include "threading/GOMutex.h"
 
 class GOConfig;
+class GOConfigReader;
+class GOGuiImageCache;
+class GOGUIMouseState;
+class GOGUIPanel;
+class GOGUIPanelCreator;
 class GOMidiDialogListener;
 class GOMidiObject;
 class GOMidiSystem;
-class GOOrganController;
 class GOOrgan;
 class GOProgressMonitor;
 class GOResizable;
 
 class GOGuiOrgan : public GODocumentBase, protected GOMidiCallback {
 private:
+  /** GUI-aware GOOrganController used only while this GOGuiOrgan has an
+   * organ loaded. Its OnLoad()/OnClear() overrides run the panel-creator
+   * orchestration that used to live in GOOrganController::OnLoad()/
+   * OnClear() directly - the rest of that GUI data (image cache, panels,
+   * main-window data, stop-window size) is still owned by
+   * GOOrganController itself for now (see LoadOrganGuiData()/
+   * ClearOrganGuiData() there) and reached here through m_OrganController's
+   * existing accessors, until a later step moves it here too. */
+  class Controller : public GOOrganController {
+  private:
+    GOGuiOrgan &r_GuiOrgan;
+
+  protected:
+    void OnLoad(GOConfigReader &cfg) override {
+      LoadOrganGuiData(cfg);
+      r_GuiOrgan.LoadOrganGui(cfg);
+    }
+    void OnClear() override {
+      r_GuiOrgan.ClearOrganGui();
+      ClearOrganGuiData();
+    }
+
+  public:
+    /**
+     * @param config the application config, forwarded to GOOrganController
+     * @param guiOrgan the enclosing GOGuiOrgan that owns this Controller
+     */
+    Controller(GOConfig &config, GOGuiOrgan &guiOrgan)
+      : GOOrganController(config, true), r_GuiOrgan(guiOrgan) {}
+    /** Clears GUI data (via OnClear()) before the base destructor frees
+     * core model data panels may reference. */
+    ~Controller() override { Clear(); }
+  };
+
   GOResizable *p_MainWindow;
   GOConfig &r_config;
   GOMidiSystem &r_MidiSystem;
@@ -36,7 +77,22 @@ private:
 
   GOMidiListener m_listener;
 
+  /** The panel-creator objects that build this organ's built-in panels
+   * (coupler, crescendo, divisionals, etc.). Temporary: the rest of the
+   * GUI data these creators populate (m_OrganController's m_panels) will
+   * move here too in a later step. */
+  ptr_vector<GOGUIPanelCreator> m_PanelCreators;
+
   void OnMidiEvent(const GOMidiEvent &event) override;
+
+  /** Builds and runs this organ's panel creators, called from
+   * Controller::OnLoad() after LoadOrganGuiData() has built the base and
+   * numbered panels the creators may add to.
+   * @param cfg the config reader for the ODF/CMB currently being loaded */
+  void LoadOrganGui(GOConfigReader &cfg);
+  /** Undoes LoadOrganGui(). Called from Controller::OnClear() before
+   * ClearOrganGuiData() frees the panels the creators may reference. */
+  void ClearOrganGui();
 
   void SyncState();
   void CloseOrgan();
@@ -47,6 +103,20 @@ public:
 
   GOOrganController *GetOrganController() const { return m_OrganController; }
   bool IsModified() const;
+
+  /** @return the image cache for the currently loaded organ, still owned
+   * by m_OrganController. */
+  GOGuiImageCache &GetImageCache();
+  /** @return the shared mouse state for the currently loaded organ's
+   * panels, still owned by m_OrganController. */
+  GOGUIMouseState &GetMouseState();
+  /**
+   * Registers a newly-built panel, called by a panel creator's
+   * CreatePanels() while building this organ's GUI. Forwards to
+   * m_OrganController, which still owns the panels array.
+   * @param panel the panel to add; ownership transfers to m_OrganController
+   */
+  void AddPanel(GOGUIPanel *panel);
 
   void ShowPanel(unsigned id);
   void ShowOrganSettingsDialog();

--- a/src/grandorgue/gui/panels/GOGUIBankedGeneralsPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIBankedGeneralsPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -15,22 +15,23 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
+#include "gui/GOGuiOrgan.h"
 
-GOGUIBankedGeneralsPanel::GOGUIBankedGeneralsPanel(
-  GOOrganController *organController)
-  : m_OrganController(organController) {}
+GOGUIBankedGeneralsPanel::GOGUIBankedGeneralsPanel(GOGuiOrgan &guiOrgan)
+  : r_GuiOrgan(guiOrgan), m_OrganController(guiOrgan.GetOrganController()) {}
 
 GOGUIBankedGeneralsPanel::~GOGUIBankedGeneralsPanel() {}
 
 void GOGUIBankedGeneralsPanel::CreatePanels(GOConfigReader &cfg) {
-  m_OrganController->AddPanel(CreateBankedGeneralsPanel(cfg));
+  r_GuiOrgan.AddPanel(CreateBankedGeneralsPanel(cfg));
 }
 
 GOGUIPanel *GOGUIBankedGeneralsPanel::CreateBankedGeneralsPanel(
   GOConfigReader &cfg) {
   GOGUIButton *button;
 
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics = new GOGUISetterDisplayMetrics(
     cfg, m_OrganController, GOGUI_SETTER_GENERALS);
   panel->Init(cfg, metrics, _("Generals"), wxT("SetterGeneralsPanel"));

--- a/src/grandorgue/gui/panels/GOGUIBankedGeneralsPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIBankedGeneralsPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,17 +10,19 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 
 class GOGUIBankedGeneralsPanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
 
   GOGUIPanel *CreateBankedGeneralsPanel(GOConfigReader &cfg);
 
 public:
-  GOGUIBankedGeneralsPanel(GOOrganController *organController);
+  GOGUIBankedGeneralsPanel(GOGuiOrgan &guiOrgan);
   virtual ~GOGUIBankedGeneralsPanel();
 
   void CreatePanels(GOConfigReader &cfg);

--- a/src/grandorgue/gui/panels/GOGUICouplerManualsAndVolumePanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUICouplerManualsAndVolumePanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -20,23 +20,25 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
+#include "gui/GOGuiOrgan.h"
 
 static const GOMidiObjectContext MIDI_CONTEXT_VOLUMES(
   wxT("volumes"), _("volumes"));
 
 GOGUICouplerManualsAndVolumePanel::GOGUICouplerManualsAndVolumePanel(
-  GOOrganController *organController)
-  : m_OrganController(organController) {}
+  GOGuiOrgan &guiOrgan)
+  : r_GuiOrgan(guiOrgan), m_OrganController(guiOrgan.GetOrganController()) {}
 
 GOGUICouplerManualsAndVolumePanel::~GOGUICouplerManualsAndVolumePanel() {}
 
 void GOGUICouplerManualsAndVolumePanel::CreatePanels(GOConfigReader &cfg) {
-  m_OrganController->AddPanel(CreatePanel(cfg));
+  r_GuiOrgan.AddPanel(CreatePanel(cfg));
 }
 
 GOGUIPanel *GOGUICouplerManualsAndVolumePanel::CreatePanel(
   GOConfigReader &cfg) {
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics = new GOGUISetterDisplayMetrics(
     cfg, m_OrganController, GOGUI_SETTER_FLOATING);
   panel->Init(

--- a/src/grandorgue/gui/panels/GOGUICouplerManualsAndVolumePanel.h
+++ b/src/grandorgue/gui/panels/GOGUICouplerManualsAndVolumePanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,17 +10,19 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 
 class GOGUICouplerManualsAndVolumePanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
 
   GOGUIPanel *CreatePanel(GOConfigReader &cfg);
 
 public:
-  GOGUICouplerManualsAndVolumePanel(GOOrganController *organController);
+  GOGUICouplerManualsAndVolumePanel(GOGuiOrgan &guiOrgan);
   ~GOGUICouplerManualsAndVolumePanel();
 
   void CreatePanels(GOConfigReader &cfg);

--- a/src/grandorgue/gui/panels/GOGUICouplerPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUICouplerPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -12,6 +12,8 @@
 #include "model/GOCoupler.h"
 #include "model/GOManual.h"
 
+#include "gui/GOGuiOrgan.h"
+
 #include "GOGUIButton.h"
 #include "GOGUIHW1Background.h"
 #include "GOGUILabel.h"
@@ -21,18 +23,25 @@
 #include "GOOrganController.h"
 #include "GOVirtualCouplerController.h"
 
+GOGUICouplerPanel::GOGUICouplerPanel(
+  GOGuiOrgan &guiOrgan, const GOVirtualCouplerController &virtualCouplers)
+  : r_GuiOrgan(guiOrgan),
+    m_OrganController(guiOrgan.GetOrganController()),
+    r_VirtualCouplers(virtualCouplers) {}
+
 void GOGUICouplerPanel::CreatePanels(GOConfigReader &cfg) {
   for (unsigned i = m_OrganController->GetFirstManualIndex();
        i <= m_OrganController->GetManualAndPedalCount();
        i++)
-    m_OrganController->AddPanel(CreateCouplerPanel(cfg, i));
+    r_GuiOrgan.AddPanel(CreateCouplerPanel(cfg, i));
 }
 
 GOGUIPanel *GOGUICouplerPanel::CreateCouplerPanel(
   GOConfigReader &cfg, unsigned manual_nr) {
   GOManual *manual = m_OrganController->GetManual(manual_nr);
 
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics = new GOGUISetterDisplayMetrics(
     cfg, m_OrganController, GOGUI_SETTER_COUPLER);
   panel->Init(

--- a/src/grandorgue/gui/panels/GOGUICouplerPanel.h
+++ b/src/grandorgue/gui/panels/GOGUICouplerPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,12 +10,14 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 class GOVirtualCouplerController;
 
 class GOGUICouplerPanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
   const GOVirtualCouplerController &r_VirtualCouplers;
 
@@ -23,9 +25,7 @@ private:
 
 public:
   GOGUICouplerPanel(
-    GOOrganController *organController,
-    const GOVirtualCouplerController &virtualCouplers)
-    : m_OrganController(organController), r_VirtualCouplers(virtualCouplers) {}
+    GOGuiOrgan &guiOrgan, const GOVirtualCouplerController &virtualCouplers);
 
   void CreatePanels(GOConfigReader &cfg);
 };

--- a/src/grandorgue/gui/panels/GOGUICrescendoPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUICrescendoPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -16,20 +16,22 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
+#include "gui/GOGuiOrgan.h"
 
-GOGUICrescendoPanel::GOGUICrescendoPanel(GOOrganController *organController)
-  : m_OrganController(organController) {}
+GOGUICrescendoPanel::GOGUICrescendoPanel(GOGuiOrgan &guiOrgan)
+  : r_GuiOrgan(guiOrgan), m_OrganController(guiOrgan.GetOrganController()) {}
 
 GOGUICrescendoPanel::~GOGUICrescendoPanel() {}
 
 void GOGUICrescendoPanel::CreatePanels(GOConfigReader &cfg) {
-  m_OrganController->AddPanel(CreateCrescendoPanel(cfg));
+  r_GuiOrgan.AddPanel(CreateCrescendoPanel(cfg));
 }
 
 GOGUIPanel *GOGUICrescendoPanel::CreateCrescendoPanel(GOConfigReader &cfg) {
   GOGUIButton *button;
 
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics = new GOGUISetterDisplayMetrics(
     cfg, m_OrganController, GOGUI_SETTER_CRESCENDO);
   panel->Init(cfg, metrics, _("Crescendo Pedal"), wxT("SetterCrescendoPanel"));

--- a/src/grandorgue/gui/panels/GOGUICrescendoPanel.h
+++ b/src/grandorgue/gui/panels/GOGUICrescendoPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,17 +10,19 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 
 class GOGUICrescendoPanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
 
   GOGUIPanel *CreateCrescendoPanel(GOConfigReader &cfg);
 
 public:
-  GOGUICrescendoPanel(GOOrganController *organController);
+  GOGUICrescendoPanel(GOGuiOrgan &guiOrgan);
   virtual ~GOGUICrescendoPanel();
 
   void CreatePanels(GOConfigReader &cfg);

--- a/src/grandorgue/gui/panels/GOGUIDivisionalsPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIDivisionalsPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -20,20 +20,22 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
+#include "gui/GOGuiOrgan.h"
 
-GOGUIDivisionalsPanel::GOGUIDivisionalsPanel(GOOrganController *organController)
-  : m_OrganController(organController) {}
+GOGUIDivisionalsPanel::GOGUIDivisionalsPanel(GOGuiOrgan &guiOrgan)
+  : r_GuiOrgan(guiOrgan), m_OrganController(guiOrgan.GetOrganController()) {}
 
 GOGUIDivisionalsPanel::~GOGUIDivisionalsPanel() {}
 
 void GOGUIDivisionalsPanel::CreatePanels(GOConfigReader &cfg) {
-  m_OrganController->AddPanel(CreateDivisionalsPanel(cfg));
+  r_GuiOrgan.AddPanel(CreateDivisionalsPanel(cfg));
 }
 
 GOGUIPanel *GOGUIDivisionalsPanel::CreateDivisionalsPanel(GOConfigReader &cfg) {
   GOGUIButton *button;
 
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics = new GOGUISetterDisplayMetrics(
     cfg, m_OrganController, GOGUI_SETTER_DIVISIONALS);
   panel->Init(cfg, metrics, _("Divisionals"), wxT("SetterDivisionalPanel"));

--- a/src/grandorgue/gui/panels/GOGUIDivisionalsPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIDivisionalsPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,17 +10,19 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 
 class GOGUIDivisionalsPanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
 
   GOGUIPanel *CreateDivisionalsPanel(GOConfigReader &cfg);
 
 public:
-  GOGUIDivisionalsPanel(GOOrganController *organController);
+  GOGUIDivisionalsPanel(GOGuiOrgan &guiOrgan);
   virtual ~GOGUIDivisionalsPanel();
 
   void CreatePanels(GOConfigReader &cfg);

--- a/src/grandorgue/gui/panels/GOGUIMasterPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIMasterPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -17,20 +17,22 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
+#include "gui/GOGuiOrgan.h"
 
-GOGUIMasterPanel::GOGUIMasterPanel(GOOrganController *organController)
-  : m_OrganController(organController) {}
+GOGUIMasterPanel::GOGUIMasterPanel(GOGuiOrgan &guiOrgan)
+  : r_GuiOrgan(guiOrgan), m_OrganController(guiOrgan.GetOrganController()) {}
 
 GOGUIMasterPanel::~GOGUIMasterPanel() {}
 
 void GOGUIMasterPanel::CreatePanels(GOConfigReader &cfg) {
-  m_OrganController->AddPanel(CreateMasterPanel(cfg));
+  r_GuiOrgan.AddPanel(CreateMasterPanel(cfg));
 }
 
 GOGUIPanel *GOGUIMasterPanel::CreateMasterPanel(GOConfigReader &cfg) {
   GOGUIButton *button;
 
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics = new GOGUISetterDisplayMetrics(
     cfg, m_OrganController, GOGUI_SETTER_MASTER);
   panel->Init(cfg, metrics, _("Master Controls"), wxT("SetterMaster"), wxT(""));

--- a/src/grandorgue/gui/panels/GOGUIMasterPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIMasterPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,17 +10,19 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 
 class GOGUIMasterPanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
 
   GOGUIPanel *CreateMasterPanel(GOConfigReader &cfg);
 
 public:
-  GOGUIMasterPanel(GOOrganController *organController);
+  GOGUIMasterPanel(GOGuiOrgan &guiOrgan);
   virtual ~GOGUIMasterPanel();
 
   void CreatePanels(GOConfigReader &cfg);

--- a/src/grandorgue/gui/panels/GOGUIMetronomePanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIMetronomePanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -15,20 +15,22 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
+#include "gui/GOGuiOrgan.h"
 
-GOGUIMetronomePanel::GOGUIMetronomePanel(GOOrganController *organController)
-  : m_OrganController(organController) {}
+GOGUIMetronomePanel::GOGUIMetronomePanel(GOGuiOrgan &guiOrgan)
+  : r_GuiOrgan(guiOrgan), m_OrganController(guiOrgan.GetOrganController()) {}
 
 GOGUIMetronomePanel::~GOGUIMetronomePanel() {}
 
 void GOGUIMetronomePanel::CreatePanels(GOConfigReader &cfg) {
-  m_OrganController->AddPanel(CreateMetronomePanel(cfg));
+  r_GuiOrgan.AddPanel(CreateMetronomePanel(cfg));
 }
 
 GOGUIPanel *GOGUIMetronomePanel::CreateMetronomePanel(GOConfigReader &cfg) {
   GOGUIButton *button;
 
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics
     = new GOGUISetterDisplayMetrics(cfg, m_OrganController, GOGUI_METRONOME);
   panel->Init(cfg, metrics, _("Metronome"), wxT("Metronome"), wxT(""));

--- a/src/grandorgue/gui/panels/GOGUIMetronomePanel.h
+++ b/src/grandorgue/gui/panels/GOGUIMetronomePanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,17 +10,19 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 
 class GOGUIMetronomePanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
 
   GOGUIPanel *CreateMetronomePanel(GOConfigReader &cfg);
 
 public:
-  GOGUIMetronomePanel(GOOrganController *organController);
+  GOGUIMetronomePanel(GOGuiOrgan &guiOrgan);
   virtual ~GOGUIMetronomePanel();
 
   void CreatePanels(GOConfigReader &cfg);

--- a/src/grandorgue/gui/panels/GOGUIPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIPanel.cpp
@@ -19,6 +19,7 @@
 #include "config/GOConfigWriter.h"
 #include "control/GOPistonControl.h"
 #include "gui/GOGuiImageCache.h"
+#include "gui/panels/GOGUIMouseState.h"
 #include "model/GOCoupler.h"
 #include "model/GODivisionalCoupler.h"
 #include "model/GOManual.h"
@@ -41,9 +42,13 @@
 #include "GOGUIPanelWidget.h"
 #include "GOOrganController.h"
 
-GOGUIPanel::GOGUIPanel(GOOrganController *organController)
+GOGUIPanel::GOGUIPanel(
+  GOOrganController *organController,
+  GOGuiImageCache &imageCache,
+  GOGUIMouseState &mouseState)
   : m_OrganController(organController),
-    m_MouseState(organController->GetMouseState()),
+    r_ImageCache(imageCache),
+    m_MouseState(mouseState),
     m_controls(0),
     m_BackgroundControls(0),
     m_Name(),
@@ -79,7 +84,7 @@ const wxString &GOGUIPanel::GetGroupName() { return m_GroupName; }
 
 const wxImage *GOGUIPanel::LoadImage(
   const wxString &filename, const wxString &maskname) {
-  return m_OrganController->GetImageCache().LoadImage(filename, maskname);
+  return r_ImageCache.LoadImage(filename, maskname);
 }
 
 GODocumentBase *GOGUIPanel::GetDocument() const {
@@ -859,5 +864,5 @@ void GOGUIPanel::HandleMouseScroll(int x, int y, int amount) {
 }
 
 const wxImage *GOGUIPanel::GetWoodImage(unsigned woodImageNumber) const {
-  return m_OrganController->GetImageCache().GetWoodImage(woodImageNumber);
+  return r_ImageCache.GetWoodImage(woodImageNumber);
 }

--- a/src/grandorgue/gui/panels/GOGUIPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIPanel.h
@@ -21,6 +21,7 @@ class GOConfigReader;
 class GOConfigWriter;
 class GODC;
 class GODocumentBase;
+class GOGuiImageCache;
 class GOGUIControl;
 class GOGUIDisplayMetrics;
 class GOGUILayoutEngine;
@@ -51,6 +52,11 @@ private:
 
 protected:
   GOOrganController *m_OrganController;
+
+  /** The image cache to load/lookup wood and control images through,
+   * captured from the enclosing GOGuiOrgan at construction (same as
+   * m_MouseState below). */
+  GOGuiImageCache &r_ImageCache;
   GOGUIMouseState &m_MouseState;
   ptr_vector<GOGUIControl> m_controls;
   unsigned m_BackgroundControls;
@@ -71,7 +77,17 @@ protected:
   void SendMousePress(int x, int y, bool right, GOGUIMouseState &state);
 
 public:
-  GOGUIPanel(GOOrganController *organController);
+  /**
+   * @param organController the organ this panel belongs to
+   * @param imageCache the image cache to load wood/control images through,
+   *   captured directly instead of via the enclosing GOGuiOrgan
+   * @param mouseState the shared mouse-drag/click state to report into,
+   *   captured directly instead of via the enclosing GOGuiOrgan
+   */
+  GOGUIPanel(
+    GOOrganController *organController,
+    GOGuiImageCache &imageCache,
+    GOGUIMouseState &mouseState);
   virtual ~GOGUIPanel();
   void Init(
     GOConfigReader &cfg,

--- a/src/grandorgue/gui/panels/GOGUIRecorderPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUIRecorderPanel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -15,20 +15,22 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
+#include "gui/GOGuiOrgan.h"
 
-GOGUIRecorderPanel::GOGUIRecorderPanel(GOOrganController *organController)
-  : m_OrganController(organController) {}
+GOGUIRecorderPanel::GOGUIRecorderPanel(GOGuiOrgan &guiOrgan)
+  : r_GuiOrgan(guiOrgan), m_OrganController(guiOrgan.GetOrganController()) {}
 
 GOGUIRecorderPanel::~GOGUIRecorderPanel() {}
 
 void GOGUIRecorderPanel::CreatePanels(GOConfigReader &cfg) {
-  m_OrganController->AddPanel(CreateRecorderPanel(cfg));
+  r_GuiOrgan.AddPanel(CreateRecorderPanel(cfg));
 }
 
 GOGUIPanel *GOGUIRecorderPanel::CreateRecorderPanel(GOConfigReader &cfg) {
   GOGUIButton *button;
 
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics
     = new GOGUISetterDisplayMetrics(cfg, m_OrganController, GOGUI_RECORDER);
   panel->Init(cfg, metrics, _("Recorder / Player"), wxT("Recorder"), wxT(""));

--- a/src/grandorgue/gui/panels/GOGUIRecorderPanel.h
+++ b/src/grandorgue/gui/panels/GOGUIRecorderPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,17 +10,19 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 
 class GOGUIRecorderPanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
 
   GOGUIPanel *CreateRecorderPanel(GOConfigReader &cfg);
 
 public:
-  GOGUIRecorderPanel(GOOrganController *organController);
+  GOGUIRecorderPanel(GOGuiOrgan &guiOrgan);
   virtual ~GOGUIRecorderPanel();
 
   void CreatePanels(GOConfigReader &cfg);

--- a/src/grandorgue/gui/panels/GOGUISequencerPanel.cpp
+++ b/src/grandorgue/gui/panels/GOGUISequencerPanel.cpp
@@ -18,20 +18,22 @@
 #include "GOGUIPanel.h"
 #include "GOGUISetterDisplayMetrics.h"
 #include "GOOrganController.h"
+#include "gui/GOGuiOrgan.h"
 
-GOGUISequencerPanel::GOGUISequencerPanel(GOOrganController *organController)
-  : m_OrganController(organController) {}
+GOGUISequencerPanel::GOGUISequencerPanel(GOGuiOrgan &guiOrgan)
+  : r_GuiOrgan(guiOrgan), m_OrganController(guiOrgan.GetOrganController()) {}
 
 GOGUISequencerPanel::~GOGUISequencerPanel() {}
 
 void GOGUISequencerPanel::CreatePanels(GOConfigReader &cfg) {
-  m_OrganController->AddPanel(CreateSequencerPanel(cfg));
+  r_GuiOrgan.AddPanel(CreateSequencerPanel(cfg));
 }
 
 GOGUIPanel *GOGUISequencerPanel::CreateSequencerPanel(GOConfigReader &cfg) {
   GOGUIButton *button;
 
-  GOGUIPanel *panel = new GOGUIPanel(m_OrganController);
+  GOGUIPanel *panel = new GOGUIPanel(
+    m_OrganController, r_GuiOrgan.GetImageCache(), r_GuiOrgan.GetMouseState());
   GOGUIDisplayMetrics *metrics = new GOGUISetterDisplayMetrics(
     cfg, m_OrganController, GOGUI_SETTER_SETTER);
   panel->Init(cfg, metrics, _("Combination Setter"), wxT("SetterPanel"));

--- a/src/grandorgue/gui/panels/GOGUISequencerPanel.h
+++ b/src/grandorgue/gui/panels/GOGUISequencerPanel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,17 +10,19 @@
 
 #include "GOGUIPanelCreator.h"
 
+class GOGuiOrgan;
 class GOGUIPanel;
 class GOOrganController;
 
 class GOGUISequencerPanel : public GOGUIPanelCreator {
 private:
+  GOGuiOrgan &r_GuiOrgan;
   GOOrganController *m_OrganController;
 
   GOGUIPanel *CreateSequencerPanel(GOConfigReader &cfg);
 
 public:
-  GOGUISequencerPanel(GOOrganController *organController);
+  GOGUISequencerPanel(GOGuiOrgan &guiOrgan);
   virtual ~GOGUISequencerPanel();
 
   void CreatePanels(GOConfigReader &cfg);


### PR DESCRIPTION
## Summary

First step of moving GUI ownership from `GOOrganController` to `GOGuiOrgan`.

- `GOGUIPanel` now takes its image cache and mouse state as constructor references instead of reaching through `m_OrganController` for them.
- The 9 panel-creator classes now take `GOGuiOrgan&` instead of `GOOrganController*`, using `GOGuiOrgan::GetOrganController()` where they still need the organ-model side.
- `GOGuiOrgan` gains a private nested `Controller : public GOOrganController` that overrides `OnLoad()`/`OnClear()`, plus new `AddPanel()`/`GetImageCache()`/`GetMouseState()` forwarders.

### Why `GOOrganController::LoadOrganGuiData()`/`ClearOrganGuiData()` appear in this diff

`GOOrganController::OnLoad()`/`OnClear()` currently hold the GUI-loading logic (panel creators, panels, main-window data, etc.) directly in their bodies. This PR needs `OnLoad()`/`OnClear()` to become plain virtual hooks that `GOGuiOrgan::Controller` can override, so the existing bodies are renamed to `LoadOrganGuiData()`/`ClearOrganGuiData()` and `OnLoad()`/`OnClear()` become thin (empty-by-default) hooks that call them.

The rest of the GUI data (image cache, panels, main-window data, stop-window size) still belongs to `GOOrganController` at this point - only the panel creators moved. `LoadOrganGuiData()`/`ClearOrganGuiData()` are therefore *temporary*: a follow-up PR will move the remaining GUI data into `GOGuiOrgan` too and fold these two methods into it, removing them from `GOOrganController` for good.

## Test plan
- [x] `make -k -j16` (Debug) builds cleanly
- [x] `ctest`/`GOTestExe` passes (aside from a pre-existing, machine-load-dependent perf-baseline flake unrelated to this change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TvAptsYdcExtfzdK5sxQAk