### PR TITLE
Added the sound processing chain framework (Stage 4)

### DIFF
--- a/src/grandorgue/CMakeLists.txt
+++ b/src/grandorgue/CMakeLists.txt
@@ -224,6 +224,8 @@ sound/ports/GOSoundPort.cpp
 sound/ports/GOSoundPortFactory.cpp
 sound/ports/GOSoundPortaudioPort.cpp
 sound/ports/GOSoundRtPort.cpp
+sound/processing/GOSoundProcessingChain.cpp
+sound/processing/GOSoundProcessingChainState.cpp
 sound/providers/GOSoundProvider.cpp
 sound/providers/GOSoundProviderSynthedTrem.cpp
 sound/providers/GOSoundProviderWave.cpp

--- a/src/grandorgue/sound/processing/GOSoundProcessingChain.cpp
+++ b/src/grandorgue/sound/processing/GOSoundProcessingChain.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSoundProcessingChain.h"
+
+#include <algorithm>
+#include <cassert>
+
+#include "GOSoundProcessingChainState.h"
+#include "GOSoundProcessingPrmMapper.h"
+#include "GOSoundProcessor.h"
+
+// Defined here, not inline in the header: even the default constructor
+// needs GOSoundProcessor's and GOSoundProcessingPrmMapper's complete
+// definitions, to generate the member-destruction code for the case where
+// a later member's construction throws; the header intentionally only
+// forward-declares them.
+GOSoundProcessingChain::GOSoundProcessingChain() = default;
+GOSoundProcessingChain::~GOSoundProcessingChain() = default;
+
+const GOSoundProcessor &GOSoundProcessingChain::GetProcessor(
+  unsigned processorI) const {
+  assert(processorI < m_processors.size());
+  return *m_processors[processorI];
+}
+
+void GOSoundProcessingChain::AddProcessor(
+  std::unique_ptr<GOSoundProcessor> pProcessor) {
+  InsertProcessor(GetNProcessors(), std::move(pProcessor));
+}
+
+void GOSoundProcessingChain::InsertProcessor(
+  unsigned position, std::unique_ptr<GOSoundProcessor> pProcessor) {
+  assert(!m_IsSetUp);
+  assert(position <= m_processors.size());
+
+  m_processors.insert(m_processors.begin() + position, std::move(pProcessor));
+  m_Generation++;
+}
+
+std::unique_ptr<GOSoundProcessor> GOSoundProcessingChain::RemoveProcessor(
+  unsigned position) {
+  assert(!m_IsSetUp);
+  assert(position < m_processors.size());
+
+  const GOSoundProcessor &processor = *m_processors[position];
+
+  for (const std::unique_ptr<GOSoundProcessingPrmMapper> &pMapper : m_mappers)
+    assert(
+      &pMapper->GetProcessor() != &processor
+      && "remove the mapper(s) referencing this processor first, via "
+         "RemoveMapper()");
+
+  std::unique_ptr<GOSoundProcessor> pRemoved
+    = std::move(m_processors[position]);
+
+  m_processors.erase(m_processors.begin() + position);
+  m_Generation++;
+
+  return pRemoved;
+}
+
+void GOSoundProcessingChain::AddMapper(
+  std::unique_ptr<GOSoundProcessingPrmMapper> pMapper) {
+  assert(!m_IsSetUp);
+  assert(
+    std::any_of(
+      m_processors.begin(),
+      m_processors.end(),
+      [&pMapper](const std::unique_ptr<GOSoundProcessor> &pProcessor) {
+        return pProcessor.get() == &pMapper->GetProcessor();
+      })
+    && "the mapper's target processor must already be in this chain");
+
+  m_mappers.push_back(std::move(pMapper));
+}
+
+std::unique_ptr<GOSoundProcessingPrmMapper> GOSoundProcessingChain::
+  RemoveMapper(const GOSoundProcessingPrmMapper &mapper) {
+  assert(!m_IsSetUp);
+
+  auto it = std::find_if(
+    m_mappers.begin(),
+    m_mappers.end(),
+    [&mapper](const std::unique_ptr<GOSoundProcessingPrmMapper> &pMapper) {
+      return pMapper.get() == &mapper;
+    });
+
+  assert(it != m_mappers.end() && "mapper not found in this chain");
+
+  std::unique_ptr<GOSoundProcessingPrmMapper> pRemoved = std::move(*it);
+
+  m_mappers.erase(it);
+
+  return pRemoved;
+}
+
+void GOSoundProcessingChain::ClearChain() {
+  assert(!m_IsSetUp);
+
+  // Mappers first: a mapper may hold a raw (non-owning) pointer to one of
+  // the chain's processors, so the referrer is cleared before the
+  // referent.
+  m_mappers.clear();
+  m_processors.clear();
+  m_Generation++;
+}
+
+void GOSoundProcessingChain::EnsureSetup(
+  unsigned nChannels, unsigned nFrames, unsigned sampleRate) {
+  const bool isFormatChanged = !m_IsSetUp || nChannels != m_NChannels
+    || nFrames != m_NFrames || sampleRate != m_SampleRate;
+
+  if (isFormatChanged) {
+    // Bumped before touching any processor, not after the loop: if a
+    // later processor's EnsureSetup() throws, any state still alive from
+    // before this call must already read as invalid, since some
+    // processors may have already been reconfigured to the new format.
+    m_Generation++;
+    // Cleared before the loop, not just left alone: if a later processor's
+    // EnsureSetup() throws, this chain must not look fully set up again
+    // until every processor has actually completed with the new format -
+    // CreateState() must not be allowed to build a state against processors
+    // left configured for a mix of the old and new format. It also forces
+    // isFormatChanged to be recomputed as true on any later retry
+    // (including a retry with the old, previously-stored format), since
+    // m_NChannels/m_NFrames/m_SampleRate below were never actually applied
+    // to every processor.
+    m_IsSetUp = false;
+
+    for (const std::unique_ptr<GOSoundProcessor> &pProcessor : m_processors)
+      pProcessor->EnsureSetup(nChannels, nFrames, sampleRate);
+
+    m_NChannels = nChannels;
+    m_NFrames = nFrames;
+    m_SampleRate = sampleRate;
+    m_IsSetUp = true;
+  }
+}
+
+void GOSoundProcessingChain::Cleanup() {
+  m_NChannels = 0;
+  m_NFrames = 0;
+  m_SampleRate = 0;
+  m_IsSetUp = false;
+  m_Generation++;
+}
+
+void GOSoundProcessingChain::EnsureParametersUpToDate() {
+  assert(m_IsSetUp);
+
+  for (const std::unique_ptr<GOSoundProcessingPrmMapper> &pMapper : m_mappers)
+    pMapper->EnsureParametersUpToDate();
+}
+
+std::unique_ptr<GOSoundProcessingChainState> GOSoundProcessingChain::
+  CreateState() const {
+  assert(m_IsSetUp && "EnsureSetup() must be called before CreateState()");
+
+  return std::make_unique<GOSoundProcessingChainState>(*this);
+}

