### PR TITLE
Add centralized test-class/test progress logging (GOTestScope)

### DIFF
--- a/src/tests/common/CMakeLists.txt
+++ b/src/tests/common/CMakeLists.txt
@@ -4,6 +4,7 @@ set(go_test_common
     GOTestResultCollection.cpp
     GOTest.cpp
     GOTestCollection.cpp
+    GOTestScope.cpp
 )
 
 add_library(GOTestLib STATIC ${go_test_common})

--- a/src/tests/common/GOTest.cpp
+++ b/src/tests/common/GOTest.cpp
@@ -9,7 +9,6 @@
 #include "config/GOConfig.h"
 #include <cstdio>
 #include <filesystem>
-#include <iostream>
 
 GOTest::GOTest(Category category) : m_Category(category) {
   // This is the magic to auto register tests in TestCollection
@@ -17,11 +16,7 @@ GOTest::GOTest(Category category) : m_Category(category) {
 }
 GOTest::~GOTest() {}
 
-bool GOTest::setUp() {
-  std::cout << "==================== " << this->GetName()
-            << " - BEGIN ====================";
-  return true;
-}
+bool GOTest::setUp() { return true; }
 
 void GOTest::run() {}
 

--- a/src/tests/common/GOTestCollection.cpp
+++ b/src/tests/common/GOTestCollection.cpp
@@ -7,6 +7,7 @@
 #include "GOTestCollection.h"
 #include "GOTestException.h"
 #include "GOTestResultCollection.h"
+#include "GOTestScope.h"
 #include <iostream>
 #include <iterator>
 #include <vector>
@@ -48,6 +49,8 @@ GOTestResultCollection GOTestCollection::Run(
     auto test = *current;
 
     if (!categoryFilter.has_value() || test->GetCategory() == *categoryFilter) {
+      GOTestScope testClassScope(GOTestScope::TEST_CLASS, test->GetName());
+
       try {
         if (test->setUp()) {
           bool isRunSucceeded = false;

--- a/src/tests/common/GOTestScope.cpp
+++ b/src/tests/common/GOTestScope.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#include "GOTestScope.h"
+
+#include <iostream>
+
+int GOTestScope::s_Depth = 0;
+
+static std::string indent_for(int depth) { return std::string(2 * depth, ' '); }
+
+GOTestScope::GOTestScope(Kind kind, const std::string &name)
+  : m_Kind(kind), m_Name(name), m_StartTime(std::chrono::steady_clock::now()) {
+  std::cout << indent_for(s_Depth)
+            << (m_Kind == TEST_CLASS ? "Test class: " : "Test: ") << m_Name
+            << std::endl;
+  s_Depth++;
+}
+
+GOTestScope::~GOTestScope() {
+  const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::steady_clock::now() - m_StartTime)
+                           .count();
+
+  s_Depth--;
+  std::cout << indent_for(s_Depth) << "done: " << m_Name << " (" << elapsedMs
+            << " ms)" << std::endl;
+}

--- a/src/tests/common/GOTestScope.h
+++ b/src/tests/common/GOTestScope.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
+ * License GPL-2.0 or later
+ * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+ */
+
+#ifndef GOTESTSCOPE_H
+#define GOTESTSCOPE_H
+
+#include <chrono>
+#include <string>
+
+/**
+ * RAII progress logger for the test framework. Prints an indented,
+ * immediately flushed line when a test class or a test starts, and another
+ * when it finishes (with the elapsed time). Nesting depth is tracked
+ * automatically, so a CI log always shows exactly which test class and
+ * which test were in flight if the process hangs.
+ */
+class GOTestScope {
+public:
+  enum Kind { TEST_CLASS, TEST };
+
+private:
+  static int s_Depth;
+
+  const Kind m_Kind;
+  const std::string m_Name;
+  const std::chrono::steady_clock::time_point m_StartTime;
+
+public:
+  GOTestScope(Kind kind, const std::string &name);
+  ~GOTestScope();
+};
+
+/**
+ * Runs callExpr as a Test, logged via GOTestScope. The test name is derived
+ * from the call expression itself. Called without a trailing semicolon, like
+ * the other declaration-style macros in this codebase.
+ */
+#define GO_RUN_TEST(callExpr)                                                  \
+  {                                                                            \
+    GOTestScope goTestScope_(GOTestScope::TEST, #callExpr);                    \
+    callExpr;                                                                  \
+  }
+
+#endif /* GOTESTSCOPE_H */

--- a/src/tests/testing/GOTestNameMap.cpp
+++ b/src/tests/testing/GOTestNameMap.cpp
@@ -6,6 +6,8 @@
 
 #include "GOTestNameMap.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestNameMap::TEST_NAME = "GOTestNameMap";
 
 void GOTestNameMap::TestAddAndGetName() {
@@ -133,8 +135,8 @@ void GOTestNameMap::TestMultipleNames() {
 }
 
 void GOTestNameMap::run() {
-  TestAddAndGetName();
-  TestEnsureNameExists();
-  TestEmptyName();
-  TestMultipleNames();
+  GO_RUN_TEST(TestAddAndGetName())
+  GO_RUN_TEST(TestEnsureNameExists())
+  GO_RUN_TEST(TestEmptyName())
+  GO_RUN_TEST(TestMultipleNames())
 }

--- a/src/tests/testing/midi/GOTestMidiPlayerContent.cpp
+++ b/src/tests/testing/midi/GOTestMidiPlayerContent.cpp
@@ -12,6 +12,8 @@
 #include "midi/GOMidiPlayerContent.h"
 #include "midi/events/GOMidiEvent.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestMidiPlayerContent::TEST_NAME
   = "GOTestMidiPlayerContent";
 
@@ -126,10 +128,10 @@ void GOTestMidiPlayerContent::TestHasNativeHeader() {
 }
 
 void GOTestMidiPlayerContent::run() {
-  TestIsMidiInputNumberMappingUsable();
-  TestComputeManualChannelsPedalFirst();
-  TestComputeManualChannelsPedalLast();
-  TestComputeManualChannelsUseInputNumber();
-  TestComputeManualChannelsUseInputNumberFallback();
-  TestHasNativeHeader();
+  GO_RUN_TEST(TestIsMidiInputNumberMappingUsable())
+  GO_RUN_TEST(TestComputeManualChannelsPedalFirst())
+  GO_RUN_TEST(TestComputeManualChannelsPedalLast())
+  GO_RUN_TEST(TestComputeManualChannelsUseInputNumber())
+  GO_RUN_TEST(TestComputeManualChannelsUseInputNumberFallback())
+  GO_RUN_TEST(TestHasNativeHeader())
 }

--- a/src/tests/testing/midi/GOTestMidiSendProxy.cpp
+++ b/src/tests/testing/midi/GOTestMidiSendProxy.cpp
@@ -8,6 +8,8 @@
 
 #include "midi/elements/GOMidiSendProxy.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestMidiSendProxy::TEST_NAME = "GOTestMidiSendProxy";
 
 void GOTestMidiSendProxy::TestDefaultState() {
@@ -74,8 +76,8 @@ void GOTestMidiSendProxy::TestStateRestorer() {
 }
 
 void GOTestMidiSendProxy::run() {
-  TestDefaultState();
-  TestToSendMidiIsIndependent();
-  TestToRecordMidiIsIndependent();
-  TestStateRestorer();
+  GO_RUN_TEST(TestDefaultState())
+  GO_RUN_TEST(TestToSendMidiIsIndependent())
+  GO_RUN_TEST(TestToRecordMidiIsIndependent())
+  GO_RUN_TEST(TestStateRestorer())
 }

--- a/src/tests/testing/sound/GOTestSoundCallbackConnector.cpp
+++ b/src/tests/testing/sound/GOTestSoundCallbackConnector.cpp
@@ -15,6 +15,8 @@
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/interfaces/GOSoundCallbackConnector.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundCallbackConnector::TEST_NAME
   = "GOTestSoundCallbackConnector";
 
@@ -195,9 +197,9 @@ void GOTestSoundCallbackConnector::TestDisconnectWaitsAsyncCallbacks() {
 }
 
 void GOTestSoundCallbackConnector::run() {
-  TestSilenceWithoutEngine();
-  TestConnectDisconnectLifecycle();
-  TestAsyncCallbacksXrun();
-  TestConnectDisconnectCyclesAsyncCallbacks();
-  TestDisconnectWaitsAsyncCallbacks();
+  GO_RUN_TEST(TestSilenceWithoutEngine())
+  GO_RUN_TEST(TestConnectDisconnectLifecycle())
+  GO_RUN_TEST(TestAsyncCallbacksXrun())
+  GO_RUN_TEST(TestConnectDisconnectCyclesAsyncCallbacks())
+  GO_RUN_TEST(TestDisconnectWaitsAsyncCallbacks())
 }

--- a/src/tests/testing/sound/GOTestSoundOrganEngine.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngine.cpp
@@ -18,6 +18,8 @@
 #include "sound/GOSoundOrganEngine.h"
 #include "sound/buffer/GOSoundBufferMutable.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundOrganEngine::TEST_NAME = "GOTestSoundOrganEngine";
 
 struct EngineConfig {
@@ -359,12 +361,12 @@ void GOTestSoundOrganEngine::TestReconnectAfterMidPeriodDisconnect() {
 }
 
 void GOTestSoundOrganEngine::run() {
-  TestSingleOutputLifecycle();
-  TestTwoOutputsLifecycle();
-  TestTwoGroupsTwoOutputsLifecycle();
-  TestSetUsedTransitions();
-  TestBuildStopCyclesAsyncCallbacksXrun();
-  TestMultipleConfigsAsyncCallbacks();
-  TestDisconnectWithXrunDeadlock();
-  TestReconnectAfterMidPeriodDisconnect();
+  GO_RUN_TEST(TestSingleOutputLifecycle())
+  GO_RUN_TEST(TestTwoOutputsLifecycle())
+  GO_RUN_TEST(TestTwoGroupsTwoOutputsLifecycle())
+  GO_RUN_TEST(TestSetUsedTransitions())
+  GO_RUN_TEST(TestBuildStopCyclesAsyncCallbacksXrun())
+  GO_RUN_TEST(TestMultipleConfigsAsyncCallbacks())
+  GO_RUN_TEST(TestDisconnectWithXrunDeadlock())
+  GO_RUN_TEST(TestReconnectAfterMidPeriodDisconnect())
 }

--- a/src/tests/testing/sound/GOTestSoundOrganEngineFactories.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineFactories.cpp
@@ -14,6 +14,8 @@
 #include "sound/tasks/GOSoundBufferTaskBase.h"
 #include "sound/tasks/GOSoundOutputTask.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundOrganEngineFactories::TEST_NAME
   = "GOTestSoundOrganEngineFactories";
 
@@ -180,8 +182,8 @@ void GOTestSoundOrganEngineFactories::
 }
 
 void GOTestSoundOrganEngineFactories::run() {
-  TestDownmixGainsWithOneGroup();
-  TestDownmixGainsWithTwoGroups();
-  TestDefaultOutputConfigs();
-  TestDefaultOutputConfigsMatchesDownmixGains();
+  GO_RUN_TEST(TestDownmixGainsWithOneGroup())
+  GO_RUN_TEST(TestDownmixGainsWithTwoGroups())
+  GO_RUN_TEST(TestDefaultOutputConfigs())
+  GO_RUN_TEST(TestDefaultOutputConfigsMatchesDownmixGains())
 }

--- a/src/tests/testing/sound/GOTestSoundOrganEngineStress.cpp
+++ b/src/tests/testing/sound/GOTestSoundOrganEngineStress.cpp
@@ -16,6 +16,8 @@
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/interfaces/GOSoundCallbackConnector.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundOrganEngineStress::TEST_NAME
   = "GOTestSoundOrganEngineStress";
 
@@ -84,6 +86,6 @@ void GOTestSoundOrganEngineStress::TestBuildStopCycles() {
 }
 
 void GOTestSoundOrganEngineStress::run() {
-  TestConnectDisconnectCycles();
-  TestBuildStopCycles();
+  GO_RUN_TEST(TestConnectDisconnectCycles())
+  GO_RUN_TEST(TestBuildStopCycles())
 }

--- a/src/tests/testing/sound/buffer/GOTestPerfSoundBufferMutable.cpp
+++ b/src/tests/testing/sound/buffer/GOTestPerfSoundBufferMutable.cpp
@@ -13,6 +13,8 @@
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/buffer/GOSoundBufferMutableMono.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestPerfSoundBufferMutable::TEST_NAME
   = "GOTestPerfSoundBufferMutable";
 
@@ -432,17 +434,17 @@ void GOTestPerfSoundBufferMutable::run() {
   std::cout << "Buffer configuration: " << NUM_CHANNELS
             << " channels (stereo)\n";
 
-  TestPerfFillWithSilence();
-  TestPerfCopyFrom();
-  TestPerfAddFrom();
-  TestPerfAddFromWithCoefficient();
-  TestPerfCopyChannelFrom();
-  TestPerfAddChannelFrom();
-  TestPerfAddChannelFromWithCoefficient();
-  TestPerfAddChannelFromMonoRecipient();
-  TestPerfAddChannelFromMono();
+  GO_RUN_TEST(TestPerfFillWithSilence())
+  GO_RUN_TEST(TestPerfCopyFrom())
+  GO_RUN_TEST(TestPerfAddFrom())
+  GO_RUN_TEST(TestPerfAddFromWithCoefficient())
+  GO_RUN_TEST(TestPerfCopyChannelFrom())
+  GO_RUN_TEST(TestPerfAddChannelFrom())
+  GO_RUN_TEST(TestPerfAddChannelFromWithCoefficient())
+  GO_RUN_TEST(TestPerfAddChannelFromMonoRecipient())
+  GO_RUN_TEST(TestPerfAddChannelFromMono())
 
   std::cout << "\n========== Performance Tests Completed ==========\n";
 
-  ReportFailedTests();
+  GO_RUN_TEST(ReportFailedTests())
 }

--- a/src/tests/testing/sound/buffer/GOTestPerfSoundBufferPlanarMutable.cpp
+++ b/src/tests/testing/sound/buffer/GOTestPerfSoundBufferPlanarMutable.cpp
@@ -13,6 +13,8 @@
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/buffer/GOSoundBufferPlanarMutable.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestPerfSoundBufferPlanarMutable::TEST_NAME
   = "GOTestPerfSoundBufferPlanarMutable";
 
@@ -453,18 +455,18 @@ void GOTestPerfSoundBufferPlanarMutable::run() {
   std::cout << "Buffer configuration: " << NUM_CHANNELS
             << " channels (stereo)\n";
 
-  TestPerfFillWithSilence();
-  TestPerfCopyFrom();
-  TestPerfAddFrom();
-  TestPerfAddFromWithCoefficient();
-  TestPerfCopyChannelFrom();
-  TestPerfAddChannelFrom();
-  TestPerfAddChannelFromWithCoefficient();
-  TestPerfDeinterleaveFrom();
-  TestPerfAddDeinterleaveFrom();
-  TestPerfInterleaveTo();
+  GO_RUN_TEST(TestPerfFillWithSilence())
+  GO_RUN_TEST(TestPerfCopyFrom())
+  GO_RUN_TEST(TestPerfAddFrom())
+  GO_RUN_TEST(TestPerfAddFromWithCoefficient())
+  GO_RUN_TEST(TestPerfCopyChannelFrom())
+  GO_RUN_TEST(TestPerfAddChannelFrom())
+  GO_RUN_TEST(TestPerfAddChannelFromWithCoefficient())
+  GO_RUN_TEST(TestPerfDeinterleaveFrom())
+  GO_RUN_TEST(TestPerfAddDeinterleaveFrom())
+  GO_RUN_TEST(TestPerfInterleaveTo())
 
   std::cout << "\n========== Performance Tests Completed ==========\n";
 
-  ReportFailedTests();
+  GO_RUN_TEST(ReportFailedTests())
 }

--- a/src/tests/testing/sound/buffer/GOTestSoundBuffer.cpp
+++ b/src/tests/testing/sound/buffer/GOTestSoundBuffer.cpp
@@ -14,6 +14,8 @@
 
 #include "sound/buffer/GOSoundBuffer.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundBuffer::TEST_NAME = "GOTestSoundBuffer";
 
 void GOTestSoundBuffer::AssertGetNItems(
@@ -203,10 +205,10 @@ void GOTestSoundBuffer::TestEdgeCases() {
 }
 
 void GOTestSoundBuffer::run() {
-  TestConstructorAndBasicProperties();
-  TestGetNItems();
-  TestGetItemIndex();
-  TestGetSubBuffer();
-  TestInvalidBuffer();
-  TestEdgeCases();
+  GO_RUN_TEST(TestConstructorAndBasicProperties())
+  GO_RUN_TEST(TestGetNItems())
+  GO_RUN_TEST(TestGetItemIndex())
+  GO_RUN_TEST(TestGetSubBuffer())
+  GO_RUN_TEST(TestInvalidBuffer())
+  GO_RUN_TEST(TestEdgeCases())
 }

--- a/src/tests/testing/sound/buffer/GOTestSoundBufferManaged.cpp
+++ b/src/tests/testing/sound/buffer/GOTestSoundBufferManaged.cpp
@@ -13,6 +13,8 @@
 
 #include "sound/buffer/GOSoundBufferManaged.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundBufferManaged::TEST_NAME
   = "GOTestSoundBufferManaged";
 
@@ -148,18 +150,18 @@ void GOTestSoundBufferManaged::TestInvalidBufferOperations() {
 }
 
 void GOTestSoundBufferManaged::run() {
-  TestDefaultConstructor();
-  TestConstructorWithDimensions();
-  TestCopyConstructorFromBuffer();
-  TestCopyConstructorFromManaged();
-  TestMoveConstructor();
-  TestCopyAssignmentFromBuffer();
-  TestCopyAssignmentFromManaged();
-  TestMoveAssignment();
-  TestResize();
-  TestResizeNoReallocation();
-  TestSwap();
-  TestComplexOperations();
-  TestSubBufferCompatibility();
-  TestInvalidBufferOperations();
+  GO_RUN_TEST(TestDefaultConstructor())
+  GO_RUN_TEST(TestConstructorWithDimensions())
+  GO_RUN_TEST(TestCopyConstructorFromBuffer())
+  GO_RUN_TEST(TestCopyConstructorFromManaged())
+  GO_RUN_TEST(TestMoveConstructor())
+  GO_RUN_TEST(TestCopyAssignmentFromBuffer())
+  GO_RUN_TEST(TestCopyAssignmentFromManaged())
+  GO_RUN_TEST(TestMoveAssignment())
+  GO_RUN_TEST(TestResize())
+  GO_RUN_TEST(TestResizeNoReallocation())
+  GO_RUN_TEST(TestSwap())
+  GO_RUN_TEST(TestComplexOperations())
+  GO_RUN_TEST(TestSubBufferCompatibility())
+  GO_RUN_TEST(TestInvalidBufferOperations())
 }

--- a/src/tests/testing/sound/buffer/GOTestSoundBufferMutable.cpp
+++ b/src/tests/testing/sound/buffer/GOTestSoundBufferMutable.cpp
@@ -12,6 +12,8 @@
 
 #include "sound/buffer/GOSoundBufferMutable.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundBufferMutable::TEST_NAME
   = "GOTestSoundBufferMutable";
 
@@ -661,19 +663,19 @@ void GOTestSoundBufferMutable::TestSingleChannelBuffer() {
 }
 
 void GOTestSoundBufferMutable::run() {
-  TestInheritanceAndMutableAccess();
-  TestFillWithSilence();
-  TestCopyFrom();
-  TestAddFrom();
-  TestAddFromWithCoefficient();
-  TestMutableGetSubBuffer();
-  TestCompatibilityChecks();
-  TestComplexOperations();
-  TestCopyChannelFrom();
-  TestAddChannelFrom();
-  TestAddChannelFromWithCoefficient();
-  TestCrossChannelOperations();
-  TestChannelOperationsWithSubBuffers();
-  TestInvalidChannelIndices();
-  TestSingleChannelBuffer();
+  GO_RUN_TEST(TestInheritanceAndMutableAccess())
+  GO_RUN_TEST(TestFillWithSilence())
+  GO_RUN_TEST(TestCopyFrom())
+  GO_RUN_TEST(TestAddFrom())
+  GO_RUN_TEST(TestAddFromWithCoefficient())
+  GO_RUN_TEST(TestMutableGetSubBuffer())
+  GO_RUN_TEST(TestCompatibilityChecks())
+  GO_RUN_TEST(TestComplexOperations())
+  GO_RUN_TEST(TestCopyChannelFrom())
+  GO_RUN_TEST(TestAddChannelFrom())
+  GO_RUN_TEST(TestAddChannelFromWithCoefficient())
+  GO_RUN_TEST(TestCrossChannelOperations())
+  GO_RUN_TEST(TestChannelOperationsWithSubBuffers())
+  GO_RUN_TEST(TestInvalidChannelIndices())
+  GO_RUN_TEST(TestSingleChannelBuffer())
 }

--- a/src/tests/testing/sound/buffer/GOTestSoundBufferMutableMono.cpp
+++ b/src/tests/testing/sound/buffer/GOTestSoundBufferMutableMono.cpp
@@ -14,6 +14,8 @@
 
 #include "sound/buffer/GOSoundBufferMutableMono.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundBufferMutableMono::TEST_NAME
   = "GOTestSoundBufferMutableMono";
 
@@ -310,11 +312,11 @@ void GOTestSoundBufferMutableMono::TestEdgeCases() {
 }
 
 void GOTestSoundBufferMutableMono::run() {
-  TestConstructorAndBasicProperties();
-  TestGetSubBuffer();
-  TestCopyChannelFrom();
-  TestCopyChannelTo();
-  TestAddChannelFrom();
-  TestInvalidBuffer();
-  TestEdgeCases();
+  GO_RUN_TEST(TestConstructorAndBasicProperties())
+  GO_RUN_TEST(TestGetSubBuffer())
+  GO_RUN_TEST(TestCopyChannelFrom())
+  GO_RUN_TEST(TestCopyChannelTo())
+  GO_RUN_TEST(TestAddChannelFrom())
+  GO_RUN_TEST(TestInvalidBuffer())
+  GO_RUN_TEST(TestEdgeCases())
 }

--- a/src/tests/testing/sound/buffer/GOTestSoundBufferPlanar.cpp
+++ b/src/tests/testing/sound/buffer/GOTestSoundBufferPlanar.cpp
@@ -13,6 +13,8 @@
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/buffer/GOSoundBufferPlanar.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundBufferPlanar::TEST_NAME
   = "GOTestSoundBufferPlanar";
 
@@ -146,9 +148,9 @@ void GOTestSoundBufferPlanar::TestEdgeCases() {
 }
 
 void GOTestSoundBufferPlanar::run() {
-  TestConstructorAndBasicProperties();
-  TestGetChannelBuffer();
-  TestInterleaveTo();
-  TestInvalidBuffer();
-  TestEdgeCases();
+  GO_RUN_TEST(TestConstructorAndBasicProperties())
+  GO_RUN_TEST(TestGetChannelBuffer())
+  GO_RUN_TEST(TestInterleaveTo())
+  GO_RUN_TEST(TestInvalidBuffer())
+  GO_RUN_TEST(TestEdgeCases())
 }

--- a/src/tests/testing/sound/buffer/GOTestSoundBufferPlanarManaged.cpp
+++ b/src/tests/testing/sound/buffer/GOTestSoundBufferPlanarManaged.cpp
@@ -9,6 +9,8 @@
 
 #include "sound/buffer/GOSoundBufferPlanarManaged.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundBufferPlanarManaged::TEST_NAME
   = "GOTestSoundBufferPlanarManaged";
 
@@ -68,15 +70,15 @@ void GOTestSoundBufferPlanarManaged::TestSwap() {
 }
 
 void GOTestSoundBufferPlanarManaged::run() {
-  TestDefaultConstructor();
-  TestConstructorWithDimensions();
-  TestCopyConstructorFromView();
-  TestCopyConstructorFromManaged();
-  TestMoveConstructor();
-  TestCopyAssignmentFromView();
-  TestCopyAssignmentFromManaged();
-  TestMoveAssignment();
-  TestResize();
-  TestResizeNoReallocation();
-  TestSwap();
+  GO_RUN_TEST(TestDefaultConstructor())
+  GO_RUN_TEST(TestConstructorWithDimensions())
+  GO_RUN_TEST(TestCopyConstructorFromView())
+  GO_RUN_TEST(TestCopyConstructorFromManaged())
+  GO_RUN_TEST(TestMoveConstructor())
+  GO_RUN_TEST(TestCopyAssignmentFromView())
+  GO_RUN_TEST(TestCopyAssignmentFromManaged())
+  GO_RUN_TEST(TestMoveAssignment())
+  GO_RUN_TEST(TestResize())
+  GO_RUN_TEST(TestResizeNoReallocation())
+  GO_RUN_TEST(TestSwap())
 }

--- a/src/tests/testing/sound/buffer/GOTestSoundBufferPlanarMutable.cpp
+++ b/src/tests/testing/sound/buffer/GOTestSoundBufferPlanarMutable.cpp
@@ -14,6 +14,8 @@
 #include "sound/buffer/GOSoundBufferMutable.h"
 #include "sound/buffer/GOSoundBufferPlanarMutable.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestSoundBufferPlanarMutable::TEST_NAME
   = "GOTestSoundBufferPlanarMutable";
 
@@ -277,15 +279,15 @@ void GOTestSoundBufferPlanarMutable::TestSingleChannelBuffer() {
 }
 
 void GOTestSoundBufferPlanarMutable::run() {
-  TestGetChannelBufferWriteThrough();
-  TestFillWithSilence();
-  TestCopyFrom();
-  TestAddFrom();
-  TestAddFromWithCoefficient();
-  TestCopyChannelFrom();
-  TestAddChannelFrom();
-  TestAddChannelFromWithCoefficient();
-  TestDeinterleaveFrom();
-  TestAddDeinterleavedFrom();
-  TestSingleChannelBuffer();
+  GO_RUN_TEST(TestGetChannelBufferWriteThrough())
+  GO_RUN_TEST(TestFillWithSilence())
+  GO_RUN_TEST(TestCopyFrom())
+  GO_RUN_TEST(TestAddFrom())
+  GO_RUN_TEST(TestAddFromWithCoefficient())
+  GO_RUN_TEST(TestCopyChannelFrom())
+  GO_RUN_TEST(TestAddChannelFrom())
+  GO_RUN_TEST(TestAddChannelFromWithCoefficient())
+  GO_RUN_TEST(TestDeinterleaveFrom())
+  GO_RUN_TEST(TestAddDeinterleavedFrom())
+  GO_RUN_TEST(TestSingleChannelBuffer())
 }

--- a/src/tests/testing/sound/playing/GOTestReleaseAlignTable.cpp
+++ b/src/tests/testing/sound/playing/GOTestReleaseAlignTable.cpp
@@ -10,6 +10,8 @@
 
 #include "sound/playing/GOSoundReleaseAlignTable.h"
 
+#include "GOTestScope.h"
+
 const std::string GOTestReleaseAlignTable::TEST_NAME
   = "GOTestReleaseAlignTable";
 
@@ -192,15 +194,15 @@ void GOTestReleaseAlignTable::TestAmplitudeOrdering() {
 }
 
 void GOTestReleaseAlignTable::run() {
-  TestComputeBucketIndexNormal();
-  TestComputeBucketIndexBelowRange();
-  TestComputeBucketIndexAboveRange();
-  TestComputeBucketIndexZeroMaxValue();
-  TestComputeBucketIndexBoundaries();
-  TestBugRegression();
-  TestSameRowPreference();
-  TestDistantSingleCell();
-  TestEmptyTable();
-  TestCellFindsItself();
-  TestAmplitudeOrdering();
+  GO_RUN_TEST(TestComputeBucketIndexNormal())
+  GO_RUN_TEST(TestComputeBucketIndexBelowRange())
+  GO_RUN_TEST(TestComputeBucketIndexAboveRange())
+  GO_RUN_TEST(TestComputeBucketIndexZeroMaxValue())
+  GO_RUN_TEST(TestComputeBucketIndexBoundaries())
+  GO_RUN_TEST(TestBugRegression())
+  GO_RUN_TEST(TestSameRowPreference())
+  GO_RUN_TEST(TestDistantSingleCell())
+  GO_RUN_TEST(TestEmptyTable())
+  GO_RUN_TEST(TestCellFindsItself())
+  GO_RUN_TEST(TestAmplitudeOrdering())
 }

--- a/src/tests/testing/sound/playing/GOTestSoundStream.cpp
+++ b/src/tests/testing/sound/playing/GOTestSoundStream.cpp
@@ -15,6 +15,7 @@
 #include "sound/playing/GOSoundStream.h"
 
 #include "GOInt.h"
+#include "GOTestScope.h"
 #include "GOWave.h"
 #include "GOWaveLoop.h"
 
@@ -346,15 +347,31 @@ void GOTestSoundStream::TestCompressedLoopWrapMatchesUncompressed() {
 void GOTestSoundStream::run() {
   for (unsigned nChannels : {1u, 2u}) {
     for (bool isCompressed : {false, true}) {
-      TestReadBlock(
-        GOSoundResample::GO_LINEAR_INTERPOLATION, isCompressed, nChannels);
-      TestReadBlock(
-        GOSoundResample::GO_POLYPHASE_INTERPOLATION, isCompressed, nChannels);
+      {
+        GOTestScope scope(
+          GOTestScope::TEST,
+          std::format(
+            "TestReadBlock(LINEAR, compressed={}, nChannels={})",
+            isCompressed,
+            nChannels));
+        TestReadBlock(
+          GOSoundResample::GO_LINEAR_INTERPOLATION, isCompressed, nChannels);
+      }
+      {
+        GOTestScope scope(
+          GOTestScope::TEST,
+          std::format(
+            "TestReadBlock(POLYPHASE, compressed={}, nChannels={})",
+            isCompressed,
+            nChannels));
+        TestReadBlock(
+          GOSoundResample::GO_POLYPHASE_INTERPOLATION, isCompressed, nChannels);
+      }
     }
   }
-  TestLoopedStreamAlwaysReturnsTrue();
-  TestLoopTransitionAcrossDifferentEndPos();
-  TestInitAlignedStream();
-  TestCompressedLoopWrapMatchesUncompressed();
-  TestInitAlignedStreamWithSilentAttack();
+  GO_RUN_TEST(TestLoopedStreamAlwaysReturnsTrue())
+  GO_RUN_TEST(TestLoopTransitionAcrossDifferentEndPos())
+  GO_RUN_TEST(TestInitAlignedStream())
+  GO_RUN_TEST(TestCompressedLoopWrapMatchesUncompressed())
+  GO_RUN_TEST(TestInitAlignedStreamWithSilentAttack())
 }

--- a/src/tests/testing/sound/tasks/GOTestPerfSoundTaskBase.cpp
+++ b/src/tests/testing/sound/tasks/GOTestPerfSoundTaskBase.cpp
@@ -16,6 +16,7 @@
 
 #include "GOSoundCooperativeTaskTestImpl.h"
 #include "GOSoundTaskTestImpl.h"
+#include "GOTestScope.h"
 
 const std::string GOTestPerfSoundTaskBase::TEST_NAME
   = "GOTestPerfSoundTaskBase";
@@ -604,13 +605,13 @@ void GOTestPerfSoundTaskBase::run() {
   std::cout << "\n========== Performance Tests for GOSoundTaskBase "
                "==========\n";
 
-  TestPerfUncontendedRunThroughput();
-  TestPerfContendedRunLatency();
-  TestPerfCooperativeThroughput();
-  TestPerfRoundProtocolCost();
-  TestPerfNextPeriodLatency();
-  TestPerfCooperativeRoundLatency();
-  TestPerfLazyPrerequisiteAccess();
+  GO_RUN_TEST(TestPerfUncontendedRunThroughput())
+  GO_RUN_TEST(TestPerfContendedRunLatency())
+  GO_RUN_TEST(TestPerfCooperativeThroughput())
+  GO_RUN_TEST(TestPerfRoundProtocolCost())
+  GO_RUN_TEST(TestPerfNextPeriodLatency())
+  GO_RUN_TEST(TestPerfCooperativeRoundLatency())
+  GO_RUN_TEST(TestPerfLazyPrerequisiteAccess())
 
   std::cout << "\n========== Performance Tests Completed ==========\n";
 

--- a/src/tests/testing/sound/tasks/GOTestSoundTaskBase.cpp
+++ b/src/tests/testing/sound/tasks/GOTestSoundTaskBase.cpp
@@ -16,6 +16,7 @@
 
 #include "GOSoundCooperativeTaskTestImpl.h"
 #include "GOSoundTaskTestImpl.h"
+#include "GOTestScope.h"
 
 const std::string GOTestSoundTaskBase::TEST_NAME = "GOTestSoundTaskBase";
 
@@ -315,21 +316,21 @@ void GOTestSoundTaskBase::TestCooperativeNewRoundAllowsFreshRound() {
 }
 
 void GOTestSoundTaskBase::run() {
-  TestInitialState();
-  TestRunCallsDoRunOnce();
-  TestRunRepeatsUntilDoRunReturnsTrue();
-  TestCompleteRoundSetsFlagAndFinishes();
-  TestNewRoundResetsState();
-  TestDiscardContentCallsNewRound();
+  GO_RUN_TEST(TestInitialState())
+  GO_RUN_TEST(TestRunCallsDoRunOnce())
+  GO_RUN_TEST(TestRunRepeatsUntilDoRunReturnsTrue())
+  GO_RUN_TEST(TestCompleteRoundSetsFlagAndFinishes())
+  GO_RUN_TEST(TestNewRoundResetsState())
+  GO_RUN_TEST(TestDiscardContentCallsNewRound())
 
-  TestConcurrentRunExecutesDoRunExactlyOnce();
-  TestConcurrentRunWithIncompleteDoRun();
-  TestConcurrentCompleteRoundAndRun();
-  TestNewRoundWaitsForInFlightRun();
-  TestNoTornStateAcrossThreads();
+  GO_RUN_TEST(TestConcurrentRunExecutesDoRunExactlyOnce())
+  GO_RUN_TEST(TestConcurrentRunWithIncompleteDoRun())
+  GO_RUN_TEST(TestConcurrentCompleteRoundAndRun())
+  GO_RUN_TEST(TestNewRoundWaitsForInFlightRun())
+  GO_RUN_TEST(TestNoTornStateAcrossThreads())
 
-  TestCooperativeReachesDoneExactlyOnce();
-  TestCooperativeThreadWithNoWorkExitsEarly();
-  TestCooperativeWaitOrStopBlocksUntilDone();
-  TestCooperativeNewRoundAllowsFreshRound();
+  GO_RUN_TEST(TestCooperativeReachesDoneExactlyOnce())
+  GO_RUN_TEST(TestCooperativeThreadWithNoWorkExitsEarly())
+  GO_RUN_TEST(TestCooperativeWaitOrStopBlocksUntilDone())
+  GO_RUN_TEST(TestCooperativeNewRoundAllowsFreshRound())
 }


### PR DESCRIPTION
## Summary
- CI run https://github.com/GrandOrgue/grandorgue/actions/runs/33991952714/job/101375645910 ("tests (functional coverage asan, Debug, ON, asan)") hung until CTest's timeout, and the log gave no indication which of the ~24 registered `GOTest` classes -- or which of their internal sub-scenarios -- was stuck.
- `GOTestCollection::Run()` printed nothing while a test ran, and the one progress print that did exist (`GOTest::setUp()`'s "BEGIN" line) had no trailing newline and was never flushed, so it didn't even show up in the failing log.
- Adds `GOTestScope`, a small RAII progress logger with two explicit concepts, **test class** (a registered `GOTest` instance, including the existing nested ones like `GOTestDrawStop::Functions`) and **test** (a named sub-scenario called from a test class's `run()`). Both print an indented, immediately-flushed start/done line with elapsed time, so a hung CI run will show exactly what was last starting.
- Wires this into `GOTestCollection::Run()` (test-class level) and into every multi-call `run()` body across the test suite (test level), via a small `GO_RUN_TEST(...)` macro following this codebase's existing declaration-style macro convention (UPPERCASE, no trailing `;`).

## Test plan
- [x] `GO_BUILD_TESTING=ON` Debug build succeeds
- [x] `./bin/GOTestExe --no-perf`: all 27 tests pass, every test class and sub-test prints an indented, flushed start/done line, including nested test classes (`GOTestDrawStop::Functions`, `GOTestDivisionalSetter::*`) and the parametrized `GOTestSoundStream` loop (shows resolved `nChannels`/`compressed` values per iteration)
- [x] `./bin/GOTestExe --perf-only`: same logging format confirmed for performance tests
- [x] Final `TESTS RESULTS` / `TESTS SUMMARY` output and pass/fail counts unchanged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>