### PR TITLE
Fixed hanging on Panic, on loading another organ and on exit (#2606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed hanging on Panic, on loading another organ, on exit and on removing an audio device in Settings https://github.com/GrandOrgue/grandorgue/issues/2606
 - Fixed Linux packages including unnecessary cpptrace/libdwarf headers and static libraries, causing RPM install conflicts with elfutils https://github.com/GrandOrgue/grandorgue/issues/2596
 - Added Belarusian, Lithuanian, Russian, and Ukrainian UI translations
 - Added capability of building GrandOrgue natively on Windows via MSYS2, without needing a Linux machine for cross-compiling https://github.com/GrandOrgue/grandorgue/issues/2378

--- a/src/grandorgue/gui/frames/GOLogWindow.cpp
+++ b/src/grandorgue/gui/frames/GOLogWindow.cpp
@@ -1,13 +1,12 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
 
 #include "GOLogWindow.h"
 
-#include <wx/app.h>
 #include <wx/artprov.h>
 #include <wx/clipbrd.h>
 #include <wx/dataobj.h>
@@ -130,6 +129,16 @@ void GOLogWindow::LogMsg(
   e.SetTimestamp(timestamp);
   GetEventHandler()->AddPendingEvent(e);
   count++;
+  /* A long operation running in the GUI thread may emit thousands of messages
+     without returning to the event loop, so the pending event queue has to be
+     drained from time to time.
+     Only this window's own queue is processed. A full wxApp::Yield() would
+     dispatch any other pending event as well, and log messages are emitted
+     from places that must not be re-entered: it used to dispatch wxEVT_METERS
+     into GOSoundOrganEngine::GetMeterInfo() and a pending toolbar click into
+     GOAppWindow::OnAudioPanic() while GOSoundOrganEngine::BuildEngine() was
+     holding m_LifecycleMutex, which deadlocked the application (issue #2606).
+   */
   if ((count % 100) == 0)
-    wxTheApp->Yield(true);
+    GetEventHandler()->ProcessPendingEvents();
 }

--- a/src/grandorgue/gui/frames/GOLogWindow.cpp
+++ b/src/grandorgue/gui/frames/GOLogWindow.cpp
@@ -13,8 +13,12 @@
 #include <wx/imaglist.h>
 #include <wx/listctrl.h>
 #include <wx/menu.h>
+#include <wx/thread.h>
 
 DEFINE_LOCAL_EVENT_TYPE(wxEVT_ADD_LOG_MESSAGE)
+
+static constexpr unsigned LOG_MESSAGE_BATCH_SIZE = 100;
+static unsigned log_message_count = 0;
 
 BEGIN_EVENT_TABLE(GOLogWindow, wxFrame)
 EVT_COMMAND(0, wxEVT_ADD_LOG_MESSAGE, GOLogWindow::OnLog)
@@ -108,9 +112,14 @@ void GOLogWindow::OnCloseWindow(wxCloseEvent &event) {
   m_List->DeleteAllItems();
 }
 
+bool GOLogWindow::HasPendingLogEvents() {
+  wxCriticalSectionLocker locker(m_pendingEventsLock);
+
+  return m_pendingEvents && !m_pendingEvents->IsEmpty();
+}
+
 void GOLogWindow::LogMsg(
   wxLogLevel level, const wxString &msg, time_t timestamp) {
-  static unsigned count = 0;
   int l;
   switch (level) {
   case wxLOG_FatalError:
@@ -128,7 +137,7 @@ void GOLogWindow::LogMsg(
   e.SetInt(l);
   e.SetTimestamp(timestamp);
   GetEventHandler()->AddPendingEvent(e);
-  count++;
+  log_message_count++;
   /* A long operation running in the GUI thread may emit thousands of messages
      without returning to the event loop, so the pending event queue has to be
      drained from time to time.
@@ -138,7 +147,11 @@ void GOLogWindow::LogMsg(
      into GOSoundOrganEngine::GetMeterInfo() and a pending toolbar click into
      GOAppWindow::OnAudioPanic() while GOSoundOrganEngine::BuildEngine() was
      holding m_LifecycleMutex, which deadlocked the application (issue #2606).
+     ProcessPendingEvents() delivers only a single event per call, so the
+     whole accumulated batch is drained by looping until the queue is
+     actually empty.
    */
-  if ((count % 100) == 0)
-    GetEventHandler()->ProcessPendingEvents();
+  if ((log_message_count % LOG_MESSAGE_BATCH_SIZE) == 0)
+    while (HasPendingLogEvents())
+      GetEventHandler()->ProcessPendingEvents();
 }

--- a/src/grandorgue/gui/frames/GOLogWindow.h
+++ b/src/grandorgue/gui/frames/GOLogWindow.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -19,6 +19,7 @@ class GOLogWindow : public wxFrame {
 private:
   wxListCtrl *m_List;
 
+  bool HasPendingLogEvents();
   void OnLog(wxCommandEvent &event);
   void OnCopy(wxCommandEvent &event);
   void OnClear(wxCommandEvent &event);

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -540,24 +540,39 @@ bool GOSoundOrganEngine::ProcessAudioCallback(
  */
 
 std::vector<float> GOSoundOrganEngine::GetMeterInfo() {
-  // GUI thread: m_LifecycleMutex prevents concurrent BuildEngine/DestroyEngine
-  // from modifying m_MeterInfo while we read it.
-  GOMutexLocker locker(m_LifecycleMutex);
+  /* GUI thread: m_LifecycleMutex prevents concurrent BuildEngine/DestroyEngine
+     from modifying m_MeterInfo while we read it.
+     The lock is taken with try_lock because the GUI thread may re-enter this
+     method while it already holds m_LifecycleMutex: BuildEngine() and
+     DestroyEngine() hold the mutex for their whole duration, and any wxLog*
+     call made from inside them reaches GOLogWindow::LogMsg, which re-enters
+     the event loop via wxApp::Yield() and dispatches the pending wxEVT_METERS.
+     m_LifecycleMutex is not recursive, so a blocking lock would deadlock the
+     application (issue #2606).
+     When the mutex is occupied, an empty result is returned and
+     GOAppWindow::OnMeters skips this meter frame. Nothing is lost: the audio
+     thread keeps accumulating peaks in m_MeterInfo until the next poll. */
+  GOMutexLocker locker(
+    m_LifecycleMutex, true, "GOSoundOrganEngine::GetMeterInfo");
+  std::vector<float> result;
 
-  // result[0] = polyphony ratio; result[1..] = per-channel peak levels.
-  // When not working, m_MeterInfo may be empty; result contains only zeros.
-  std::vector<float> result(m_MeterInfo.size() + 1, 0.0f);
+  if (locker.IsLocked()) {
+    // result[0] = polyphony ratio; result[1..] = per-channel peak levels.
+    // When not working, m_MeterInfo may be empty; result contains only zeros.
+    result.assign(m_MeterInfo.size() + 1, 0.0f);
 
-  if (IsWorking()) {
-    const unsigned hardPolyphony = GetHardPolyphony();
-    float *pResult = result.data();
+    if (IsWorking()) {
+      const unsigned hardPolyphony = GetHardPolyphony();
+      float *pResult = result.data();
 
-    assert(hardPolyphony > 0);
-    // GetAndResetUsedPolyphony() reads accumulated peak polyphony and resets it
-    *(pResult++) = m_SamplerPlayer.GetAndResetUsedPolyphony()
-      / static_cast<float>(hardPolyphony);
-    for (std::atomic<float> &v : m_MeterInfo)
-      *(pResult++) = v.exchange(0.0f);
+      assert(hardPolyphony > 0);
+      // GetAndResetUsedPolyphony() reads accumulated peak polyphony and resets
+      // it
+      *(pResult++) = m_SamplerPlayer.GetAndResetUsedPolyphony()
+        / static_cast<float>(hardPolyphony);
+      for (std::atomic<float> &v : m_MeterInfo)
+        *(pResult++) = v.exchange(0.0f);
+    }
   }
   return result;
 }

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -170,6 +170,9 @@ private:
   // Any function that must guarantee the lifecycle state does not change
   // during its execution (e.g. GetMeterInfo) must acquire this mutex before
   // reading m_LifecycleState.
+  // The mutex is not recursive, and BuildEngine/DestroyEngine may re-enter the
+  // wx event loop while holding it (logging calls wxApp::Yield). Functions
+  // called from event handlers must therefore lock it with try_lock only.
   GOMutex m_LifecycleMutex;
 
   std::atomic<LifecycleState> m_LifecycleState;
@@ -189,7 +192,9 @@ private:
   // [B3] m_MeterInfo: per-channel peak levels for the meter display
   //   — uses nTotalChannels accumulated over m_OutputStates [B2]
   //   — audio thread: NextPeriod() writes via atomic_fetch_max_relaxed()
-  //   — GUI thread: GetMeterInfo() reads and resets under m_LifecycleMutex
+  //   — GUI thread: GetMeterInfo() reads and resets it when it succeeds in
+  //     try-locking m_LifecycleMutex; otherwise the poll is skipped and the
+  //     peaks stay accumulated until the next one
   std::vector<std::atomic<float>> m_MeterInfo;
   // [B4] mp_DownmixTask: optional stereo downmix task (only when m_IsDownmix)
   //   — uses mp_AudioGroupTasks [B1] via SetOutputs()
@@ -359,6 +364,15 @@ public:
    */
 
   uint64_t GetTime() const { return m_SamplerPlayer.GetTime(); }
+
+  /**
+   * Returns the current meter values for the GUI: result[0] is the polyphony
+   * ratio, result[1..] are the per-channel peak levels, which are reset by
+   * this call.
+   * Never blocks: if m_LifecycleMutex is occupied (the engine is being built
+   * or destroyed) an empty vector is returned and the caller must skip the
+   * meter frame.
+   */
   std::vector<float> GetMeterInfo();
   GOScheduler &GetScheduler() { return m_scheduler; }
 


### PR DESCRIPTION
Fixes #2606.

## Problem

`GOSoundOrganEngine::BuildEngine()` and `DestroyEngine()` hold `m_LifecycleMutex` for their whole duration. Creating a scheduler thread inside `BuildEngine()` logs a message, and `GOLogWindow::LogMsg()` called `wxApp::Yield()` on every 100th message of the session. `Yield()` re-entered the event loop on the GUI thread and dispatched arbitrary pending events while the mutex was held.

Two victims were observed in gdb on a locally reproduced hang:

**1. The meter timer**

```
GOAppWindow::OnAudioPanic
 └ GOOrganController::StartOrgan
    └ GOSoundOrganEngine::BuildEngine          ← holds m_LifecycleMutex
       └ new GOSchedulerThread → wxLogDebug("Create Thread")
          └ GOLogWindow::LogMsg → wxTheApp->Yield(true)
             └ wxEVT_METERS → GOAppWindow::OnMeters
                └ GOSoundOrganEngine::GetMeterInfo → locks m_LifecycleMutex  ✗
```

**2. A pending toolbar click (after the first one was fixed)**

```
GOAppWindow::OnAudioPanic                      ← first click
 └ ... → GOSoundOrganEngine::BuildEngine       ← holds m_LifecycleMutex
    └ ... → wxTheApp->Yield(true)
       └ wxToolBarBase::OnLeftClick            ← second, pending click
          └ GOAppWindow::OnAudioPanic → StartOrgan
             └ GOSoundOrganEngine::BuildEngine → locks m_LifecycleMutex  ✗
```

`GOMutex` wraps `std::timed_mutex` and is not recursive, so in both cases the GUI thread deadlocked with itself.

### Why two audio devices were needed to reproduce it

There is no structural dependency on the device count. `GOSoundSystem::OpenSoundSystem()` / `CloseSoundSystem()` loop over ports and each port emits its own batch of log messages, so a second device adds a fixed number of lines per open/close cycle. That shifts where the "every 100th message" boundary falls — into the locked region of `BuildEngine()`. The offset is stable within a session, hence the hang reproduced on every Panic. With one device the boundary happens to fall outside the lock; the bug was latent, not absent.

### Regression range

`GetMeterInfo()` started taking a mutex in 8eef1087 "Fixed data race in GOSoundOrganEngine::GetMeterInfo (#2486)", first shipped in **3.17.2-1**. Before that the re-entrant call was harmless, which matches the report of 3.17.1 working and 3.17.3 hanging.

## Fix

**`GOLogWindow::LogMsg()`** now drains only its own pending queue with `wxEvtHandler::ProcessPendingEvents()` instead of calling `wxApp::Yield()`. The queue still does not grow unboundedly during long GUI-thread operations, which is what the `Yield()` was added for in 0b338b76 (2013), but events belonging to other handlers are no longer dispatched from inside a `wxLog*` call.

**`GOSoundOrganEngine::GetMeterInfo()`** additionally locks `m_LifecycleMutex` with `try_lock` and returns an empty vector while the engine is being built or destroyed. `GOAppWindow::OnMeters()` already skips meter frames of an unexpected size, and the peaks stay accumulated in `m_MeterInfo` until the next poll, so nothing is lost. This keeps the GUI thread from blocking on the engine lifecycle under any other nested event dispatch, such as a modal dialog or `wxProgressDialog::Update()`.

## Testing

- Reproduced the hang on a Debug+ASAN build with two JACK output devices, and confirmed both backtraces above with gdb.
- After the fix: Panic pressed repeatedly across several 100-message boundaries, loading another organ, exiting, and removing the second audio device in Settings — no hangs. Meters still animate during playback and drop to zero after Panic.
- `GOTestFunctional` passes. `GOTestPerf` fails on this machine on sound-buffer throughput baselines in a Debug+ASAN build, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLPRpmXC7NVqNQDBQhv1NK