--- a/src/grandorgue/sound/processing/GOSoundProcessingChain.h
+++ b/src/grandorgue/sound/processing/GOSoundProcessingChain.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDPROCESSINGCHAIN_H
+#define GOSOUNDPROCESSINGCHAIN_H
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+class GOSoundProcessingChainState;
+class GOSoundProcessingPrmMapper;
+class GOSoundProcessor;
+
+/**
+ * An ordered list of GOSoundProcessor%s, run in that order by every
+ * GOSoundProcessingChainState created from this chain, plus the
+ * GOSoundProcessingPrmMapper%s that keep those processors' parameters up to
+ * date. Owns both lists as two independent vectors rather than a paired
+ * struct: cardinality between processors and mappers is not 1:1 (a
+ * processor may need no mapper) and mapper order carries no meaning, unlike
+ * processor order, which is the DSP signal path.
+ *
+ * Lifecycle (enforced by assert(), not by the type system):
+ *  1. Build phase: add processors/mappers via AddProcessor(),
+ *     InsertProcessor(), AddMapper(); remove via RemoveProcessor() or
+ *     RemoveMapper(). Allowed only while !m_IsSetUp (asserted).
+ *     RemoveProcessor() additionally asserts that no remaining mapper still
+ *     references the processor being removed (RemoveMapper() it first).
+ *  2. EnsureSetup(): forwards the audio format to every processor
+ *     currently in the chain. May be called repeatedly, with the same or
+ *     different arguments each time (every processor must treat a
+ *     same-arguments call as a cheap no-op, per GOSoundProcessor's own
+ *     contract). Its first call sets m_IsSetUp, which from then on forbids
+ *     any further topology mutation (step 1) until step 4.
+ *  3. CreateState() / EnsureParametersUpToDate(): CreateState() builds a
+ *     GOSoundProcessingChainState; asserts m_IsSetUp. May be called any
+ *     number of times - once per independent DSP-memory instance (e.g. one
+ *     per audio group of a windchest) - all sharing this one chain.
+ *     EnsureParametersUpToDate() forwards to every mapper, pushing fresh
+ *     parameter values into the processors ahead of a Process() round;
+ *     also asserts m_IsSetUp, and is expected to be called repeatedly,
+ *     once per round, throughout this step.
+ *  4. Cleanup() (optional): the exact inverse of step 2 - clears the
+ *     stored format and resets m_IsSetUp to false, re-entering the build
+ *     phase (step 1). Does not touch processors/mappers.
+ *  5. ClearChain() (optional, only meaningful after step 4, since it too
+ *     requires !m_IsSetUp): the exact inverse of step 1 - removes every
+ *     processor and mapper, returning the chain to an empty topology, as
+ *     if freshly constructed.
+ *
+ * Any GOSoundProcessingChainState still alive from step 3 becomes invalid
+ * (IsValid() false) the moment step 4 or 5 runs, since what it was built
+ * for (the format, the topology) is no longer intact. From step 4 or 5,
+ * return to step 1 to build the chain anew. Except for the build/set-up
+ * split above, the chain does not track which GOSoundProcessingChainState
+ * objects were created from it, or whether any are still alive: mutating
+ * the chain while a state is alive is not prevented, only detected
+ * reactively by that state's own IsValid().
+ */
+class GOSoundProcessingChain {
+private:
+  friend class GOTestSoundProcessingChain; // direct access for unit tests
+
+  // Owned processors, in signal-path order; Process() walks them in this
+  // order.
+  std::vector<std::unique_ptr<GOSoundProcessor>> m_processors;
+  // Owned mappers; order carries no meaning (each touches disjoint
+  // parameters of the processors above).
+  std::vector<std::unique_ptr<GOSoundProcessingPrmMapper>> m_mappers;
+  // Format from the most recent EnsureSetup() call, or all-zero before the
+  // first call since construction or the last Cleanup(); compared against
+  // on each EnsureSetup() call, purely to decide whether m_Generation needs
+  // bumping (see below) - not otherwise read.
+  unsigned m_NChannels = 0;
+  unsigned m_NFrames = 0;
+  unsigned m_SampleRate = 0;
+  // Monotonically increasing counter, bumped by every operation that
+  // actually changes something a live GOSoundProcessingChainState depends
+  // on: InsertProcessor(), RemoveProcessor(), ClearChain(), Cleanup(), and
+  // an EnsureSetup() call whose arguments differ from the previous one (or
+  // is the first call since construction/Cleanup()). Returned as-is by
+  // GetSignature(), instead of hashing processor addresses: once a removed
+  // processor is destroyed, the allocator can reuse its address for a
+  // later one, which would let a stale state's snapshot coincidentally
+  // match a live but different chain. A counter that only ever increases
+  // cannot repeat a value already seen from this chain, so it cannot
+  // collide this way.
+  size_t m_Generation = 0;
+  // True once EnsureSetup() has been called at least once since
+  // construction or the last Cleanup(); guards the build-phase/set-up-phase
+  // split documented above.
+  bool m_IsSetUp = false;
+
+public:
+  GOSoundProcessingChain();
+  ~GOSoundProcessingChain();
+
+  GOSoundProcessingChain(const GOSoundProcessingChain &) = delete;
+  GOSoundProcessingChain &operator=(const GOSoundProcessingChain &) = delete;
+
+  unsigned GetNProcessors() const { return (unsigned)m_processors.size(); }
+
+  /** @return whether this chain has no processors (an empty state's Process()
+   * is then a no-op) */
+  bool IsEmpty() const { return m_processors.empty(); }
+
+  /**
+   * @param processorI Position in the signal path (0-based)
+   * @return the processor at that position
+   */
+  const GOSoundProcessor &GetProcessor(unsigned processorI) const;
+
+  /**
+   * @return an opaque value for GOSoundProcessingChainState's own staleness
+   *   self-check only: currently just m_Generation, but callers must treat
+   *   it as opaque, not as a generation number, since that's an
+   *   implementation detail. Not a stable or serializable value.
+   */
+  size_t GetSignature() const { return m_Generation; }
+
+  /** Step 1. Appends a processor; it will run after all previously added
+   * ones. Equivalent to InsertProcessor(GetNProcessors(), ...). Only
+   * allowed while !m_IsSetUp (asserted); see the class doc. */
+  void AddProcessor(std::unique_ptr<GOSoundProcessor> pProcessor);
+
+  /** Step 1. Inserts a processor at the given 0-based position in the
+   * signal path; every processor previously at or after that position
+   * shifts one step later. Only allowed while !m_IsSetUp (asserted); see
+   * the class doc. */
+  void InsertProcessor(
+    unsigned position, std::unique_ptr<GOSoundProcessor> pProcessor);
+
+  /** Step 1. Removes the processor at the given position and returns
+   * ownership to the caller; every later processor shifts one step
+   * earlier. Only allowed while !m_IsSetUp (asserted); see the class doc.
+   * Also asserts that no remaining mapper still references this processor
+   * (RemoveMapper() it first), since returning ownership to the caller may
+   * lead to the processor being destroyed, which would leave such a
+   * mapper's reference dangling. */
+  std::unique_ptr<GOSoundProcessor> RemoveProcessor(unsigned position);
+
+  /** Step 1. Appends a mapper; mapper order is irrelevant (they touch
+   * disjoint parameters). Only allowed while !m_IsSetUp (asserted); see
+   * the class doc. Also asserts that the mapper's GetProcessor() is
+   * already one of this chain's own processors, so a mapper can never
+   * outlive or reach outside the chain it's installed on. */
+  void AddMapper(std::unique_ptr<GOSoundProcessingPrmMapper> pMapper);
+
+  /** Step 1. Removes the given mapper (by identity) and returns ownership
+   * to the caller. Only allowed while !m_IsSetUp (asserted); see the class
+   * doc. */
+  std::unique_ptr<GOSoundProcessingPrmMapper> RemoveMapper(
+    const GOSoundProcessingPrmMapper &mapper);
+
+  /** Step 5. The exact inverse of step 1: removes every processor and
+   * mapper, returning the chain to an empty topology. Only allowed while
+   * !m_IsSetUp (asserted); see the class doc. */
+  void ClearChain();
+
+  /** Step 2. Forwards EnsureSetup() to every processor, in order; see the
+   * class doc for the full lifecycle. */
+  void EnsureSetup(unsigned nChannels, unsigned nFrames, unsigned sampleRate);
+
+  /** Step 4. The exact inverse of step 2; see the class doc. */
+  void Cleanup();
+
+  /** Step 3. Forwards EnsureParametersUpToDate() to every mapper. Asserts
+   * m_IsSetUp; see the class doc. */
+  void EnsureParametersUpToDate();
+
+  /** Step 3. @return a new DSP-memory instance of this chain: one state
+   * per processor. Asserts EnsureSetup() has been called at least once;
+   * see the class doc. */
+  std::unique_ptr<GOSoundProcessingChainState> CreateState() const;
+};
+
+#endif /* GOSOUNDPROCESSINGCHAIN_H */

--- a/src/grandorgue/sound/processing/GOSoundProcessingChainState.cpp
+++ b/src/grandorgue/sound/processing/GOSoundProcessingChainState.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSoundProcessingChainState.h"
+
+#include <cassert>
+
+#include "GOSoundProcessor.h"
+#include "GOSoundProcessorState.h"
+
+GOSoundProcessingChainState::GOSoundProcessingChainState(
+  const GOSoundProcessingChain &chain)
+  : r_chain(chain), m_ChainSignatureAtCreation(chain.GetSignature()) {
+  for (unsigned nProcessors = chain.GetNProcessors(), processorI = 0;
+       processorI < nProcessors;
+       processorI++)
+    m_states.push_back(chain.GetProcessor(processorI).CreateState());
+}
+
+GOSoundProcessingChainState::~GOSoundProcessingChainState() = default;
+
+void GOSoundProcessingChainState::Reset() {
+  for (const std::unique_ptr<GOSoundProcessorState> &pState : m_states)
+    pState->Reset();
+}
+
+void GOSoundProcessingChainState::Process(GOSoundBufferPlanarMutable &buffer) {
+  assert(IsValid());
+
+  for (unsigned nStates = (unsigned)m_states.size(), stateI = 0;
+       stateI < nStates;
+       stateI++)
+    r_chain.GetProcessor(stateI).Process(*m_states[stateI], buffer);
+}

--- a/src/grandorgue/sound/processing/GOSoundProcessingChainState.h
+++ b/src/grandorgue/sound/processing/GOSoundProcessingChainState.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDPROCESSINGCHAINSTATE_H
+#define GOSOUNDPROCESSINGCHAINSTATE_H
+
+#include <memory>
+#include <vector>
+
+#include "GOSoundProcessingChain.h"
+
+class GOSoundBufferPlanarMutable;
+class GOSoundProcessorState;
+
+/**
+ * One independent DSP-memory instance of a GOSoundProcessingChain: exactly
+ * one GOSoundProcessorState per processor of the chain, in the same order.
+ * A chain owner (e.g. a windchest group) creates one of these per audio
+ * group, all sharing the same GOSoundProcessingChain: this is what lets one
+ * GOSoundProcessor instance serve every audio group of its windchest, while
+ * each audio group's DSP memory stays independent. The chain must outlive
+ * every GOSoundProcessingChainState created from it.
+ */
+class GOSoundProcessingChainState {
+private:
+  friend class GOTestSoundProcessingChain; // direct access for unit tests
+  friend class GOTestSoundProcessorTyped;  // direct access for unit tests
+
+  // The chain this state was created from; must outlive this state. Reused
+  // by Process() to reach GetProcessor(stateI) for each state stored below.
+  const GOSoundProcessingChain &r_chain;
+  // r_chain's signature at construction time; compared against its current
+  // signature by IsValid() to detect that r_chain has since been mutated
+  // (topology and/or format) out from under this state.
+  const size_t m_ChainSignatureAtCreation;
+  // One state per processor of r_chain, same order; each touched only by
+  // this chain state's own Process() calls, never shared with another
+  // chain state.
+  std::vector<std::unique_ptr<GOSoundProcessorState>> m_states;
+
+public:
+  /** Builds one state per processor of the chain, via each processor's
+   * CreateState(). */
+  explicit GOSoundProcessingChainState(const GOSoundProcessingChain &chain);
+
+  // Defined in the .cpp: a vector<unique_ptr<GOSoundProcessorState>>'s
+  // implicit destructor needs GOSoundProcessorState's complete definition,
+  // which this header intentionally doesn't include (only forward-declares
+  // it).
+  ~GOSoundProcessingChainState();
+
+  GOSoundProcessingChainState(const GOSoundProcessingChainState &) = delete;
+  GOSoundProcessingChainState &operator=(const GOSoundProcessingChainState &)
+    = delete;
+
+  unsigned GetNStates() const { return (unsigned)m_states.size(); }
+
+  /** @return whether r_chain's current signature (topology and format)
+   * still matches what this state was created for. Process() asserts this;
+   * see GOSoundProcessingChain's class doc for the lifecycle this
+   * protects against. */
+  bool IsValid() const {
+    return m_ChainSignatureAtCreation == r_chain.GetSignature();
+  }
+
+  /** Resets the DSP memory of every processor state. */
+  void Reset();
+
+  /**
+   * Runs every processor of the chain, in order, in place on the buffer.
+   * An empty chain leaves the buffer untouched (the loop is empty). Not
+   * const: this state is owned by exactly one caller (never shared), and
+   * it mutates the DSP memory of every GOSoundProcessorState it holds.
+   */
+  void Process(GOSoundBufferPlanarMutable &buffer);
+};
+
+#endif /* GOSOUNDPROCESSINGCHAINSTATE_H */

--- a/src/grandorgue/sound/processing/GOSoundProcessingPrmMapper.h
+++ b/src/grandorgue/sound/processing/GOSoundProcessingPrmMapper.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDPROCESSINGPRMMAPPER_H
+#define GOSOUNDPROCESSINGPRMMAPPER_H
+
+class GOSoundProcessor;
+
+/**
+ * Copies values owned by the GUI/MIDI thread (organ model, config) into the
+ * parameters of one GOSoundProcessor, once per round, outside Process().
+ * This directory (sound/processing/) must not depend on model/: concrete,
+ * model-aware mappers live in a future sound/mappers/ directory.
+ */
+class GOSoundProcessingPrmMapper {
+protected:
+  // The single processor this mapper writes parameters into; must outlive
+  // this mapper. Exposed via GetProcessor() so
+  // GOSoundProcessingChain::RemoveProcessor() can refuse removing a
+  // processor a still-installed mapper depends on.
+  GOSoundProcessor &r_processor;
+
+public:
+  explicit GOSoundProcessingPrmMapper(GOSoundProcessor &processor)
+    : r_processor(processor) {}
+  virtual ~GOSoundProcessingPrmMapper() = default;
+
+  const GOSoundProcessor &GetProcessor() const { return r_processor; }
+
+  /**
+   * Re-reads the source values and writes them into the target processor's
+   * parameters. Must not touch any GOSoundProcessorState, and must not be
+   * called concurrently with Process() on the same processor.
+   */
+  virtual void EnsureParametersUpToDate() = 0;
+};
+
+#endif /* GOSOUNDPROCESSINGPRMMAPPER_H */

--- a/src/grandorgue/sound/processing/GOSoundProcessor.h
+++ b/src/grandorgue/sound/processing/GOSoundProcessor.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDPROCESSOR_H
+#define GOSOUNDPROCESSOR_H
+
+#include <memory>
+
+class GOSoundBufferPlanarMutable;
+class GOSoundProcessorState;
+
+/**
+ * A DSP unit whose own instance holds only parameters (written by a
+ * GOSoundProcessingPrmMapper between rounds, read but never written by
+ * Process()); all mutable DSP memory lives in the GOSoundProcessorState
+ * objects it creates via CreateState(). This split is what lets a single
+ * GOSoundProcessor instance be shared, read-only, by every
+ * GOSoundProcessingChainState of the chain it belongs to.
+ *
+ * Call order contract: CreateState() has no format parameters of its own,
+ * so a processor whose state depends on the audio format (e.g. one entry
+ * per channel) must have EnsureSetup() called at least once, with the
+ * format it will be used with, before CreateState() — and should assert
+ * that in both CreateState() and Process(). A processor indifferent to the
+ * format is exempt. Either way, CreateState() must allocate everything the
+ * state will ever need; Process() must not allocate (it runs on the audio
+ * thread).
+ */
+class GOSoundProcessor {
+public:
+  virtual ~GOSoundProcessor() = default;
+
+  /**
+   * Idempotent configuration of the audio format. Repeated calls with the
+   * same arguments must be cheap no-ops; a call with different arguments
+   * must reconfigure. Called from the setup thread, never from Process().
+   * @param nChannels Number of audio channels the buffers passed to
+   *   Process() will have
+   * @param nFrames Number of frames per channel the buffers passed to
+   *   Process() will have
+   * @param sampleRate Audio sample rate, in Hz
+   */
+  virtual void EnsureSetup(
+    unsigned nChannels, unsigned nFrames, unsigned sampleRate)
+    = 0;
+
+  /** @return a fresh, already-reset DSP-memory object for one chain state */
+  virtual std::unique_ptr<GOSoundProcessorState> CreateState() const = 0;
+
+  /**
+   * Processes the buffer in place, using and updating only the given state.
+   * const: this instance may be shared by many GOSoundProcessingChainState
+   * objects at once, so it may only read its own parameters here, never
+   * write them.
+   * @param state The DSP memory of the calling chain state; must have been
+   *   created by this processor's CreateState()
+   * @param buffer The buffer to process in place
+   */
+  virtual void Process(
+    GOSoundProcessorState &state, GOSoundBufferPlanarMutable &buffer) const = 0;
+};
+
+#endif /* GOSOUNDPROCESSOR_H */

--- a/src/grandorgue/sound/processing/GOSoundProcessorState.h
+++ b/src/grandorgue/sound/processing/GOSoundProcessorState.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDPROCESSORSTATE_H
+#define GOSOUNDPROCESSORSTATE_H
+
+/**
+ * Per-instance DSP memory of one GOSoundProcessor. Exactly one
+ * GOSoundProcessorState is touched by the Process() calls of exactly one
+ * GOSoundProcessingChainState: it is never shared between chain instances,
+ * which is what lets a single GOSoundProcessor instance be used by many
+ * independent chain states (e.g. one per audio group of a windchest).
+ */
+class GOSoundProcessorState {
+public:
+  virtual ~GOSoundProcessorState() = default;
+
+  /**
+   * Clears the accumulated DSP memory contents to their initial values, as
+   * if no audio had been processed yet. Does not free any allocation.
+   */
+  virtual void Reset() = 0;
+};
+
+#endif /* GOSOUNDPROCESSORSTATE_H */

--- a/src/grandorgue/sound/processing/GOSoundProcessorTyped.h
+++ b/src/grandorgue/sound/processing/GOSoundProcessorTyped.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDPROCESSORTYPED_H
+#define GOSOUNDPROCESSORTYPED_H
+
+#include <cassert>
+#include <memory>
+#include <type_traits>
+
+#include "GOSoundProcessor.h"
+#include "GOSoundProcessorState.h"
+
+/**
+ * Base for a GOSoundProcessor whose concrete GOSoundProcessorState type is
+ * known at compile time. A concrete processor derives from
+ * GOSoundProcessorTyped<TState> and implements CreateTypedState() and the
+ * typed Process(TState&, buffer) instead of the untyped GOSoundProcessor
+ * entry points, which this class implements once for every subclass by
+ * downcasting the untyped GOSoundProcessorState& it receives.
+ *
+ * The downcast is an ordinary virtual call to the typed Process(), not a
+ * static_cast<Derived*>(this) (that would need TProcessor as a second
+ * template parameter and give up compile-time verification that the
+ * subclass actually implements the typed overload: a subclass that forgot
+ * it would have the call silently recurse into the untyped Process()
+ * forever instead of failing to build). The extra virtual call this costs
+ * is negligible next to the DSP work Process() does.
+ */
+template <typename TState>
+class GOSoundProcessorTyped : public GOSoundProcessor {
+  static_assert(
+    std::is_base_of_v<GOSoundProcessorState, TState>,
+    "TState must derive from GOSoundProcessorState");
+
+public:
+  std::unique_ptr<GOSoundProcessorState> CreateState() const final {
+    return CreateTypedState();
+  }
+
+  void Process(GOSoundProcessorState &state, GOSoundBufferPlanarMutable &buffer)
+    const final {
+    assert(dynamic_cast<TState *>(&state));
+    Process(static_cast<TState &>(state), buffer);
+  }
+
+protected:
+  /** @return a fresh, already-reset TState object for one chain state */
+  virtual std::unique_ptr<TState> CreateTypedState() const = 0;
+
+  /**
+   * The typed entry point a concrete processor implements instead of the
+   * untyped GOSoundProcessor::Process().
+   * @param state The DSP memory of the calling chain state, already known
+   *   to be a TState
+   * @param buffer The buffer to process in place
+   */
+  virtual void Process(
+    TState &state, GOSoundBufferPlanarMutable &buffer) const = 0;
+};
+
+#endif /* GOSOUNDPROCESSORTYPED_H */

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -35,6 +35,8 @@
 #include "testing/sound/buffer/GOTestSoundBufferPlanarMutable.h"
 #include "testing/sound/playing/GOTestReleaseAlignTable.h"
 #include "testing/sound/playing/GOTestSoundStream.h"
+#include "testing/sound/processing/GOTestSoundProcessingChain.h"
+#include "testing/sound/processing/GOTestSoundProcessorTyped.h"
 #include "testing/sound/reverb/GOTestSoundReverb.h"
 #include "testing/sound/tasks/GOTestPerfSoundTaskBase.h"
 #include "testing/sound/tasks/GOTestSoundTaskBase.h"
@@ -81,6 +83,8 @@ int main(int argc, char *argv[]) {
   GOTestSoundBufferPlanarManaged testSoundBufferPlanarManaged;
   GOTestPerfSoundBufferMutable testPerfSoundBufferMutable;
   GOTestPerfSoundBufferPlanarMutable testPerfSoundBufferPlanarMutable;
+  GOTestSoundProcessingChain testSoundProcessingChain;
+  GOTestSoundProcessorTyped testSoundProcessorTyped;
   GOTestSoundOrganEngine testSoundOrganEngine;
   GOTestSoundOrganEngineFactories testSoundOrganEngineFactories;
   GOTestSoundCallbackConnector testSoundCallbackConnector;

--- a/src/tests/testing/CMakeLists.txt
+++ b/src/tests/testing/CMakeLists.txt
@@ -26,6 +26,9 @@ set(go_tests
     sound/GOTestSoundOrganEngineStress.cpp
     sound/playing/GOTestReleaseAlignTable.cpp
     sound/playing/GOTestSoundStream.cpp
+    sound/processing/GOSoundProcessingTestImpls.cpp
+    sound/processing/GOTestSoundProcessingChain.cpp
+    sound/processing/GOTestSoundProcessorTyped.cpp
     sound/reverb/GOTestSoundReverb.cpp
     sound/tasks/GOSoundCooperativeTaskTestImpl.cpp
     sound/tasks/GOSoundTaskTestImpl.cpp

--- a/src/tests/testing/sound/processing/GOSoundProcessingTestImpls.cpp
+++ b/src/tests/testing/sound/processing/GOSoundProcessingTestImpls.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOSoundProcessingTestImpls.h"
+
+#include <algorithm>
+#include <cassert>
+
+#include "sound/buffer/GOSoundBufferPlanarMutable.h"
+
+GOAddConstProcessor::GOAddConstProcessor(
+  float value, std::vector<int> *pLog, int id)
+  : m_value(value), p_log(pLog), m_id(id) {}
+
+void GOAddConstProcessor::EnsureSetup(
+  unsigned nChannels, unsigned nFrames, unsigned sampleRate) {
+  m_NSetups++;
+  m_LastNChannels = nChannels;
+  m_LastNFrames = nFrames;
+  m_LastSampleRate = sampleRate;
+}
+
+std::unique_ptr<GOCountingProcessorState> GOAddConstProcessor::
+  CreateTypedState() const {
+  return std::make_unique<GOCountingProcessorState>();
+}
+
+void GOAddConstProcessor::Process(
+  GOCountingProcessorState &state, GOSoundBufferPlanarMutable &buffer) const {
+  for (unsigned nItems = buffer.GetNItems(), itemI = 0; itemI < nItems; itemI++)
+    buffer.GetData()[itemI] += m_value;
+
+  if (p_log)
+    p_log->push_back(m_id);
+}
+
+GOScaleProcessor::GOScaleProcessor(float value) : m_value(value) {}
+
+std::unique_ptr<GOCountingProcessorState> GOScaleProcessor::CreateTypedState()
+  const {
+  return std::make_unique<GOCountingProcessorState>();
+}
+
+void GOScaleProcessor::Process(
+  GOCountingProcessorState &state, GOSoundBufferPlanarMutable &buffer) const {
+  for (unsigned nItems = buffer.GetNItems(), itemI = 0; itemI < nItems; itemI++)
+    buffer.GetData()[itemI] *= m_value;
+}
+
+void GOOnePoleState::Reset() { std::fill(m_prev.begin(), m_prev.end(), 0.0f); }
+
+GOOnePoleProcessor::GOOnePoleProcessor(float alpha) : m_alpha(alpha) {}
+
+std::unique_ptr<GOOnePoleState> GOOnePoleProcessor::CreateTypedState() const {
+  assert(m_NChannels && "EnsureSetup() must be called before CreateState()");
+
+  return std::make_unique<GOOnePoleState>(m_NChannels);
+}
+
+void GOOnePoleProcessor::Process(
+  GOOnePoleState &state, GOSoundBufferPlanarMutable &buffer) const {
+  const unsigned nChannels = buffer.GetNChannels();
+
+  assert(nChannels == m_NChannels);
+
+  for (unsigned channelI = 0; channelI < nChannels; channelI++) {
+    GOSoundBufferMutableMono channelBuffer = buffer.GetChannelBuffer(channelI);
+    float prev = state.GetPrev(channelI);
+
+    for (unsigned nFrames = channelBuffer.GetNFrames(), frameI = 0;
+         frameI < nFrames;
+         frameI++) {
+      const float y
+        = m_alpha * channelBuffer.GetData()[frameI] + (1.0f - m_alpha) * prev;
+
+      channelBuffer.GetData()[frameI] = y;
+      prev = y;
+    }
+
+    state.SetPrev(channelI, prev);
+  }
+}
+
+GOCountingMapper::GOCountingMapper(
+  GOAddConstProcessor &processor, bool isPushingValue, float newValue)
+  : GOSoundProcessingPrmMapper(processor),
+    m_IsPushingValue(isPushingValue),
+    m_NewValue(newValue) {}
+
+void GOCountingMapper::EnsureParametersUpToDate() {
+  m_NCalls++;
+
+  if (m_IsPushingValue)
+    static_cast<GOAddConstProcessor &>(r_processor).SetValue(m_NewValue);
+}

--- a/src/tests/testing/sound/processing/GOSoundProcessingTestImpls.h
+++ b/src/tests/testing/sound/processing/GOSoundProcessingTestImpls.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOSOUNDPROCESSINGTESTIMPLS_H
+#define GOSOUNDPROCESSINGTESTIMPLS_H
+
+#include <vector>
+
+#include "sound/processing/GOSoundProcessingPrmMapper.h"
+#include "sound/processing/GOSoundProcessorState.h"
+#include "sound/processing/GOSoundProcessorTyped.h"
+
+/** Fake state that only counts Reset() calls; used by the reach tests. */
+class GOCountingProcessorState : public GOSoundProcessorState {
+private:
+  // Number of Reset() calls seen so far.
+  unsigned m_NResets = 0;
+
+public:
+  void Reset() override { m_NResets++; }
+
+  unsigned GetNResets() const { return m_NResets; }
+};
+
+/**
+ * Fake processor that adds a constant to every sample of the buffer.
+ * Optionally pushes an id into a shared ordering log, and tracks
+ * EnsureSetup() calls/arguments, for the ordering and reach tests.
+ */
+class GOAddConstProcessor
+  : public GOSoundProcessorTyped<GOCountingProcessorState> {
+private:
+  // Constant added to every sample in Process(); mutable via SetValue() so
+  // GOCountingMapper can demonstrate writing a new parameter into a
+  // processor.
+  float m_value;
+  // Optional shared ordering log; null if this instance doesn't use one.
+  std::vector<int> *p_log;
+  // Value pushed to *p_log on each Process() call.
+  const int m_id;
+  // Number of EnsureSetup() calls seen so far.
+  unsigned m_NSetups = 0;
+  // Arguments received by the most recent EnsureSetup() call.
+  unsigned m_LastNChannels = 0;
+  unsigned m_LastNFrames = 0;
+  unsigned m_LastSampleRate = 0;
+
+public:
+  explicit GOAddConstProcessor(
+    float value, std::vector<int> *pLog = nullptr, int id = 0);
+
+  void EnsureSetup(
+    unsigned nChannels, unsigned nFrames, unsigned sampleRate) override;
+
+  unsigned GetNSetups() const { return m_NSetups; }
+  unsigned GetLastNChannels() const { return m_LastNChannels; }
+  unsigned GetLastNFrames() const { return m_LastNFrames; }
+  unsigned GetLastSampleRate() const { return m_LastSampleRate; }
+
+  /** Overwrites the constant added by Process(); the parameter GOCountingMapper
+   * writes. */
+  void SetValue(float value) { m_value = value; }
+
+protected:
+  std::unique_ptr<GOCountingProcessorState> CreateTypedState() const override;
+
+  void Process(
+    GOCountingProcessorState &state,
+    GOSoundBufferPlanarMutable &buffer) const override;
+};
+
+/**
+ * Fake processor that multiplies every sample of the buffer by a constant.
+ * Paired with GOAddConstProcessor to make chain order observable end-to-end
+ * (add-then-scale != scale-then-add), not just via a shared log.
+ */
+class GOScaleProcessor
+  : public GOSoundProcessorTyped<GOCountingProcessorState> {
+private:
+  // Multiplier applied to every sample in Process().
+  const float m_value;
+
+public:
+  explicit GOScaleProcessor(float value);
+
+  void EnsureSetup(
+    unsigned nChannels, unsigned nFrames, unsigned sampleRate) override {}
+
+protected:
+  std::unique_ptr<GOCountingProcessorState> CreateTypedState() const override;
+
+  void Process(
+    GOCountingProcessorState &state,
+    GOSoundBufferPlanarMutable &buffer) const override;
+};
+
+/**
+ * Per-channel DSP memory of GOOnePoleProcessor: one carried previous output
+ * sample per channel.
+ */
+class GOOnePoleState : public GOSoundProcessorState {
+private:
+  // One carried previous-sample value per channel; read and updated by
+  // GOOnePoleProcessor::Process(), zeroed by Reset(). Sized once at
+  // construction time, from the processor's EnsureSetup()-supplied channel
+  // count; never resized afterwards.
+  std::vector<float> m_prev;
+
+public:
+  /** Zero-fills m_prev to exactly nChannels entries. */
+  explicit GOOnePoleState(unsigned nChannels) : m_prev(nChannels, 0.0f) {}
+
+  void Reset() override;
+
+  float GetPrev(unsigned channelI) const { return m_prev[channelI]; }
+  void SetPrev(unsigned channelI, float value) { m_prev[channelI] = value; }
+};
+
+/**
+ * Fake one-pole IIR processor: y[n] = alpha*x[n] + (1-alpha)*y[n-1],
+ * carrying y[-1] in the GOOnePoleState across Process() calls. This is the
+ * stateful fake the processor-sharing test depends on: two GOOnePoleState
+ * objects created from the same GOOnePoleProcessor must evolve
+ * independently.
+ */
+class GOOnePoleProcessor : public GOSoundProcessorTyped<GOOnePoleState> {
+private:
+  // IIR coefficient, fixed at construction (no mapper needed for this fake).
+  const float m_alpha;
+  // Channel count from the most recent EnsureSetup() call; used to size
+  // every GOOnePoleState this processor creates.
+  unsigned m_NChannels = 0;
+
+public:
+  explicit GOOnePoleProcessor(float alpha);
+
+  void EnsureSetup(
+    unsigned nChannels, unsigned nFrames, unsigned sampleRate) override {
+    m_NChannels = nChannels;
+  }
+
+protected:
+  std::unique_ptr<GOOnePoleState> CreateTypedState() const override;
+
+  void Process(
+    GOOnePoleState &state, GOSoundBufferPlanarMutable &buffer) const override;
+};
+
+/**
+ * Fake mapper that counts EnsureParametersUpToDate() calls, and optionally
+ * writes a new constant into its target GOAddConstProcessor, to demonstrate
+ * a mapper's real role of pushing a value into a processor's parameters.
+ */
+class GOCountingMapper : public GOSoundProcessingPrmMapper {
+private:
+  // Number of EnsureParametersUpToDate() calls seen so far.
+  unsigned m_NCalls = 0;
+  // Whether EnsureParametersUpToDate() should push m_NewValue into the
+  // target processor, or just count the call.
+  const bool m_IsPushingValue;
+  // New constant to write into the target processor, if m_IsPushingValue.
+  const float m_NewValue;
+
+public:
+  explicit GOCountingMapper(
+    GOAddConstProcessor &processor,
+    bool isPushingValue = false,
+    float newValue = 0);
+
+  void EnsureParametersUpToDate() override;
+
+  unsigned GetNCalls() const { return m_NCalls; }
+};
+
+#endif /* GOSOUNDPROCESSINGTESTIMPLS_H */

--- a/src/tests/testing/sound/processing/GOTestSoundProcessingChain.cpp
+++ b/src/tests/testing/sound/processing/GOTestSoundProcessingChain.cpp
@@ -1,0 +1,466 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundProcessingChain.h"
+
+#include <cstring>
+#include <format>
+#include <vector>
+
+#include "GOSoundProcessingTestImpls.h"
+#include "sound/buffer/GOSoundBufferPlanarManaged.h"
+#include "sound/buffer/GOSoundBufferPlanarMutable.h"
+#include "sound/processing/GOSoundProcessingChain.h"
+#include "sound/processing/GOSoundProcessingChainState.h"
+
+const std::string GOTestSoundProcessingChain::TEST_NAME
+  = "GOTestSoundProcessingChain";
+
+void GOTestSoundProcessingChain::TestEmptyChainLeavesBufferUntouched() {
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 2, 8);
+
+  fillWithSequential(buffer, 1.0f);
+
+  GOSoundBufferPlanarManaged snapshot(buffer);
+  GOSoundProcessingChain chain;
+
+  GOAssert(chain.IsEmpty(), "a chain with no processors should be empty");
+
+  chain.EnsureSetup(2, 8, 44100);
+
+  std::unique_ptr<GOSoundProcessingChainState> pState = chain.CreateState();
+
+  GOAssert(
+    pState->GetNStates() == 0,
+    "an empty chain's state should have no processor states");
+
+  pState->Reset(); // must not crash on an empty state
+  pState->Process(buffer);
+
+  GOAssert(
+    std::memcmp(buffer.GetData(), snapshot.GetData(), buffer.GetNBytes()) == 0,
+    "an empty chain must leave the buffer untouched");
+}
+
+void GOTestSoundProcessingChain::TestProcessorsRunInOrder() {
+  std::vector<int> log;
+  GOSoundProcessingChain loggingChain;
+
+  loggingChain.AddProcessor(
+    std::make_unique<GOAddConstProcessor>(0.0f, &log, 1));
+  loggingChain.AddProcessor(
+    std::make_unique<GOAddConstProcessor>(0.0f, &log, 2));
+  loggingChain.AddProcessor(
+    std::make_unique<GOAddConstProcessor>(0.0f, &log, 3));
+  loggingChain.EnsureSetup(1, 1, 44100);
+
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(logBuffer, 1, 1);
+
+  logBuffer.FillWithSilence();
+
+  std::unique_ptr<GOSoundProcessingChainState> pLoggingState
+    = loggingChain.CreateState();
+
+  pLoggingState->Process(logBuffer);
+
+  GOAssert(
+    log.size() == 3 && log[0] == 1 && log[1] == 2 && log[2] == 3,
+    "processors should run in the order they were added");
+
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(arithBuffer, 1, 1);
+
+  arithBuffer.FillWithSilence();
+
+  GOSoundProcessingChain addThenScale;
+
+  addThenScale.AddProcessor(std::make_unique<GOAddConstProcessor>(1.0f));
+  addThenScale.AddProcessor(std::make_unique<GOScaleProcessor>(2.0f));
+  addThenScale.EnsureSetup(1, 1, 44100);
+  addThenScale.CreateState()->Process(arithBuffer);
+
+  GOAssert(
+    arithBuffer.GetData()[0] == 2.0f,
+    std::format(
+      "add(+1)-then-scale(x2) on 0 should give 2.0 (got: {})",
+      arithBuffer.GetData()[0]));
+
+  arithBuffer.FillWithSilence();
+
+  GOSoundProcessingChain scaleThenAdd;
+
+  scaleThenAdd.AddProcessor(std::make_unique<GOScaleProcessor>(2.0f));
+  scaleThenAdd.AddProcessor(std::make_unique<GOAddConstProcessor>(1.0f));
+  scaleThenAdd.EnsureSetup(1, 1, 44100);
+  scaleThenAdd.CreateState()->Process(arithBuffer);
+
+  GOAssert(
+    arithBuffer.GetData()[0] == 1.0f,
+    std::format(
+      "scale(x2)-then-add(+1) on 0 should give 1.0 (got: {})",
+      arithBuffer.GetData()[0]));
+}
+
+void GOTestSoundProcessingChain::TestEnsureSetupReachesEveryProcessor() {
+  GOSoundProcessingChain chain;
+  GOAddConstProcessor *pProcessors[3];
+
+  for (int processorI = 0; processorI < 3; processorI++) {
+    std::unique_ptr<GOAddConstProcessor> pProcessor
+      = std::make_unique<GOAddConstProcessor>(0.0f);
+
+    pProcessors[processorI] = pProcessor.get();
+    chain.AddProcessor(std::move(pProcessor));
+  }
+
+  chain.EnsureSetup(2, 64, 44100);
+
+  for (int processorI = 0; processorI < 3; processorI++) {
+    GOAddConstProcessor *pProcessor = pProcessors[processorI];
+
+    GOAssert(
+      pProcessor->GetNSetups() == 1,
+      std::format(
+        "processor {} should have received exactly one EnsureSetup() call",
+        processorI));
+    GOAssert(
+      pProcessor->GetLastNChannels() == 2 && pProcessor->GetLastNFrames() == 64
+        && pProcessor->GetLastSampleRate() == 44100,
+      std::format(
+        "processor {} should have received the exact EnsureSetup() arguments",
+        processorI));
+  }
+}
+
+void GOTestSoundProcessingChain::TestResetReachesEveryState() {
+  GOSoundProcessingChain chain;
+
+  for (int processorI = 0; processorI < 3; processorI++)
+    chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f));
+  chain.EnsureSetup(1, 1, 44100);
+
+  std::unique_ptr<GOSoundProcessingChainState> pState = chain.CreateState();
+
+  pState->Reset();
+
+  // Being a friend of GOSoundProcessingChainState, inspect each state
+  // directly: the public interface alone (GetNStates()) cannot confirm
+  // Reset() individually reached every one of them.
+  for (const std::unique_ptr<GOSoundProcessorState> &pRawState :
+       pState->m_states) {
+    GOCountingProcessorState *pCountingState
+      = dynamic_cast<GOCountingProcessorState *>(pRawState.get());
+
+    GOAssert(
+      pCountingState && pCountingState->GetNResets() == 1,
+      "each processor state should have received exactly one Reset() call");
+  }
+}
+
+void GOTestSoundProcessingChain::
+  TestEnsureParametersUpToDateReachesEveryMapper() {
+  GOSoundProcessingChain chain;
+  std::unique_ptr<GOAddConstProcessor> pTargetProcessorOwner
+    = std::make_unique<GOAddConstProcessor>(1.0f);
+  GOAddConstProcessor *pTargetProcessor = pTargetProcessorOwner.get();
+
+  chain.AddProcessor(std::move(pTargetProcessorOwner));
+  chain.AddMapper(std::make_unique<GOCountingMapper>(*pTargetProcessor));
+  chain.AddMapper(
+    std::make_unique<GOCountingMapper>(*pTargetProcessor, true, 5.0f));
+
+  GOAssert(
+    chain.m_mappers.size() == 2,
+    "chain.m_mappers should have exactly the 2 added mappers");
+
+  chain.EnsureSetup(1, 1, 44100);
+  chain.EnsureParametersUpToDate();
+
+  for (const std::unique_ptr<GOSoundProcessingPrmMapper> &pRawMapper :
+       chain.m_mappers) {
+    GOCountingMapper *pCountingMapper
+      = dynamic_cast<GOCountingMapper *>(pRawMapper.get());
+
+    GOAssert(
+      pCountingMapper && pCountingMapper->GetNCalls() == 1,
+      "each mapper should have received exactly one EnsureParametersUpToDate() "
+      "call");
+  }
+
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 1, 1);
+
+  buffer.FillWithSilence();
+  chain.CreateState()->Process(buffer);
+
+  GOAssert(
+    buffer.GetData()[0] == 5.0f,
+    std::format(
+      "the mapper's new constant should have taken effect (got: {})",
+      buffer.GetData()[0]));
+}
+
+void GOTestSoundProcessingChain::TestInsertProcessorInsertsAtPosition() {
+  std::vector<int> log;
+  GOSoundProcessingChain chain;
+
+  // Build phase: 1, 3, then insert 2 in between -> expected order 1, 2, 3.
+  chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f, &log, 1));
+  chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f, &log, 3));
+  chain.InsertProcessor(
+    1, std::make_unique<GOAddConstProcessor>(0.0f, &log, 2));
+
+  GOAssert(
+    chain.GetNProcessors() == 3,
+    "InsertProcessor() should grow the processor count by one");
+
+  chain.EnsureSetup(1, 1, 44100);
+
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 1, 1);
+
+  buffer.FillWithSilence();
+  chain.CreateState()->Process(buffer);
+
+  GOAssert(
+    log.size() == 3 && log[0] == 1 && log[1] == 2 && log[2] == 3,
+    "InsertProcessor() should splice the new processor into the requested "
+    "position in the signal path");
+}
+
+void GOTestSoundProcessingChain::
+  TestRemoveProcessorReturnsOwnershipAndShiftsOrder() {
+  std::vector<int> log;
+  GOSoundProcessingChain chain;
+
+  chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f, &log, 1));
+
+  std::unique_ptr<GOAddConstProcessor> pMiddleOwner
+    = std::make_unique<GOAddConstProcessor>(0.0f, &log, 2);
+  GOAddConstProcessor *pMiddleProcessor = pMiddleOwner.get();
+
+  chain.AddProcessor(std::move(pMiddleOwner));
+  chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f, &log, 3));
+
+  std::unique_ptr<GOSoundProcessor> pRemoved = chain.RemoveProcessor(1);
+
+  GOAssert(
+    pRemoved.get() == pMiddleProcessor,
+    "RemoveProcessor() should return ownership of the exact object removed");
+  GOAssert(
+    chain.GetNProcessors() == 2,
+    "RemoveProcessor() should shrink the processor count by one");
+
+  chain.EnsureSetup(1, 1, 44100);
+
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 1, 1);
+
+  buffer.FillWithSilence();
+  chain.CreateState()->Process(buffer);
+
+  GOAssert(
+    log.size() == 2 && log[0] == 1 && log[1] == 3,
+    "the removed processor's id should no longer appear in the Process() "
+    "order, and the later processor should shift into its place");
+}
+
+void GOTestSoundProcessingChain::TestRemoveMapperAllowsRemovingItsProcessor() {
+  GOSoundProcessingChain chain;
+  std::unique_ptr<GOAddConstProcessor> pProcessorOwner
+    = std::make_unique<GOAddConstProcessor>(0.0f);
+  GOAddConstProcessor *pProcessor = pProcessorOwner.get();
+
+  chain.AddProcessor(std::move(pProcessorOwner));
+
+  std::unique_ptr<GOSoundProcessingPrmMapper> pMapperOwner
+    = std::make_unique<GOCountingMapper>(*pProcessor);
+  GOSoundProcessingPrmMapper *pMapper = pMapperOwner.get();
+
+  chain.AddMapper(std::move(pMapperOwner));
+
+  // Removing the processor while its mapper is still installed must be
+  // refused (asserted); remove the mapper first.
+  std::unique_ptr<GOSoundProcessingPrmMapper> pRemovedMapper
+    = chain.RemoveMapper(*pMapper);
+
+  GOAssert(
+    pRemovedMapper.get() == pMapper,
+    "RemoveMapper() should return ownership of the exact mapper removed");
+  GOAssert(chain.m_mappers.empty(), "RemoveMapper() should remove the mapper");
+
+  std::unique_ptr<GOSoundProcessor> pRemovedProcessor
+    = chain.RemoveProcessor(0);
+
+  GOAssert(
+    pRemovedProcessor.get() == pProcessor,
+    "RemoveProcessor() should now succeed once no mapper references the "
+    "processor any more");
+}
+
+void GOTestSoundProcessingChain::TestClearChainRemovesProcessorsAndMappers() {
+  GOSoundProcessingChain chain;
+  std::unique_ptr<GOAddConstProcessor> pProcessorOwner1
+    = std::make_unique<GOAddConstProcessor>(0.0f);
+  std::unique_ptr<GOAddConstProcessor> pProcessorOwner2
+    = std::make_unique<GOAddConstProcessor>(0.0f);
+  GOAddConstProcessor *pProcessor1 = pProcessorOwner1.get();
+  GOAddConstProcessor *pProcessor2 = pProcessorOwner2.get();
+
+  chain.AddProcessor(std::move(pProcessorOwner1));
+  chain.AddProcessor(std::move(pProcessorOwner2));
+  chain.AddMapper(std::make_unique<GOCountingMapper>(*pProcessor1));
+  chain.AddMapper(std::make_unique<GOCountingMapper>(*pProcessor2));
+
+  chain.ClearChain();
+
+  GOAssert(
+    chain.IsEmpty() && chain.GetNProcessors() == 0,
+    "ClearChain() should remove every processor");
+  GOAssert(chain.m_mappers.empty(), "ClearChain() should remove every mapper");
+
+  // The chain must still be fully usable afterward, exactly as if freshly
+  // constructed.
+  std::vector<int> log;
+
+  chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f, &log, 42));
+  chain.EnsureSetup(1, 1, 44100);
+
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 1, 1);
+
+  buffer.FillWithSilence();
+  chain.CreateState()->Process(buffer);
+
+  GOAssert(
+    log.size() == 1 && log[0] == 42,
+    "a chain rebuilt after ClearChain() should process normally");
+}
+
+void GOTestSoundProcessingChain::TestIsValidReflectsChainState() {
+  GOSoundProcessingChain chain;
+
+  chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f));
+  chain.EnsureSetup(1, 1, 44100);
+
+  std::unique_ptr<GOSoundProcessingChainState> pState = chain.CreateState();
+
+  GOAssert(
+    pState->IsValid(),
+    "a freshly created state must be valid against its chain");
+
+  // P1: reconfiguring the format under a live state must invalidate it.
+  chain.EnsureSetup(2, 1, 44100);
+
+  GOAssert(
+    !pState->IsValid(),
+    "a state must become invalid once the chain's format changes under it");
+
+  // Cleanup() wipes the format out from under any still-alive state too.
+  GOSoundProcessingChain otherChain;
+
+  otherChain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f));
+  otherChain.EnsureSetup(1, 1, 44100);
+
+  std::unique_ptr<GOSoundProcessingChainState> pOtherState
+    = otherChain.CreateState();
+
+  GOAssert(pOtherState->IsValid(), "a freshly created state must be valid");
+
+  otherChain.Cleanup();
+
+  GOAssert(
+    !pOtherState->IsValid(),
+    "a state must become invalid once its chain is Cleanup()'d");
+}
+
+void GOTestSoundProcessingChain::TestEnsureSetupNoOpDoesNotInvalidateState() {
+  GOSoundProcessingChain chain;
+
+  chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f));
+  chain.EnsureSetup(1, 1, 44100);
+
+  std::unique_ptr<GOSoundProcessingChainState> pState = chain.CreateState();
+
+  GOAssert(
+    pState->IsValid(),
+    "a freshly created state must be valid against its chain");
+
+  // Repeating EnsureSetup() with the exact same arguments must not disturb
+  // a live state: per GOSoundProcessor's own contract, a same-arguments
+  // call is a cheap no-op, so nothing the state depends on has changed.
+  chain.EnsureSetup(1, 1, 44100);
+
+  GOAssert(
+    pState->IsValid(),
+    "a same-arguments EnsureSetup() call must not invalidate a live state");
+}
+
+void GOTestSoundProcessingChain::TestChainReusableAfterAllStatesDestroyed() {
+  std::vector<int> firstLog;
+  GOSoundProcessingChain chain;
+
+  chain.AddProcessor(std::make_unique<GOAddConstProcessor>(0.0f, &firstLog, 1));
+  chain.InsertProcessor(
+    0, std::make_unique<GOAddConstProcessor>(0.0f, &firstLog, 0));
+  chain.EnsureSetup(1, 1, 44100);
+
+  {
+    std::unique_ptr<GOSoundProcessingChainState> pState = chain.CreateState();
+
+    GOAssert(pState->IsValid(), "the initial state must be valid");
+
+    GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 1, 1);
+
+    buffer.FillWithSilence();
+    pState->Process(buffer);
+
+    GOAssert(
+      firstLog.size() == 2 && firstLog[0] == 0 && firstLog[1] == 1,
+      "the initial chain should process in the built order");
+  } // pState destroyed here: no live state remains.
+
+  // Full teardown and rebuild with a different topology and format.
+  chain.Cleanup();
+  chain.ClearChain();
+
+  std::vector<int> secondLog;
+
+  chain.AddProcessor(
+    std::make_unique<GOAddConstProcessor>(0.0f, &secondLog, 7));
+  chain.AddProcessor(
+    std::make_unique<GOAddConstProcessor>(0.0f, &secondLog, 8));
+  chain.RemoveProcessor(0);
+  chain.EnsureSetup(2, 4, 48000);
+
+  std::unique_ptr<GOSoundProcessingChainState> pFreshState
+    = chain.CreateState();
+
+  GOAssert(
+    pFreshState->IsValid(),
+    "a state created after a full rebuild must be valid");
+
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 2, 4);
+
+  buffer.FillWithSilence();
+  pFreshState->Process(buffer);
+
+  GOAssert(
+    secondLog.size() == 1 && secondLog[0] == 8,
+    "the rebuilt chain should reflect the new topology (only processor 8 "
+    "remains) rather than any trace of the old one");
+}
+
+void GOTestSoundProcessingChain::run() {
+  TestEmptyChainLeavesBufferUntouched();
+  TestProcessorsRunInOrder();
+  TestEnsureSetupReachesEveryProcessor();
+  TestResetReachesEveryState();
+  TestEnsureParametersUpToDateReachesEveryMapper();
+  TestInsertProcessorInsertsAtPosition();
+  TestRemoveProcessorReturnsOwnershipAndShiftsOrder();
+  TestRemoveMapperAllowsRemovingItsProcessor();
+  TestClearChainRemovesProcessorsAndMappers();
+  TestIsValidReflectsChainState();
+  TestEnsureSetupNoOpDoesNotInvalidateState();
+  TestChainReusableAfterAllStatesDestroyed();
+}

--- a/src/tests/testing/sound/processing/GOTestSoundProcessingChain.h
+++ b/src/tests/testing/sound/processing/GOTestSoundProcessingChain.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDPROCESSINGCHAIN_H
+#define GOTESTSOUNDPROCESSINGCHAIN_H
+
+#include "../buffer/GOTestSoundBufferBase.h"
+
+class GOTestSoundProcessingChain : public GOTestSoundBufferBase {
+private:
+  static const std::string TEST_NAME;
+
+  void TestEmptyChainLeavesBufferUntouched();
+  void TestProcessorsRunInOrder();
+  void TestEnsureSetupReachesEveryProcessor();
+  void TestResetReachesEveryState();
+  void TestEnsureParametersUpToDateReachesEveryMapper();
+  void TestInsertProcessorInsertsAtPosition();
+  void TestRemoveProcessorReturnsOwnershipAndShiftsOrder();
+  void TestRemoveMapperAllowsRemovingItsProcessor();
+  void TestClearChainRemovesProcessorsAndMappers();
+  void TestIsValidReflectsChainState();
+  void TestEnsureSetupNoOpDoesNotInvalidateState();
+  void TestChainReusableAfterAllStatesDestroyed();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTSOUNDPROCESSINGCHAIN_H */

--- a/src/tests/testing/sound/processing/GOTestSoundProcessorTyped.cpp
+++ b/src/tests/testing/sound/processing/GOTestSoundProcessorTyped.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestSoundProcessorTyped.h"
+
+#include <cmath>
+#include <cstring>
+#include <format>
+#include <vector>
+
+#include "GOSoundProcessingTestImpls.h"
+#include "sound/buffer/GOSoundBufferPlanarMutable.h"
+#include "sound/processing/GOSoundProcessingChain.h"
+#include "sound/processing/GOSoundProcessingChainState.h"
+
+const std::string GOTestSoundProcessorTyped::TEST_NAME
+  = "GOTestSoundProcessorTyped";
+
+void GOTestSoundProcessorTyped::TestOneProcessorTwoIndependentStates() {
+  const float alpha = 0.5f;
+  const std::vector<float> sequenceA = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+  const std::vector<float> sequenceB = {2.0f, 2.0f, 2.0f, 2.0f, 2.0f};
+  const unsigned nSamples = sequenceA.size();
+
+  GOSoundProcessingChain chain;
+
+  chain.AddProcessor(std::make_unique<GOOnePoleProcessor>(alpha));
+  chain.EnsureSetup(1, 1, 44100);
+
+  std::unique_ptr<GOSoundProcessingChainState> pStateA = chain.CreateState();
+  std::unique_ptr<GOSoundProcessingChainState> pStateB = chain.CreateState();
+
+  GOAssert(
+    pStateA->m_states[0].get() != pStateB->m_states[0].get(),
+    "the two chain states must hold two distinct processor state objects");
+
+  std::vector<float> gotA(nSamples);
+  std::vector<float> gotB(nSamples);
+  float expectedPrevA = 0.0f;
+  float expectedPrevB = 0.0f;
+
+  for (unsigned sampleI = 0; sampleI < nSamples; sampleI++) {
+    GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(bufferA, 1, 1);
+
+    bufferA.GetData()[0] = sequenceA[sampleI];
+    pStateA->Process(bufferA);
+    gotA[sampleI] = bufferA.GetData()[0];
+
+    GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(bufferB, 1, 1);
+
+    bufferB.GetData()[0] = sequenceB[sampleI];
+    pStateB->Process(bufferB);
+    gotB[sampleI] = bufferB.GetData()[0];
+
+    const float expectedA
+      = alpha * sequenceA[sampleI] + (1.0f - alpha) * expectedPrevA;
+    const float expectedB
+      = alpha * sequenceB[sampleI] + (1.0f - alpha) * expectedPrevB;
+
+    GOAssert(
+      std::abs(gotA[sampleI] - expectedA) < 1e-6f,
+      std::format(
+        "state A sample {}: expected {} (got: {})",
+        sampleI,
+        expectedA,
+        gotA[sampleI]));
+    GOAssert(
+      std::abs(gotB[sampleI] - expectedB) < 1e-6f,
+      std::format(
+        "state B sample {}: expected {} (got: {})",
+        sampleI,
+        expectedB,
+        gotB[sampleI]));
+
+    expectedPrevA = expectedA;
+    expectedPrevB = expectedB;
+  }
+
+  // Direct proof B never perturbed A: re-run sequence A alone, in a fresh
+  // chain state of the same chain, and expect a bit-identical result.
+  std::unique_ptr<GOSoundProcessingChainState> pSoloStateA
+    = chain.CreateState();
+  std::vector<float> soloA(nSamples);
+
+  for (unsigned sampleI = 0; sampleI < nSamples; sampleI++) {
+    GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 1, 1);
+
+    buffer.GetData()[0] = sequenceA[sampleI];
+    pSoloStateA->Process(buffer);
+    soloA[sampleI] = buffer.GetData()[0];
+  }
+
+  GOAssert(
+    std::memcmp(soloA.data(), gotA.data(), nSamples * sizeof(float)) == 0,
+    "state A's output must be bit-identical whether or not state B was "
+    "interleaved with it");
+}
+
+void GOTestSoundProcessorTyped::TestTypedDispatch() {
+  GOOnePoleProcessor processor(0.5f);
+
+  processor.EnsureSetup(1, 1, 44100);
+
+  std::unique_ptr<GOSoundProcessorState> pState = processor.CreateState();
+
+  GOAssert(
+    dynamic_cast<GOOnePoleState *>(pState.get()),
+    "CreateState() should return an object of the concrete typed state type");
+
+  // Call through the untyped base entry point and confirm it reaches the
+  // typed Process() override (same formula as the typed test above, with
+  // alpha=0.5 and a single sample of amplitude 1.0: expected output 0.5).
+  GOSoundProcessor &untypedProcessor = processor;
+  GO_DECLARE_LOCAL_SOUND_BUFFER_PLANAR(buffer, 1, 1);
+
+  buffer.GetData()[0] = 1.0f;
+  untypedProcessor.Process(*pState, buffer);
+
+  GOAssert(
+    std::abs(buffer.GetData()[0] - 0.5f) < 1e-6f,
+    std::format(
+      "the untyped Process() call should reach the typed override (got: {})",
+      buffer.GetData()[0]));
+}
+
+void GOTestSoundProcessorTyped::run() {
+  TestOneProcessorTwoIndependentStates();
+  TestTypedDispatch();
+}

--- a/src/tests/testing/sound/processing/GOTestSoundProcessorTyped.h
+++ b/src/tests/testing/sound/processing/GOTestSoundProcessorTyped.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2006 Milan Digital Audio LLC
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSOUNDPROCESSORTYPED_H
+#define GOTESTSOUNDPROCESSORTYPED_H
+
+#include "../buffer/GOTestSoundBufferBase.h"
+
+class GOTestSoundProcessorTyped : public GOTestSoundBufferBase {
+private:
+  static const std::string TEST_NAME;
+
+  void TestOneProcessorTwoIndependentStates();
+  void TestTypedDispatch();
+
+public:
+  std::string GetName() override { return TEST_NAME; }
+  void run() override;
+};
+
+#endif /* GOTESTSOUNDPROCESSORTYPED_H */


### PR DESCRIPTION
## Summary
- Introduces the processor/state/mapper roles and a GOSoundProcessingChain that composes them under src/grandorgue/sound/processing/, so a windchest's DSP chain can be built without inventing more abstractions.
- Purely additive: no existing source file's logic changes, only two CMakeLists.txt file lists and GOTestExe.cpp's test registration block.

Related: groundwork for #709 (pitch-based tremulant / vibrato) and #717 (swell box shelf EQ), and an upcoming per-windchest reverb effect; does not itself close an issue.

## Test plan
- [x] Clean build succeeds
- [x] GOTestExe — GOTestSoundProcessingChain and GOTestSoundProcessorTyped pass